### PR TITLE
worker: Use json-e to parse triggers

### DIFF
--- a/default-cards/contrib/triggered-action.json
+++ b/default-cards/contrib/triggered-action.json
@@ -23,8 +23,7 @@
               "type": "string"
             },
             "target": {
-              "type": "string",
-              "pattern": "^[\\{\\}\\.\\w\\[\\]-]+$"
+              "type": [ "string", "object" ]
             },
             "arguments": {
               "type": "object"

--- a/lib/jellyscript/index.js
+++ b/lib/jellyscript/index.js
@@ -218,6 +218,8 @@ exports.getTypeTriggers = (typeCard) => {
 				input: {}
 			})
 
+			const valueProperty = `source.${arg}`
+
 			triggers.push({
 				slug: slugify(`triggered-action-${typeCard.slug}-${path.output.join('-')}`),
 				type: 'triggered-action',
@@ -227,10 +229,18 @@ exports.getTypeTriggers = (typeCard) => {
 				data: {
 					action: 'action-set-add',
 					type: typeCard.slug,
-					target: '{source.data.target}',
+					target: {
+						$eval: 'source.data.target'
+					},
 					arguments: {
 						property: path.output.join('.'),
-						value: `{source.${arg}}`
+						value: {
+							$if: valueProperty,
+							then: {
+								$eval: valueProperty
+							},
+							else: []
+						}
 					},
 					filter: {
 						type: 'object',

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -110,7 +110,7 @@ module.exports = class Worker {
 				throw new errors.WorkerInvalidTrigger(`Invalid action: ${trigger.action}`)
 			}
 
-			if (!trigger.card || !_.isString(trigger.card)) {
+			if (!trigger.card || (!_.isString(trigger.card) && !_.isPlainObject(trigger.card))) {
 				throw new errors.WorkerInvalidTrigger(`Invalid card: ${trigger.card}`)
 			}
 

--- a/lib/worker/triggers.js
+++ b/lib/worker/triggers.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const objectTemplate = require('object-template')
+const jsone = require('json-e')
 const jsonSchema = require('../json-schema')
 
 /**
@@ -66,13 +66,15 @@ const matchesCard = (trigger, card) => {
  */
 const compileTrigger = (trigger, card) => {
 	try {
-		return objectTemplate.compile(trigger, {
+		return jsone(trigger, {
 			source: card
-		}, {
-			delimiters: [ '\\{', '\\}' ]
 		})
 	} catch (error) {
-		return null
+		if (error.name === 'InterpreterError') {
+			return null
+		}
+
+		throw error
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9038,6 +9038,14 @@
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
+    "json-e": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/json-e/-/json-e-2.6.0.tgz",
+      "integrity": "sha1-72/9sxBRfTPJ1Qf/tNZ8WCqWv8U=",
+      "requires": {
+        "json-stable-stringify": "1.0.1"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -9077,7 +9085,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -9108,8 +9115,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "formulajs": "^1.0.8",
     "history": "^4.7.2",
     "howler": "^2.0.12",
+    "json-e": "^2.6.0",
     "localforage": "^1.6.0",
     "lodash": "^4.17.5",
     "mark.js": "^8.11.1",

--- a/test/jellyscript/index.spec.js
+++ b/test/jellyscript/index.spec.js
@@ -596,10 +596,18 @@ ava.test('.getTypeTriggers() should report back watchers when aggregating events
 			data: {
 				type: 'thread',
 				action: 'action-set-add',
-				target: '{source.data.target}',
+				target: {
+					$eval: 'source.data.target'
+				},
 				arguments: {
 					property: 'data.mentions',
-					value: '{source.data.mentions}'
+					value: {
+						$if: 'source.data.mentions',
+						then: {
+							$eval: 'source.data.mentions'
+						},
+						else: []
+					}
 				},
 				filter: {
 					type: 'object',

--- a/test/worker/executor.spec.js
+++ b/test/worker/executor.spec.js
@@ -781,9 +781,13 @@ ava.test('.insertCard() should remove previously inserted type triggered actions
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -816,9 +820,13 @@ ava.test('.insertCard() should remove previously inserted type triggered actions
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -913,9 +921,13 @@ ava.test('.insertCard() should remove previously inserted type triggered actions
 			target: typeCard.id,
 			arguments: {
 				properties: {
-					slug: '{source.data.slug}',
+					slug: {
+						$eval: 'source.data.slug'
+					},
 					data: {
-						number: '{source.data.number}'
+						number: {
+							$eval: 'source.data.number'
+						}
 					}
 				}
 			}
@@ -1060,11 +1072,19 @@ ava.test('.insertCard() should pre-register a triggered action if using AGGREGAT
 	test.deepEqual(test.context.triggers, [
 		{
 			action: 'action-set-add',
-			card: '{source.data.target}',
+			card: {
+				$eval: 'source.data.target'
+			},
 			filter: test.context.triggers[0].filter,
 			arguments: {
 				property: 'data.mentions',
-				value: '{source.data.payload.mentions}'
+				value: {
+					$if: 'source.data.payload.mentions',
+					then: {
+						$eval: 'source.data.payload.mentions'
+					},
+					else: []
+				}
 			}
 		}
 	])

--- a/test/worker/index.spec.js
+++ b/test/worker/index.spec.js
@@ -682,7 +682,7 @@ ava.test('.execute() AGGREGATE should work with $$ prefixed properties', async (
 								properties: {
 									$$mentions: {
 										type: 'array',
-										$formula: 'AGGREGATE($events, "data.payload.$$mentions")'
+										$formula: 'AGGREGATE($events, "data.payload[\'$$mentions\']")'
 									}
 								},
 								additionalProperties: true

--- a/test/worker/triggers.spec.js
+++ b/test/worker/triggers.spec.js
@@ -242,9 +242,13 @@ ava.test('.getRequest() should parse source templates in the triggered action ar
 		card: typeCard.id,
 		arguments: {
 			properties: {
-				slug: '{source.data.slug}',
+				slug: {
+					$eval: 'source.data.slug'
+				},
 				data: {
-					number: '{source.data.number}'
+					number: {
+						$eval: 'source.data.number'
+					}
 				}
 			}
 		}
@@ -309,9 +313,13 @@ ava.test('.getRequest() should return null if one of the templates is unsatisfie
 		card: typeCard.id,
 		arguments: {
 			properties: {
-				slug: '{source.data.slug}',
+				slug: {
+					$eval: 'source.data.slug'
+				},
 				data: {
-					number: '{source.data.number}'
+					number: {
+						$eval: 'source.data.number'
+					}
 				}
 			}
 		}
@@ -370,9 +378,13 @@ ava.test('.getTypeTriggers() should return a trigger card with a matching type',
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -422,9 +434,13 @@ ava.test('.getTypeTriggers() should not return inactive cards', async (test) => 
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -470,9 +486,13 @@ ava.test('.getTypeTriggers() should ignore non-matching cards', async (test) => 
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -505,9 +525,13 @@ ava.test('.getTypeTriggers() should ignore non-matching cards', async (test) => 
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -557,9 +581,13 @@ ava.test('.getTypeTriggers() should ignore cards that are not triggered actions'
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -592,9 +620,13 @@ ava.test('.getTypeTriggers() should ignore cards that are not triggered actions'
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}
@@ -643,9 +675,13 @@ ava.test('.getTypeTriggers() should not return triggered actions not associated 
 				target: typeCard.id,
 				arguments: {
 					properties: {
-						slug: '{source.data.slug}',
+						slug: {
+							$eval: 'source.data.slug'
+						},
 						data: {
-							number: '{source.data.number}'
+							number: {
+								$eval: 'source.data.number'
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Should be faster, plus we don't have to support our own object
templating engine.

Change-type: major