### PR TITLE
worker: Fix expansion concurrency issues on triggered actions

### DIFF
--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -138,9 +138,9 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object) => {
 	}
 
 	if (options.triggers) {
-		let matchCard = insertedCard
-
 		await Bluebird.map(options.triggers, async (trigger) => {
+			let matchCard = insertedCard
+
 			// Ignore triggered actions whose start date is in the future
 			if (options.currentTime < triggers.getStartDate({
 				data: trigger


### PR DESCRIPTION
We have a mutable `matchCard` variable that is either a reference to the
card on which we're processing triggered actions, or a deep clone of it
with the `target` property expanded.

Right below its declaration, we're processing triggered actions
concurrently (with `Bluebird.map`), which means that there is a
potential race condition where the `matchCard` variable will be
re-mutated to its non-expanded case after a mutation caused by another
trigger, and therefore a certain triggered action will not run.

Change-type: patch