### PR TITLE
core: Generalize links .evaluate() function to use link cards

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -22,7 +22,6 @@ _.each([
 	'JellyfishDatabaseError',
 	'JellyfishElementAlreadyExists',
 	'JellyfishNoElement',
-	'JellyfishUnknownLinkType',
 	'JellyfishSessionExpired',
 	'JellyfishNoAction',
 	'JellyfishNoView',

--- a/lib/core/links.js
+++ b/lib/core/links.js
@@ -14,8 +14,20 @@
  * limitations under the License.
  */
 
-const errors = require('./errors')
+const Bluebird = require('bluebird')
 const jsonSchema = require('./json-schema')
+
+const resolveLink = (linkCard, linkName, id) => {
+	if (linkCard.name === linkName && linkCard.data.from === id) {
+		return linkCard.data.to
+	}
+
+	if (linkCard.data.inverseName === linkName && linkCard.data.to === id) {
+		return linkCard.data.from
+	}
+
+	return null
+}
 
 /**
  * @summary Evaluate a card link
@@ -52,57 +64,63 @@ const jsonSchema = require('./json-schema')
  * }
  */
 exports.evaluate = async (context, card, name, linkSchema) => {
-	// TODO: These types of links are hardcoded, but in the
-	// future, we should represent all link types using link
-	// cards, and modify this function to take a look at those
-	// cards to resolve the link requests.
-
-	switch (name) {
-		case 'is attached to': {
-			const targetId = card.data && card.data.target
-			if (!targetId) {
-				return []
-			}
-
-			return jsonSchema.filter(linkSchema, await context.query({
+	const linkCards = await context.query({
+		type: 'object',
+		required: [ 'type', 'name', 'active', 'data' ],
+		properties: {
+			type: {
+				type: 'string',
+				const: 'link'
+			},
+			name: {
+				type: 'string'
+			},
+			active: {
+				type: 'boolean',
+				const: true
+			},
+			data: {
 				type: 'object',
-				required: [ 'id' ],
-				additionalProperties: true,
+				required: [ 'inverseName', 'from', 'to' ],
 				properties: {
-					id: {
-						type: 'string',
-						const: targetId
+					inverseName: {
+						type: 'string'
+					},
+					from: {
+						type: 'string'
+					},
+					to: {
+						type: 'string'
 					}
 				}
-			}))
+			}
 		}
-		case 'has attached element': {
-			const querySchema = jsonSchema.merge([
-				{
-					type: 'object',
-					required: [ 'data' ],
-					properties: {
-						data: {
-							type: 'object',
-							required: [ 'target' ],
-							properties: {
-								target: {
-									type: 'string',
-									const: card.id
-								}
-							}
-						}
-					}
-				},
-				linkSchema
-			])
+	})
 
-			return jsonSchema.filter(querySchema, await context.query(querySchema))
+	return Bluebird.reduce(linkCards, async (accumulator, linkCard) => {
+		const id = resolveLink(linkCard, name, card.id)
+		if (!id) {
+			return accumulator
 		}
-		default: {
-			throw new errors.JellyfishUnknownLinkType(`Unknown link: ${name}`)
-		}
-	}
+
+		const cards = await context.query({
+			type: 'object',
+			required: [ 'id', 'active' ],
+			additionalProperties: true,
+			properties: {
+				id: {
+					type: 'string',
+					const: id
+				},
+				active: {
+					type: 'boolean',
+					const: true
+				}
+			}
+		})
+
+		return accumulator.concat(jsonSchema.filter(linkSchema, cards) || [])
+	}, [])
 }
 
 /**

--- a/test/unit/core/backend.spec.js
+++ b/test/unit/core/backend.spec.js
@@ -852,43 +852,79 @@ ava.test('.query() should be able to limit and skip the results', async (test) =
 ava.test('.query() should be able to query using links', async (test) => {
 	const thread1 = await test.context.backend.upsertElement({
 		type: 'thread',
+		active: true,
 		data: {}
 	})
 
 	const thread2 = await test.context.backend.upsertElement({
 		type: 'thread',
+		active: true,
 		data: {}
 	})
 
 	await test.context.backend.upsertElement({
 		type: 'thread',
+		active: true,
 		data: {}
 	})
 
-	await test.context.backend.upsertElement({
+	const card1 = await test.context.backend.upsertElement({
 		type: 'message',
+		active: true,
 		data: {
 			payload: 'foo',
-			target: thread1.id,
 			count: 1
 		}
 	})
 
 	await test.context.backend.upsertElement({
+		type: 'link',
+		active: true,
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached element',
+			from: card1.id,
+			to: thread1.id
+		}
+	})
+
+	const card2 = await test.context.backend.upsertElement({
 		type: 'message',
+		active: true,
 		data: {
 			payload: 'bar',
-			target: thread1.id,
 			count: 2
 		}
 	})
 
 	await test.context.backend.upsertElement({
+		type: 'link',
+		active: true,
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached element',
+			from: card2.id,
+			to: thread1.id
+		}
+	})
+
+	const card3 = await test.context.backend.upsertElement({
 		type: 'message',
+		active: true,
 		data: {
 			payload: 'baz',
-			target: thread2.id,
 			count: 3
+		}
+	})
+
+	await test.context.backend.upsertElement({
+		type: 'link',
+		active: true,
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached element',
+			from: card3.id,
+			to: thread2.id
 		}
 	})
 
@@ -987,27 +1023,51 @@ ava.test('.query() should be able to query using links', async (test) => {
 ava.test('.query() should omit a result if a link does not match', async (test) => {
 	const thread = await test.context.backend.upsertElement({
 		type: 'thread',
+		active: true,
 		data: {}
 	})
 
 	const foo = await test.context.backend.upsertElement({
 		type: 'foo',
+		active: true,
 		data: {}
 	})
 
-	await test.context.backend.upsertElement({
+	const card1 = await test.context.backend.upsertElement({
 		type: 'message',
+		active: true,
 		data: {
-			payload: 'foo',
-			target: thread.id
+			payload: 'foo'
 		}
 	})
 
 	await test.context.backend.upsertElement({
-		type: 'message',
+		type: 'link',
+		active: true,
+		name: 'is attached to',
 		data: {
-			payload: 'bar',
-			target: foo.id
+			inverseName: 'has attached element',
+			from: card1.id,
+			to: thread.id
+		}
+	})
+
+	const card2 = await test.context.backend.upsertElement({
+		type: 'message',
+		active: true,
+		data: {
+			payload: 'bar'
+		}
+	})
+
+	await test.context.backend.upsertElement({
+		type: 'link',
+		active: true,
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached element',
+			from: card2.id,
+			to: foo.id
 		}
 	})
 

--- a/test/unit/core/links.spec.js
+++ b/test/unit/core/links.spec.js
@@ -17,7 +17,6 @@
 const ava = require('ava')
 const _ = require('lodash')
 const links = require('../../../lib/core/links')
-const errors = require('../../../lib/core/errors')
 const helpers = require('./helpers')
 
 ava.test.beforeEach(async (test) => {
@@ -29,7 +28,7 @@ ava.test.beforeEach(async (test) => {
 
 ava.test.afterEach(helpers.kernel.afterEach)
 
-ava.test('.evaluate() should throw an error if the link is unknown', async (test) => {
+ava.test('.evaluate() should return an empty array if the link is unknown', async (test) => {
 	const input = await test.context.kernel.insertCard(test.context.kernel.sessions.admin, {
 		type: 'card',
 		active: true,
@@ -38,9 +37,11 @@ ava.test('.evaluate() should throw an error if the link is unknown', async (test
 		data: {}
 	})
 
-	await test.throws(links.evaluate(test.context.context, input, 'foo bar baz', {
+	const results = await links.evaluate(test.context.context, input, 'foo bar baz', {
 		type: 'object'
-	}), errors.JellyfishUnknownLinkType)
+	})
+
+	test.deepEqual(results, [])
 })
 
 ava.test('.evaluate(is attached to) should return an empty array if the target does not exist', async (test) => {
@@ -294,8 +295,7 @@ ava.test('.evaluate(has attached element) should return matching elements', asyn
 		{
 			id: card2.id,
 			data: {
-				count: 2,
-				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+				count: 2
 			}
 		}
 	])
@@ -427,22 +427,19 @@ ava.test('.evaluateCard() should return multiple cards per link', async (test) =
 			{
 				id: card1.id,
 				data: {
-					count: 1,
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+					count: 1
 				}
 			},
 			{
 				id: card2.id,
 				data: {
-					count: 2,
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+					count: 2
 				}
 			},
 			{
 				id: card3.id,
 				data: {
-					count: 3,
-					target: '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+					count: 3
 				}
 			}
 		]


### PR DESCRIPTION
This means we can now understand any link defined in any link card, but
performance won't be great. The next step is to use some sort of
materialized views to speed things up.

Change-type: minor