### PR TITLE
Allow line breaks to be added when typing a chat message

### DIFF
--- a/lib/ui/components/AutocompleteTextarea.tsx
+++ b/lib/ui/components/AutocompleteTextarea.tsx
@@ -205,11 +205,16 @@ const SubAuto = ({
 	placeholder,
 	...props
 }: AutoProps) => {
+	const rows = Math.min(
+		(value || '').split('\n').length,
+		10,
+	);
+
 	return (
 		<Container {...props}>
 			<ReactTextareaAutocomplete
 				className={className}
-				rows={1}
+				rows={rows || 1}
 				value={value}
 				onChange={onChange}
 				onKeyPress={onKeyPress}
@@ -258,6 +263,7 @@ interface AutoState {
 }
 
 interface AutoCompleteAreaProps extends AutoProps {
+	onTextSubmit: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }
 
 class AutoCompleteArea extends React.Component<AutoCompleteAreaProps, AutoState> {
@@ -329,8 +335,10 @@ class AutoCompleteArea extends React.Component<AutoCompleteAreaProps, AutoState>
 	}
 
 	public handleOnKeyPress = (e: any) => {
-		if (this.props.onKeyPress) {
-			this.props.onKeyPress(e);
+		// If the Enter key is pressed without the shift modifier, run the submit
+		// callback
+		if (e.key === 'Enter' && !e.shiftKey && this.props.onTextSubmit) {
+			this.props.onTextSubmit(e);
 		}
 	}
 
@@ -339,7 +347,7 @@ class AutoCompleteArea extends React.Component<AutoCompleteAreaProps, AutoState>
 			value,
 			className,
 			onChange,
-			onKeyPress,
+			onTextSubmit,
 			placeholder,
 			...props
 		} = this.props;

--- a/lib/ui/lens/Timeline.tsx
+++ b/lib/ui/lens/Timeline.tsx
@@ -231,10 +231,8 @@ export class Renderer extends TailStreamer<DefaultRendererProps, RendererState> 
 		this.setState({ newMessage: e.target.value });
 	}
 
-	public handleNewMessageKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter') {
-			this.addMessage(e);
-		}
+	public handleNewMessageSubmit = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		this.addMessage(e);
 	}
 
 	public handleCheckboxToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -352,7 +350,7 @@ export class Renderer extends TailStreamer<DefaultRendererProps, RendererState> 
 							className="new-message-input"
 							value={this.state.newMessage}
 							onChange={this.handleNewMessageChange}
-							onKeyPress={this.handleNewMessageKeyPress}
+							onTextSubmit={this.handleNewMessageSubmit}
 							placeholder="Type to comment on this thread..."
 						/>
 

--- a/lib/ui/lens/support/SupportThreadTimeline.tsx
+++ b/lib/ui/lens/support/SupportThreadTimeline.tsx
@@ -247,10 +247,8 @@ export class Renderer extends TailStreamer<DefaultRendererProps, RendererState> 
 		});
 	}
 
-	public handleNewMessageKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter') {
-			this.addMessage(e);
-		}
+	public handleNewMessageSubmit = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		this.addMessage(e);
 	}
 
 	public handleCheckboxToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -382,7 +380,7 @@ export class Renderer extends TailStreamer<DefaultRendererProps, RendererState> 
 								className="new-message-input"
 								value={this.state.newMessage}
 								onChange={this.handleNewMessageChange}
-								onKeyPress={this.handleNewMessageKeyPress}
+								onTextSubmit={this.handleNewMessageSubmit}
 								placeholder={whisper ? 'Type your comment...' : 'Type your reply...'}
 							/>
 						</Box>


### PR DESCRIPTION
Fixes #398

This allows line breaks to be added, but they're not rendered as expected, as the markdown renderer ignores the line break.
I will need to follow up with a rendition version bump once
https://github.com/balena-io-modules/rendition/pull/645 is merged

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>