### PR TITLE
server: Fix transient ECONNRESET during server tests

### DIFF
--- a/lib/server/action-server.js
+++ b/lib/server/action-server.js
@@ -17,6 +17,8 @@
 const Worker = require('../worker')
 const actionLibrary = require('../action-library')
 
+let run = true
+
 const SCHEMA_ACTIVE_TRIGGERS = {
 	type: 'object',
 	properties: {
@@ -74,6 +76,10 @@ const processQueue = (jellyfish, worker, session, onRequest, onError) => {
 			})
 		}).then(onRequest)
 	}).catch(onError).then(() => {
+		if (!run) {
+			return
+		}
+
 		setTimeout(() => {
 			processQueue(jellyfish, worker, session, onRequest, onError)
 		}, 10)
@@ -104,7 +110,16 @@ exports.start = async (jellyfish, session, onRequest, onError) => {
 
 	await refreshTriggers()
 
+	run = true
 	processQueue(jellyfish, worker, session, onRequest, onError)
+
+	worker.stop = async () => {
+		triggerStream.removeAllListeners()
+		triggerStream.close()
+		await exports.flush(jellyfish, session, worker)
+		run = false
+	}
+
 	return worker
 }
 
@@ -124,5 +139,5 @@ exports.flush = async (jellyfish, session, worker) => {
 		throw new Constructor(result.data.message)
 	}
 
-	await exports.flush(session)
+	await exports.flush(jellyfish, session, worker)
 }

--- a/lib/server/create-server.js
+++ b/lib/server/create-server.js
@@ -38,6 +38,7 @@ const createServer = async (options) => {
 	const {
 		app,
 		port,
+		server,
 		socketServer
 	} = await createWebServer(config)
 
@@ -172,7 +173,14 @@ const createServer = async (options) => {
 	return {
 		jellyfish,
 		port,
-		worker
+		worker,
+		close: async () => {
+			await worker.stop()
+			return new Bluebird((resolve) => {
+				server.close()
+				server.once('close', resolve)
+			})
+		}
 	}
 }
 

--- a/lib/server/web-server.js
+++ b/lib/server/web-server.js
@@ -104,6 +104,7 @@ exports.createWebServer = (config) => {
 		return {
 			port,
 			app,
+			server,
 			socketServer
 		}
 	})

--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -68,11 +68,7 @@ ava.test.beforeEach(async (test) => {
 	process.env.SERVER_DATABASE = `test_${randomstring.generate()}`
 
 	test.context.server = await createServer({
-		// TODO: Fix this hack, which is needed because otherwise
-		// multiple tests start server instances on the same port
-		// and don't stop them afterwards, so requests from certain
-		// test cases end up in the instances from previous tests, etc
-		port: _.random(8000, 9999)
+		port: 9999
 	})
 
 	test.context.session = test.context.server.jellyfish.sessions.admin
@@ -109,6 +105,12 @@ ava.test.beforeEach(async (test) => {
 			})
 		})
 	}
+})
+
+ava.test.afterEach(async (test) => {
+	test.context.sdk.cancelAllStreams()
+	test.context.sdk.cancelAllRequests()
+	await test.context.server.close()
 })
 
 ava.test.serial('.query() should only return the user itself for the guest user', async (test) => {


### PR DESCRIPTION
The server tests start a new server before each test case, but don't
stop it afterwards. After a while, the servers stop responding to
requests.

Change-type: patch