### PR TITLE
Improve view data loading behaviour

### DIFF
--- a/lib/ui/lens/View.tsx
+++ b/lib/ui/lens/View.tsx
@@ -215,7 +215,7 @@ class ViewRenderer extends React.Component<ViewRendererProps, ViewRendererState>
 		}
 
 		this.setState({ filters });
-	}, 750);
+	}, 350);
 
 	public loadViewWithFilters(view: Card, filters: JSONSchema6[]): void {
 		const syntheticViewCard = _.cloneDeep(view);
@@ -232,6 +232,7 @@ class ViewRenderer extends React.Component<ViewRendererProps, ViewRendererState>
 			});
 		});
 
+		this.props.actions.clearViewData(syntheticViewCard);
 		this.props.actions.loadViewResults(syntheticViewCard);
 		this.props.actions.streamView(syntheticViewCard);
 	}


### PR DESCRIPTION
Fixes #971

- Only store data in redux if its the most recent request from a view
- Clear view data whilst waiting for query results
- Decrease debounce timeout

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>