### PR TITLE
fix: Test helper was failing when GH token is not available

### DIFF
--- a/test/unit/action-library/helpers.js
+++ b/test/unit/action-library/helpers.js
@@ -163,6 +163,9 @@ exports.integrations = {
 	},
 
 	scenario: async (ava, suite) => {
+		if (!_.isFunction(ava.serial)) {
+			return
+		}
 		for (const testCaseName of Object.keys(suite.scenarios)) {
 			const testCase = suite.scenarios[testCaseName]
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Andreas Fitzek <andreas@resin.io>