### PR TITLE
prevent circle build from running on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     branches:
       ignore:
         - /(.*)-build-[a-f0-9]{40}$/
+        - master
     docker:
       - image: resinci/jellyfish-test
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>