### PR TITLE
core: Ensure skip and limit work on single-element queries

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -799,6 +799,10 @@ module.exports = class Backend {
    */
 	async query (schema, options = {}) {
 		if ((schema.properties.id && schema.properties.id.const) || (schema.properties.slug && schema.properties.slug.const)) {
+			if (options.skip || options.limit === 0) {
+				return []
+			}
+
 			// Performance shortcut
 			let element = null
 

--- a/test/core/backend.spec.js
+++ b/test/core/backend.spec.js
@@ -634,6 +634,114 @@ ava.test('.query() should be able to skip the results', async (test) => {
 	test.deepEqual(_.sortBy(results, [ 'test' ]), [ result3 ])
 })
 
+ava.test('.query() should be able to skip the results of a one-element query', async (test) => {
+	const card = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 1,
+		data: {
+			timestamp: '2018-07-20T23:15:45.702Z'
+		}
+	})
+
+	const results = await test.context.backend.query({
+		type: 'object',
+		properties: {
+			id: {
+				type: 'string',
+				const: card.id
+			}
+		},
+		required: [ 'id' ]
+	}, {
+		skip: 1
+	})
+
+	test.deepEqual(results, [])
+})
+
+ava.test('.query() should not skip the results of a one-element query if skip is set to zero', async (test) => {
+	const card = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 1,
+		data: {
+			timestamp: '2018-07-20T23:15:45.702Z'
+		}
+	})
+
+	const results = await test.context.backend.query({
+		type: 'object',
+		properties: {
+			id: {
+				type: 'string',
+				const: card.id
+			}
+		},
+		required: [ 'id' ]
+	}, {
+		skip: 0
+	})
+
+	test.deepEqual(results, [
+		{
+			id: card.id
+		}
+	])
+})
+
+ava.test('.query() should be able to limit the results of a one-element query to 0', async (test) => {
+	const card = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 1,
+		data: {
+			timestamp: '2018-07-20T23:15:45.702Z'
+		}
+	})
+
+	const results = await test.context.backend.query({
+		type: 'object',
+		properties: {
+			id: {
+				type: 'string',
+				const: card.id
+			}
+		},
+		required: [ 'id' ]
+	}, {
+		limit: 0
+	})
+
+	test.deepEqual(results, [])
+})
+
+ava.test('.query() should not omit the results of a one-element query if limit is set to one', async (test) => {
+	const card = await test.context.backend.upsertElement({
+		type: 'card',
+		test: 1,
+		data: {
+			timestamp: '2018-07-20T23:15:45.702Z'
+		}
+	})
+
+	const results = await test.context.backend.query({
+		type: 'object',
+		properties: {
+			id: {
+				type: 'string',
+				const: card.id
+			}
+		},
+		required: [ 'id' ]
+	}, {
+		limit: 1
+	})
+
+	test.deepEqual(results, [
+		{
+			id: card.id
+		}
+	])
+})
+
 ava.test('.query() should be able to limit and skip the results', async (test) => {
 	await test.context.backend.upsertElement({
 		type: 'card',


### PR DESCRIPTION
Change-type: patch
See: https://github.com/resin-io/jellyfish/pull/585