### PR TITLE
worker: Extract DB queue related functionality into lib/queue

### DIFF
--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -15,7 +15,6 @@
  */
 
 const Bluebird = require('bluebird')
-const utils = require('./utils')
 
 /**
  * @summary The execution event card type slug
@@ -61,8 +60,9 @@ const EXECUTION_EVENT_TYPE = 'execute'
  * console.log(card.id)
  */
 exports.post = async (jellyfish, session, options, results, ctx) => {
+	const date = new Date()
 	const data = {
-		timestamp: utils.getCurrentTimestamp(),
+		timestamp: date.toISOString(),
 		target: options.action,
 		actor: options.actor,
 		payload: {
@@ -76,7 +76,7 @@ exports.post = async (jellyfish, session, options, results, ctx) => {
 
 	const contents = {
 		type: EXECUTION_EVENT_TYPE,
-		slug: utils.getEventSlug(EXECUTION_EVENT_TYPE, data),
+		slug: `${EXECUTION_EVENT_TYPE}-${data.actor}-${date.valueOf()}`,
 		version: '1.0.0',
 		active: true,
 		links: {},

--- a/lib/queue/index.js
+++ b/lib/queue/index.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use jellyfish file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const events = require('./events')
+
+/**
+ * @summary Wait for an action request results
+ * @function
+ * @public
+ *
+ * @param {Object} jellyfish - jellyfish instance
+ * @param {String} session - session id
+ * @param {Object} options - options
+ * @param {String} options.actor - actor id
+ * @param {String} options.action - action id
+ * @param {String} options.card - action input card id
+ * @returns {Object} results
+ *
+ * @example
+ * const session = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+ * const results = await queue.waitResults(jellyfish, session, {
+ *   action: '57692206-8da2-46e1-91c9-159b2c6928ef',
+ *   card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+ *   actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+ * })
+ *
+ * console.log(results.data)
+ */
+exports.waitResults = async (jellyfish, session, options) => {
+	const request = await events.wait(jellyfish, session, options)
+	if (!request) {
+		throw new Error(`Request not found: ${JSON.stringify(request, null, 2)}`)
+	}
+
+	return {
+		error: request.data.payload.error,
+		timestamp: request.data.payload.timestamp,
+		data: request.data.payload.data
+	}
+}
+
+/**
+ * @summary Post execution results
+ * @function
+ * @public
+ *
+ * @param {Object} jellyfish - jellyfish instance
+ * @param {String} session - session id
+ * @param {Object} options - options
+ * @param {String} options.id - request id
+ * @param {String} options.actor - actor id
+ * @param {String} options.action - action id
+ * @param {String} options.timestamp - action timestamp
+ * @param {String} options.card - action input card id
+ * @param {String} [options.originator] - action originator card id
+ * @param {Object} results - action results
+ * @param {Boolean} results.error - whether the result is an error
+ * @param {Any} results.data - action result
+ * @returns {Object} event card
+ *
+ * @example
+ * const session = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+ * const card = await queue.postResults(jellyfish, session, {
+ *   id: '414f2345-4f5e-4571-820f-28a49731733d',
+ *   action: '57692206-8da2-46e1-91c9-159b2c6928ef',
+ *   card: '033d9184-70b2-4ec9-bc39-9a249b186422',
+ *   actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
+ *   originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+ *   timestamp: '2018-06-30T19:34:42.829Z'
+ * }, {
+ *   error: false,
+ *   data: '414f2345-4f5e-4571-820f-28a49731733d'
+ * })
+ *
+ * console.log(card.id)
+ */
+exports.postResults = events.post
+
+/**
+ * @summary Get the last execution event given an originator
+ * @function
+ * @public
+ *
+ * @param {Object} jellyfish - jellyfish instance
+ * @param {String} session - session id
+ * @param {String} originator - originator card id
+ * @param {Object} ctx - execution context
+ * @returns {(Object|Null)} last execution event
+ *
+ * @example
+ * const originator = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
+ *
+ * const executeEvent = await queue.getLastExecutionEvent(jellyfish, session, originator)
+ * if (executeEvent) {
+ *   console.log(executeEvent.data.timestamp)
+ * }
+ */
+exports.getLastExecutionEvent = events.getLastExecutionEvent

--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -17,6 +17,7 @@
 const Bluebird = require('bluebird')
 const randomstring = require('randomstring')
 const sync = require('../sync')
+const queue = require('../queue')
 const logger = require('../logger').getLogger('jellyfish:http')
 const context = require('../logger/context')
 const fs = require('fs')
@@ -280,7 +281,7 @@ exports.bindRoutes = (jellyfish, worker, app, socketServer) => {
 		}
 
 		return worker.enqueue(request.sessionToken, action, ctx).then((id) => {
-			return worker.waitResults(request.sessionToken, id)
+			return queue.waitResults(jellyfish, request.sessionToken, id)
 		}).then(async (results) => {
 			if (!results.error && request.files) {
 				const cardId = results.data.id

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -17,13 +17,13 @@
 const Bluebird = require('bluebird')
 const _ = require('lodash')
 const uuid = require('uuid/v4')
-const events = require('./events')
 const errors = require('./errors')
 const executor = require('./executor')
 const utils = require('./utils')
 const triggers = require('./triggers')
 const MemoryQueue = require('./memory-queue')
 const jellyscript = require('../jellyscript')
+const queue = require('../queue')
 const ctx = require('../logger/context')
 
 module.exports = class Worker {
@@ -400,7 +400,7 @@ module.exports = class Worker {
 			}
 		})
 
-		await events.post(this.jellyfish, session, {
+		await queue.postResults(this.jellyfish, session, {
 			id: request.id,
 			action: request.action.id,
 			originator: request.originator,
@@ -410,42 +410,6 @@ module.exports = class Worker {
 		}, result, execCtx)
 
 		return result
-	}
-
-	/**
-	 * @summary Wait for an action request results
-	 * @function
-	 * @public
-	 *
-	 * @param {String} session - session id
-	 * @param {Object} options - options
-	 * @param {String} options.actor - actor id
-	 * @param {String} options.action - action id
-	 * @param {String} options.card - action input card id
-	 * @returns {Object} results
-	 *
-	 * @example
-	 * const worker = new Worker({ ... })
-	 * const session = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
-	 * const results = await worker.waitResults(jellyfish, session, {
-	 *   action: '57692206-8da2-46e1-91c9-159b2c6928ef',
-	 *   card: '033d9184-70b2-4ec9-bc39-9a249b186422',
-	 *   actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
-	 * })
-	 *
-	 * console.log(results.data)
-	 */
-	async waitResults (session, options) {
-		const request = await events.wait(this.jellyfish, session, options, this.getExecutionContext())
-		if (!request) {
-			throw new Error(`Request not found: ${JSON.stringify(request, null, 2)}`)
-		}
-
-		return {
-			error: request.data.payload.error,
-			timestamp: request.data.payload.timestamp,
-			data: request.data.payload.data
-		}
 	}
 
 	/**
@@ -483,7 +447,7 @@ module.exports = class Worker {
 				return null
 			}
 
-			const lastExecutionEvent = await events.getLastExecutionEvent(
+			const lastExecutionEvent = await queue.getLastExecutionEvent(
 				this.jellyfish, session, trigger.id, this.getExecutionContext())
 			const nextExecutionDate = triggers.getNextExecutionDate({
 				data: trigger

--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -19,6 +19,7 @@ const Bluebird = require('bluebird')
 const _ = require('lodash')
 const randomstring = require('randomstring')
 const helpers = require('../sdk/helpers')
+const queue = require('../../../lib/queue')
 
 ava.before(helpers.sdk.beforeEach)
 ava.after(helpers.sdk.afterEach)
@@ -713,7 +714,8 @@ if (process.env.NODE_ENV === 'production') {
 		test.is(result.code, 200)
 		test.false(result.response.error)
 
-		const requestResult = await test.context.server.worker.waitResults(test.context.session, result.response.data)
+		const requestResult = await queue.waitResults(
+			test.context.jellyfish, test.context.session, result.response.data)
 
 		test.false(requestResult.error)
 		const card = await test.context.jellyfish.getCardById(test.context.session, requestResult.data.id)
@@ -755,7 +757,8 @@ if (process.env.NODE_ENV === 'production') {
 		test.is(result.code, 200)
 		test.false(result.response.error)
 
-		const requestResult = await test.context.server.worker.waitResults(test.context.session, result.response.data)
+		const requestResult = await queue.waitResults(
+			test.context.jellyfish, test.context.session, result.response.data)
 
 		test.false(requestResult.error)
 		const card = await test.context.jellyfish.getCardById(test.context.session, requestResult.data.id)

--- a/test/integration/sync/helpers.js
+++ b/test/integration/sync/helpers.js
@@ -20,6 +20,7 @@ const path = require('path')
 const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 const syncHelpers = require('../../unit/sync/helpers')
+const queue = require('../../../lib/queue')
 
 const webhookScenario = async (test, testCase, integration, stub) => {
 	await nock(stub.baseUrl)
@@ -63,7 +64,8 @@ const webhookScenario = async (test, testCase, integration, stub) => {
 		})
 
 		await test.context.flush(test.context.session)
-		const result = await test.context.worker.waitResults(test.context.session, request)
+		const result = await queue.waitResults(
+			test.context.jellyfish, test.context.session, request)
 		test.false(result.error)
 		cards.push(...result.data)
 	}

--- a/test/unit/queue/events.spec.js
+++ b/test/unit/queue/events.spec.js
@@ -17,7 +17,7 @@
 const ava = require('ava')
 const Bluebird = require('bluebird')
 const helpers = require('./helpers')
-const events = require('../../../lib/worker/events')
+const events = require('../../../lib/queue/events')
 
 ava.beforeEach(helpers.jellyfish.beforeEach)
 ava.afterEach(helpers.jellyfish.afterEach)

--- a/test/unit/queue/helpers.js
+++ b/test/unit/queue/helpers.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const helpers = require('../core/helpers')
+
+exports.jellyfish = {
+	beforeEach: async (test) => {
+		await helpers.jellyfish.beforeEach(test)
+		test.context.session = test.context.jellyfish.sessions.admin
+
+		const session = await test.context.jellyfish.getCardById(test.context.session, test.context.session)
+		test.context.actor = await test.context.jellyfish.getCardById(test.context.session, session.data.actor)
+
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/execute.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/create.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/update.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/message.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/account.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/triggered-action.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-create-card.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-create-event.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-set-add.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-create-user.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-create-session.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-update-card.json'))
+		await test.context.jellyfish.insertCard(test.context.session,
+			require('../../../default-cards/contrib/action-delete-card.json'))
+	},
+
+	afterEach: async (test) => {
+		await helpers.jellyfish.afterEach(test)
+	}
+}


### PR DESCRIPTION
As a starting point to centralize the action queue and be able to have
more than one worker in the system.

Change-type: patch