### PR TITLE
core: Centralize backend.js RethinkDB upsert logic

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -68,23 +68,6 @@ const getBucketsForSchema = (schema) => {
 	return [ getBucketForType(type) ]
 }
 
-const handleInsertionResults = (table, results, object, cache, options = {}) => {
-	if (results.errors === 0) {
-		const id = _.get(results, [ 'generated_keys', '0' ]) || object.id
-		const result = Object.assign({}, object)
-		result.id = id
-
-		if (options.unsetFromCache) {
-			cache.unset(object)
-		}
-
-		cache.set(table, result)
-		return result
-	}
-
-	throw new errors.JellyfishDatabaseError(results.first_error)
-}
-
 const mergeStreams = async (keys, createFunction) => {
 	const emitter = new EventEmitter()
 	const streams = {}
@@ -278,6 +261,40 @@ const getElementBySlugFromTable = async (backend, table, slug) => {
 		}
 	}
 
+	return result
+}
+
+const upsertObject = async (backend, table, object, current, options) => {
+	// Links is a computed property
+	if (object.links) {
+		object.links = (current && current.links) || {}
+	}
+
+	const results = current && current.id
+		? await rethinkdb
+			.db(backend.database)
+			.table(table)
+			.get(current.id)
+			.replace(object)
+			.run(backend.connection)
+		: await rethinkdb
+			.db(backend.database)
+			.table(table)
+			.insert(object)
+			.run(backend.connection)
+
+	if (results.errors !== 0) {
+		throw new errors.JellyfishDatabaseError(results.first_error)
+	}
+
+	const result = Object.assign({}, object)
+	result.id = _.get(results, [ 'generated_keys', '0' ]) || object.id
+
+	if (options.unsetFromCache) {
+		backend.cache.unset(object)
+	}
+
+	backend.cache.set(table, result)
 	return result
 }
 
@@ -591,11 +608,6 @@ module.exports = class Backend {
 	async insertElement (object) {
 		const table = getBucketForType(object.type)
 
-		// Links is a computed property
-		if (object.links) {
-			object.links = {}
-		}
-
 		if (object.id && await this.getElementById(object.id)) {
 			throw new errors.JellyfishElementAlreadyExists(`There is already an element with id ${object.id}`)
 		}
@@ -605,13 +617,7 @@ module.exports = class Backend {
 		}
 
 		debug(`Inserting element to table ${table} in database ${this.database}`)
-		const results = await rethinkdb
-			.db(this.database)
-			.table(table)
-			.insert(object)
-			.run(this.connection)
-
-		return handleInsertionResults(table, results, object, this.cache, {
+		return upsertObject(this, table, object, null, {
 			unsetFromCache: true
 		})
 	}
@@ -641,19 +647,8 @@ module.exports = class Backend {
 			if (object.id) {
 				const element = await this.getElementById(object.id)
 				if (element) {
-					if (object.links) {
-						object.links = element.links
-					}
-
 					debug(`Updating element by id ${object.id} in table ${table} in database ${this.database}`)
-					const results = await rethinkdb
-						.db(this.database)
-						.table(table)
-						.get(element.id)
-						.replace(object)
-						.run(this.connection)
-
-					return handleInsertionResults(table, results, object, this.cache, {
+					return upsertObject(this, table, object, element, {
 						unsetFromCache: true
 					})
 				}
@@ -671,19 +666,8 @@ module.exports = class Backend {
 						`There is already an element with slug ${object.slug} but the id is not ${object.id}`)
 				}
 
-				if (object.links) {
-					object.links = element.links
-				}
-
 				debug(`Updating element by id ${object.id} in table ${table} in database ${this.database}`)
-				const results = await rethinkdb
-					.db(this.database)
-					.table(table)
-					.get(element.id)
-					.replace(object)
-					.run(this.connection)
-
-				return handleInsertionResults(table, results, object, this.cache, {
+				return upsertObject(this, table, object, element, {
 					unsetFromCache: true
 				})
 			}
@@ -701,18 +685,7 @@ module.exports = class Backend {
 				id: element.id
 			})
 
-			if (finalObject.links) {
-				finalObject.links = element.links
-			}
-
-			const results = await rethinkdb
-				.db(this.database)
-				.table(table)
-				.get(element.id)
-				.replace(finalObject)
-				.run(this.connection)
-
-			return handleInsertionResults(table, results, finalObject, this.cache, {
+			return upsertObject(this, table, finalObject, element, {
 				unsetFromCache: false
 			})
 		}


### PR DESCRIPTION
Right now insertion/update logic is scattered all over
`lib/core/backend.js`. This brings it all together so then we can easily
update it from one place.

There are some changes coming related to links.

Change-type: patch