### PR TITLE
fix(UI): Hide "group by" control if it cannot be used

### DIFF
--- a/lib/ui/lens/View.tsx
+++ b/lib/ui/lens/View.tsx
@@ -290,8 +290,8 @@ class ViewRenderer extends React.Component<ViewRendererProps, ViewRendererState>
 										)}
 									</ButtonGroup>
 								</If>
-								<If condition={groups.length > 0}>
-									<Box ml={3} color={lensSupportsGroups ? undefined : '#ccc'}>
+								{groups.length > 0 && lensSupportsGroups &&
+									<Box ml={3}>
 										Group by:
 										<Select
 											ml={2}
@@ -311,7 +311,7 @@ class ViewRenderer extends React.Component<ViewRendererProps, ViewRendererState>
 											})}
 										</Select>
 									</Box>
-								</If>
+								}
 							</Flex>
 						</Flex>
 


### PR DESCRIPTION
Fixes #598

The new behaviour looks like this:
![groups](https://user-images.githubusercontent.com/15064535/44455881-15708180-a5f7-11e8-959c-f7ac2e6962ff.gif)


Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>