### PR TITLE
permissions: Throw an error if a user has no permissions defined

### DIFF
--- a/default-cards/core/user.json
+++ b/default-cards/core/user.json
@@ -45,7 +45,10 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "pattern": "^[a-z0-9-]+$"
+                "pattern": "^[a-z0-9-]+$",
+                "not": {
+                  "const": "user-admin"
+                }
               }
             }
           },

--- a/default-cards/core/view-read-user-admin.json
+++ b/default-cards/core/view-read-user-admin.json
@@ -1,0 +1,20 @@
+{
+  "slug": "view-read-user-admin",
+  "name": "Kernel admin user read permissions",
+  "type": "view",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "allOf": [
+      {
+        "name": "All cards",
+        "schema": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    ]
+  }
+}

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -18,17 +18,18 @@ const _ = require('lodash')
 const typedErrors = require('typed-errors')
 
 _.each([
-	'JellyfishUnknownCardType',
+	'JellyfishAuthenticationError',
 	'JellyfishDatabaseError',
 	'JellyfishElementAlreadyExists',
-	'JellyfishNoElement',
-	'JellyfishSessionExpired',
+	'JellyfishInvalidExpression',
 	'JellyfishNoAction',
-	'JellyfishNoView',
-	'JellyfishAuthenticationError',
+	'JellyfishNoElement',
 	'JellyfishNoIdentifier',
+	'JellyfishNoView',
+	'JellyfishPermissionsError',
 	'JellyfishSchemaMismatch',
-	'JellyfishInvalidExpression'
+	'JellyfishSessionExpired',
+	'JellyfishUnknownCardType'
 ], (error) => {
 	exports[error] = typedErrors.makeTypedError(error)
 })

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -92,7 +92,8 @@ module.exports = class Kernel {
 		await Promise.all([
 			unsafeUpsert(CARDS.type),
 			unsafeUpsert(CARDS.session),
-			unsafeUpsert(CARDS.user)
+			unsafeUpsert(CARDS.user),
+			unsafeUpsert(CARDS['view-read-user-admin'])
 		])
 
 		const adminUser = await unsafeUpsert(CARDS['user-admin'])

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -253,6 +253,11 @@ exports.getQuery = async (backend, session, schema, options) => {
 		writeMode: options.writeMode
 	})
 
+	// Users must have a role view to be able to access anything
+	if (views.length === 0) {
+		throw new errors.JellyfishPermissionsError('User must have at least 1 role or permission view')
+	}
+
 	const filters = views.map((view) => {
 		return exports.getViewSchema(view)
 	})


### PR DESCRIPTION
Adds a user specific permission for the kernel admin user

Fixes #750 

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>