### PR TITLE
worker: Fix race condition when waiting for a request execution

### DIFF
--- a/lib/worker/events.js
+++ b/lib/worker/events.js
@@ -156,14 +156,6 @@ exports.getLastExecutionEvent = async (jellyfish, session, originator) => {
  * console.log(card.id)
  */
 exports.wait = async (jellyfish, session, id) => {
-	const request = await jellyfish.getCardById(session, id, {
-		type: EXECUTION_EVENT_TYPE
-	})
-
-	if (request) {
-		return request
-	}
-
 	const stream = await jellyfish.stream(session, {
 		type: 'object',
 		additionalProperties: true,
@@ -183,6 +175,15 @@ exports.wait = async (jellyfish, session, id) => {
 		},
 		required: [ 'id', 'active', 'type' ]
 	})
+
+	const request = await jellyfish.getCardById(session, id, {
+		type: EXECUTION_EVENT_TYPE
+	})
+
+	if (request) {
+		stream.close()
+		return request
+	}
 
 	let result = null
 


### PR DESCRIPTION
When the server receives an action request through its HTTP API, it
enqueues it and starts waiting for the result.

The wait function algorithm looks like this:

- Check if the request has been executed already, if so return it
- Open a stream to wait for it

The race condition can happen if the action request is executed after we
checked if the request has been executed, but before we open the stream.
In this case, the worker will just hang forever waiting for the result.

Change-type: patch