### PR TITLE
chore(Sentry): Add Sentry reporting for server and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ And then run:
 npm start
 ```
 
+If you would like to have errors reported to sentry, you can provide a sentry
+DSN using the environment variable `SENTRY_DSN_SERVER` for server errors and
+`SENTRY_DSN_UI` for UI errors.

--- a/lib/error-reporter.js
+++ b/lib/error-reporter.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Raven = require('raven')
+const debug = require('debug')('jellyfish:errors')
+
+class Reporter {
+	constructor () {
+		if (process.env.NODE_ENV === 'production') {
+			if (process.env.SENTRY_DSN_SERVER) {
+				Raven.config(process.env.SENTRY_DSN_SERVER).install()
+				this.initialized = true
+				debug('Raven error reporter initialized')
+			} else {
+				debug('No SENTRY_DSN environment variable provided: skipping Raven setup')
+			}
+		} else {
+			debug('NODE_ENV environment variable is not "production": skipping Raven setup')
+		}
+
+		this.reportException = this.reportException.bind(this)
+	}
+
+	reportException (error) {
+		if (!this.initialized) {
+			return
+		}
+		Raven.captureException(error)
+	}
+}
+
+module.exports = new Reporter()

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -20,6 +20,9 @@ const _ = require('lodash')
 const actionServer = require('../action-server')
 const core = require('../core')
 const {
+	reportException
+} = require('../error-reporter')
+const {
 	getConfig
 } = require('./config')
 const {
@@ -175,4 +178,10 @@ const createServer = async (options) => {
 	}
 }
 
-module.exports = createServer
+module.exports = () => {
+	return createServer()
+		.catch((error) => {
+			reportException(error)
+			throw error
+		})
+}

--- a/lib/ui/index.tsx
+++ b/lib/ui/index.tsx
@@ -1,8 +1,15 @@
+import * as Raven from 'raven-js';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { store } from './core';
 import { JellyfishUI } from './JellyfishUI';
+
+const SENTRY_DSN = process.env.SENTRY_DSN_UI;
+
+if (process.env.NODE_ENV === 'production' && SENTRY_DSN) {
+	Raven.config(SENTRY_DSN).install();
+}
 
 ReactDOM.render(
 	<Provider store={store}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2524,6 +2524,11 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chart.js": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.2.tgz",
@@ -3345,6 +3350,11 @@
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -9897,6 +9907,16 @@
         "escape-string-regexp": "1.0.5"
       }
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
+      }
+    },
     "md5-hex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
@@ -14705,6 +14725,30 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
+    "raven": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz",
+      "integrity": "sha512-bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "md5": "2.2.1",
+        "stack-trace": "0.0.10",
+        "timed-out": "4.0.1",
+        "uuid": "3.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+        }
+      }
+    },
+    "raven-js": {
+      "version": "3.26.4",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.26.4.tgz",
+      "integrity": "sha512-5VmC3IWhTQJkaiQaCY0S5V8za4bpUgbbuVT1MkDH7JVqgu8CPQ750XaFF8BVRbLV9F5nvoz7n0UT0CKteDuZAg=="
+    },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
@@ -16616,6 +16660,11 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -17147,8 +17196,7 @@
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "timers-browserify": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "mark.js": "^8.11.1",
     "moment": "^2.22.1",
     "object-hash": "^1.3.0",
+    "raven": "^2.6.3",
+    "raven-js": "^3.26.4",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,8 @@ const config = {
 			'process.env': {
 				API_URL: JSON.stringify(process.env.API_URL),
 				API_PREFIX: JSON.stringify(process.env.API_PREFIX || 'api/v2/'),
-				NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+				NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+				SENTRY_DSN_UI: JSON.stringify(process.env.SENTRY_DSN_UI)
 			}
 		}),
 


### PR DESCRIPTION
If the `NODE_ENV` environment variable is set to production and a sentry
DSN is provided, errors will be reported to sentry.
The server and UI read the sentry DSN different environment variables,
`SENTRY_DSN_SERVER` and `SENTRY_DSN_UI` respectively.
The UI error reporting uses standard blanket reporting for any unhandled
exception.
The server must explicitly report exceptions using the new
`error-reporter.js` module that exposes a `reportException` method.
Presently only errors in the web server bootstrap are reported to
sentry.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>