### PR TITLE
fix(core): Make the "Keywords" field in scratchpad entries an array

### DIFF
--- a/default-cards/contrib/scratchpad-entry.json
+++ b/default-cards/contrib/scratchpad-entry.json
@@ -81,7 +81,10 @@
               "type": "boolean"
             },
             "Keywords": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "Entry needs review": {
               "type": "boolean"

--- a/scripts/scratchpad-import.js
+++ b/scripts/scratchpad-import.js
@@ -82,6 +82,10 @@ const entries = _.map(source.Scratchpad, ({
 		delete data.$PENSIEVE_IMPORTED_COPY_FIELD_KEY1
 	}
 
+	if (data.Keywords) {
+		data.Keywords = data.Keywords.split(' ')
+	}
+
 	return {
 		type: 'scratchpad-entry',
 		name: Title || 'No name set',


### PR DESCRIPTION
Fixes #540

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>