### PR TITLE
worker: Add interval option to triggered actions

### DIFF
--- a/default-cards/contrib/triggered-action.json
+++ b/default-cards/contrib/triggered-action.json
@@ -20,6 +20,10 @@
               "type": "string",
               "format": "date-time"
             },
+            "interval": {
+              "type": "string",
+              "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$"
+            },
             "filter": {
               "type": "object"
             },
@@ -33,11 +37,23 @@
               "type": "object"
             }
           },
-          "required": [
-            "filter",
-            "action",
-            "target",
-            "arguments"
+          "oneOf": [
+            {
+              "required": [
+                "filter",
+                "action",
+                "target",
+                "arguments"
+              ]
+            },
+            {
+              "required": [
+                "interval",
+                "action",
+                "target",
+                "arguments"
+              ]
+            }
           ]
         }
       },

--- a/lib/worker/errors.js
+++ b/lib/worker/errors.js
@@ -21,6 +21,7 @@ _.each([
 	'WorkerNoElement',
 	'WorkerInvalidAction',
 	'WorkerInvalidTrigger',
+	'WorkerInvalidDuration',
 	'WorkerSchemaMismatch',
 	'WorkerAuthenticationError'
 ], (error) => {

--- a/lib/worker/triggers.js
+++ b/lib/worker/triggers.js
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+const _ = require('lodash')
 const jsone = require('json-e')
 const skhema = require('skhema')
+const moment = require('moment')
+const errors = require('./errors')
 
 /**
  * @summary Check if a trigger matches a card
@@ -233,4 +236,42 @@ exports.getStartDate = (trigger) => {
 
 	// The oldest possible date
 	return new Date('1970-01-01Z00:00:00:000')
+}
+
+/**
+ * @summary Get the next execution date for a trigger
+ * @function
+ * @public
+ *
+ * @param {Object} trigger - triggered action card
+ * @param {Date} lastExecutionDate - last execution date
+ * @returns {(Date|Null)} next execution date, if any
+ *
+ * @example
+ * const nextExecutionDate = triggers.getNextExecutionDate({ ... }, new Date())
+ * if (nextExecutionDate) {
+ *   console.log(nextExecutionDate.toISOString())
+ * }
+ */
+exports.getNextExecutionDate = (trigger, lastExecutionDate) => {
+	if (!trigger || !trigger.data || !trigger.data.interval) {
+		return null
+	}
+
+	const startDate = exports.getStartDate(trigger)
+	if (!lastExecutionDate ||
+			!_.isDate(lastExecutionDate) ||
+			isNaN(lastExecutionDate.getTime())) {
+		return startDate
+	}
+
+	// The interval should be an ISO 8601 duration string, like PT1H
+	const duration = moment.duration(trigger.data.interval).asMilliseconds()
+	if (duration === 0) {
+		throw new errors.WorkerInvalidDuration(`Invalid interval: ${trigger.data.interval}`)
+	}
+
+	const intervals = Math.floor(Math.abs(lastExecutionDate - startDate) / duration)
+	const times = lastExecutionDate >= startDate || intervals === 0 ? intervals + 1 : 0
+	return new Date(startDate.getTime() + (duration * times))
 }


### PR DESCRIPTION
This interval option is an ISO 8601 duration string that determines how
often the triggered action should run.

Change-type: minor
Depends-on: https://github.com/resin-io/jellyfish/pull/654