### PR TITLE
Expose the card type in `create` card payload

### DIFF
--- a/default-cards/contrib/update.json
+++ b/default-cards/contrib/update.json
@@ -29,6 +29,10 @@
             "payload": {
               "type": "object",
               "properties": {
+                "type": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]+$"
+                },
                 "slug": {
                   "type": "string",
                   "pattern": "^[a-z0-9-]+$"

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -132,7 +132,7 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object) => {
 			card: insertedCard.id,
 			arguments: {
 				type: eventName,
-				payload: _.omit(evaluationResult, [ 'type', 'id' ])
+				payload: _.omit(evaluationResult, [ 'id' ])
 			}
 		})
 	}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "timeout": "5m",
     "verbose": true,
     "concurrency": 3,
-    "failFast": true,
+    "failFast": false,
     "files": [
       "test/unit/**/*.spec.js",
       "test/integration/**/*.spec.js"

--- a/test/unit/action-library/integrations/front/inbound-archive-message/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-archive-message/expected.json
@@ -69,6 +69,7 @@
         "timestamp": "2018-10-10T22:22:30.285Z",
         "payload": {
           "name": "Archive message",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],
@@ -99,6 +100,7 @@
         "timestamp": "2018-10-10T22:22:37.849Z",
         "payload": {
           "name": "Archive message",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],
@@ -144,7 +146,8 @@
             "alertsUser": [],
             "description": "",
             "status": "open"
-          }
+          },
+          "type": "support-thread"
         }
       }
     }

--- a/test/unit/action-library/integrations/front/inbound-archive-unarchive/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-archive-unarchive/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-10-08T18:49:54.763Z",
         "payload": {
           "name": "Unarchive",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],
@@ -61,6 +62,7 @@
         "timestamp": "2018-10-08T18:50:09.298Z",
         "payload": {
           "name": "Unarchive",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],
@@ -106,7 +108,8 @@
             "alertsUser": [],
             "description": "",
             "status": "open"
-          }
+          },
+          "type": "support-thread"
         }
       }
     }

--- a/test/unit/action-library/integrations/front/inbound-archive/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-archive/expected.json
@@ -50,6 +50,7 @@
         "timestamp": "2018-10-08T18:32:44.690Z",
         "payload": {
           "name": "open-close",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],
@@ -80,6 +81,7 @@
         "timestamp": "2018-10-08T18:33:08.140Z",
         "payload": {
           "name": "open-close",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-comment-comment/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-comment-comment/expected.json
@@ -69,6 +69,7 @@
         "timestamp": "2018-10-08T18:42:29.447Z",
         "payload": {
           "name": "Send me a comment",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-delay-message-cancel/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-delay-message-cancel/expected.json
@@ -50,6 +50,7 @@
         "timestamp": "2018-10-10T22:19:18.154Z",
         "payload": {
           "name": "Delay cancel",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-delay-message/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-delay-message/expected.json
@@ -69,6 +69,7 @@
         "timestamp": "2018-10-10T21:39:51.388Z",
         "payload": {
           "name": "Delay me!",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-delete-message/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-delete-message/expected.json
@@ -84,7 +84,8 @@
             "alertsUser": [],
             "description": "",
             "status": "open"
-          }
+          },
+          "type": "support-thread"
         }
       }
     },
@@ -114,7 +115,8 @@
             "alertsUser": [],
             "description": "",
             "status": "archived"
-          }
+          },
+          "type": "support-thread"
         }
       }
     },
@@ -129,6 +131,7 @@
         "timestamp": "2018-10-10T22:29:00.113Z",
         "payload": {
           "name": "Delete message test",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-delete-undelete/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-delete-undelete/expected.json
@@ -46,7 +46,8 @@
             "alertsUser": [],
             "description": "",
             "status": "open"
-          }
+          },
+          "type": "support-thread"
         }
       }
     },
@@ -76,7 +77,8 @@
             "alertsUser": [],
             "description": "",
             "status": "archived"
-          }
+          },
+          "type": "support-thread"
         }
       }
     },
@@ -91,6 +93,7 @@
         "timestamp": "2018-10-08T18:51:29.916Z",
         "payload": {
           "name": "Undelete",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-delete/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-delete/expected.json
@@ -50,6 +50,7 @@
         "timestamp": "2018-10-08T18:35:21.954Z",
         "payload": {
           "name": "Inbound delete",
+          "type": "support-thread",
           "active": true,
           "tags": [],
           "version": "1.0.0",
@@ -80,6 +81,7 @@
         "timestamp": "2018-10-08T18:35:32.544Z",
         "payload": {
           "name": "Inbound delete",
+          "type": "support-thread",
           "active": true,
           "tags": [],
           "version": "1.0.0",

--- a/test/unit/action-library/integrations/front/inbound-inbound-inbound/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-inbound-inbound/expected.json
@@ -69,6 +69,7 @@
         "timestamp": "2018-10-08T18:39:45.162Z",
         "payload": {
           "name": "Multiple in a row",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-message/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-message/expected.json
@@ -69,6 +69,7 @@
         "timestamp": "2018-10-10T22:13:52.817Z",
         "payload": {
           "name": "Test Reply",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-no-body/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-no-body/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-10-08T18:38:50.061Z",
         "payload": {
           "name": "No body",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-snooze-cancel/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-snooze-cancel/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-10-10T21:34:20.263Z",
         "payload": {
           "name": "Snooze cancel",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -61,6 +62,7 @@
         "timestamp": "2018-10-10T21:34:27.674Z",
         "payload": {
           "name": "Snooze cancel",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -91,6 +93,7 @@
         "timestamp": "2018-10-10T21:34:32.255Z",
         "payload": {
           "name": "Snooze cancel",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-snooze/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-snooze/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-10-10T21:35:21.998Z",
         "payload": {
           "name": "Snooze me",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -61,6 +62,7 @@
         "timestamp": "2018-10-10T21:35:33.868Z",
         "payload": {
           "name": "Snooze me",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/inbound-tag-tag/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-tag-tag/expected.json
@@ -4,7 +4,10 @@
     "type": "support-thread",
     "version": "1.0.0",
     "active": true,
-    "tags": [ "foo", "bar" ],
+    "tags": [
+      "foo",
+      "bar"
+    ],
     "requires": [],
     "capabilities": [],
     "data": {
@@ -50,6 +53,7 @@
         "timestamp": "2018-10-08T18:36:28.538Z",
         "payload": {
           "name": "Inbound tag",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -80,9 +84,12 @@
         "timestamp": "2018-10-08T18:36:48.985Z",
         "payload": {
           "name": "Inbound tag",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
-          "tags": [ "foo" ],
+          "tags": [
+            "foo"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {
@@ -110,9 +117,13 @@
         "timestamp": "2018-10-08T18:37:01.634Z",
         "payload": {
           "name": "Inbound tag",
+          "type": "support-thread",
           "version": "1.0.0",
           "active": true,
-          "tags": [ "foo", "bar" ],
+          "tags": [
+            "foo",
+            "bar"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {

--- a/test/unit/action-library/integrations/front/inbound-tag-untag/expected.json
+++ b/test/unit/action-library/integrations/front/inbound-tag-untag/expected.json
@@ -50,6 +50,7 @@
         "timestamp": "2018-10-08T18:37:50.787Z",
         "payload": {
           "name": "Tag untag",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -80,9 +81,12 @@
         "timestamp": "2018-10-08T18:37:58.816Z",
         "payload": {
           "name": "Tag untag",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
-          "tags": [ "foo" ],
+          "tags": [
+            "foo"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {
@@ -110,6 +114,7 @@
         "timestamp": "2018-10-08T18:38:05.068Z",
         "payload": {
           "name": "Tag untag",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/front/outbound/expected.json
+++ b/test/unit/action-library/integrations/front/outbound/expected.json
@@ -50,6 +50,7 @@
         "timestamp": "2018-10-10T22:09:21.921Z",
         "payload": {
           "name": "Outbound test",
+          "type": "support-thread",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/github/issue-close-comment/expected.json
+++ b/test/unit/action-library/integrations/github/issue-close-comment/expected.json
@@ -50,6 +50,7 @@
         "timestamp": "2018-09-26T17:54:37Z",
         "payload": {
           "name": "Comment on closed issue",
+          "type": "issue",
           "version": "1.0.0",
           "active": true,
           "tags": [],
@@ -80,6 +81,7 @@
         "timestamp": "2018-09-26T17:56:59Z",
         "payload": {
           "name": "Comment on closed issue",
+          "type": "issue",
           "version": "1.0.0",
           "active": true,
           "tags": [],

--- a/test/unit/action-library/integrations/github/issue-close-label-toggle/expected.json
+++ b/test/unit/action-library/integrations/github/issue-close-label-toggle/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-09-27T14:29:09Z",
         "payload": {
           "name": "Issue close label toggle",
+          "type": "issue",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -61,6 +62,7 @@
         "timestamp": "2018-09-27T14:30:19Z",
         "payload": {
           "name": "Issue close label toggle",
+          "type": "issue",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -91,9 +93,12 @@
         "timestamp": "2018-09-27T14:31:38Z",
         "payload": {
           "name": "Issue close label toggle",
+          "type": "issue",
           "active": true,
           "version": "1.0.0",
-          "tags": [ "chore" ],
+          "tags": [
+            "chore"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {
@@ -121,6 +126,7 @@
         "timestamp": "2018-09-27T14:32:50Z",
         "payload": {
           "name": "Issue close label toggle",
+          "type": "issue",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/github/issue-closed-with-comment/expected.json
+++ b/test/unit/action-library/integrations/github/issue-closed-with-comment/expected.json
@@ -65,7 +65,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -95,7 +96,8 @@
             "description": "",
             "status": "closed",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-comment-edit-with-missing-ref/expected.json
+++ b/test/unit/action-library/integrations/github/issue-comment-edit-with-missing-ref/expected.json
@@ -65,7 +65,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-comment-edit/expected.json
+++ b/test/unit/action-library/integrations/github/issue-comment-edit/expected.json
@@ -65,7 +65,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-delete-comment-with-missing-ref-which-is-still-returned/expected.json
+++ b/test/unit/action-library/integrations/github/issue-delete-comment-with-missing-ref-which-is-still-returned/expected.json
@@ -84,7 +84,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-delete-comment-with-missing-ref/expected.json
+++ b/test/unit/action-library/integrations/github/issue-delete-comment-with-missing-ref/expected.json
@@ -65,7 +65,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-delete-comment/expected.json
+++ b/test/unit/action-library/integrations/github/issue-delete-comment/expected.json
@@ -65,7 +65,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-delete-second-comment-with-missing-ref/expected.json
+++ b/test/unit/action-library/integrations/github/issue-delete-second-comment-with-missing-ref/expected.json
@@ -84,7 +84,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-delete-second-comment/expected.json
+++ b/test/unit/action-library/integrations/github/issue-delete-second-comment/expected.json
@@ -84,7 +84,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-edit-body/expected.json
+++ b/test/unit/action-library/integrations/github/issue-edit-body/expected.json
@@ -46,7 +46,8 @@
             "description": "Initial body",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -76,7 +77,8 @@
             "description": "Updated body",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-edit-second-comment-with-missing-ref/expected.json
+++ b/test/unit/action-library/integrations/github/issue-edit-second-comment-with-missing-ref/expected.json
@@ -84,7 +84,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-edit-second-comment/expected.json
+++ b/test/unit/action-library/integrations/github/issue-edit-second-comment/expected.json
@@ -84,7 +84,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-edit-title/expected.json
+++ b/test/unit/action-library/integrations/github/issue-edit-title/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -76,7 +77,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-close-open/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-close-open/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -76,7 +77,8 @@
             "description": "",
             "status": "closed",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -106,7 +108,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-close/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-close/expected.json
@@ -46,7 +46,8 @@
             "description": "Foo Bar",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -76,7 +77,8 @@
             "description": "Foo Bar",
             "status": "closed",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-label-toggle/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-label-toggle/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -63,7 +64,9 @@
           "name": "Issue label removal",
           "version": "1.0.0",
           "active": true,
-          "tags": [ "bug" ],
+          "tags": [
+            "bug"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {
@@ -76,7 +79,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     },
@@ -106,7 +110,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-with-assignee/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-with-assignee/expected.json
@@ -46,7 +46,8 @@
             "description": "Hello",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-with-comments/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-with-comments/expected.json
@@ -84,7 +84,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-with-labels/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-with-labels/expected.json
@@ -4,7 +4,10 @@
     "type": "issue",
     "version": "1.0.0",
     "active": true,
-    "tags": [ "core", "good first issue" ],
+    "tags": [
+      "core",
+      "good first issue"
+    ],
     "requires": [],
     "capabilities": [],
     "data": {
@@ -33,7 +36,10 @@
           "name": "Issue with labels",
           "active": true,
           "version": "1.0.0",
-          "tags": [ "core", "good first issue" ],
+          "tags": [
+            "core",
+            "good first issue"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {
@@ -46,7 +52,8 @@
             "description": "Foo Bar",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-without-body-lowercase-headers/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-without-body-lowercase-headers/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/issue-open-without-body/expected.json
+++ b/test/unit/action-library/integrations/github/issue-open-without-body/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "issue"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/pr-approve-merge/expected.json
+++ b/test/unit/action-library/integrations/github/pr-approve-merge/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-10-10T10:34:00Z",
         "payload": {
           "name": "Test PR",
+          "type": "pull-request",
           "active": true,
           "version": "1.0.0",
           "tags": [],
@@ -61,6 +62,7 @@
         "timestamp": "2018-10-10T10:44:15Z",
         "payload": {
           "name": "Test PR",
+          "type": "pull-request",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/github/pr-changes-requested/expected.json
+++ b/test/unit/action-library/integrations/github/pr-changes-requested/expected.json
@@ -31,6 +31,7 @@
         "timestamp": "2018-10-10T10:04:00Z",
         "payload": {
           "name": "Open close PR",
+          "type": "pull-request",
           "active": true,
           "version": "1.0.0",
           "tags": [],

--- a/test/unit/action-library/integrations/github/pr-comment/expected.json
+++ b/test/unit/action-library/integrations/github/pr-comment/expected.json
@@ -65,7 +65,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/pr-inline-comment/expected.json
+++ b/test/unit/action-library/integrations/github/pr-inline-comment/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/pr-label/expected.json
+++ b/test/unit/action-library/integrations/github/pr-label/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     },
@@ -63,7 +64,9 @@
           "name": "PR labels",
           "version": "1.0.0",
           "active": true,
-          "tags": [ "core" ],
+          "tags": [
+            "core"
+          ],
           "requires": [],
           "capabilities": [],
           "data": {
@@ -76,7 +79,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     },
@@ -106,7 +110,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/pr-open-close/expected.json
+++ b/test/unit/action-library/integrations/github/pr-open-close/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     },
@@ -76,7 +77,8 @@
             "description": "",
             "status": "closed",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     }

--- a/test/unit/action-library/integrations/github/pr-review-request/expected.json
+++ b/test/unit/action-library/integrations/github/pr-review-request/expected.json
@@ -46,7 +46,8 @@
             "description": "",
             "status": "open",
             "archived": false
-          }
+          },
+          "type": "pull-request"
         }
       }
     }

--- a/test/unit/worker/executor.spec.js
+++ b/test/unit/worker/executor.spec.js
@@ -288,6 +288,7 @@ ava('.insertCard() should add a create event if attachEvents is true', async (te
 				type: 'create',
 				payload: {
 					slug: 'foo-bar-baz',
+					type: 'card',
 					version: '1.0.0',
 					active: true,
 					links: {},
@@ -322,6 +323,7 @@ ava('.insertCard() should add a create event not overriding even if override is 
 				type: 'create',
 				payload: {
 					slug: 'foo-bar-baz',
+					type: 'card',
 					version: '1.0.0',
 					active: true,
 					links: {},
@@ -364,6 +366,7 @@ ava('.insertCard() should add an update event if attachEvents is true and overri
 				payload: {
 					slug: 'foo-bar-baz',
 					version: '1.0.0',
+					type: 'card',
 					active: false,
 					links: {},
 					markers: [],
@@ -431,6 +434,7 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 				payload: {
 					active: true,
 					version: '1.0.0',
+					type: 'card',
 					slug: 'foo',
 					links: {},
 					markers: [],
@@ -510,6 +514,7 @@ ava('.insertCard() should not execute non-matching triggered actions', async (te
 				payload: {
 					active: true,
 					version: '1.0.0',
+					type: 'card',
 					slug: 'foo',
 					links: {},
 					markers: [],
@@ -605,6 +610,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 				payload: {
 					active: true,
 					version: '1.0.0',
+					type: 'card',
 					slug: 'foo',
 					links: {},
 					markers: [],
@@ -722,6 +728,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 				payload: {
 					version: '1.0.0',
 					active: true,
+					type: 'card',
 					slug: 'foo',
 					links: {},
 					markers: [],

--- a/test/unit/worker/index.spec.js
+++ b/test/unit/worker/index.spec.js
@@ -1980,6 +1980,7 @@ ava('should add an update event if updating a card', async (test) => {
 				payload: {
 					active: true,
 					slug: 'foo',
+					type: 'card',
 					version: '1.0.0',
 					links: timeline[0].data.payload.links,
 					tags: [],
@@ -2010,9 +2011,10 @@ ava('should add an update event if updating a card', async (test) => {
 				target: createResult.data.id,
 				timestamp: timeline[1].data.timestamp,
 				payload: {
-					slug: 'foo',
-					version: '1.0.0',
 					active: true,
+					slug: 'foo',
+					type: 'card',
+					version: '1.0.0',
 					links: timeline[1].data.payload.links,
 					tags: [],
 					markers: [],


### PR DESCRIPTION
This allows us to create triggered actions that will run when a card of
a specific type is created.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>