### PR TITLE
chore(Tests): Run tests against production data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: rethinkdb --daemon --bind all
-      - run: npm test
+      - run: npm test -- --with-restore
 
       # Stress Testing
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,11 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: apt-get update && apt-get install -y git
+      # pip, jq and wget are required to restore a production database backup
+      - run: apt-get update && apt-get install -y git jq wget python-pip
+
+      # Install the rethinkdb python driver so rethinkdb-restore can be run
+      - run: pip install rethinkdb
 
       # Because `node_modules` gets cached, any changes to the SDK will be
       # ignored, as the package already exists there and npm lifecycle events

--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,4 @@ webpack-bundle-report.html
 
 # Execution files
 rethinkdb_data
-.tar.gz
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -64,3 +64,15 @@ And then run:
 npm start
 ```
 
+Testing
+-------
+
+Run `npm test` to start the test suite. By default a production backup will be
+restored and used to run tests, requiring that you provide a compose.io API
+token as the `COMPOSE_TOKEN` environment variable. This behaviour can be skipped
+using the `--skip-restore` flag, which is useful for local development and
+testing.
+
+```
+npm test -- --skip-restore
+```

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ npm start
 Testing
 -------
 
-Run `npm test` to start the test suite. By default a production backup will be
-restored and used to run tests, requiring that you provide a compose.io API
-token as the `COMPOSE_TOKEN` environment variable. This behaviour can be skipped
-using the `--skip-restore` flag, which is useful for local development and
-testing.
+Run `npm test` to start the test suite. Optionally, a production backup can be
+restored and used to run the test suite again, providing additional test
+coverage. This feature requires that you provide a compose.io API token as the
+`COMPOSE_TOKEN` environment variable. This behaviour can be triggered using the
+`--with-restore` flag.
 
 ```
-npm test -- --skip-restore
+npm test -- --with-restore
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "DEBUG=jellyfish:* node lib/index.js",
     "start:profiler": "DEBUG=jellyfish:* node profiler.js",
-    "test": "npm run lint && npm run test:command",
+    "test": "./scripts/ci-test.sh",
     "test:command": "TEST_DB_HOST=localhost TEST_PROXY_PORT=9999 TEST_DB_PORT=28015 API_URL='http://localhost:8000' NODE_ENV=test nyc --reporter=lcov ava",
     "posttest": "./scripts/scrub-test-databases.js",
     "lint": "npm run eslint && npm run tslint",

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -3,22 +3,26 @@
 # If any command fails, exit with a failure code
 set -e
 
+DB_NAME="jellyfish_prod"
+
 # Linters
 echo "Running linters"
 npm run lint
 
-# If the --skip-restore flag is set, then don't pull a production backup.
-# This is useful for development testing
-if [[ $* == *--skip-restore* ]]; then
-	echo "Skipping restore step..."
-else
-	# Import the latest production backup and restore it to rethinkdb
-	echo "Importing latest production backup"
-	./scripts/import-latest-production-backup.sh
-
-	echo "Sanitizing user emails and passwords"
-	./scripts/sanitize-users.js
-fi
 
 echo "Running tests"
 npm run test:command
+
+# If the --with-restore flag is set, then a production backup is restored and the
+# tests are run again, against the restored backup.
+if [[ $* == *--with-restore* ]]; then
+	# Import the latest production backup and restore it to rethinkdb
+	echo "Importing latest production backup"
+	TARGET_DATABASE="$DB_NAME" ./scripts/import-latest-production-backup.sh
+
+	echo "Sanitizing user emails and passwords"
+	./scripts/sanitize-users.js
+
+	echo "Running tests against production backup"
+	TEST_DB_NAME="$DB_NAME" npm run test:command
+fi

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -21,7 +21,7 @@ if [[ $* == *--with-restore* ]]; then
 	TARGET_DATABASE="$DB_NAME" ./scripts/import-latest-production-backup.sh
 
 	echo "Sanitizing user emails and passwords"
-	./scripts/sanitize-users.js
+	TARGET_DATABASE="$DB_NAME" ./scripts/sanitize-users.js
 
 	echo "Running tests against production backup"
 	TEST_DB_NAME="$DB_NAME" npm run test:command

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # If any command fails, exit with a failure code
 set -e

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# If any command fails, exit with a failure code
+set -e
+
+# Linters
+echo "Running linters"
+npm run lint
+
+# If the --skip-restore flag is set, then don't pull a production backup.
+# This is useful for development testing
+if [[ $* == *--skip-restore* ]]; then
+	echo "Skipping restore step..."
+else
+	# Import the latest production backup and restore it to rethinkdb
+	echo "Importing latest production backup"
+	./scripts/import-latest-production-backup.sh
+
+	echo "Sanitizing user emails and passwords"
+	./scripts/sanitize-users.js
+fi
+
+echo "Running tests"
+npm run test:command

--- a/scripts/import-latest-production-backup.sh
+++ b/scripts/import-latest-production-backup.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
+# This script downloads the latest production database backup and restores it to
+# a rethinkdb running on localhost.
+# The script requires that you provide a compise.io API token using the
+# `COMPOSE_TOKEN` environment variable.
+# By default the backup is restored to a database with the name `jellyfish_production_data`,
+# this can be overridden using the `TARGET_DATABASE` environment variable
+
 set -e
 TOKEN="$COMPOSE_TOKEN"
 set -u
+
+FOLDER="jellyfish_production_data"
+DATABASE=${TARGET_DATABASE:-"$FOLDER"}
 
 if [ -z "$TOKEN" ]; then
   echo "Please set the COMPOSE_TOKEN environment variable" 1>&2
@@ -30,5 +40,16 @@ OUTPUT="jellyfish-backup.tar.gz"
 echo "Downloading $BACKUP_URL"
 wget -O "$OUTPUT" "$BACKUP_URL"
 
-rethinkdb restore "$OUTPUT" --connect localhost
+# Rethinkdb provides no method for changing the database that you import into.
+# As a workaround, the tarball is unpacked and the data directory is renamed
+# See https://github.com/rethinkdb/rethinkdb/issues/4274
+mkdir -p "$FOLDER"
+tar -xvzf "$OUTPUT" -C "$FOLDER" --strip-components 1
+
+mv "$FOLDER"/jellyfish "$FOLDER"/"$DATABASE"
+
+echo "Importing data into database: $DATABASE"
+
+rethinkdb import -d "$FOLDER" --connect localhost
 rm "$OUTPUT"
+rm -rf "$FOLDER"

--- a/scripts/sanitize-users.js
+++ b/scripts/sanitize-users.js
@@ -46,8 +46,6 @@ const sanitize = async () => {
 		additionalProperties: true
 	})
 
-	console.log(users)
-
 	console.log(`Sanitizing ${users.length} users`)
 
 	await Promise.map(

--- a/scripts/sanitize-users.js
+++ b/scripts/sanitize-users.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+const Promise = require('bluebird')
+const _ = require('lodash')
+const rethinkdb = require('rethinkdb')
+
+// Hashed password for string 'password'
+const PASSWORD_HASH = 'd310765c8cdc225e0ed52624dc04445e0a72f21fc218ad1727fda09044eb4f4ff600876420ee4f81dfe46b1ee2e10b2571be5306ea1416abc1e1e30794ac6567'
+
+// Ignore these users as modifying their email and password could be bad
+const USER_BLACKLIST = [
+	'user-admin',
+	'user-guest',
+	'user-actions'
+]
+
+// Sanitize email addresses and passwords for all users
+const sanitize = async () => {
+	const connection = await rethinkdb.connect()
+
+	const cursor = await rethinkdb.db('jellyfish')
+		.table('cards')
+		.filter({
+			type: 'user'
+		})
+		.run(connection)
+
+	const users = await cursor.toArray()
+
+	console.log(`Sanitizing ${users.length} users`)
+
+	await Promise.map(
+		users,
+		(user) => {
+			if (_.includes(USER_BLACKLIST, user.slug)) {
+				return null
+			}
+
+			return rethinkdb.db('jellyfish')
+				.table('cards')
+				.filter({
+					slug: user.slug
+				})
+				.update({
+					data: {
+						email: `${user.slug}@example.com`,
+						password: {
+							hash: PASSWORD_HASH
+						}
+					}
+				})
+				.run(connection)
+		},
+		{
+			concurrency: 10
+		}
+	)
+
+	console.log('Done!')
+
+	connection.close()
+}
+
+sanitize()

--- a/scripts/sanitize-users.js
+++ b/scripts/sanitize-users.js
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
+/**
+ * This script retrieves all user cards from a specified database and replaces
+ * the email addresses and passwords with dummy values. The databse to sanitize
+ * is specified using the `TARGET_DATABASE environment variable
+ */
+
 const Promise = require('bluebird')
 const _ = require('lodash')
-const rethinkdb = require('rethinkdb')
+const createServer = require('../lib/server')
 
 // Hashed password for string 'password'
 const PASSWORD_HASH = 'd310765c8cdc225e0ed52624dc04445e0a72f21fc218ad1727fda09044eb4f4ff600876420ee4f81dfe46b1ee2e10b2571be5306ea1416abc1e1e30794ac6567'
@@ -16,16 +22,31 @@ const USER_BLACKLIST = [
 
 // Sanitize email addresses and passwords for all users
 const sanitize = async () => {
-	const connection = await rethinkdb.connect()
+	if (!process.env.TARGET_DATABASE) {
+		throw new Error('Please set the TARGET_DATABASE environment variable')
+	}
 
-	const cursor = await rethinkdb.db('jellyfish')
-		.table('cards')
-		.filter({
-			type: 'user'
-		})
-		.run(connection)
+	const dbName = process.env.TARGET_DATABASE
 
-	const users = await cursor.toArray()
+	process.env.SERVER_DATABASE = dbName
+
+	console.log('Starting server')
+
+	const {
+		jellyfish
+	} =	await createServer()
+
+	const users = await jellyfish.query(jellyfish.sessions.admin, {
+		type: 'object',
+		properties: {
+			type: {
+				const: 'user'
+			}
+		},
+		additionalProperties: true
+	})
+
+	console.log(users)
 
 	console.log(`Sanitizing ${users.length} users`)
 
@@ -36,29 +57,31 @@ const sanitize = async () => {
 				return null
 			}
 
-			return rethinkdb.db('jellyfish')
-				.table('cards')
-				.filter({
-					slug: user.slug
-				})
-				.update({
-					data: {
-						email: `${user.slug}@example.com`,
-						password: {
-							hash: PASSWORD_HASH
-						}
-					}
-				})
-				.run(connection)
+			if (_.get(user, [ 'data', 'email' ])) {
+				user.data.email = `${user.slug}@example.com`
+			}
+
+			if (_.get(user, [ 'data', 'password', 'hash' ])) {
+				user.data.password.hash = PASSWORD_HASH
+			}
+
+			return jellyfish.insertCard(jellyfish.sessions.admin, user, {
+				override: true
+			})
 		},
 		{
 			concurrency: 10
 		}
 	)
+	.catch((error) => {
+		console.error(error)
+
+		process.exit(1)
+	})
 
 	console.log('Done!')
 
-	connection.close()
+	process.exit(0)
 }
 
 sanitize()

--- a/test/core/helpers.js
+++ b/test/core/helpers.js
@@ -25,7 +25,7 @@ exports.backend = {
 		test.context.backend = new Backend(cache, {
 			host: process.env.TEST_DB_HOST,
 			port: process.env.TEST_DB_PORT,
-			database: `test_${randomstring.generate()}`
+			database: process.env.TEST_DB_NAME || `test_${randomstring.generate()}`
 		})
 
 		await test.context.backend.connect()


### PR DESCRIPTION
A number of incidents have occurred where tests have passed, but failed
when running on production due to pre-existing card data. To help
mitigate this, the test script will now download and restore a database
backup from the Jellyfish production instance before running tests.
To help prevent bad situations from happening all user cards have their
password reset to 'password' and their emails changed to a dummy value
before the tests are run.

Because you may not always want this behaviour when running tests, you
can provide the `--skip-restore` flag to disable this new behaviour.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>