### PR TITLE
test: fix data entry issue in puppeteer that causes test instability

### DIFF
--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -748,7 +748,7 @@ ava.test.serial('should add and evaluate a time triggered action', async (test) 
 			return results
 		}
 
-		if (times > 50) {
+		if (times > 100) {
 			throw new Error(`Did not get ${length} results in time`)
 		}
 

--- a/test/integration/ui/index.spec.js
+++ b/test/integration/ui/index.spec.js
@@ -267,7 +267,22 @@ ava.test.serial('should allow team-admin users to update user\'s roles', async (
 	await page.waitForSelector('#root_data_roles_1', WAIT_OPTS)
 
 	// Enter the 'user-team' role as a new role
-	await page.type('#root_data_roles_1', 'user-team')
+	// Using page.type to change this input field regularly cuases characters to
+	// be "dropped" - the workaround here is to use a script to set the value of
+	// the input, and then trigger a change event that React can respond to
+	await page.evaluate(() => {
+		const input = document.getElementById('root_data_roles_1')
+		const lastValue = input.value
+		input.value = 'user-team'
+		const event = new window.Event('input', {
+			bubbles: true
+		})
+		const tracker = _.get(input, [ '_valueTracker' ])
+		if (tracker) {
+			tracker.setValue(lastValue)
+		}
+		input.dispatchEvent(event)
+	})
 
 	// Add a small delay to allow the form change to propagate
 	await Bluebird.delay(500)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>