### PR TITLE
server: Store external event webhook headers 

### DIFF
--- a/default-cards/contrib/external-event.json
+++ b/default-cards/contrib/external-event.json
@@ -15,12 +15,16 @@
               "type": "string",
               "pattern": "^[a-z0-9-]+$"
             },
+            "headers": {
+              "type": "object"
+            },
             "payload": {
               "type": "object"
             }
           },
           "required": [
             "source",
+            "headers",
             "payload"
           ]
         }

--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -151,6 +151,7 @@ exports.bindRoutes = (jellyfish, worker, app, socketServer) => {
 					properties: {
 						data: {
 							source: request.params.provider,
+							headers: request.headers,
 							payload: request.body
 						}
 					}


### PR DESCRIPTION
As originally commited by @sqweelygig in
https://github.com/resin-io/jellyfish/pull/640.

Change-type: patch