### PR TITLE
circleci: Ignore VersionBot build branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ dependencies:
   pre:
 jobs:
   build:
+    branches:
+      ignore:
+        - /(.*)-build-[a-f0-9]{40}$/
     docker:
       - image: resinci/jellyfish-test
 


### PR DESCRIPTION
Like `112-jsonnet-build-9d000165b319e56bf2e6edf893fb249d3da29c07`.

Change-type: patch