### PR TITLE
Ignore gumpf files created by development process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,12 @@ webpack-bundle-report.html
 
 # End of https://www.gitignore.io/api/node
 
+# Development Files
+.scratch/
+*.iml
+.idea/
+.vscode/
+
+# Execution files
 rethinkdb_data
 .tar.gz


### PR DESCRIPTION
Add to .gitignore lines for some common IDEs, and a location to stash
scratch files, such as .sh and dev config files.

Change-type: patch
Signed-off-by: Andrew Lucas <andrewl@resin.io>