### PR TITLE
core: Remove Backend.query() micro-optimization for simplicity reasons

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -828,12 +828,6 @@ module.exports = class Backend {
 
 		const sortExpression = schema[SORT_KEY]
 		const tables = getBucketsForSchema(schema)
-		if (tables.length === 1) {
-			const results = await queryTable(this, tables[0], schema, options)
-			return sortExpression
-				? jellyscript.sort(results, sortExpression)
-				: results
-		}
 
 		const queries = await Promise.all(tables.map((table) => {
 			return queryTable(this, table, schema, options)


### PR DESCRIPTION
This optimization seems to make very little difference in practice.
Removing it simplifies the flow of the .query() function.

Change-type: patch