### PR TITLE
Support test scripts written in TypeScript

### DIFF
--- a/lib/utils/string-testers.ts
+++ b/lib/utils/string-testers.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as moment from 'moment';
+import UrlRegex = require('url-regex');
+
+export function isUrl(focus: string): boolean {
+	return UrlRegex({ exact: true }).test(focus);
+}
+
+export function isSingleLine(focus: string): boolean {
+	return !/[\r\n]/.test(focus);
+}
+
+export function isSlug(focus: string): boolean {
+	return /^[a-z0-9-]+$/.test(focus);
+}
+
+export function hasSpace(focus: string): boolean {
+	return /\s/.test(focus);
+}
+
+export function isTime(focus: string): boolean {
+	return moment(focus).isValid();
+}
+
+export function hasContent(focus: string): boolean {
+	return focus.trim() !== '';
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "DEBUG=jellyfish:* node lib/index.js",
     "start:profiler": "DEBUG=jellyfish:* node profiler.js",
     "test": "npm run lint && npm run test:command",
-    "test:command": "TEST_DB_HOST=localhost TEST_PROXY_PORT=9999 TEST_DB_PORT=28015 API_URL='http://localhost:8000' NODE_ENV=test nyc --reporter=lcov ava",
+    "test:command": "nyc --reporter=lcov ava-ts && TEST_DB_HOST=localhost TEST_PROXY_PORT=9999 TEST_DB_PORT=28015 API_URL='http://localhost:8000' NODE_ENV=test nyc --reporter=lcov ava",
     "posttest": "./scripts/scrub-test-databases.js",
     "lint": "npm run eslint && npm run tslint",
     "eslint": "eslint lib test stress webpack.config.js",
@@ -35,6 +35,7 @@
       "./test/test-helpers/ui-setup.js"
     ],
     "files": [
+      "test/**/*.spec.ts",
       "test/**/*.spec.js"
     ],
     "babel": {
@@ -47,7 +48,9 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/bluebird": "^3.5.20",
+    "@types/url-regex": "^4.0.0",
     "ava": "^0.22.0",
+    "ava-ts": "^0.25.0",
     "babel-preset-react": "^6.24.1",
     "cache-loader": "^1.2.2",
     "cli-spinner": "^0.2.8",
@@ -135,6 +138,7 @@
     "static-eval": "^2.0.0",
     "styled-components": "^3.2.5",
     "typed-errors": "^1.1.0",
+    "url-regex": "^4.1.1",
     "uuid": "^3.2.1"
   }
 }

--- a/test/utils/string-testers.spec.ts
+++ b/test/utils/string-testers.spec.ts
@@ -1,0 +1,135 @@
+import * as ava from 'ava';
+import * as _ from 'lodash';
+import * as stringTesters from '../../lib/utils/string-testers';
+
+function testStrings(testStrings: string[], testFunction: (focus: string) => boolean, expectation: boolean) {
+	return (test: ava.AssertContext) => {
+		const expectations = _.fill(_.clone(testStrings), expectation);
+		const results = _.map(testStrings, testFunction);
+		test.deepEqual(results, expectations);
+	};
+}
+
+ava.test('stringTesters.isUrl() should pass example good urls', testStrings(
+	[
+		'http://example.com',
+		'https://example.com',
+		'http://example.com/path',
+		'http://example.com/index.html',
+		'http://example.com?foo=bar',
+		'http://example.com#anchor',
+	],
+	stringTesters.isUrl,
+	true,
+));
+
+ava.test('stringTesters.isUrl() should fail example bad urls', testStrings(
+	[
+		'not a url',
+		'http:/example.com',
+		'http://example.com duff',
+	],
+	stringTesters.isUrl,
+	false,
+));
+
+ava.test('stringTesters.isSingleLine() should pass example single line strings', testStrings(
+	[
+		'not a url',
+		'http:/example.com',
+		'http://example.com duff',
+	],
+	stringTesters.isSingleLine,
+	true,
+));
+
+ava.test('stringTesters.isSingleLine() should fail example multi line strings', testStrings(
+	[
+		'line one\rline two',
+		'line one\nline two',
+		'line one\r\nline two',
+		'line one\n\rline two',
+	],
+	stringTesters.isSingleLine,
+	false,
+));
+
+ava.test('stringTesters.isSlug() should pass example slugs', testStrings(
+	[
+		'abc',
+		'not-a-url',
+		'http-example-com',
+		'abc-123',
+	],
+	stringTesters.isSlug,
+	true,
+));
+
+ava.test('stringTesters.isSlug() should fail example non-slug strings', testStrings(
+	[
+		'',
+		'CapitalLetters',
+		'has spaces',
+		'http://example.com',
+		'under_score',
+	],
+	stringTesters.isSlug,
+	false,
+));
+
+ava.test('stringTesters.hasSpace() should pass example strings with whitespace', testStrings(
+	[
+		'not a url',
+		'http://example.com duff',
+	],
+	stringTesters.hasSpace,
+	true,
+));
+
+ava.test('stringTesters.hasSpace() should fail example strings without whitespace', testStrings(
+	[
+		'foo',
+		'http://example.com',
+	],
+	stringTesters.hasSpace,
+	false,
+));
+
+ava.test('stringTesters.isTime() should pass example time strings', testStrings(
+	[
+		'2018-07-30T16:39:12Z',
+	],
+	stringTesters.isTime,
+	true,
+));
+
+ava.test('stringTesters.isTime() should fail example non-time strings', testStrings(
+	[
+		'not a url',
+		'http:/example.com',
+		'http://example.com duff',
+	],
+	stringTesters.isTime,
+	false,
+));
+
+ava.test('stringTesters.hasContent() should pass example strings with content', testStrings(
+	[
+		'not a url',
+		'http:/example.com',
+		'http://example.com duff',
+	],
+	stringTesters.hasContent,
+	true,
+));
+
+ava.test('stringTesters.hasContent() should fail pure whitespace strings', testStrings(
+	[
+		'',
+		' ',
+		'	',
+		'\r\n',
+	],
+	stringTesters.hasContent,
+	false,
+));


### PR DESCRIPTION
Install the TypeScript port of ava, add this to the test:command and
test .spec.ts files

Add the simple (but used by JellySync) string-testers utility library
and a test suite for it, to test the testers

Change-type: patch
Signed-off-by: Andrew Lucas <andrewl@resin.io>