### PR TITLE
core: Add support for a $$sort expression in queries

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -20,6 +20,7 @@ const EventEmitter = require('events').EventEmitter
 const debug = require('debug')('jellyfish:backend')
 const reqlSchema = require('reql-schema')
 const jsonSchema = require('../json-schema')
+const jellyscript = require('../jellyscript')
 const errors = require('./errors')
 
 const BUCKETS = {
@@ -29,6 +30,7 @@ const BUCKETS = {
 }
 
 const ALL_BUCKETS = Object.values(BUCKETS)
+const SORT_KEY = '$$sort'
 
 const getBucketForType = (type) => {
 	// We decided to store certain cards in
@@ -824,9 +826,13 @@ module.exports = class Backend {
 			return _.compact([ jsonSchema.filter(schema, _.cloneDeep(element)) ])
 		}
 
+		const sortExpression = schema[SORT_KEY]
 		const tables = getBucketsForSchema(schema)
 		if (tables.length === 1) {
-			return queryTable(this, tables[0], schema, options)
+			const results = await queryTable(this, tables[0], schema, options)
+			return sortExpression
+				? jellyscript.sort(results, sortExpression)
+				: results
 		}
 
 		const queries = await Promise.all(tables.map((table) => {
@@ -838,7 +844,9 @@ module.exports = class Backend {
 			items.push(...result)
 		}
 
-		return items
+		return sortExpression
+			? jellyscript.sort(items, sortExpression)
+			: items
 	}
 
 	/**

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -263,6 +263,15 @@ exports.getQuery = async (backend, session, schema, options) => {
 	}
 
 	return jsonSchema.merge(_.map(filters, (filter) => {
+		// If json-e encounters a property that starts with more than one
+		// dollar sign, then it will remove one for some reason. The
+		// only way I found to workaround this is to double escape before
+		// calling json-e, so that the resulting key remains accurate.
+		if (filter.$$sort) {
+			filter.$$$sort = filter.$$sort
+			Reflect.deleteProperty(filter, '$$sort')
+		}
+
 		return jsone(filter, {
 			user
 		})

--- a/lib/jellyscript/index.d.ts
+++ b/lib/jellyscript/index.d.ts
@@ -5,5 +5,4 @@ interface EvaluateOptions {
 
 export declare function evaluate(expression: string, options: EvaluateOptions): {
 	value: any;
-	watchers: Array<{ [k: string]: any }>;
 };

--- a/lib/jellyscript/index.js
+++ b/lib/jellyscript/index.js
@@ -90,6 +90,19 @@ exports.evaluate = (expression, options) => {
 	}
 }
 
+exports.sort = (list, expression) => {
+	return list.sort((element1, element2) => {
+		return exports.evaluate(expression, {
+			input: {
+				// eslint-disable-next-line id-length
+				a: element1,
+				// eslint-disable-next-line id-length
+				b: element2
+			}
+		}).value ? -1 : 1
+	})
+}
+
 const getDefaultValueForType = (type) => {
 	switch (type) {
 	case 'array': return []

--- a/test/core/backend.spec.js
+++ b/test/core/backend.spec.js
@@ -518,6 +518,38 @@ ava.test('.query() should not return unspecified properties', async (test) => {
 	])
 })
 
+ava.test('.query() should be able to provide a sort function', async (test) => {
+	const result1 = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 3
+	})
+
+	const result2 = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 1
+	})
+
+	const result3 = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 2
+	})
+
+	const results = await test.context.backend.query({
+		type: 'object',
+		$$sort: 'input.a.test > input.b.test',
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'card'
+			}
+		},
+		required: [ 'type' ]
+	})
+
+	test.deepEqual(results, [ result1, result3, result2 ])
+})
+
 ava.test('.query() should be able to limit the results', async (test) => {
 	const result1 = await test.context.backend.upsertElement({
 		type: 'card',

--- a/test/core/kernel.spec.js
+++ b/test/core/kernel.spec.js
@@ -527,6 +527,53 @@ ava.test('.query() should be able to limit the results', async (test) => {
 	test.deepEqual(_.sortBy(results, [ 'data', 'test' ]), [ result1, result2 ])
 })
 
+ava.test('.query() should be able to sort the results', async (test) => {
+	const result1 = await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			test: 2
+		}
+	})
+
+	const result2 = await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			test: 3
+		}
+	})
+
+	const result3 = await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			test: 1
+		}
+	})
+
+	const results = await test.context.kernel.query(test.context.kernel.sessions.admin, {
+		type: 'object',
+		$$sort: 'input.a.data.test < input.b.data.test',
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'card'
+			}
+		},
+		required: [ 'type' ]
+	})
+
+	test.deepEqual(results, [ result3, result1, result2 ])
+})
+
 ava.test('.query() should be able to skip the results', async (test) => {
 	await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
 		type: 'card',


### PR DESCRIPTION
JSON Schema queries can now contain a `$$sort` top level key that
contains a Jellyscript sort function.

Change-type: minor