### PR TITLE
core: Add non-production runtime assertions on kernel getters

### DIFF
--- a/lib/core/assert.js
+++ b/lib/core/assert.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require('lodash')
+const assert = require('assert')
+
+// This will be evaluated once, and then
+// cached by the module system, so future
+// requires won't have to do this check
+
+if (process.env.NODE_ENV === 'production') {
+	for (const fn of Object.keys(assert)) {
+		exports[fn] = _.noop
+	}
+} else {
+	module.exports = assert
+}

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -16,6 +16,7 @@
 
 const logger = require('../logger').getLogger('jellyfish:kernel')
 const _ = require('lodash')
+const assert = require('./assert')
 const jsonSchema = require('./json-schema')
 const errors = require('./errors')
 const CARDS = require('./cards')
@@ -205,6 +206,7 @@ module.exports = class Kernel {
 			ctx: options.ctx
 		})
 
+		assert.ok(results.length <= 1, `More than one card with id ${id}`)
 		return results[0] || null
 	}
 
@@ -266,6 +268,7 @@ module.exports = class Kernel {
 			ctx: options.ctx
 		})
 
+		assert.ok(results.length <= 1, `More than one card with slug ${slug}`)
 		return results[0] || null
 	}
 


### PR DESCRIPTION
This asserts system can be used for cases that the server can recover
from, but that shouldn't happen in the first place. The assertions will
only run during testing/development and will NOT run in production.

In this case, if two cards have the same ids or slugs, then the server
will be fine with it by just returning the first one, while throwing
would crash the whole system. We still want to catch these cases on our
test runs.

Change-type: patch