### PR TITLE
logger: Prohibit missing context in logger functions

### DIFF
--- a/lib/logger/context.js
+++ b/lib/logger/context.js
@@ -5,6 +5,10 @@ module.exports.systemContext = {
 	id: 'SYSTEM'
 }
 
+module.exports.testContext = {
+	id: 'TEST'
+}
+
 module.exports.newPrefixContext = (name) => {
 	const id = `${name}-${randomstring.generate(20)}`
 	return {

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -70,7 +70,10 @@ module.exports.getLogger = _.memoize((name) => {
 		: (config.logLevel[name] || 'debug')
 	const myFormat = winston.format.printf((info) => {
 		const additionalArgs = info.additionalArgs
-		const id = _.get(info, [ 'ctx', 'id' ], 'MISSING-TRANSACTION')
+		const id = _.get(info, [ 'ctx', 'id' ])
+		if (!id) {
+			throw new Error('Missing context')
+		}
 
 		let idField = `${id}`
 		const workerid = _.get(info, [ 'ctx', 'workerid' ])

--- a/test/unit/core/backend.spec.js
+++ b/test/unit/core/backend.spec.js
@@ -25,9 +25,9 @@ ava.afterEach(helpers.backend.afterEach)
 
 ava('.disconnect() should not throw if called multiple times', async (test) => {
 	await test.notThrowsAsync(async () => {
-		await test.context.backend.disconnect()
-		await test.context.backend.disconnect()
-		await test.context.backend.disconnect()
+		await test.context.backend.disconnect(test.context.logContext)
+		await test.context.backend.disconnect(test.context.logContext)
+		await test.context.backend.disconnect(test.context.logContext)
 	})
 })
 
@@ -35,14 +35,16 @@ ava('.disconnect() should gracefully close streams', async (test) => {
 	await test.notThrowsAsync(async () => {
 		await test.context.backend.stream({
 			type: 'object'
-		})
-		await test.context.backend.disconnect()
+		}, test.context.logContext)
+		await test.context.backend.disconnect(test.context.logContext)
 	})
 })
 
 ava('.getElementById() should return null if the element id is not present', async (test) => {
-	await test.context.backend.createTable('test')
-	const result = await test.context.backend.getElementById('test', '4a962ad9-20b5-4dd8-a707-bf819593cc84')
+	await test.context.backend.createTable('test', test.context.logContext)
+	const result = await test.context.backend.getElementById('4a962ad9-20b5-4dd8-a707-bf819593cc84', {
+		ctx: test.context.logContext
+	})
 	test.deepEqual(result, null)
 })
 
@@ -50,12 +52,16 @@ ava('.getElementById() should not break the cache if trying to query a valid slu
 	const element = await test.context.backend.upsertElement({
 		slug: 'example',
 		test: 'foo'
-	})
+	}, test.context.logContext)
 
-	const result1 = await test.context.backend.getElementById('example')
+	const result1 = await test.context.backend.getElementById('example', {
+		ctx: test.context.logContext
+	})
 	test.deepEqual(result1, null)
 
-	const result2 = await test.context.backend.getElementBySlug('example')
+	const result2 = await test.context.backend.getElementBySlug('example', {
+		ctx: test.context.logContext
+	})
 	test.deepEqual(result2, element)
 })
 

--- a/test/unit/core/helpers.js
+++ b/test/unit/core/helpers.js
@@ -18,6 +18,7 @@ const randomstring = require('randomstring')
 const Backend = require('../../../lib/core/backend')
 const Cache = require('../../../lib/core/cache')
 const Kernel = require('../../../lib/core/kernel')
+const logContext = require('../../../lib/logger/context')
 
 exports.generateRandomSlug = (options) => {
 	const suffix = randomstring.generate().toLowerCase()
@@ -37,17 +38,19 @@ exports.backend = {
 				mock: true,
 				database: dbName
 			})
+
 		test.context.backend = new Backend(cache, {
 			host: process.env.DB_HOST,
 			port: process.env.DB_PORT,
 			database: dbName
 		})
 
+		test.context.logContext = logContext.testContext
 		test.context.generateRandomSlug = exports.generateRandomSlug
-		await test.context.backend.connect()
+		await test.context.backend.connect(test.context.logContext)
 	},
 	afterEach: async (test) => {
-		await test.context.backend.destroy()
+		await test.context.backend.destroy(test.context.logContext)
 	}
 }
 


### PR DESCRIPTION
As far as I can see, this reveals some issues in our code more than
being something valid, so sounds like a good thing to enforce.

Change-type: patch