### PR TITLE
default-cards: Prepare cards to take links

### DIFF
--- a/default-cards/core/card.json
+++ b/default-cards/core/card.json
@@ -33,16 +33,7 @@
           }
         },
         "links": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "from": {
-              "type": "object"
-            },
-            "to": {
-              "type": "object"
-            }
-          }
+          "type": "object"
         },
         "active": {
           "type": "boolean"

--- a/default-cards/core/link.json
+++ b/default-cards/core/link.json
@@ -15,6 +15,11 @@
           "type": "string",
           "const": "link"
         },
+        "links": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
         "data": {
           "type": "object",
           "properties": {
@@ -33,7 +38,7 @@
           "required": [ "inverseName", "from", "to" ]
         }
       },
-      "required": [ "name", "type", "data" ]
+      "required": [ "name", "type", "links", "data" ]
     }
   }
 }

--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -399,6 +399,13 @@ module.exports = class Backend {
 				.table(table)
 				.indexCreate('type')
 				.run(this.connection)
+
+			// Lets make sure the table is ready before continuing
+			await rethinkdb
+				.db(this.database)
+				.table(table)
+				.wait()
+				.run(this.connection)
 		}
 
 		await this.cache.connect()

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -101,7 +101,8 @@ module.exports = class Kernel {
 			CARDS.card,
 			CARDS.action,
 			CARDS['action-request'],
-			CARDS.view
+			CARDS.view,
+			CARDS.link
 		].map((card) => {
 			debug(`Upserting core card ${card.slug}`)
 			return this.insertCard(this.sessions.admin, card, {

--- a/lib/server/create-server.js
+++ b/lib/server/create-server.js
@@ -63,7 +63,6 @@ exports.createServer = async (options) => {
 		require('../../default-cards/contrib/action-update-card.json'),
 		require('../../default-cards/contrib/action-upsert-card.json'),
 		require('../../default-cards/contrib/create.json'),
-		require('../../default-cards/contrib/link.json'),
 		require('../../default-cards/contrib/event.json'),
 		require('../../default-cards/contrib/execute.json'),
 		require('../../default-cards/contrib/triggered-action.json'),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "ava": {
     "timeout": "5m",
     "verbose": true,
-    "concurrency": 3,
+    "serial": true,
     "failFast": true,
     "files": [
       "test/unit/**/*.spec.js",


### PR DESCRIPTION
- Link cards might not contain links themselves, at least for now, for
simplicity

- Simplify the links property of cards. The keys will be actual link
names, and not `from` and `to` as originally planned

Change-type: patch