### PR TITLE
server: Take an optional "type" param in webhook route

### DIFF
--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -130,7 +130,13 @@ exports.bindRoutes = (jellyfish, worker, app, socketServer) => {
 		return respond(handler, response)
 	})
 
-	app.all('/api/v2/hooks/:provider', (request, response) => {
+	// Some services, such as Workable, require the user to register
+	// different endpoints for every type of event we're interested in,
+	// which means we can't send more than one event type to
+	// /api/v2/hooks/workable. As a solution, we can allow this rule to
+	// have an optional "type" parameter that is not used for anything
+	// apart from differentiating the endpoints.
+	app.all('/api/v2/hooks/:provider/:type*?', (request, response) => {
 		if (_.isEmpty(request.body)) {
 			return error400('Invalid external event', response)
 		}


### PR DESCRIPTION
To workaround artificial conflict detection systems when registering
more than one event listener to one webhook URL.

Change-type: minor