### PR TITLE
package.json: Upgrade skhema to v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16121,9 +16121,9 @@
       }
     },
     "skhema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/skhema/-/skhema-2.0.1.tgz",
-      "integrity": "sha512-wWgKYQ9L4zVDMCr9sGVHzkAEAFf6wGDYzzaNQFwwV1pt0NB+CxZnmkA/v09Ge6+h/fPGWPUJGI3h1avwMgGs9A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/skhema/-/skhema-2.0.2.tgz",
+      "integrity": "sha512-lIkr4IieSBRyvNUdCmdg8k5wvzVBMWFuH7LjwlQ75E9Pi5eA+MzwFLVL5ERYOB0+6649MX+dSH9LDTn2orU5eg==",
       "requires": {
         "@types/json-schema": "6.0.1",
         "ajv": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "rendition": "^4.18.1",
     "reql-schema": "^1.0.0",
     "rethinkdb": "^2.3.3",
-    "skhema": "^2.0.1",
+    "skhema": "^2.0.2",
     "socket.io": "^2.1.0",
     "static-eval": "^2.0.0",
     "styled-components": "^3.2.5",


### PR DESCRIPTION
This version fixes an issue when merging JSON Schemas including the
`enum` property, where one of the schemas would overwrite the other.

See: https://github.com/resin-io-modules/skhema/pull/9
Change-type: patch