### PR TITLE
jellyscript: Simplify .evaluate() and .evaluateObject() interfaces

### DIFF
--- a/lib/jellyscript/index.js
+++ b/lib/jellyscript/index.js
@@ -68,67 +68,11 @@ exports.evaluate = (expression, options) => {
 
 	if (_.isNil(options.input)) {
 		return {
-			value: null,
-			watchers: []
+			value: null
 		}
 	}
 
 	const ast = esprima.parse(expression).body[0].expression
-
-	// Aggregating over $events is a special case
-	if (ast.type === 'CallExpression' &&
-			ast.callee.type === 'Identifier' &&
-			ast.callee.name === 'AGGREGATE' &&
-			ast.arguments[0].type === 'Identifier' &&
-			ast.arguments[0].name === '$events') {
-		return {
-			value: null,
-			watchers: [
-				{
-					type: ast.callee.name,
-
-					// We want to consider events whose target is
-					// the current context we're evaluating
-					filter: {
-						type: 'object',
-						required: [ 'data' ],
-						properties: {
-							data: {
-								type: 'object',
-								required: [ 'target', 'payload' ],
-								properties: {
-									payload: {
-										type: 'object'
-									},
-									target: {
-										type: 'object',
-										required: [ 'type' ],
-										properties: {
-											type: {
-												type: 'string',
-												const: options.context.type
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-
-					// Because we know we're dealing with events
-					target: [ 'data', 'target' ],
-
-					// The evaluated aggregation callback
-					arguments: [
-						runAST(ast.arguments[1], {
-							context: options.context,
-							input: options.input
-						})
-					]
-				}
-			]
-		}
-	}
 
 	const result = runAST(ast, {
 		context: options.context,
@@ -137,18 +81,12 @@ exports.evaluate = (expression, options) => {
 
 	if (_.isError(result)) {
 		return {
-			value: null,
-			watchers: []
+			value: null
 		}
 	}
 
-	if (_.isUndefined(result)) {
-		throw new Error(`Invalid expression: ${expression}`)
-	}
-
 	return {
-		value: result,
-		watchers: []
+		value: result || null
 	}
 }
 
@@ -160,8 +98,6 @@ const getDefaultValueForType = (type) => {
 }
 
 exports.evaluateObject = (schema, object) => {
-	const watchers = []
-
 	for (const path of card.getFormulasPaths(schema)) {
 		if (_.isEmpty(object)) {
 			continue
@@ -174,25 +110,13 @@ exports.evaluateObject = (schema, object) => {
 			input
 		})
 
-		if (!_.isEmpty(result.watchers)) {
-			if (_.isArray(input)) {
-				_.set(object, path.output, _.union(input, result.value))
-			}
-
-			for (const watcher of result.watchers) {
-				watcher.sourceProperty = path.output
-				watchers.push(watcher)
-			}
-		} else if (!_.isNull(result.value)) {
+		if (!_.isNull(result.value)) {
 			// Mutates input object
 			_.set(object, path.output, result.value)
 		}
 	}
 
-	return {
-		object,
-		watchers
-	}
+	return object
 }
 
 const slugify = (string) => {

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -126,7 +126,7 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object) => {
 		writeMode: true
 	})
 
-	const evaluationResult = jellyscript.evaluateObject(typeCard.data.schema, properties).object
+	const evaluationResult = jellyscript.evaluateObject(typeCard.data.schema, properties)
 	const insertedCard = await jellyfish.insertCard(session, evaluationResult, {
 		override: options.override
 	})

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -234,7 +234,7 @@ module.exports = class Worker {
 			arguments: jellyscript.evaluateObject(
 				utils.getActionArgumentsSchema(cards.action),
 				options.arguments
-			).object
+			)
 		}
 
 		await this.queue.enqueue(request)

--- a/test/jellyscript/index.spec.js
+++ b/test/jellyscript/index.spec.js
@@ -68,7 +68,6 @@ ava.test('.evaluate(): should return null if no input', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: null
 	})
 })
@@ -82,7 +81,6 @@ ava.test('.evaluate(): should resolve a number formula', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: 4
 	})
 })
@@ -96,7 +94,6 @@ ava.test('.evaluate(): should resolve composite formulas', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: 8
 	})
 })
@@ -111,7 +108,6 @@ ava.test('.evaluate(): should access other properties from the card', (test) => 
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: 5
 	})
 })
@@ -143,7 +139,6 @@ ava.test('AGGREGATE: should ignore duplicates', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: [ 'foo', 'bar', 'baz', 'qux' ]
 	})
 })
@@ -162,7 +157,6 @@ ava.test('AGGREGATE: should aggregate a set of object properties', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: [ 'foo', 'bar' ]
 	})
 })
@@ -174,7 +168,6 @@ ava.test('REGEX_MATCH: should extract a set of mentions', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: [ '@johndoe', '@janedoe' ]
 	})
 })
@@ -186,54 +179,7 @@ ava.test('REGEX_MATCH: should consider duplicates', (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
 		value: [ '@johndoe', '@janedoe', '@johndoe' ]
-	})
-})
-
-ava.test('AGGREGATE: should generate a watcher if aggregating $events', (test) => {
-	const result = jellyscript.evaluate('AGGREGATE($events, "mentions")', {
-		context: {
-			type: 'thread',
-			links: {},
-			tags: [],
-			active: true,
-			data: {}
-		},
-		input: 'foo'
-	})
-
-	test.deepEqual(result.value, null)
-	test.is(result.watchers.length, 1)
-
-	test.deepEqual(result.watchers[0].target, [ 'data', 'target' ])
-	test.is(result.watchers[0].type, 'AGGREGATE')
-	test.deepEqual(result.watchers[0].arguments, [ 'mentions' ])
-
-	test.deepEqual(result.watchers[0].filter, {
-		type: 'object',
-		required: [ 'data' ],
-		properties: {
-			data: {
-				type: 'object',
-				required: [ 'target', 'payload' ],
-				properties: {
-					payload: {
-						type: 'object'
-					},
-					target: {
-						type: 'object',
-						required: [ 'type' ],
-						properties: {
-							type: {
-								type: 'string',
-								const: 'thread'
-							}
-						}
-					}
-				}
-			}
-		}
 	})
 })
 
@@ -251,10 +197,7 @@ ava.test('.evaluateObject() should evaluate a number formula', async (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			foo: 9
-		}
+		foo: 9
 	})
 })
 
@@ -272,10 +215,7 @@ ava.test('.evaluateObject() should evaluate a formula in a $ prefixed property',
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			$foo: 9
-		}
+		$foo: 9
 	})
 })
 
@@ -293,10 +233,7 @@ ava.test('.evaluateObject() should evaluate a formula in a $$ prefixed property'
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			$$foo: 9
-		}
+		$$foo: 9
 	})
 })
 
@@ -314,10 +251,7 @@ ava.test('.evaluateObject() should ignore missing formulas', async (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			bar: 3
-		}
+		bar: 3
 	})
 })
 
@@ -335,10 +269,7 @@ ava.test('.evaluateObject() should not ignore the zero number as missing', async
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			foo: 2
-		}
+		foo: 2
 	})
 })
 
@@ -370,12 +301,9 @@ ava.test('.evaluateObject() should evaluate nested formulas', async (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			foo: {
-				bar: {
-					baz: 4
-				}
+		foo: {
+			bar: {
+				baz: 4
 			}
 		}
 	})
@@ -405,10 +333,7 @@ ava.test('.evaluateObject() should evaluate a password hash', async (test) => {
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			foo: hash.value
-		}
+		foo: hash.value
 	})
 })
 
@@ -429,136 +354,9 @@ ava.test('.evaluateObject() should not do anything if the schema has no formulas
 	})
 
 	test.deepEqual(result, {
-		watchers: [],
-		object: {
-			foo: '1',
-			bar: 2
-		}
+		foo: '1',
+		bar: 2
 	})
-})
-
-ava.test('.evaluateObject() should report back watchers when aggregating events', async (test) => {
-	const result = jellyscript.evaluateObject({
-		type: 'object',
-		properties: {
-			data: {
-				type: 'object',
-				properties: {
-					mentions: {
-						type: 'array',
-						$$formula: 'AGGREGATE($events, "mentions")'
-					}
-				}
-			}
-		}
-	}, {
-		type: 'thread',
-		links: {},
-		tags: [],
-		active: true,
-		data: {
-			mentions: []
-		}
-	})
-
-	test.deepEqual(result.object, {
-		type: 'thread',
-		links: {},
-		tags: [],
-		active: true,
-		data: {
-			mentions: []
-		}
-	})
-
-	test.is(result.watchers.length, 1)
-
-	test.deepEqual(result.watchers[0].filter, {
-		type: 'object',
-		required: [ 'data' ],
-		properties: {
-			data: {
-				type: 'object',
-				required: [ 'target', 'payload' ],
-				properties: {
-					payload: {
-						type: 'object'
-					},
-					target: {
-						type: 'object',
-						required: [ 'type' ],
-						properties: {
-							type: {
-								type: 'string',
-								const: 'thread'
-							}
-						}
-					}
-				}
-			}
-		}
-	})
-
-	test.is(result.watchers[0].type, 'AGGREGATE')
-	test.deepEqual(result.watchers[0].sourceProperty, [ 'data', 'mentions' ])
-	test.deepEqual(result.watchers[0].target, [ 'data', 'target' ])
-	test.deepEqual(result.watchers[0].arguments, [ 'mentions' ])
-})
-
-ava.test('.evaluateObject() should report back watchers when aggregating events if the array is missing', async (test) => {
-	const result = jellyscript.evaluateObject({
-		type: 'object',
-		properties: {
-			data: {
-				type: 'object',
-				properties: {
-					mentions: {
-						type: 'array',
-						$$formula: 'AGGREGATE($events, "mentions")'
-					}
-				}
-			}
-		}
-	}, {
-		type: 'thread',
-		links: {},
-		tags: [],
-		active: true,
-		data: {}
-	})
-
-	test.is(result.watchers.length, 1)
-
-	test.deepEqual(result.watchers[0].filter, {
-		type: 'object',
-		required: [ 'data' ],
-		properties: {
-			data: {
-				type: 'object',
-				required: [ 'target', 'payload' ],
-				properties: {
-					payload: {
-						type: 'object'
-					},
-					target: {
-						type: 'object',
-						required: [ 'type' ],
-						properties: {
-							type: {
-								type: 'string',
-								const: 'thread'
-							}
-						}
-					}
-				}
-			}
-		}
-	})
-
-	test.is(result.watchers[0].type, 'AGGREGATE')
-	test.deepEqual(result.watchers[0].sourceProperty, [ 'data', 'mentions' ])
-	test.deepEqual(result.watchers[0].target, [ 'data', 'target' ])
-	test.deepEqual(result.watchers[0].arguments, [ 'mentions' ])
 })
 
 ava.test('.getTypeTriggers() should report back watchers when aggregating events', async (test) => {


### PR DESCRIPTION
We are handling watchers in .getTypeTriggers() so there is no need to
also handle that case in the evaluate functions.

Change-type: patch