### PR TITLE
Review linting of the repo

### DIFF
--- a/lib/ui/components/Login.tsx
+++ b/lib/ui/components/Login.tsx
@@ -184,7 +184,8 @@ class Base extends React.Component<LoginProps, LoginState> {
 										</Button>
 									</Box>
 									<Txt color="#908c99" fontSize={0} my={4} align="center">
-										By clicking "Sign up" you confirm that you have performed the <Link blank={true} href="https://bosshamster.deviantart.com/art/Summoning-Cthulhu-For-Dummies-31645860">initiation rituals</Link>
+										By clicking "Sign up" you confirm that you have performed the
+										<Link blank={true} href="https://bosshamster.deviantart.com/art/Summoning-Cthulhu-For-Dummies-31645860">initiation rituals</Link>
 									</Txt>
 								</form>
 							</React.Fragment>

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,7 @@
     "only-arrow-functions": [false],
     "quotemark": [true, "single", "avoid-escape", "jsx-double"],
     "max-classes-per-file": [false],
-    "max-line-length": [180],
+    "max-line-length": [true, 180],
     "member-access": false,
     "member-ordering": [false],
     "no-consecutive-blank-lines": false,


### PR DESCRIPTION
In discussion with Juan set tslint to prefer that we don't use
semi-colons.
I also enabled the previously broken line-length rule. This triggered
the only non-semi-colon change, which is a line break in the initiation
rituals text.

Set eslint to ignore */dist/ folders rather than sdk/*, so that it is
more compatible with other typescript modules and so that non-built js
within /sdk is linted.

Lock down typescript version to ~ rather than ^ because typescript
openly put breaking changes in minor versions.  The version chosen I
took from package-lock.json.
https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes

Change-type: patch
Signed-off-by: Andrew Lucas <andrewl@resin.io>