### PR TITLE
makefile: Add a target to build the dist directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ else
 COVERAGE_COMMAND =
 endif
 
+dist:
+	mkdir $@
+
 dist/docs.html: lib/server/api.yaml | dist
 	redoc-cli bundle -o $@ $<
 


### PR DESCRIPTION
If its not there, then the Makefile will try to find a rule for it given
`dist/docs.html` and fail.

Change-type: patch