### PR TITLE
Worker: Add query to methods provided to action-library

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -27,20 +27,20 @@ const jellyscript = require('../jellyscript')
 
 module.exports = class Worker {
 	/**
-   * @summary The Jellyfish Actions Worker
-   * @class
-   * @public
-   *
+	 * @summary The Jellyfish Actions Worker
+	 * @class
+	 * @public
+	 *
 	 * @param {Object} jellyfish - jellyfish instance
 	 * @param {String} session - worker privileged session id
 	 * @param {Object} actionLibrary - action library
-   *
-   * @example
+	 *
+	 * @example
 	 * const worker = new Worker({ ... }, '4a962ad9-20b5-4dd8-a707-bf819593cc84', {
 	 *   'action-create-card': { ... },
 	 *   'action-update-card': { ... }
 	 * })
-   */
+	 */
 	constructor (jellyfish, session, actionLibrary) {
 		this.jellyfish = jellyfish
 		this.queue = new MemoryQueue()
@@ -52,6 +52,7 @@ module.exports = class Worker {
 			errors,
 			getCardById: this.jellyfish.getCardById.bind(this.jellyfish),
 			getCardBySlug: this.jellyfish.getCardBySlug.bind(this.jellyfish),
+			query: this.jellyfish.query.bind(this.jellyfish),
 			privilegedSession: session,
 			insertCard: this.insertCard.bind(this)
 		}


### PR DESCRIPTION
Surface the jellyfish.query method within the action-library context

While I was there I noticed that some JSDoc whitespace wasn't
consistent with its choice of character

Change-type: patch
Signed-off-by: Andrew Lucas <andrewl@resin.io>