### PR TITLE
core: Implement basic links support for queries 

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -23,6 +23,7 @@ const reqlSchema = require('reql-schema')
 const skhema = require('skhema')
 const jellyscript = require('../jellyscript')
 const errors = require('./errors')
+const links = require('./links')
 
 const BUCKETS = {
 	cards: 'cards',
@@ -32,6 +33,7 @@ const BUCKETS = {
 
 const ALL_BUCKETS = Object.values(BUCKETS)
 const SORT_KEY = '$$sort'
+const LINK_KEY = '$$links'
 
 const getBucketForType = (type) => {
 	// We decided to store certain cards in
@@ -196,12 +198,24 @@ const queryTable = async (backend, table, schema, options) => {
 	}
 
 	const cursor = await query.run(backend.connection)
+	const elements = await Bluebird.map(await cursor.toArray(), async (card) => {
+		const result = await links.evaluateCard({
+			query: options.subquery || backend.query.bind(backend)
+		}, card, schema[LINK_KEY] || {})
+		if (!result) {
+			return null
+		}
 
-	// This is a VERY inefficient way to query a RethinkDB database
-	// using JSON schema. This is meant to be used as a prototype,
-	// and we should implement a proper JSON Schema to ReQL translator.
-	const items = await cursor.toArray()
-	return skhema.filter(schema, items)
+		if (!_.isEmpty(result)) {
+			card.links = result
+		}
+
+		return card
+	}, {
+		concurrency: 3
+	})
+
+	return skhema.filter(schema, _.compact(elements))
 }
 
 const getElementByIdFromTable = async (backend, table, id) => {
@@ -805,6 +819,7 @@ module.exports = class Backend {
 	 * @param {Object} [options] - options
 	 * @param {Number} [options.limit] - limit
 	 * @param {Number} [options.skip] - skip
+	 * @param {Function} [options.subquery] - sub-query function
    * @returns {Object[]} results
    *
    * @example

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -22,6 +22,7 @@ _.each([
 	'JellyfishDatabaseError',
 	'JellyfishElementAlreadyExists',
 	'JellyfishNoElement',
+	'JellyfishUnknownLinkType',
 	'JellyfishSessionExpired',
 	'JellyfishNoAction',
 	'JellyfishNoView',

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -315,7 +315,12 @@ module.exports = class Kernel {
 
 		return this.backend.query(filteredQuery, {
 			limit: options.limit,
-			skip: options.skip
+			skip: options.skip,
+
+			// Do any nested queries with the same permissions
+			subquery: async (subschema) => {
+				return this.query(session, subschema, options)
+			}
 		})
 	}
 

--- a/lib/core/links.js
+++ b/lib/core/links.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const errors = require('./errors')
+const jsonSchema = require('./json-schema')
+
+/**
+ * @summary Evaluate a card link
+ * @function
+ * @private
+ *
+ * @description
+ * This function is exported for testability purposes.
+ *
+ * @param {Object} context - context
+ * @param {Function} context.query - query function
+ * @param {Object} card - card
+ * @param {String} name - link name
+ * @param {Object} linkSchema - link JSON Schema
+ * @returns {Object[]} link results
+ *
+ * @example
+ * const results = links.evaluate({ ... }, {
+ *   type: 'foo',
+ *   data: {}
+ * }, 'is attached to', {
+ *   type: 'object',
+ *   required: [ 'type' ],
+ *   properties: {
+ *     type: {
+ *       type: 'string',
+ *       const: 'message'
+ *     }
+ *   }
+ * })
+ *
+ * for (const result of results) {
+ *   console.log(result)
+ * }
+ */
+exports.evaluate = async (context, card, name, linkSchema) => {
+	// TODO: These types of links are hardcoded, but in the
+	// future, we should represent all link types using link
+	// cards, and modify this function to take a look at those
+	// cards to resolve the link requests.
+
+	switch (name) {
+		case 'is attached to': {
+			const targetId = card.data && card.data.target
+			if (!targetId) {
+				return []
+			}
+
+			return jsonSchema.filter(linkSchema, await context.query({
+				type: 'object',
+				required: [ 'id' ],
+				additionalProperties: true,
+				properties: {
+					id: {
+						type: 'string',
+						const: targetId
+					}
+				}
+			}))
+		}
+		case 'has attached element': {
+			const querySchema = jsonSchema.merge([
+				{
+					type: 'object',
+					required: [ 'data' ],
+					properties: {
+						data: {
+							type: 'object',
+							required: [ 'target' ],
+							properties: {
+								target: {
+									type: 'string',
+									const: card.id
+								}
+							}
+						}
+					}
+				},
+				linkSchema
+			])
+
+			return jsonSchema.filter(querySchema, await context.query(querySchema))
+		}
+		default: {
+			throw new errors.JellyfishUnknownLinkType(`Unknown link: ${name}`)
+		}
+	}
+}
+
+/**
+ * @summary Evaluate all links from a card
+ * @function
+ * @public
+ *
+ * @param {Object} context - context
+ * @param {Function} context.query - query function
+ * @param {Object} card - card
+ * @param {Object} schema - links definition schema
+ * @returns {(Object|Null)} resulting links
+ *
+ * @example
+ * const results = links.evaluateCard({ ... }, {
+ *   type: 'foo',
+ *   data: {}
+ * }, {
+ *   'is attached to', {
+ *     type: 'object',
+ *     required: [ 'type' ],
+ *     properties: {
+ *       type: {
+ *         type: 'string',
+ *         const: 'message'
+ *       }
+ *     }
+ *   }
+ * })
+ *
+ * for (const result of results['is attached to']) {
+ *   console.log(result)
+ * }
+ */
+exports.evaluateCard = async (context, card, schema) => {
+	const result = {}
+
+	for (const name of Object.keys(schema)) {
+		result[name] = await exports.evaluate(context, card, name, schema[name])
+
+		// Abort at the first link evaluation error
+		if (result[name].length === 0) {
+			return null
+		}
+	}
+
+	return result
+}

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -271,6 +271,10 @@ exports.getQuery = async (backend, session, schema, options) => {
 			filter.$$$sort = filter.$$sort
 			Reflect.deleteProperty(filter, '$$sort')
 		}
+		if (filter.$$links) {
+			filter.$$$links = filter.$$links
+			Reflect.deleteProperty(filter, '$$links')
+		}
 
 		return jsone(filter, {
 			user

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "ava": {
     "timeout": "5m",
     "verbose": true,
-    "serial": true,
+    "concurrency": 3,
     "failFast": true,
     "files": [
       "test/unit/**/*.spec.js",

--- a/test/unit/core/kernel.spec.js
+++ b/test/unit/core/kernel.spec.js
@@ -1222,6 +1222,174 @@ ava.test('.query() should take a view card with two filters', async (test) => {
 	])
 })
 
+ava.test('.query() should be able to query using links', async (test) => {
+	const parent1 = await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			thread: true,
+			number: 1
+		}
+	})
+
+	const parent2 = await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			thread: true,
+			number: 2
+		}
+	})
+
+	await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			thread: true,
+			number: 3
+		}
+	})
+
+	await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			thread: false,
+			target: parent1.id,
+			count: 1
+		}
+	})
+
+	await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			thread: false,
+			target: parent1.id,
+			count: 2
+		}
+	})
+
+	await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
+		type: 'card',
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			thread: false,
+			target: parent2.id,
+			count: 3
+		}
+	})
+
+	const results = await test.context.kernel.query(test.context.kernel.sessions.admin, {
+		type: 'object',
+		required: [ 'type', 'links', 'data' ],
+		$$sort: 'input.a.data.count < input.b.data.count',
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				required: [ 'id', 'data' ],
+				properties: {
+					id: {
+						type: 'string'
+					},
+					data: {
+						type: 'object',
+						required: [ 'thread' ],
+						properties: {
+							thread: {
+								type: 'boolean',
+								const: true
+							}
+						}
+					}
+				}
+			}
+		},
+		properties: {
+			type: {
+				type: 'string',
+				const: 'card'
+			},
+			links: {
+				type: 'object',
+				additionalProperties: true
+			},
+			data: {
+				type: 'object',
+				required: [ 'count' ],
+				properties: {
+					count: {
+						type: 'number'
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, [
+		{
+			type: 'card',
+			links: {
+				'is attached to': [
+					{
+						id: parent1.id,
+						data: {
+							thread: true
+						}
+					}
+				]
+			},
+			data: {
+				count: 1
+			}
+		},
+		{
+			type: 'card',
+			links: {
+				'is attached to': [
+					{
+						id: parent1.id,
+						data: {
+							thread: true
+						}
+					}
+				]
+			},
+			data: {
+				count: 2
+			}
+		},
+		{
+			type: 'card',
+			links: {
+				'is attached to': [
+					{
+						id: parent2.id,
+						data: {
+							thread: true
+						}
+					}
+				]
+			},
+			data: {
+				count: 3
+			}
+		}
+	])
+})
+
 ava.test.cb('.stream() should report back new elements that match a certain slug', (test) => {
 	test.context.kernel.stream(test.context.kernel.sessions.admin, {
 		type: 'object',

--- a/test/unit/core/links.spec.js
+++ b/test/unit/core/links.spec.js
@@ -1,0 +1,483 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ava = require('ava')
+const _ = require('lodash')
+const links = require('../../../lib/core/links')
+const errors = require('../../../lib/core/errors')
+const helpers = require('./helpers')
+
+ava.test.beforeEach(async (test) => {
+	await helpers.backend.beforeEach(test)
+	test.context.context = {
+		query: test.context.backend.query.bind(test.context.backend)
+	}
+})
+
+ava.test.afterEach(helpers.backend.afterEach)
+
+ava.test('.evaluate() should throw an error if the link is unknown', async (test) => {
+	await test.throws(links.evaluate(test.context.context, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {}
+	}, 'foo bar baz', {
+		type: 'object'
+	}), errors.JellyfishUnknownLinkType)
+})
+
+ava.test('.evaluate(is attached to) should return an empty array if the target does not exist', async (test) => {
+	const results = await links.evaluate(test.context.context, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	}, 'is attached to', {
+		type: 'object'
+	})
+
+	test.deepEqual(results, [])
+})
+
+ava.test('.evaluate(is attached to) should return an empty array if the target exists but does not match', async (test) => {
+	const card = await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			count: 1
+		}
+	})
+
+	const results = await links.evaluate(test.context.context, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: card.id
+		}
+	}, 'is attached to', {
+		type: 'object',
+		required: [ 'data' ],
+		properties: {
+			data: {
+				type: 'object',
+				required: [ 'count' ],
+				properties: {
+					count: {
+						type: 'number',
+						const: 9
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, [])
+})
+
+ava.test('.evaluate(is attached to) should return the declared target properties', async (test) => {
+	const card = await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			greeting: 'hello',
+			count: 1
+		}
+	})
+
+	const results = await links.evaluate(test.context.context, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: card.id
+		}
+	}, 'is attached to', {
+		type: 'object',
+		required: [ 'data' ],
+		properties: {
+			data: {
+				type: 'object',
+				required: [ 'greeting', 'count' ],
+				properties: {
+					greeting: {
+						type: 'string'
+					},
+					count: {
+						type: 'number',
+						const: 1
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, [
+		{
+			data: {
+				greeting: 'hello',
+				count: 1
+			}
+		}
+	])
+})
+
+ava.test('.evaluate(is attached to) should return the whole target if additionalProperties is set', async (test) => {
+	const card = await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			greeting: 'hello',
+			count: 1
+		}
+	})
+
+	const results = await links.evaluate(test.context.context, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: card.id
+		}
+	}, 'is attached to', {
+		type: 'object',
+		additionalProperties: true,
+		required: [ 'data' ],
+		properties: {
+			data: {
+				type: 'object',
+				additionalProperties: true,
+				required: [ 'count' ],
+				properties: {
+					count: {
+						type: 'number',
+						const: 1
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, [
+		{
+			id: card.id,
+			type: 'card',
+			active: true,
+			links: {},
+			tags: [],
+			data: {
+				greeting: 'hello',
+				count: 1
+			}
+		}
+	])
+})
+
+ava.test('.evaluate(has attached element) should return an empty array if the card has no timeline', async (test) => {
+	const results = await links.evaluate(test.context.context, {
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {}
+	}, 'has attached element', {
+		type: 'object'
+	})
+
+	test.deepEqual(results, [])
+})
+
+ava.test('.evaluate(has attached element) should return matching elements', async (test) => {
+	await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			count: 1,
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	const card2 = await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			count: 2,
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			count: 3,
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	const results = await links.evaluate(test.context.context, {
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {}
+	}, 'has attached element', {
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				type: 'string'
+			},
+			data: {
+				type: 'object',
+				required: [ 'count' ],
+				properties: {
+					count: {
+						type: 'number',
+						const: 2
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, [
+		{
+			id: card2.id,
+			data: {
+				count: 2,
+				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+			}
+		}
+	])
+})
+
+ava.test('.evaluateCard() should return one link of one type given one match', async (test) => {
+	const card = await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			greeting: 'hello',
+			count: 1
+		}
+	})
+
+	const results = await links.evaluateCard(test.context.context, {
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: card.id
+		}
+	}, {
+		'is attached to': {
+			type: 'object',
+			required: [ 'data' ],
+			properties: {
+				data: {
+					type: 'object',
+					required: [ 'greeting' ],
+					properties: {
+						greeting: {
+							type: 'string',
+							const: 'hello'
+						}
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, {
+		'is attached to': [
+			{
+				data: {
+					greeting: 'hello'
+				}
+			}
+		]
+	})
+})
+
+ava.test('.evaluateCard() should return multiple cards per link', async (test) => {
+	const card1 = await test.context.backend.insertElement({
+		type: 'card',
+		count: 1,
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	const card2 = await test.context.backend.insertElement({
+		type: 'card',
+		count: 2,
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	const card3 = await test.context.backend.insertElement({
+		type: 'card',
+		count: 3,
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	const results = await links.evaluateCard(test.context.context, {
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {}
+	}, {
+		'has attached element': {
+			type: 'object',
+			required: [ 'id', 'count' ],
+			properties: {
+				id: {
+					type: 'string'
+				},
+				count: {
+					type: 'number'
+				}
+			}
+		}
+	})
+
+	results['has attached element'] = _.sortBy(results['has attached element'], (card) => {
+		return card.count
+	})
+
+	test.deepEqual(results, {
+		'has attached element': [
+			{
+				id: card1.id,
+				count: 1,
+				data: {
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+				}
+			},
+			{
+				id: card2.id,
+				count: 2,
+				data: {
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+				}
+			},
+			{
+				id: card3.id,
+				count: 3,
+				data: {
+					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+				}
+			}
+		]
+	})
+})
+
+ava.test('.evaluateCard() should return false if one link is unsatisfied', async (test) => {
+	const card = await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			greeting: 'hello',
+			count: 1
+		}
+	})
+
+	await test.context.backend.insertElement({
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			count: 1,
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+		}
+	})
+
+	const results = await links.evaluateCard(test.context.context, {
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			target: card.id
+		}
+	}, {
+		'has attached element': {
+			type: 'object'
+		},
+		'is attached to': {
+			type: 'object',
+			required: [ 'data' ],
+			properties: {
+				data: {
+					type: 'object',
+					required: [ 'greeting' ],
+					properties: {
+						greeting: {
+							type: 'string',
+							const: 'bar'
+						}
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(results, null)
+})


### PR DESCRIPTION
Query schemas can declare a `$$links` keyword consisting of a key value
pair of link type and link schema. We currently support two types of
links:

- `is attached to`: The target of a card
- `has been attached to by`: The timeline of a card

These work by inspecting the `data.target` property, but will be
generalized in the future to work with separate link cards, and
therefore support richer link types.

The result of evaluating a link is stored in the cards' `links` top
level property. If you want to see the link matches of your query, you
can whitelist such property.

Change-type: minor