### PR TITLE
core: Prevent clients from modifying the "links" property

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -528,6 +528,11 @@ module.exports = class Backend {
 	async insertElement (object) {
 		const table = getBucketForType(object.type)
 
+		// Links is a computed property
+		if (object.links) {
+			object.links = {}
+		}
+
 		if (object.id && await this.getElementById(object.id)) {
 			throw new errors.JellyfishElementAlreadyExists(`There is already an element with id ${object.id}`)
 		}
@@ -570,12 +575,48 @@ module.exports = class Backend {
 		const table = getBucketForType(object.type)
 
 		if (!object.slug) {
-			if (object.id && await this.getElementById(object.id)) {
+			if (object.id) {
+				const element = await this.getElementById(object.id)
+				if (element) {
+					if (object.links) {
+						object.links = element.links
+					}
+
+					debug(`Updating element by id ${object.id} in table ${table} in database ${this.database}`)
+					const results = await rethinkdb
+						.db(this.database)
+						.table(table)
+						.get(element.id)
+						.replace(object)
+						.run(this.connection)
+
+					return handleInsertionResults(table, results, object, this.cache, {
+						unsetFromCache: true
+					})
+				}
+			}
+
+			return this.insertElement(object)
+		}
+
+		if (object.id) {
+			const element = await this.getElementById(object.id)
+			if (element) {
+				const elementBySlug = await this.getElementBySlug(object.slug)
+				if (elementBySlug && elementBySlug.id !== object.id) {
+					throw new errors.JellyfishElementAlreadyExists(
+						`There is already an element with slug ${object.slug} but the id is not ${object.id}`)
+				}
+
+				if (object.links) {
+					object.links = element.links
+				}
+
 				debug(`Updating element by id ${object.id} in table ${table} in database ${this.database}`)
 				const results = await rethinkdb
 					.db(this.database)
 					.table(table)
-					.get(object.id)
+					.get(element.id)
 					.replace(object)
 					.run(this.connection)
 
@@ -583,28 +624,6 @@ module.exports = class Backend {
 					unsetFromCache: true
 				})
 			}
-
-			return this.insertElement(object)
-		}
-
-		if (object.id && await this.getElementById(object.id)) {
-			const element = await this.getElementBySlug(object.slug)
-			if (element && element.id !== object.id) {
-				throw new errors.JellyfishElementAlreadyExists(
-					`There is already an element with slug ${object.slug} but the id is not ${object.id}`)
-			}
-
-			debug(`Updating element by id ${object.id} in table ${table} in database ${this.database}`)
-			const results = await rethinkdb
-				.db(this.database)
-				.table(table)
-				.get(object.id)
-				.replace(object)
-				.run(this.connection)
-
-			return handleInsertionResults(table, results, object, this.cache, {
-				unsetFromCache: true
-			})
 		}
 
 		const element = await this.getElementBySlug(object.slug)
@@ -618,6 +637,10 @@ module.exports = class Backend {
 			const finalObject = Object.assign({}, object, {
 				id: element.id
 			})
+
+			if (finalObject.links) {
+				finalObject.links = element.links
+			}
 
 			const results = await rethinkdb
 				.db(this.database)

--- a/test/unit/core/backend.spec.js
+++ b/test/unit/core/backend.spec.js
@@ -134,6 +134,18 @@ ava.test('.insertElement() should insert an element with a non-existent id and s
 	test.deepEqual(element, result)
 })
 
+ava.test('.insertElement() should not be able to set any links', async (test) => {
+	const result = await test.context.backend.insertElement({
+		type: 'card',
+		links: {
+			foo: 'bar'
+		}
+	})
+
+	const element = await test.context.backend.getElementById(result.id)
+	test.deepEqual(element.links, {})
+})
+
 ava.test('.insertElement() should fail to insert an element with an existent id', async (test) => {
 	const result = await test.context.backend.insertElement({
 		foo: 'bar'
@@ -204,6 +216,58 @@ ava.test('.upsertElement() should create multiple elements given same content an
 	test.deepEqual(element1, result1)
 	test.deepEqual(element2, result2)
 	test.deepEqual(element3, result3)
+})
+
+ava.test('.upsertElement() should not be able to set links using an id', async (test) => {
+	const result = await test.context.backend.upsertElement({
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		links: {
+			foo: 'bar'
+		},
+		test: 'foo'
+	})
+
+	const element = await test.context.backend.getElementById(result.id)
+	test.deepEqual(element.links, {})
+})
+
+ava.test('.upsertElement() should not be able to set links using both an id and a slug', async (test) => {
+	const result = await test.context.backend.upsertElement({
+		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		slug: 'foo-bar',
+		links: {
+			foo: 'bar'
+		},
+		test: 'foo'
+	})
+
+	const element = await test.context.backend.getElementById(result.id)
+	test.deepEqual(element.links, {})
+})
+
+ava.test('.upsertElement() should not be able to set links using a slug', async (test) => {
+	const result = await test.context.backend.upsertElement({
+		slug: 'foo-bar',
+		links: {
+			foo: 'bar'
+		},
+		test: 'foo'
+	})
+
+	const element = await test.context.backend.getElementBySlug(result.slug)
+	test.deepEqual(element.links, {})
+})
+
+ava.test('.upsertElement() should not be able to set links using no id nor slug', async (test) => {
+	const result = await test.context.backend.upsertElement({
+		links: {
+			foo: 'bar'
+		},
+		test: 'foo'
+	})
+
+	const element = await test.context.backend.getElementById(result.id)
+	test.deepEqual(element.links, {})
 })
 
 ava.test('.upsertElement() should insert a card with an id', async (test) => {


### PR DESCRIPTION
This will be a computed property, so we don't want users to freely set
whatever they want and mess up functionality that relies on such cache.

Change-type: major