### PR TITLE
core: Stop dynamically requiring core cards

### DIFF
--- a/lib/core/cards.js
+++ b/lib/core/cards.js
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-const fs = require('fs')
-const path = require('path')
-const CARDS_DIRECTORY_PATH = path.join(path.resolve(__dirname, '..', '..', 'default-cards', 'core'))
-
-module.exports = fs.readdirSync(CARDS_DIRECTORY_PATH).reduce((accumulator, card) => {
-	accumulator[path.basename(card, path.extname(card))] = require(path.join(CARDS_DIRECTORY_PATH, card))
-	return accumulator
-}, {})
+// Dynamic requires messes up static analysis
+module.exports = {
+	'action-request': require('../../default-cards/core/action-request.json'),
+	action: require('../../default-cards/core/action.json'),
+	card: require('../../default-cards/core/card.json'),
+	event: require('../../default-cards/core/event.json'),
+	link: require('../../default-cards/core/link.json'),
+	session: require('../../default-cards/core/session.json'),
+	type: require('../../default-cards/core/type.json'),
+	'user-admin': require('../../default-cards/core/user-admin.json'),
+	user: require('../../default-cards/core/user.json'),
+	'view-read-user-admin': require('../../default-cards/core/view-read-user-admin.json'),
+	view: require('../../default-cards/core/view.json')
+}


### PR DESCRIPTION
This makes statically analyzing requires difficult, and its the only
place in the system where we are doing this. If it gets unmanageable, we
can auto-generate a version of this file at built time to keep it
static.

Change-type: patch