### PR TITLE
Do not use enums in queries if there is only one choice

### DIFF
--- a/lib/ui/lens/ChatThreadList.tsx
+++ b/lib/ui/lens/ChatThreadList.tsx
@@ -83,8 +83,11 @@ export class Renderer extends TailStreamer<DefaultRendererProps, RendererState> 
 					data: {
 						type: 'object',
 						properties: {
-							target: {
+							target: threads.length > 1 ? {
 								enum: _.map(threads, 'id'),
+							} : {
+								type: 'string',
+								const: threads[0]
 							},
 						},
 						required: [ 'target' ],


### PR DESCRIPTION
This is a small, but yet not bad, improvement.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>