### PR TITLE
worker: Add "originator" property to action execute events

### DIFF
--- a/default-cards/contrib/execute.json
+++ b/default-cards/contrib/execute.json
@@ -16,6 +16,10 @@
               "type": "string",
               "format": "date-time"
             },
+            "originator": {
+              "type": "string",
+              "format": "uuid"
+            },
             "target": {
               "type": "string",
               "format": "uuid"

--- a/lib/server/action-server.js
+++ b/lib/server/action-server.js
@@ -20,6 +20,9 @@ const actionLibrary = require('../action-library')
 const SCHEMA_ACTIVE_TRIGGERS = {
 	type: 'object',
 	properties: {
+		id: {
+			type: 'string'
+		},
 		active: {
 			type: 'boolean',
 			const: true
@@ -33,7 +36,7 @@ const SCHEMA_ACTIVE_TRIGGERS = {
 			additionalProperties: true
 		}
 	},
-	required: [ 'active', 'type', 'data' ]
+	required: [ 'id', 'active', 'type', 'data' ]
 }
 
 const getActorKey = async (jellyfish, session, actorId) => {
@@ -86,6 +89,7 @@ exports.start = async (jellyfish, session, onRequest, onError) => {
 		const triggers = await jellyfish.query(session, SCHEMA_ACTIVE_TRIGGERS)
 		worker.setTriggers(triggers.map((trigger) => {
 			return {
+				id: trigger.id,
 				action: trigger.data.action,
 				card: trigger.data.target,
 				filter: trigger.data.filter,

--- a/lib/worker/events.js
+++ b/lib/worker/events.js
@@ -37,6 +37,7 @@ const EXECUTION_EVENT_TYPE = 'execute'
  * @param {String} options.action - action id
  * @param {String} options.timestamp - action timestamp
  * @param {String} options.card - action input card id
+ * @param {String} [options.originator] - action originator card id
  * @param {Object} results - action results
  * @param {Boolean} results.error - whether the result is an error
  * @param {Any} results.data - action result
@@ -49,6 +50,7 @@ const EXECUTION_EVENT_TYPE = 'execute'
  *   action: '57692206-8da2-46e1-91c9-159b2c6928ef',
  *   card: '033d9184-70b2-4ec9-bc39-9a249b186422',
  *   actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+ *   originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
  *   timestamp: '2018-06-30T19:34:42.829Z'
  * }, {
  *   error: false,
@@ -58,7 +60,7 @@ const EXECUTION_EVENT_TYPE = 'execute'
  * console.log(card.id)
  */
 exports.post = async (jellyfish, session, options, results) => {
-	return jellyfish.insertCard(session, {
+	const contents = {
 		id: options.id,
 		type: EXECUTION_EVENT_TYPE,
 		active: true,
@@ -75,7 +77,66 @@ exports.post = async (jellyfish, session, options, results) => {
 				data: results.data
 			}
 		}
+	}
+
+	if (options.originator) {
+		contents.data.originator = options.originator
+	}
+
+	return jellyfish.insertCard(session, contents)
+}
+
+/**
+ * @summary Get the last execution event given an originator
+ * @function
+ * @public
+ *
+ * @param {Object} jellyfish - jellyfish instance
+ * @param {String} session - session id
+ * @param {String} originator - originator card id
+ * @returns {(Object|Null)} last execution event
+ *
+ * @example
+ * const originator = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+ *
+ * const executeEvent = await events.getLastExecutionEvent(jellyfish, session, originator)
+ * if (executeEvent) {
+ *   console.log(executeEvent.data.timestamp)
+ * }
+ */
+exports.getLastExecutionEvent = async (jellyfish, session, originator) => {
+	// The .query() function automatically sorts by data.timestamp, so
+	// we don't have to manually specify any sorting in this case.
+	const events = await jellyfish.query(session, {
+		type: 'object',
+		required: [ 'active', 'type', 'data' ],
+		additionalProperties: true,
+		properties: {
+			active: {
+				type: 'boolean',
+				const: true
+			},
+			type: {
+				type: 'string',
+				const: EXECUTION_EVENT_TYPE
+			},
+			data: {
+				type: 'object',
+				required: [ 'originator' ],
+				additionalProperties: true,
+				properties: {
+					originator: {
+						type: 'string',
+						const: originator
+					}
+				}
+			}
+		}
+	}, {
+		limit: 1
 	})
+
+	return events[0] || null
 }
 
 /**

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -192,6 +192,7 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object) => {
 			// Also from the locally cached triggers
 			_.remove(options.triggers, (element) => {
 				return _.isEqual(element, {
+					id: trigger.id,
 					action: trigger.data.action,
 					card: trigger.data.target,
 					filter: trigger.data.filter,
@@ -205,7 +206,7 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object) => {
 		await Bluebird.map(jellyscript.getTypeTriggers(insertedCard), async (trigger) => {
 			// We don't want to use the actions queue here
 			// so that watchers are applied right away
-			await jellyfish.insertCard(session, trigger, {
+			const insertedTrigger = await jellyfish.insertCard(session, trigger, {
 				override: true
 			})
 
@@ -213,6 +214,7 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object) => {
 			// right away for performance reasons
 			return options.setTriggers(options.triggers.concat([
 				{
+					id: insertedTrigger.id,
 					action: trigger.data.action,
 					card: trigger.data.target,
 					filter: trigger.data.filter,

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -110,6 +110,10 @@ module.exports = class Worker {
 	 */
 	setTriggers (triggers) {
 		this.triggers = triggers.map((trigger) => {
+			if (!trigger.id || !_.isString(trigger.id)) {
+				throw new errors.WorkerInvalidTrigger(`Invalid id: ${trigger.id}`)
+			}
+
 			if (!trigger.action || !_.isString(trigger.action)) {
 				throw new errors.WorkerInvalidTrigger(`Invalid action: ${trigger.action}`)
 			}
@@ -127,6 +131,7 @@ module.exports = class Worker {
 			}
 
 			return {
+				id: trigger.id,
 				action: trigger.action,
 				card: trigger.card,
 				filter: trigger.filter,
@@ -195,6 +200,7 @@ module.exports = class Worker {
 	 * @param {String} options.action - action slug
 	 * @param {String} options.card - action input card id
 	 * @param {Object} options.arguments - action arguments
+	 * @param {String} [options.originator] - card id that originated this action
 	 * @returns {String} action request id
 	 *
 	 * @example
@@ -202,6 +208,7 @@ module.exports = class Worker {
 	 * const id = await worker.enqueue('4a962ad9-20b5-4dd8-a707-bf819593cc84', {
 	 *   action: 'action-create-card',
 	 *   card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+	 *   originator: '2ebb5e46-ef8a-485b-ba04-e8266d8c0677',
 	 *   arguments: {
 	 *     properties: {
 	 *       data: {
@@ -230,6 +237,7 @@ module.exports = class Worker {
 			card: options.card,
 			actor: cards.session.data.actor,
 			action: cards.action,
+			originator: options.originator,
 			timestamp: utils.getCurrentTimestamp(),
 			arguments: jellyscript.evaluateObject(
 				utils.getActionArgumentsSchema(cards.action),
@@ -257,6 +265,7 @@ module.exports = class Worker {
 	 * @param {String} request.timestamp - action timestamp
 	 * @param {String} request.card - action input card id
 	 * @param {Object} request.arguments - action arguments
+	 * @param {String} [request.originator] - action originator card id]
 	 * @returns {Object} action result
 	 *
 	 * @example
@@ -289,6 +298,7 @@ module.exports = class Worker {
 		await events.post(this.jellyfish, session, {
 			id: request.id,
 			action: request.action.id,
+			originator: request.originator,
 			card: request.card,
 			actor: request.actor,
 			timestamp: request.timestamp

--- a/lib/worker/triggers.js
+++ b/lib/worker/triggers.js
@@ -98,6 +98,7 @@ const compileTrigger = (trigger, card) => {
  * if (request) {
  *   console.log(request.action)
  *   console.log(request.arguments)
+ *   console.log(request.originator)
  *   console.log(request.card)
  * }
  */
@@ -121,6 +122,7 @@ exports.getRequest = (trigger, card, matchCard) => {
 	return {
 		action: trigger.action,
 		arguments: compiledTrigger.arguments,
+		originator: trigger.id,
 		card: compiledTrigger.card
 	}
 }

--- a/test/unit/worker/events.spec.js
+++ b/test/unit/worker/events.spec.js
@@ -233,3 +233,191 @@ ava.test.cb('.wait() should ignore cards that do not match the id', (test) => {
 		})
 	}).catch(test.end)
 })
+
+ava.test('.getLastExecutionEvent() should return the last execution event given one event', async (test) => {
+	await events.post(test.context.jellyfish, test.context.session, {
+		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
+		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		timestamp: '2018-06-30T19:34:42.829Z'
+	}, {
+		error: false,
+		data: '414f2345-4f5e-4571-820f-28a49731733d'
+	})
+
+	const event = await events.getLastExecutionEvent(
+		test.context.jellyfish,
+		test.context.session,
+		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+
+	test.deepEqual(event, {
+		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		type: 'execute',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			target: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			timestamp: event.data.timestamp,
+			payload: {
+				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+				data: '414f2345-4f5e-4571-820f-28a49731733d',
+				error: false,
+				timestamp: '2018-06-30T19:34:42.829Z'
+			}
+		}
+	})
+})
+
+ava.test('.getLastExecutionEvent() should return the last event given a matching and non-matching event', async (test) => {
+	await events.post(test.context.jellyfish, test.context.session, {
+		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
+		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		timestamp: '2018-06-30T19:34:42.829Z'
+	}, {
+		error: false,
+		data: '414f2345-4f5e-4571-820f-28a49731733d'
+	})
+
+	await events.post(test.context.jellyfish, test.context.session, {
+		id: 'dc2bebe9-217f-4802-9d3a-2248925fba44',
+		action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
+		card: '5201aae8-c937-4f92-940d-827d857bbcc2',
+		actor: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
+		originator: '6f3ff72e-5305-4397-b86f-ca1ea5f06f5f',
+		timestamp: '2018-08-30T19:34:42.829Z'
+	}, {
+		error: false,
+		data: 'a5acb93e-c949-4d2c-859c-62c8949fdfe6'
+	})
+
+	const event = await events.getLastExecutionEvent(
+		test.context.jellyfish,
+		test.context.session,
+		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+
+	test.deepEqual(event, {
+		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		type: 'execute',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			target: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			timestamp: event.data.timestamp,
+			payload: {
+				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+				data: '414f2345-4f5e-4571-820f-28a49731733d',
+				error: false,
+				timestamp: '2018-06-30T19:34:42.829Z'
+			}
+		}
+	})
+})
+
+ava.test('.getLastExecutionEvent() should return the last execution event given two matching events', async (test) => {
+	await events.post(test.context.jellyfish, test.context.session, {
+		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
+		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		timestamp: '2018-06-30T19:34:42.829Z'
+	}, {
+		error: false,
+		data: '414f2345-4f5e-4571-820f-28a49731733d'
+	})
+
+	await events.post(test.context.jellyfish, test.context.session, {
+		id: 'dc2bebe9-217f-4802-9d3a-2248925fba44',
+		action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
+		card: '5201aae8-c937-4f92-940d-827d857bbcc2',
+		actor: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		timestamp: '2018-03-30T19:34:42.829Z'
+	}, {
+		error: false,
+		data: 'a5acb93e-c949-4d2c-859c-62c8949fdfe6'
+	})
+
+	const event = await events.getLastExecutionEvent(
+		test.context.jellyfish,
+		test.context.session,
+		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+
+	test.deepEqual(event, {
+		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		type: 'execute',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			target: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			timestamp: event.data.timestamp,
+			payload: {
+				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+				data: '414f2345-4f5e-4571-820f-28a49731733d',
+				error: false,
+				timestamp: '2018-06-30T19:34:42.829Z'
+			}
+		}
+	})
+})
+
+ava.test('.getLastExecutionEvent() should return null given no matching event', async (test) => {
+	await events.post(test.context.jellyfish, test.context.session, {
+		id: 'dc2bebe9-217f-4802-9d3a-2248925fba44',
+		action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
+		card: '5201aae8-c937-4f92-940d-827d857bbcc2',
+		actor: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
+		originator: '6f3ff72e-5305-4397-b86f-ca1ea5f06f5f',
+		timestamp: '2018-03-30T19:34:42.829Z'
+	}, {
+		error: false,
+		data: 'a5acb93e-c949-4d2c-859c-62c8949fdfe6'
+	})
+
+	const event = await events.getLastExecutionEvent(
+		test.context.jellyfish,
+		test.context.session,
+		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+	test.deepEqual(event, null)
+})
+
+ava.test('.getLastExecutionEvent() should only consider execute cards', async (test) => {
+	await test.context.jellyfish.insertCard(test.context.session, {
+		type: 'card',
+		active: true,
+		links: {},
+		tags: [],
+		data: {
+			timestamp: '2018-06-30T19:34:42.829Z',
+			target: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			payload: {
+				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+				timestamp: '2018-06-32T19:34:42.829Z',
+				error: false,
+				data: '414f2345-4f5e-4571-820f-28a49731733d'
+			}
+		}
+	})
+
+	const event = await events.getLastExecutionEvent(
+		test.context.jellyfish,
+		test.context.session,
+		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+	test.deepEqual(event, null)
+})

--- a/test/unit/worker/executor.spec.js
+++ b/test/unit/worker/executor.spec.js
@@ -337,6 +337,7 @@ ava.test('.insertCard() should execute one matching triggered action', async (te
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const triggers = [
 		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -393,6 +394,7 @@ ava.test('.insertCard() should execute one matching triggered action', async (te
 		{
 			action: 'action-create-card',
 			card: typeCard.id,
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			arguments: {
 				properties: {
 					slug: 'foo-bar-baz'
@@ -466,6 +468,7 @@ ava.test('.insertCard() should execute more than one matching triggered action',
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const triggers = [
 		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -491,6 +494,7 @@ ava.test('.insertCard() should execute more than one matching triggered action',
 			}
 		},
 		{
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -547,6 +551,7 @@ ava.test('.insertCard() should execute more than one matching triggered action',
 		{
 			action: 'action-create-card',
 			card: typeCard.id,
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			arguments: {
 				properties: {
 					slug: 'foo-bar-baz'
@@ -556,6 +561,7 @@ ava.test('.insertCard() should execute more than one matching triggered action',
 		{
 			action: 'action-create-card',
 			card: typeCard.id,
+			originator: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			arguments: {
 				properties: {
 					slug: 'bar-baz-qux'
@@ -569,6 +575,7 @@ ava.test('.insertCard() should execute the matching triggered actions given more
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const triggers = [
 		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -594,6 +601,7 @@ ava.test('.insertCard() should execute the matching triggered actions given more
 			}
 		},
 		{
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -650,6 +658,7 @@ ava.test('.insertCard() should execute the matching triggered actions given more
 		{
 			action: 'action-create-card',
 			card: typeCard.id,
+			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			arguments: {
 				properties: {
 					slug: 'foo-bar-baz'
@@ -1071,6 +1080,7 @@ ava.test('.insertCard() should pre-register a triggered action if using AGGREGAT
 
 	test.deepEqual(test.context.triggers, [
 		{
+			id: test.context.triggers[0].id,
 			action: 'action-set-add',
 			card: {
 				$eval: 'source.data.target'

--- a/test/unit/worker/triggers.spec.js
+++ b/test/unit/worker/triggers.spec.js
@@ -63,6 +63,7 @@ ava.test('.getRequest() should return null if the filter only has a type but the
 ava.test('.getRequest() should return a request if the filter only has a type and there is a match', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 		filter: {
 			type: 'object',
 			required: [ 'type' ],
@@ -99,6 +100,7 @@ ava.test('.getRequest() should return a request if the filter only has a type an
 	test.deepEqual(request, {
 		action: 'action-create-card',
 		card: typeCard.id,
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 		arguments: {
 			properties: {
 				slug: 'foo-bar-baz'
@@ -110,6 +112,7 @@ ava.test('.getRequest() should return a request if the filter only has a type an
 ava.test('.getRequest() should return a request given a complex matching filter', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 		filter: {
 			type: 'object',
 			required: [ 'type', 'data' ],
@@ -159,6 +162,7 @@ ava.test('.getRequest() should return a request given a complex matching filter'
 	test.deepEqual(request, {
 		action: 'action-create-card',
 		card: typeCard.id,
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 		arguments: {
 			properties: {
 				slug: 'foo-bar-baz'
@@ -222,6 +226,7 @@ ava.test('.getRequest() should return null given a complex non-matching filter',
 ava.test('.getRequest() should parse source templates in the triggered action arguments', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 		filter: {
 			type: 'object',
 			required: [ 'data' ],
@@ -279,6 +284,7 @@ ava.test('.getRequest() should parse source templates in the triggered action ar
 	test.deepEqual(request, {
 		action: 'action-create-card',
 		card: typeCard.id,
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 		arguments: {
 			properties: {
 				slug: 'hello-world',


### PR DESCRIPTION
This property can store the id of a card that originated the action
execution. We use this to track that an action was originated through a
registered trigger to then be able to track what a trigger caused over
its lifetime.

Change-type: minor