### PR TITLE
test: Convert server .sendHook() into a generic .http() function

### DIFF
--- a/test/integration/server/helpers.js
+++ b/test/integration/server/helpers.js
@@ -26,16 +26,12 @@ exports.server = {
 		test.context.session = test.context.server.jellyfish.sessions.admin
 		test.context.guestSession = test.context.server.jellyfish.sessions.guest
 
-		test.context.sendHook = (method, provider, type, payload) => {
-			let targetUrl = `http://localhost:${test.context.server.port}/api/v2/hooks/${provider}`
-			if (type) {
-				targetUrl += `/${type}`
-			}
-
+		test.context.http = (method, uri, payload) => {
 			return new Bluebird((resolve, reject) => {
 				request({
 					method,
-					url: targetUrl,
+					baseUrl: `http://localhost:${test.context.server.port}`,
+					url: uri,
 					json: true,
 					body: payload
 				}, (error, response, body) => {

--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -703,7 +703,7 @@ ava.test.serial('Users should not be able to login as the core admin user', asyn
 })
 
 ava.test.serial('should be able to post an external event', async (test) => {
-	const result = await test.context.sendHook('POST', 'test', null, {
+	const result = await test.context.http('POST', '/api/v2/hooks/test', {
 		foo: 'bar',
 		bar: 'baz'
 	})
@@ -743,7 +743,7 @@ ava.test.serial('should be able to post an external event', async (test) => {
 })
 
 ava.test.serial('should be able to post an external event with a type', async (test) => {
-	const result = await test.context.sendHook('POST', 'test', 'foobarbaz', {
+	const result = await test.context.http('POST', '/api/v2/hooks/test/foobarbaz', {
 		foo: 'bar',
 		bar: 'baz'
 	})


### PR DESCRIPTION
Change-type: patch