### PR TITLE
core: Require type in .getElementBy(Id|Slug) functions

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -775,8 +775,8 @@ module.exports = class Backend {
    * @private
    *
    * @param {String} id - id
-	 * @param {Object} [options] - options
-	 * @param {String} [options.type] - element type
+	 * @param {Object} options - options
+	 * @param {String} options.type - element type
 	 * @param {Object} [options.ctx] - execution context
    * @returns {(Object|Null)} element
    *
@@ -789,67 +789,42 @@ module.exports = class Backend {
    *   data: 'foo'
    * })
    *
-   * const element = await backend.getElementById(id)
+	 * const element = await backend.getElementById(id, {
+	 *   type: 'test'
+	 * })
    *
    * console.log(element.data)
    * > 'foo'
    */
 	async getElementById (id, options = {}) {
-		if (options.type) {
-			const table = getBucketForType(options.type)
-
-			if (this.cache) {
-				const cacheResult = await this.cache.getById(table, id)
-				if (cacheResult.hit) {
-					return cacheResult.element
-				}
-			}
-
-			const result = await getElementByIdFromTable(this, table, id, options.ctx)
-
-			if (this.cache) {
-				if (result) {
-					await this.cache.set(table, result)
-				} else {
-					await this.cache.setMissingId(table, id)
-				}
-			}
-
-			return result
-		}
+		const table = getBucketForType(options.type)
 
 		if (this.cache) {
-			for (const table of ALL_BUCKETS) {
-				const cacheResult = await this.cache.getById(table, id)
-				if (cacheResult.hit && cacheResult.element) {
-					return cacheResult.element
-				}
+			const cacheResult = await this.cache.getById(table, id)
+			if (cacheResult.hit) {
+				return cacheResult.element
 			}
 		}
 
-		for (const table of ALL_BUCKETS) {
-			if (this.cache) {
-				const cacheResult = await this.cache.getById(table, id)
-				if (cacheResult.hit && !cacheResult.element) {
-					continue
-				}
-			}
+		const result = await getElementByIdFromTable(this, table, id, options.ctx)
 
-			const result = await getElementByIdFromTable(this, table, id, options.ctx)
+		if (this.cache) {
 			if (result) {
-				if (this.cache) {
-					await this.cache.set(table, result)
+				for (const bucket of ALL_BUCKETS) {
+					if (bucket === table) {
+						await this.cache.set(bucket, result)
+					} else {
+						await this.cache.setMissingId(bucket, id)
+					}
 				}
 
-				return result
-			}
-
-			if (this.cache) {
+				await this.cache.set(table, result)
+			} else {
 				await this.cache.setMissingId(table, id)
 			}
 		}
 
-		return null
+		return result
 	}
 
 	/**
@@ -858,8 +833,8 @@ module.exports = class Backend {
    * @private
    *
    * @param {String} slug - slug
-	 * @param {Object} [options] - options
-	 * @param {String} [options.type] - element type
+	 * @param {Object} options - options
+	 * @param {String} options.type - element type
 	 * @param {Object} [options.ctx] - execution context
    * @returns {(Object|Null)} element
    *
@@ -873,67 +848,40 @@ module.exports = class Backend {
    *   data: 'foo'
    * })
    *
-   * const element = await backend.getElementBySlug('hello')
+	 * const element = await backend.getElementBySlug('hello', {
+	 *   type: 'test'
+	 * })
    *
    * console.log(element.data)
    * > 'foo'
    */
 	async getElementBySlug (slug, options = {}) {
-		if (options.type) {
-			const table = getBucketForType(options.type)
-
-			if (this.cache) {
-				const cacheResult = await this.cache.getBySlug(table, slug)
-				if (cacheResult.hit) {
-					return cacheResult.element
-				}
-			}
-
-			const result = await getElementBySlugFromTable(this, table, slug, options.ctx)
-
-			if (this.cache) {
-				if (result) {
-					await this.cache.set(table, result)
-				} else {
-					await this.cache.setMissingSlug(table, slug)
-				}
-			}
-
-			return result
-		}
+		const table = getBucketForType(options.type)
 
 		if (this.cache) {
-			for (const table of ALL_BUCKETS) {
-				const cacheResult = await this.cache.getBySlug(table, slug)
-				if (cacheResult.hit && cacheResult.element) {
-					return cacheResult.element
-				}
+			const cacheResult = await this.cache.getBySlug(table, slug)
+			if (cacheResult.hit) {
+				return cacheResult.element
 			}
 		}
 
-		for (const table of ALL_BUCKETS) {
-			if (this.cache) {
-				const cacheResult = await this.cache.getBySlug(table, slug)
-				if (cacheResult.hit && !cacheResult.element) {
-					continue
-				}
-			}
+		const result = await getElementBySlugFromTable(this, table, slug, options.ctx)
 
-			const result = await getElementBySlugFromTable(this, table, slug, options.ctx)
+		if (this.cache) {
 			if (result) {
-				if (this.cache) {
-					await this.cache.set(table, result)
+				for (const bucket of ALL_BUCKETS) {
+					if (bucket === table) {
+						await this.cache.set(bucket, result)
+					} else {
+						await this.cache.setMissingSlug(bucket, slug)
+					}
 				}
-
-				return result
-			}
-
-			if (this.cache) {
+			} else {
 				await this.cache.setMissingSlug(table, slug)
 			}
 		}
 
-		return null
+		return result
 	}
 
 	/**


### PR DESCRIPTION
I found that in all cases where we're using these direct getters, we
always know the type we are expecting in result. Therefore it makes
sense to make it required, simplifying a lot of the logic to traverse
through tables, and to make it very hard to introduce performance
regressions that impact database reads.

Change-type: patch