### PR TITLE
Fix permission filter construction for multiple roles

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -174,7 +174,6 @@ exports.getViews = async (backend, roles, ctx) => {
  * @private
  *
  * @param {Object} card - view card
- * @param {Object} ctx - execution context
  * @returns {(Object|Null)} schema
  *
  * @example
@@ -182,7 +181,7 @@ exports.getViews = async (backend, roles, ctx) => {
  * const schema = permissionFilter.getViewSchema(card)
  * console.log(schema)
  */
-exports.getViewSchema = (card, ctx) => {
+exports.getViewSchema = (card) => {
 	if (!card) {
 		return null
 	}
@@ -204,7 +203,7 @@ exports.getViewSchema = (card, ctx) => {
 }
 
 /**
- * @summary Get the views for the user's roles
+ * @summary Get the view schemas for the user's roles
  * @function
  * @private
  *
@@ -213,7 +212,7 @@ exports.getViewSchema = (card, ctx) => {
  * @param {Object} [options] - options
  * @param {Boolean} [options.writeMode] - enable write mode
  * @param {Object} [options.ctx] - execution context
- * @returns {Object[]} views
+ * @returns {Object[]} view schemas
  *
  * @example
  * const user = await kernel.getCardBySlug('4a962ad9-20b5-4dd8-a707-bf819593cc84', 'user-admin')
@@ -223,21 +222,36 @@ exports.getViewSchema = (card, ctx) => {
  *   console.log(view)
  * }
  */
-const getRoleViews = (backend, user, options = {}) => {
+const getRoleViews = async (backend, user, options = {}) => {
 	const modes = options.writeMode ? [ 'read', 'write' ] : [ 'read' ]
 
-	const roles = _.chain([ user.slug ])
-		.concat(user.data.roles)
-		.reduce((accumulator, role) => {
-			Reflect.apply(accumulator.push, accumulator, _.map(modes, (mode) => {
-				return `view-${mode}-${role}`
-			}))
+	const viewSchemas = []
 
-			return accumulator
-		}, [])
-		.value()
+	const roles = [ user.slug, ...user.data.roles ]
 
-	return this.getViews(backend, roles, options.ctx)
+	for (const role of roles) {
+		const modeRoles = modes.map((mode) => {
+			return `view-${mode}-${role}`
+		})
+
+		const viewCards = await exports.getViews(backend, modeRoles, options.ctx)
+
+		const views = viewCards.map((card) => {
+			return exports.getViewSchema(card)
+		})
+
+		// If there is a read and write view for a role, they should be evaluated
+		// using AND, making write mode more restrictive in scope
+		if (views.length > 1) {
+			viewSchemas.push({
+				allOf: views
+			})
+		} else if (views.length) {
+			viewSchemas.push(views[0])
+		}
+	}
+
+	return viewSchemas
 }
 
 /**
@@ -334,6 +348,25 @@ const createMarkersQuery = (markers) => {
 	}
 }
 
+const evalSchema = (user, schema) => {
+	// If json-e encounters a property that starts with more than one
+	// dollar sign, then it will remove one for some reason. The
+	// only way I found to workaround this is to double escape before
+	// calling json-e, so that the resulting key remains accurate.
+	if (schema.$$sort) {
+		schema.$$$sort = schema.$$sort
+		Reflect.deleteProperty(schema, '$$sort')
+	}
+	if (schema.$$links) {
+		schema.$$$links = schema.$$links
+		Reflect.deleteProperty(schema, '$$links')
+	}
+
+	return jsone(schema, {
+		user
+	})
+}
+
 /**
  * @summary Get a final filtered query
  * @function
@@ -362,47 +395,58 @@ const createMarkersQuery = (markers) => {
 exports.getQuery = async (backend, session, schema, options) => {
 	const user = await exports.getSessionUser(backend, session, options.ctx)
 
-	const views = await getRoleViews(backend, user, {
+	const evalFn = _.partial(evalSchema, user)
+
+	const permissionFilters = await getRoleViews(backend, user, {
 		writeMode: options.writeMode,
 		ctx: options.ctx
 	})
 
 	// Users must have a role view to be able to access anything
-	if (views.length === 0) {
+	if (permissionFilters.length === 0) {
 		throw new errors.JellyfishPermissionsError('User must have at least 1 role or permission view')
 	}
-
-	const filters = views.map((view) => {
-		return exports.getViewSchema(view)
-	})
 
 	const userMarkers = await getUserMarkers(backend, user)
 
 	const markersQuery = createMarkersQuery(userMarkers)
 
-	filters.push(markersQuery)
+	const compiledSchema = {
+		type: 'object',
+		properties: {},
+
+		// At least on permission must match
+		anyOf: permissionFilters.map(evalFn)
+	}
 
 	if (schema) {
 		const finalSchema = schema.type === CARDS.view.slug ? exports.getViewSchema(schema) : schema
-		filters.push(finalSchema)
+		const evaledSchema = evalFn(finalSchema)
+		const {
+			anyOf,
+			...values
+		} = evaledSchema
+
+		if (anyOf) {
+			compiledSchema.allOf = [
+				{
+					anyOf
+				}
+			]
+		}
+
+		Object.assign(compiledSchema, values)
 	}
 
-	return jsonSchema.merge(_.map(filters, (filter) => {
-		// If json-e encounters a property that starts with more than one
-		// dollar sign, then it will remove one for some reason. The
-		// only way I found to workaround this is to double escape before
-		// calling json-e, so that the resulting key remains accurate.
-		if (filter.$$sort) {
-			filter.$$$sort = filter.$$sort
-			Reflect.deleteProperty(filter, '$$sort')
+	// The markers must match
+	if (compiledSchema.properties.markers) {
+		if (!compiledSchema.allOf) {
+			compiledSchema.allOf = []
 		}
-		if (filter.$$links) {
-			filter.$$$links = filter.$$links
-			Reflect.deleteProperty(filter, '$$links')
-		}
+		compiledSchema.allOf.push(markersQuery)
+	} else {
+		compiledSchema.properties.markers = markersQuery.properties.markers
+	}
 
-		return jsone(filter, {
-			user
-		})
-	}))
+	return compiledSchema
 }

--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -170,6 +170,39 @@ ava.serial('.query() the guest user should only see its own private fields', asy
 	})
 })
 
+ava.serial('Users with multiple roles should see cards accessible to either role', async (test) => {
+	const {
+		sdk
+	} = test.context
+
+	const userDetails = {
+		username: randomstring.generate(),
+		email: `${randomstring.generate()}@example.com`,
+		password: 'foobarbaz'
+	}
+
+	const user = await sdk.auth.signup(userDetails)
+
+	// Update the role on the team user
+	await test.context.jellyfish.insertCard(
+		test.context.session,
+		_.merge(user, {
+			data: {
+				roles: [ 'user-community', 'user-team' ]
+			}
+		}),
+		{
+			override: true
+		}
+	)
+
+	await sdk.auth.login(userDetails)
+
+	const scratchpad = await sdk.card.get('view-scratchpad')
+
+	test.not(scratchpad, null)
+})
+
 ava.serial('.query() should be able to see previously restricted cards after a permissions change', async (test) => {
 	const {
 		sdk

--- a/test/unit/core/kernel.spec.js
+++ b/test/unit/core/kernel.spec.js
@@ -1022,6 +1022,7 @@ ava('.insertCard() should restrict the visibility of the user using write roles'
 	}))
 
 	const readUserType = await test.context.kernel.getCardBySlug(session.id, 'user')
+
 	test.is(readUserType.slug, 'user')
 
 	const writeUserType = await test.context.kernel.getCardBySlug(session.id, 'user', {
@@ -1978,7 +1979,8 @@ ava('.query() should not consider active links to inactive cards', async (test) 
 					count: {
 						type: 'number'
 					}
-				}
+				},
+				additionalProperties: false
 			}
 		}
 	})
@@ -2088,8 +2090,7 @@ ava('.query() should not consider inactive links', async (test) => {
 						required: [ 'thread' ],
 						properties: {
 							thread: {
-								type: 'boolean',
-								const: true
+								type: 'boolean'
 							}
 						}
 					}
@@ -2112,7 +2113,8 @@ ava('.query() should not consider inactive links', async (test) => {
 					count: {
 						type: 'number'
 					}
-				}
+				},
+				additionalProperties: true
 			}
 		}
 	})
@@ -2133,7 +2135,8 @@ ava('.query() should not consider inactive links', async (test) => {
 				]
 			},
 			data: {
-				count: 2
+				count: 2,
+				thread: false
 			}
 		}
 	])
@@ -2277,7 +2280,8 @@ ava('.query() should be able to query using links', async (test) => {
 					count: {
 						type: 'number'
 					}
-				}
+				},
+				additionalProperties: false
 			}
 		}
 	})
@@ -2445,7 +2449,8 @@ ava('.query() should be able to query using links using the target property', as
 					count: {
 						type: 'number'
 					}
-				}
+				},
+				additionalProperties: false
 			}
 		}
 	})


### PR DESCRIPTION
Fixes #672

This change preserves the semantics of the original query, whilst
restricting it using permissions and markers.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>