### PR TITLE
worker: Only consider type triggers with filters

### DIFF
--- a/lib/worker/triggers.js
+++ b/lib/worker/triggers.js
@@ -165,11 +165,18 @@ exports.getTypeTriggers = async (jellyfish, session, type) => {
 			data: {
 				type: 'object',
 				additionalProperties: true,
-				required: [ 'type' ],
+
+				// We only want to consider cards that act based on a filter
+				required: [ 'type', 'filter' ],
+
 				properties: {
 					type: {
 						type: 'string',
 						const: type
+					},
+					filter: {
+						type: 'object',
+						additionalProperties: true
 					}
 				}
 			}


### PR DESCRIPTION
This is a small PR to set things up for time-triggered actions. These
type of triggered actions only differ in that they won't have a filter,
so we must update the worker to only consider type triggers that do
contain a filter (i.e. are based on insertion of other cards).

Change-type: patch