### PR TITLE
test: Use the worker to process action library import actions

### DIFF
--- a/test/unit/action-library/front.spec.js
+++ b/test/unit/action-library/front.spec.js
@@ -21,7 +21,7 @@ const helpers = require('./helpers')
 ava.beforeEach(helpers.integrations.beforeEach)
 ava.afterEach(helpers.integrations.afterEach)
 
-helpers.integrations.scenario(ava, {
+helpers.integrations.scenario(process.env.INTEGRATION_FRONT_TOKEN ? ava : ava.skip, {
 	integration: require('../../../lib/action-library/integrations/front'),
 	scenarios: require('./integrations/front'),
 	slices: _.range(0, 2),
@@ -29,7 +29,7 @@ helpers.integrations.scenario(ava, {
 	stubRegex: /^\/conversations\/.+\/(messages|inboxes)$/,
 	source: 'front',
 	options: {
-		token: 'xxxxxxxxxxxxxxxxxx'
+		token: process.env.INTEGRATION_FRONT_TOKEN
 	},
 	isAuthorized: (self, request) => {
 		return request.headers.authorization === `Bearer ${self.options.token}`

--- a/test/unit/action-library/github.spec.js
+++ b/test/unit/action-library/github.spec.js
@@ -21,7 +21,7 @@ const helpers = require('./helpers')
 ava.beforeEach(helpers.integrations.beforeEach)
 ava.afterEach(helpers.integrations.afterEach)
 
-helpers.integrations.scenario(ava, {
+helpers.integrations.scenario(process.env.INTEGRATION_GITHUB_TOKEN ? ava : ava.skip, {
 	integration: require('../../../lib/action-library/integrations/github'),
 	scenarios: require('./integrations/github'),
 	slices: _.range(0, 3),
@@ -29,7 +29,7 @@ helpers.integrations.scenario(ava, {
 	stubRegex: /^\/repos\/.+\/.+\/issues\/\d+\/comments$/,
 	source: 'github',
 	options: {
-		token: 'xxxxxxxxxxxxxxxxxx'
+		token: process.env.INTEGRATION_GITHUB_TOKEN
 	},
 	isAuthorized: (self, request) => {
 		return request.headers.authorization &&

--- a/test/unit/worker/helpers.js
+++ b/test/unit/worker/helpers.js
@@ -34,6 +34,8 @@ exports.jellyfish = {
 		await test.context.jellyfish.insertCard(test.context.session,
 			require('../../../default-cards/contrib/message.json'))
 		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/account.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
 			require('../../../default-cards/contrib/triggered-action.json'))
 		await test.context.jellyfish.insertCard(test.context.session,
 			require('../../../default-cards/contrib/action-create-card.json'))


### PR DESCRIPTION
We were previously calling the `lib/action-library/sync.js` module
directly, so we where not testing some extra code that lives in the
import actions (mainly to validate who is creating the actual cards in
the system).

Change-type: patch