### PR TITLE
core: Setup secondary indexes for card types

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -219,6 +219,38 @@ module.exports = class Backend {
 		// See https://github.com/rethinkdb/rethinkdb/issues/6160
 		await rethinkdb.db(this.database).wait().run(this.connection)
 
+		for (const table of await this.getTables()) {
+			// Get rid of old indexes, so we can be sure
+			// they get re-created every time the server
+			// restarts, to accomodate for updates, etc.
+			const indexes = await rethinkdb
+				.db(this.database)
+				.table(table)
+				.indexList()
+				.run(this.connection)
+			for (const index of indexes) {
+				await rethinkdb
+					.db(this.database)
+					.table(table)
+					.indexDrop(index)
+					.run(this.connection)
+			}
+
+			// Add secondary indexes for card types, as
+			// querying for all cards of a certain type
+			// is a very common access pattern.
+			await rethinkdb
+				.db(this.database)
+				.table(table)
+				.indexCreate('type')
+				.run(this.connection)
+			await rethinkdb
+				.db(this.database)
+				.table(table)
+				.indexWait('type')
+				.run(this.connection)
+		}
+
 		await this.cache.connect()
 	}
 


### PR DESCRIPTION
Querying for a set of cards from a given type is a very common use case.
Secondary indexes for types gives us a small boost.

Change-type: patch