### PR TITLE
eslint: Require one-level indentation in switch constructs

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -188,6 +188,7 @@ rules:
   indent:
     - error
     - tab
+    - SwitchCase: 1
   line-comment-position:
     - error
     - position: above

--- a/lib/jellyscript/index.js
+++ b/lib/jellyscript/index.js
@@ -105,8 +105,8 @@ exports.sort = (list, expression) => {
 
 const getDefaultValueForType = (type) => {
 	switch (type) {
-	case 'array': return []
-	default: return null
+		case 'array': return []
+		default: return null
 	}
 }
 


### PR DESCRIPTION
ESLint by default forbids indentation of `case` and `default` blocks,
which looks a bit weird. I found a way to tweak it with the `SwitchCase`
option.

Change-type: patch
See: https://github.com/resin-io/jellyfish/pull/585