### PR TITLE
test: Import latest production backup to local database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ webpack-bundle-report.html
 # End of https://www.gitignore.io/api/node
 
 rethinkdb_data
+.tar.gz

--- a/scripts/import-latest-production-backup.sh
+++ b/scripts/import-latest-production-backup.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -e
+TOKEN="$COMPOSE_TOKEN"
+set -u
+
+if [ -z "$TOKEN" ]; then
+  echo "Please set the COMPOSE_TOKEN environment variable" 1>&2
+  exit 1
+fi
+
+COMPOSE_API_PREFIX=https://api.compose.io/2016-07
+
+# The Jellyfish production instance
+DEPLOYMENT_ID=5a941f82eddb0ae421771519
+
+BACKUP_PATH="$(curl \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/hal+json" \
+  "$COMPOSE_API_PREFIX/deployments/$DEPLOYMENT_ID/backups" \
+  | jq -r '._embedded.backups[0]._links.self.href')"
+
+BACKUP_URL="$(curl \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/hal+json" \
+  "$COMPOSE_API_PREFIX/$BACKUP_PATH" \
+  | jq -r '.download_link')"
+
+OUTPUT="jellyfish-backup.tar.gz"
+echo "Downloading $BACKUP_URL"
+wget -O "$OUTPUT" "$BACKUP_URL"
+
+rethinkdb restore "$OUTPUT" --connect localhost
+rm "$OUTPUT"


### PR DESCRIPTION
Given a Compose API token (which you can create from the Compose panel),
this script will pull the latest backup, and import it to your local
database. Running `npm start` right afterwards allows you to play with
it locally for development purposes.

Change-type: patch