### PR TITLE
default-cards: Support spaces in tags

### DIFF
--- a/default-cards/contrib/action-create-card.json
+++ b/default-cards/contrib/action-create-card.json
@@ -40,7 +40,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[a-zA-Z0-9-_/]+$"
+              "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
             }
           },
           "links": {

--- a/default-cards/contrib/action-update-card.json
+++ b/default-cards/contrib/action-update-card.json
@@ -25,7 +25,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[a-zA-Z0-9-_/]+$"
+              "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
             }
           },
           "links": {

--- a/default-cards/contrib/action-upsert-card.json
+++ b/default-cards/contrib/action-upsert-card.json
@@ -36,7 +36,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[a-zA-Z0-9-_/]+$"
+              "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
             }
           },
           "links": {

--- a/default-cards/contrib/issue.json
+++ b/default-cards/contrib/issue.json
@@ -17,7 +17,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-_/]+$"
+            "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
           },
           "$$formula": "AGGREGATE($events, 'tags')"
         },

--- a/default-cards/contrib/scratchpad-entry.json
+++ b/default-cards/contrib/scratchpad-entry.json
@@ -16,7 +16,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-_/]+$"
+            "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
           },
           "$$formula": "AGGREGATE($events, 'tags')"
         },

--- a/default-cards/contrib/thread.json
+++ b/default-cards/contrib/thread.json
@@ -13,7 +13,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-_/]+$"
+            "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
           },
           "$$formula": "AGGREGATE($events, 'tags')"
         },

--- a/default-cards/contrib/update.json
+++ b/default-cards/contrib/update.json
@@ -39,7 +39,7 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z0-9-_/]+$"
+                    "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
                   }
                 },
                 "links": {

--- a/default-cards/core/card.json
+++ b/default-cards/core/card.json
@@ -29,7 +29,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-_/]+$"
+            "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s]+[a-zA-Z0-9-_/]$"
           }
         },
         "links": {


### PR DESCRIPTION
We will need these in order to store GitHub labels, which may contain
spaces.

Change-type: minor