### PR TITLE
Dockerize

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       # --unsafe-perm flag allows the postinstall script to run correctly
       - run:
           name: Install Dependencies
-          command: npm ci --unsafe-perm
+          command: npm ci --unsafe-perm && make build
 
       - run:
           name: Generate Docs

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.circleci
+.cache-loader
+.nyc_ouput
+coverage
+rethinkdb_data
+node_modules
+jellyfish-files
+docker-compose.local.yml
+Dockerfile

--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,1 +1,7 @@
 reviewers: 1
+docker:
+  builds:
+    - path: .
+      dockerfile: Dockerfile
+      docker_repo: balena/jellyfish
+      publish: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM node:dubnium as base
+
+RUN apt-get update && apt-get install make
+
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app
+COPY package-lock.json /usr/src/app
+RUN npm install
+
+COPY . /usr/src/app
+RUN make build
+
+FROM node:dubnium as test
+
+# Install rethinkdb for tests
+RUN echo "deb http://download.rethinkdb.com/apt jessie main" | tee /etc/apt/sources.list.d/rethinkdb.list && \
+		wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | apt-key add - && \
+		apt-get update && \
+		apt-get install -yq rethinkdb make
+
+# See https://crbug.com/795759
+RUN apt-get update && apt-get install -yq libgconf-2-4
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb
+
+WORKDIR /usr/src/app
+
+COPY --from=base /usr/src/app /usr/src/app
+
+RUN rethinkdb --daemon --bind all && \
+		make lint && \
+		make test-unit COVERAGE=0 && \
+		make test-integration COVERAGE=0
+
+FROM node:dubnium as runtime
+
+WORKDIR /usr/src/app
+
+COPY --from=base /usr/src/app /usr/src/app
+
+CMD [ "make", "start-server" ]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,24 @@
+version: "3"
+services:
+  web:
+    build: .
+    command: make start-server
+    ports:
+     - "8000:8000"
+    links:
+     - rethinkdb
+    volumes: [
+      ".:/usr/src/app"
+    ]
+    environment:
+     - DB_HOST=rethinkdb
+     - DB_USER=admin
+     - DB_PASSWORD=12345678
+     - NODE_ENV=debug
+  rethinkdb:
+    image: balena/balena-rethinkdb
+    environment:
+     - DB_PASSWORD=12345678
+    ports:
+     - "8080:8080"
+     - "28015:28015"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,2 @@
+version: "3"
+# Use this file to make local changes for the docker-compose setup

--- a/lib/server/config.js
+++ b/lib/server/config.js
@@ -13,10 +13,10 @@ exports.getConfig = (options = {}) => {
 		}
 		: {
 			port: options.port || 8000,
-			dbPort: 28015,
-			dbHost: 'localhost',
-			dbUser: '',
-			dbPassword: '',
+			dbPort: process.env.DB_PORT || 28015,
+			dbHost: process.env.DB_HOST || 'localhost',
+			dbUser: process.env.DB_USER || '',
+			dbPassword: process.env.DB_PASSWORD || '',
 			dbCert: null,
 			actionsUsername: 'actions',
 			actionsPassword: 'test',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5982,6 +5982,7 @@
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6044,7 +6045,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -6332,12 +6334,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -6413,7 +6417,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -16378,6 +16383,12 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
       "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+    },
+    "supervisor": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/supervisor/-/supervisor-0.12.0.tgz",
+      "integrity": "sha1-3n5jNwFbKRhRwQ81OMSn8EkX7ME=",
+      "dev": true
     },
     "supports-color": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "start": "make start-server",
+    "start-dev": "make start-dev-server",
     "test": "make lint test",
-    "postinstall": "make build",
     "heroku-postbuild": "npm install -g redoc-cli && make dist/docs.html"
   },
   "ava": {
@@ -63,6 +63,7 @@
     "puppeteer": "^1.6.2",
     "request": "^2.85.0",
     "source-map-loader": "^0.2.3",
+    "supervisor": "^0.12.0",
     "thread-loader": "^1.1.5",
     "ts-loader": "^4.0.1",
     "ts-node": "^6.0.0",

--- a/scripts/scrub-test-databases.js
+++ b/scripts/scrub-test-databases.js
@@ -2,6 +2,7 @@
 
 const Promise = require('bluebird')
 const rethinkdb = require('rethinkdb')
+const _ = require('lodash')
 const Spinner = require('cli-spinner').Spinner
 
 // Removes rethinkdb databases that are prefixed with `test_`
@@ -10,7 +11,9 @@ const scrub = async () => {
 
 	spinner.start()
 
-	const connection = await rethinkdb.connect(this.options)
+	const connection = await rethinkdb.connect(_.merge({
+		host: process.env.JF_RETHINKDB_SERVICE_HOST || process.env.DB_HOST || 'localhost'
+	}, this.options))
 
 	const list = await rethinkdb
 		.dbList()


### PR DESCRIPTION
This creates a docker image (`balena/jellyfish`) for JF, using the balenaCI.
During the build process the image is created, tested and pushed to the registry.
This also adds a docker-compose file to run JF and a rethinkdb instance using docker compose.