### PR TITLE
Sync: Add user-sync

### DIFF
--- a/default-cards/contrib/user-actions.json
+++ b/default-cards/contrib/user-actions.json
@@ -1,0 +1,13 @@
+{
+  "slug": "user-actions",
+  "type": "user",
+  "name": "The actions user",
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "disallowLogin": true,
+    "email": "accounts+jellyfish@resin.io",
+    "roles": []
+  }
+}

--- a/default-cards/contrib/view-read-user-actions.json
+++ b/default-cards/contrib/view-read-user-actions.json
@@ -293,88 +293,6 @@
         }
       },
       {
-        "name": "Views",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "view"
-            },
-            "slug": {
-              "type": "string",
-              "enum": [
-                "view-all-messages",
-                "view-all-views",
-                "view-my-alerts",
-                "view-my-mentions"
-              ]
-            },
-            "id": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [ "id", "slug", "type" ]
-        }
-      },
-      {
-        "name": "My views",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "view"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "actor": {
-                  "type": "string",
-                  "const": {
-                    "$eval": "user.id"
-                  }
-                }
-              },
-              "required": [ "actor" ],
-              "additionalProperties": true
-            }
-          },
-          "additionalProperties": true,
-          "required": [ "data", "type" ]
-        }
-      },
-      {
-        "name": "My views",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "view"
-            },
-            "id": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "actor": {
-                  "type": "string",
-                  "const": {
-                    "$eval": "user.id"
-                  }
-                }
-              },
-              "required": [ "actor" ]
-            }
-          },
-          "additionalProperties": true,
-          "required": [ "id", "slug", "type" ]
-        }
-      },
-      {
         "name": "Contrib cards",
         "schema": {
           "type": "object",
@@ -396,32 +314,6 @@
         }
       },
       {
-        "name": "My subscriptions",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "subscription"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "actor": {
-                  "type": "string",
-                  "const": {
-                    "$eval": "user.id"
-                  }
-                }
-              },
-              "additionalProperties": true,
-              "required": [ "actor" ]
-            }
-          },
-          "additionalProperties": true,
-          "required": [ "data", "type" ]
-        }
-      },
-      {
         "name": "Other users",
         "schema": {
           "type": "object",
@@ -438,8 +330,7 @@
               "not": {
                 "enum": [
                   "user-admin",
-                  "user-guest",
-                  "user-actions"
+                  "user-guest"
                 ]
               }
             },

--- a/default-cards/contrib/view-read-user-actions.json
+++ b/default-cards/contrib/view-read-user-actions.json
@@ -1,0 +1,461 @@
+{
+  "slug": "view-read-user-actions",
+  "name": "Actions role read permissions",
+  "type": "view",
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "allOf": [
+      {
+        "name": "Active cards",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean",
+              "const": true
+            }
+          },
+          "required": [ "active" ]
+        }
+      }
+    ],
+    "anyOf": [
+      {
+        "name": "Types",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "type"
+            },
+            "slug": {
+              "enum": [
+                "action",
+                "action-request",
+                "execute",
+                "card",
+                "create",
+                "message",
+                "session",
+                "subscription",
+                "thread",
+                "triggered-action",
+                "update",
+                "view"
+              ]
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "required": [ "schema" ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "slug", "type", "data" ]
+        }
+      },
+      {
+        "name": "Actions",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string",
+              "enum": [
+                "action-create-card",
+                "action-create-event",
+                "action-create-session",
+                "action-create-user",
+                "action-set-add",
+                "action-update-card"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "const": "action"
+            },
+            "data": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "required": [ "id", "slug", "type", "data" ]
+        }
+      },
+      {
+        "name": "Events",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "anyOf": [
+                { "const": "create" },
+                { "const": "update" }
+              ]
+            },
+            "data": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [ "timestamp", "target", "actor", "payload" ],
+              "properties": {
+                "timestamp": {
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                },
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                },
+                "payload": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "required": [ "type", "data" ]
+        }
+      },
+      {
+        "name": "My Action Executions",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "execute"
+            },
+            "data": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "actor"
+              ],
+              "properties": {
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "type", "data" ]
+        }
+      },
+      {
+        "name": "My Action Requests",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "action-request"
+            },
+            "data": {
+              "type": "object",
+              "required": [
+                "actor",
+                "target",
+                "action",
+                "timestamp",
+                "arguments",
+                "executed"
+              ],
+              "properties": {
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                },
+                "target": {
+                  "type": "string"
+                },
+                "action": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                },
+                "arguments": {
+                  "type": "object"
+                },
+                "executed": {
+                  "type": "boolean"
+                },
+                "result": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "type", "data" ]
+        }
+      },
+      {
+        "name": "Timelines",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "create",
+                "update"
+              ]
+            },
+            "data": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "required": [ "id", "type", "data" ]
+        }
+      },
+      {
+        "name": "Myself",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "slug": {
+              "type": "string",
+              "const": {
+                "$eval": "user.slug"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "user"
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "slug", "type" ]
+        }
+      },
+      {
+        "name": "My sessions",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "session"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "data", "id", "type" ]
+        }
+      },
+      {
+        "name": "Views",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "view"
+            },
+            "slug": {
+              "type": "string",
+              "enum": [
+                "view-all-messages",
+                "view-all-views",
+                "view-my-alerts",
+                "view-my-mentions"
+              ]
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "id", "slug", "type" ]
+        }
+      },
+      {
+        "name": "My views",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "view"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                }
+              },
+              "required": [ "actor" ],
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "data", "type" ]
+        }
+      },
+      {
+        "name": "My views",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "view"
+            },
+            "id": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                }
+              },
+              "required": [ "actor" ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "id", "slug", "type" ]
+        }
+      },
+      {
+        "name": "Contrib cards",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "thread",
+                "message",
+                "triggered-action"
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "type" ]
+        }
+      },
+      {
+        "name": "My subscriptions",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "subscription"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "actor": {
+                  "type": "string",
+                  "const": {
+                    "$eval": "user.id"
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "required": [ "actor" ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [ "data", "type" ]
+        }
+      },
+      {
+        "name": "Other users",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "user"
+            },
+            "slug": {
+              "type": "string",
+              "not": {
+                "enum": [
+                  "user-admin",
+                  "user-guest",
+                  "user-actions"
+                ]
+              }
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [ "id", "type", "data" ]
+        }
+      }
+    ]
+  }
+}

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -99,28 +99,30 @@ const createServer = async (options) => {
 		})
 	})
 
-	const guestUser = await jellyfish.insertCard(
-		jellyfish.sessions.admin,
-		require('../../default-cards/contrib/user-guest.json'),
-		{
+	await Bluebird.map([ 'guest', 'actions' ], async (userId) => {
+		const userCard = await jellyfish.insertCard(
+			jellyfish.sessions.admin,
+			require(`../../default-cards/contrib/user-${userId}.json`),
+			{
+				override: true
+			}
+		)
+
+		const userSession = await jellyfish.insertCard(jellyfish.sessions.admin, {
+			slug: `session-${userId}`,
+			type: 'session',
+			links: {},
+			tags: [],
+			active: true,
+			data: {
+				actor: userCard.id
+			}
+		}, {
 			override: true
-		}
-	)
+		})
 
-	const guestUserSession = await jellyfish.insertCard(jellyfish.sessions.admin, {
-		slug: 'session-guest',
-		type: 'session',
-		links: {},
-		tags: [],
-		active: true,
-		data: {
-			actor: guestUser.id
-		}
-	}, {
-		override: true
+		jellyfish.sessions[userId] = userSession.id
 	})
-
-	jellyfish.sessions.guest = guestUserSession.id
 
 	const worker = await actionServer.start(
 		jellyfish,


### PR DESCRIPTION
Add user card for sync user

Copy view-read-user-community (as a jumping off point) and add the
single extra action of action-emit-webhook

Add the sync user by bundling the existing code for the password-less
guest user, and invoking it on both guest and sync

Change-type: patch
Signed-off-by: Andrew Lucas <andrewl@resin.io>