### PR TITLE
core: Retrieve elements by slug using .getAll() and an index

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -267,8 +267,8 @@ const getElementBySlugFromTable = async (backend, table, slug) => {
 		cursor = await rethinkdb
 			.db(backend.database)
 			.table(table)
-			.filter({
-				slug
+			.getAll(slug, {
+				index: 'slug'
 			})
 			.limit(1)
 			.run(backend.connection)
@@ -502,6 +502,12 @@ module.exports = class Backend {
 				.db(this.database)
 				.table(table)
 				.wait()
+				.run(this.connection)
+
+			await rethinkdb
+				.db(this.database)
+				.table(table)
+				.indexCreate('slug')
 				.run(this.connection)
 
 			if (table === BUCKETS.cards) {


### PR DESCRIPTION
Turns out `.filter()` can't use indexes, and thus getting an element by
slug (a common pattern) on a big database is really, really expensive.
This gives us a ~75% improvement as far as I could see on my system.

Change-type: patch