### PR TITLE
Server: Bind to a port as early as possible

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -128,21 +128,56 @@ const createServer = () => {
 		next()
 	})
 
-	return Promise.resolve(core.create({
-		tables: {
-			cards: 'cards',
-			requests: 'requests',
-			sessions: 'sessions'
-		},
-		backend: {
-			host: app.get('db-host'),
-			port: app.get('db-port'),
-			user: app.get('db-user'),
-			password: app.get('db-password'),
-			certificate: app.get('db-cert'),
-			database: app.get('database')
+	// Resolve the promise once the server is ready to accept incoming
+	// connections.
+	return new Promise((resolve) => {
+		// The .listen callback will be called regardless of if there is an
+		// EADDRINUSE error, which means that the promise will resolve with
+		// the incorrect port if the port is already in use. To get around
+		// this, we add a listener for the `listening` event, which can be
+		// removed if the port bind fails
+		const listenCallback = () => {
+			resolve()
 		}
-	})).tap((jellyfish) => {
+
+		const listenOnPort = (port) => {
+			server.listen(port)
+				.on('listening', listenCallback)
+		}
+
+		server.on('error', (error) => {
+			// If the server is running in a test environment and the
+			// port is in use, try binding to a higher port number.
+			if (error.code === 'EADDRINUSE' && process.env.NODE_ENV === 'test') {
+				// The original listener has to be removed, otherwise it will be
+				// triggered when the server finds an available port
+				debug(`Port ${error.port} is already in use, attempting to bind to ${error.port + 1}`)
+				server.removeListener('listening', listenCallback)
+				server.close()
+				return listenOnPort(error.port + 1)
+			}
+
+			throw error
+		})
+
+		listenOnPort(app.get('port'))
+	}).then(() => {
+		return Promise.resolve(core.create({
+			tables: {
+				cards: 'cards',
+				requests: 'requests',
+				sessions: 'sessions'
+			},
+			backend: {
+				host: app.get('db-host'),
+				port: app.get('db-port'),
+				user: app.get('db-user'),
+				password: app.get('db-password'),
+				certificate: app.get('db-cert'),
+				database: app.get('database')
+			}
+		}))
+	}).tap((jellyfish) => {
 		// Insert cards essential to the correct function of the actions server,
 		// and cards that don't contain $formula fields.
 		// Any remaining cards will be inserted using the actions server itself
@@ -434,48 +469,14 @@ const createServer = () => {
 									})
 							})
 						})
-
-						// Resolve the promise once the server is ready to accept incoming
-						// connections.
-						return new Promise((resolve) => {
-							// The .listen callback will be called regardless of if there is an
-							// EADDRINUSE error, which means that the promise will resolve with
-							// the incorrect port if the port is already in use. To get around
-							// this, we add a listener for the `listening` event, which can be
-							// removed if the port bind fails
-							const listenCallback = () => {
-								const port = server.address().port
-								debug(`HTTP app listening on port ${port}!`)
-								resolve(port)
-							}
-
-							const listenOnPort = (port) => {
-								server.listen(port)
-									.on('listening', listenCallback)
-							}
-
-							server.on('error', (error) => {
-								// If the server is running in a test environment and the
-								// port is in use, try binding to a higher port number.
-								if (error.code === 'EADDRINUSE' && process.env.NODE_ENV === 'test') {
-									// The original listener has to be removed, otherwise it will be
-									// triggered when the server finds an available port
-									debug(`Port ${error.port} is already in use, attempting to bind to ${error.port + 1}`)
-									server.removeListener('listening', listenCallback)
-									server.close()
-									return listenOnPort(error.port + 1)
-								}
-
-								throw error
-							})
-
-							listenOnPort(app.get('port'))
-						})
 					}).catch((error) => {
 						throw error
 					})
 			})
-				.then((port) => {
+				.then(() => {
+					const port = server.address().port
+					debug(`HTTP app listening on port ${port}!`)
+
 					// Resolve the jellyfish core after starting the server for testing purposes
 					jellyfish.sessions.guest = guestUserSession.id
 					return {


### PR DESCRIPTION
- This will help on architectures that require a port bind to indicate
readiness

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>