### PR TITLE
Fix sporadic sharding replica issues

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -135,6 +135,11 @@ module.exports = class Backend {
 				.run(this.connection)
 		}
 
+		// Prevent sporadic replica error:
+		//   Cannot perform read: primary replica for shard ["", +inf) not available]
+		// See https://github.com/rethinkdb/rethinkdb/issues/6160
+		await rethinkdb.db(this.database).wait().run(this.connection)
+
 		this.tables = new Set(await this.getTables())
 	}
 


### PR DESCRIPTION
This happens on the test suite, because we create and destroy many
databases in a short amount of time.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>