### PR TITLE
core: Improve backend logging

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -121,13 +121,20 @@ const createTableStream = async (backend, table, schema, ctx) => {
 
 	const emitter = new EventEmitter()
 
-	logger.debug(ctx, `Opening stream in table ${table}`)
+	logger.info(ctx, 'Streaming from table', {
+		table,
+		database: backend.database
+	})
+
 	const cursor = await reqlSchema(backend.database, table, schema)
 		.changes()
 		.run(backend.connection)
 
 	emitter.close = () => {
-		logger.debug(ctx, `Closing stream in table ${table}`)
+		logger.info(ctx, 'Closing stream', {
+			table,
+			database: backend.database
+		})
 
 		// eslint-disable-next-line no-underscore-dangle
 		cursor._endFlag = true
@@ -185,7 +192,10 @@ const createTableStream = async (backend, table, schema, ctx) => {
 }
 
 const queryTable = async (backend, table, schema, options) => {
-	logger.debug(options.ctx, `Querying entries in table ${table}`)
+	logger.info(options.ctx, 'Querying from table', {
+		table,
+		database: backend.database
+	})
 
 	let query = await reqlSchema(backend.database, table, schema)
 
@@ -243,7 +253,11 @@ const resolveLinks = async (backend, schema, options, card) => {
 }
 
 const getElementByIdFromTable = async (backend, table, id, ctx) => {
-	logger.debug(ctx, `Getting element by id ${id} from table ${table} in database ${backend.database}`)
+	logger.info(ctx, 'Getting element by id', {
+		id,
+		table,
+		database: backend.database
+	})
 
 	let cursor = null
 	try {
@@ -282,7 +296,12 @@ const getElementByIdFromTable = async (backend, table, id, ctx) => {
 }
 
 const getElementBySlugFromTable = async (backend, table, slug, ctx) => {
-	logger.debug(ctx, `Getting element by slug ${slug} from table ${table} in database ${backend.database}`)
+	logger.info(ctx, 'Getting element by slug', {
+		slug,
+		table,
+		database: backend.database
+	})
+
 	let result = null
 	try {
 		result = await rethinkdb
@@ -311,6 +330,20 @@ const upsertObject = async (backend, table, object, options) => {
 	}
 
 	const elementId = uuid()
+
+	if (options.replace) {
+		logger.info(options.ctx, 'Upserting element', {
+			table,
+			slug: insertedObject.slug,
+			database: backend.database
+		})
+	} else {
+		logger.info(options.ctx, 'Updating element', {
+			table,
+			slug: insertedObject.slug,
+			database: backend.database
+		})
+	}
 
 	// Its very important, for concurrency issues, that inserts/upserts
 	// remain atomic, in that there is only one atomic request sent to
@@ -465,7 +498,11 @@ module.exports = class Backend {
 	async reset (ctx) {
 		const tables = await this.getTables()
 		await Promise.all(tables.map((table) => {
-			logger.debug(ctx, `Dropping table ${table}`)
+			logger.info(ctx, 'Dropping table', {
+				table,
+				database: this.database
+			})
+
 			return rethinkdb
 				.db(this.database)
 				.tableDrop(table)
@@ -500,7 +537,9 @@ module.exports = class Backend {
 
 		await this.disconnect()
 		const connection = await rethinkdb.connect(this.options)
-		logger.debug(ctx, 'Destroying the database')
+		logger.info(ctx, 'Dropping database', {
+			database: this.database
+		})
 
 		await rethinkdb.dbDrop(this.database).run(connection)
 		await connection.close()
@@ -524,25 +563,34 @@ module.exports = class Backend {
    */
 	async connect (ctx) {
 		if (!this.connection) {
-			logger.debug(ctx, 'Connecting to database')
+			logger.info(ctx, 'Connecting to database', {
+				database: this.database
+			})
 			this.connection = await rethinkdb.connect(this.options)
 		}
 
-		logger.debug(ctx, 'Querying database list')
+		logger.info(ctx, 'Listing databases')
 		const databases = await rethinkdb
 			.dbList()
 			.run(this.connection)
 
 		if (!databases.includes(this.database)) {
-			logger.debug(ctx, `Creating database ${this.database}`)
 			if (this.cache) {
 				await this.cache.reset()
 			}
+
+			logger.info(ctx, 'Creating database', {
+				database: this.database
+			})
 
 			await rethinkdb
 				.dbCreate(this.database)
 				.run(this.connection)
 		}
+
+		logger.info(ctx, 'Waiting for database', {
+			database: this.database
+		})
 
 		// Prevent sporadic replica error:
 		//   Cannot perform read: primary replica for shard ["", +inf) not available]
@@ -550,6 +598,11 @@ module.exports = class Backend {
 		await rethinkdb.db(this.database).wait().run(this.connection)
 
 		for (const table of await this.getTables(ctx)) {
+			logger.info(ctx, 'Dropping table indexes', {
+				table,
+				database: this.database
+			})
+
 			// Get rid of old indexes, so we can be sure
 			// they get re-created every time the server
 			// restarts, to accomodate for updates, etc.
@@ -570,6 +623,11 @@ module.exports = class Backend {
 		for (const table of ALL_BUCKETS) {
 			await this.createTable(table, ctx)
 
+			logger.info(ctx, 'Waiting for table', {
+				table,
+				database: this.database
+			})
+
 			// Lets make sure the table is ready before continuing
 			await rethinkdb
 				.db(this.database)
@@ -577,11 +635,21 @@ module.exports = class Backend {
 				.wait()
 				.run(this.connection)
 
+			logger.info(ctx, 'Creating table indexes', {
+				table,
+				database: this.database
+			})
+
 			await rethinkdb
 				.db(this.database)
 				.table(table)
 				.indexCreate('id')
 				.run(this.connection)
+
+			logger.info(ctx, 'Waiting for table indexes', {
+				table,
+				database: this.database
+			})
 
 			// Wait for all indexes to be ready
 			await rethinkdb
@@ -615,7 +683,9 @@ module.exports = class Backend {
 		} = this
 		if (connection) {
 			this.connection = null
-			logger.debug(ctx, 'Disconnecting from database')
+			logger.info(ctx, 'Disconnecting from database', {
+				database: this.database
+			})
 
 			_.forEach(this.openStreams, (stream, id) => {
 				stream.close()
@@ -651,7 +721,10 @@ module.exports = class Backend {
 	 * }
    */
 	getTables (ctx) {
-		logger.debug(ctx, 'Querying table list')
+		logger.info(ctx, 'Listing tables', {
+			database: this.database
+		})
+
 		return rethinkdb
 			.db(this.database)
 			.tableList()
@@ -698,7 +771,11 @@ module.exports = class Backend {
    */
 	async createTable (name, ctx) {
 		if (!await this.hasTable(name, ctx)) {
-			logger.debug(ctx, `Creating table ${name} in database ${this.database}`)
+			logger.info(ctx, 'Creating table', {
+				table: name,
+				database: this.database
+			})
+
 			await rethinkdb
 				.db(this.database)
 				.tableCreate(name, {
@@ -732,7 +809,6 @@ module.exports = class Backend {
    */
 	async insertElement (object, ctx) {
 		const table = getBucketForType(object.type)
-		logger.debug(ctx, `Inserting element to table ${table} in database ${this.database}`)
 		return upsertObject(this, table, object, {
 			unsetFromCache: true,
 			replace: false,
@@ -761,7 +837,6 @@ module.exports = class Backend {
    */
 	async upsertElement (object, ctx) {
 		const table = getBucketForType(object.type)
-		logger.debug(ctx, `Updating element ${object.slug} in table ${table} in database ${this.database}`)
 		return upsertObject(this, table, object, {
 			unsetFromCache: false,
 			replace: true,
@@ -818,10 +893,21 @@ module.exports = class Backend {
 			return result
 		}
 
+		logger.warn(options.ctx, 'Looping through all tables to find an element by id', {
+			id,
+			database: this.database
+		})
+
 		if (this.cache) {
 			for (const table of ALL_BUCKETS) {
 				const cacheResult = await this.cache.getById(table, id)
 				if (cacheResult.hit && cacheResult.element) {
+					logger.warn(options.ctx, 'Found element after table iteration', {
+						slug: cacheResult.element.slug,
+						type: cacheResult.element.type,
+						table
+					})
+
 					return cacheResult.element
 				}
 			}
@@ -840,6 +926,12 @@ module.exports = class Backend {
 				if (this.cache) {
 					await this.cache.set(table, result)
 				}
+
+				logger.warn(options.ctx, 'Found element after table iteration', {
+					slug: result.slug,
+					type: result.type,
+					table
+				})
 
 				return result
 			}
@@ -902,10 +994,21 @@ module.exports = class Backend {
 			return result
 		}
 
+		logger.warn(options.ctx, 'Looping through all tables to find an element by slug', {
+			slug,
+			database: this.database
+		})
+
 		if (this.cache) {
 			for (const table of ALL_BUCKETS) {
 				const cacheResult = await this.cache.getBySlug(table, slug)
 				if (cacheResult.hit && cacheResult.element) {
+					logger.warn(options.ctx, 'Found element after table iteration', {
+						slug: cacheResult.element.slug,
+						type: cacheResult.element.type,
+						table
+					})
+
 					return cacheResult.element
 				}
 			}
@@ -924,6 +1027,12 @@ module.exports = class Backend {
 				if (this.cache) {
 					await this.cache.set(table, result)
 				}
+
+				logger.warn(options.ctx, 'Found element after table iteration', {
+					slug: result.slug,
+					type: result.type,
+					table
+				})
 
 				return result
 			}
@@ -984,6 +1093,13 @@ module.exports = class Backend {
 
 			const type = schema.properties.type && schema.properties.type.const
 
+			if (!type) {
+				logger.warn(options.ctx, 'Unspecified type in query for constant id/slug', {
+					schema,
+					database: this.database
+				})
+			}
+
 			if (schema.properties.id && schema.properties.id.const) {
 				element = await this.getElementById(schema.properties.id.const, {
 					ctx: options.ctx,
@@ -1023,6 +1139,10 @@ module.exports = class Backend {
 				? jellyscript.sort(results, sortExpression)
 				: results
 		}
+
+		logger.warn(options.ctx, 'Looping through all tables to execute a query', {
+			database: this.database
+		})
 
 		const items = _.flatten(await Bluebird.map(tables, (table) => {
 			return queryTable(this, table, schema, options)
@@ -1085,6 +1205,12 @@ module.exports = class Backend {
    */
 	async stream (schema, ctx) {
 		const tables = getBucketsForSchema(schema)
+
+		if (tables.length > 1) {
+			logger.warn(ctx, 'Looping through all tables to execute a stream', {
+				database: this.database
+			})
+		}
 
 		const emitter = tables.length === 1
 			? await createTableStream(this, tables[0], schema, ctx)

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -174,6 +174,13 @@ module.exports = class Kernel {
 	async getCardById (session, id, options = {}) {
 		logger.debug(options.ctx, `Fetching card by id ${id}`)
 
+		if (!options.type) {
+			logger.warn(options.ctx,
+				'Unspecified type when getting element by id', {
+					id
+				})
+		}
+
 		const schema = options.type ? {
 			type: 'object',
 			properties: {
@@ -235,6 +242,13 @@ module.exports = class Kernel {
    */
 	async getCardBySlug (session, slug, options = {}) {
 		logger.debug(options.ctx, `Fetching card by slug ${slug}`)
+
+		if (!options.type) {
+			logger.warn(options.ctx,
+				'Unspecified type when getting element by slug', {
+					slug
+				})
+		}
 
 		const schema = options.type ? {
 			type: 'object',


### PR DESCRIPTION
This was a result of digging a lot into database I/O for performance
reasonn. These logs only happen right before an actual RethinknDB
request happens, so they provide excellent profiling points.

Change-type: patch