### PR TITLE
Core/SDK: Prevent users from logging in as the core admin user

### DIFF
--- a/default-cards/contrib/view-read-user-community.json
+++ b/default-cards/contrib/view-read-user-community.json
@@ -380,6 +380,16 @@
               "type": "string",
               "const": "user"
             },
+            "slug": {
+              "type": "string",
+              "not": {
+                "enum": [
+                  "user-admin",
+                  "user-guest",
+                  "user-actions"
+                ]
+              }
+            },
             "data": {
               "type": "object",
               "properties": {

--- a/default-cards/contrib/view-read-user-guest.json
+++ b/default-cards/contrib/view-read-user-guest.json
@@ -228,6 +228,12 @@
             "type": {
               "type": "string",
               "const": "user"
+            },
+            "slug": {
+              "type": "string",
+              "not": {
+                "const": "user-admin"
+              }
             }
           },
           "additionalProperties": false,

--- a/lib/sdk/lib/auth.ts
+++ b/lib/sdk/lib/auth.ts
@@ -93,6 +93,10 @@ export class AuthSdk {
 		email: string;
 		password: string;
 	}): Bluebird<Card> {
+		// Normalize username and email to lower case
+		username = username.toLowerCase();
+		email = email.toLowerCase();
+
 		if (!USERNAME_REGEX.test(username)) {
 			throw new Error('Usernames can only contain alphanumeric characters and dashes, and must be at least 5 characters long');
 		}
@@ -166,7 +170,8 @@ export class AuthSdk {
 		username: string;
 		password: string;
 	}): Bluebird<Card> {
-		const slug = `user-${options.username}`;
+		// Normalize username to lower case
+		const slug = `user-${options.username}`.toLowerCase();
 
 		const passwordArgument = options.password ?
 			{


### PR DESCRIPTION
Fixes #399
Fixes #400

The sdk now normalizes username and emails to lowercase in the `signup`
and `login` methods

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>