### PR TITLE
worker: Test that time-triggers can evaluate current timestamp

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -412,10 +412,18 @@ module.exports = class Worker {
 			// is no input card that caused the trigger.
 			const inputCard = null
 
-			return this.enqueue(session, triggers.getRequest(trigger, inputCard, {
+			const request = triggers.getRequest(trigger, inputCard, {
 				currentDate: options.currentDate,
 				matchCard: inputCard
-			}))
+			})
+
+			// This can happen if the trigger contains
+			// an invalid template interpolation
+			if (!request) {
+				return null
+			}
+
+			return this.enqueue(session, request)
 		}, {
 			concurrency: 5
 		})


### PR DESCRIPTION
This is passed as context on the JSON-e evaluation. This commit adds a
test case to ensure this remains to work.

Change-type: patch