### PR TITLE
worker: Don't expose source in .getRequest() if no input card

### DIFF
--- a/lib/worker/triggers.js
+++ b/lib/worker/triggers.js
@@ -24,7 +24,7 @@ const skhema = require('skhema')
  *
  * @param {Object} trigger - trigger
  * @param {Object} trigger.filter - filter
- * @param {Object} card - card
+ * @param {(Object|Null)} card - card
  * @returns {Boolean} whether the trigger matches the card
  *
  * @example
@@ -35,6 +35,10 @@ const skhema = require('skhema')
  * }
  */
 const matchesCard = (trigger, card) => {
+	if (!card) {
+		return true
+	}
+
 	// A small performance shortcut, given that most triggered
 	// actions do filtering based on the card type
 	if (trigger.filter.properties &&
@@ -55,7 +59,7 @@ const matchesCard = (trigger, card) => {
  * @param {Object} trigger - trigger
  * @param {String} trigger.card - card id
  * @param {Object} trigger.arguments - arguments
- * @param {Object} card - card
+ * @param {(Object|Null)} card - card
  * @param {Date} currentDate - current date
  * @returns {Object} compiled data
  *
@@ -68,10 +72,15 @@ const matchesCard = (trigger, card) => {
  */
 const compileTrigger = (trigger, card, currentDate) => {
 	try {
-		return jsone(trigger, {
-			timestamp: currentDate.toISOString(),
-			source: card
-		})
+		const context = {
+			timestamp: currentDate.toISOString()
+		}
+
+		if (card) {
+			context.source = card
+		}
+
+		return jsone(trigger, context)
 	} catch (error) {
 		if (error.name === 'InterpreterError') {
 			return null

--- a/test/unit/worker/triggers.spec.js
+++ b/test/unit/worker/triggers.spec.js
@@ -115,6 +115,125 @@ ava.test('.getRequest() should return a request if the filter only has a type an
 	})
 })
 
+ava.test('.getRequest() should return a request if the input match card is null', async (test) => {
+	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
+	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		filter: {
+			type: 'object',
+			required: [ 'type' ],
+			properties: {
+				type: {
+					type: 'string',
+					const: 'foo'
+				}
+			}
+		},
+		action: 'action-create-card',
+		card: typeCard.id,
+		arguments: {
+			properties: {
+				slug: 'foo-bar-baz'
+			}
+		}
+	}
+
+	const request = await triggers.getRequest(trigger, {
+		type: 'bar',
+		active: true,
+		links: {},
+		tags: [],
+		data: {}
+	}, {
+		currentDate: new Date(),
+		matchCard: null
+	})
+
+	test.deepEqual(request, {
+		action: 'action-create-card',
+		card: typeCard.id,
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		arguments: {
+			properties: {
+				slug: 'foo-bar-baz'
+			}
+		}
+	})
+})
+
+ava.test('.getRequest() should return a request if both the input card and the match card are null', async (test) => {
+	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
+	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		filter: {
+			type: 'object',
+			required: [ 'type' ],
+			properties: {
+				type: {
+					type: 'string',
+					const: 'foo'
+				}
+			}
+		},
+		action: 'action-create-card',
+		card: typeCard.id,
+		arguments: {
+			properties: {
+				slug: 'foo-bar-baz'
+			}
+		}
+	}
+
+	const request = await triggers.getRequest(trigger, null, {
+		currentDate: new Date(),
+		matchCard: null
+	})
+
+	test.deepEqual(request, {
+		action: 'action-create-card',
+		card: typeCard.id,
+		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		arguments: {
+			properties: {
+				slug: 'foo-bar-baz'
+			}
+		}
+	})
+})
+
+ava.test('.getRequest() should return null if referencing source when no input card', async (test) => {
+	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
+	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		filter: {
+			type: 'object',
+			required: [ 'type' ],
+			properties: {
+				type: {
+					type: 'string',
+					const: 'foo'
+				}
+			}
+		},
+		action: 'action-create-card',
+		card: typeCard.id,
+		arguments: {
+			properties: {
+				slug: {
+					$eval: 'source.type'
+				}
+			}
+		}
+	}
+
+	const request = await triggers.getRequest(trigger, null, {
+		currentDate: new Date(),
+		matchCard: null
+	})
+
+	test.deepEqual(request, null)
+})
+
 ava.test('.getRequest() should return a request given a complex matching filter', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
 	const trigger = {


### PR DESCRIPTION
Time triggered actions don't have an input card as there is no insertion
(but time) that triggers them. We still want to be able to generate
action requests out of those, so we must modify `triggers.getRequest()`
to react to the fact that the input card is now optional.

This basically means that the `source` property will not be accessible
in time-based triggered action templates.

Change-type: patch