### PR TITLE
fix(UI): Stop filter button from wrapping to two lines

### DIFF
--- a/lib/ui/lens/View.tsx
+++ b/lib/ui/lens/View.tsx
@@ -264,9 +264,6 @@ class ViewRenderer extends React.Component<ViewRendererProps, ViewRendererState>
 											filters={this.state.filters}
 											onFiltersUpdate={this.updateFilters}
 											onViewsUpdate={this.saveView}
-											addFilterButtonProps={{
-												style: { flex: '0 0 137px' },
-											}}
 											renderMode={['add', 'search']}
 										/>
 									</Box>


### PR DESCRIPTION
Fixes #604

A small change to fix a styling quirk, the button now looks like this:
![screen shot 2018-08-22 at 10 29 46](https://user-images.githubusercontent.com/15064535/44455567-53b97100-a5f6-11e8-8d1d-3331e96e764a.png)


Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>