### PR TITLE
core: Require type in .getElementBy(Id|Slug) functions

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -927,8 +927,8 @@ module.exports = class Backend {
    * @private
    *
    * @param {String} id - id
-	 * @param {Object} [options] - options
-	 * @param {String} [options.type] - element type
+	 * @param {Object} options - options
+	 * @param {String} options.type - element type
 	 * @param {Object} [options.ctx] - execution context
    * @returns {(Object|Null)} element
    *
@@ -941,84 +941,38 @@ module.exports = class Backend {
    *   data: 'foo'
    * })
    *
-   * const element = await backend.getElementById(id)
+	 * const element = await backend.getElementById(id, {
+	 *   type: 'card'
+	 * })
    *
    * console.log(element.data)
    * > 'foo'
    */
 	async getElementById (id, options = {}) {
-		if (options.type) {
-			const table = getBucketForType(options.type)
-
-			if (this.cache) {
-				const cacheResult = await this.cache.getById(table, id)
-				if (cacheResult.hit) {
-					return cacheResult.element
-				}
-			}
-
-			const result = await getElementByIdFromTable(this, table, id, options.ctx)
-
-			if (this.cache) {
-				if (result) {
-					await this.cache.set(table, result)
-				} else {
-					await this.cache.setMissingId(table, id)
-				}
-			}
-
-			return result
+		if (!options.type) {
+			throw new errors.JellyfishNoIdentifier(`No type when getting element by id: ${id}`)
 		}
 
-		logger.debug(options.ctx, 'Looping through all tables to find an element by id', {
-			id,
-			database: this.database
-		})
+		const table = getBucketForType(options.type)
 
 		if (this.cache) {
-			for (const table of ALL_BUCKETS) {
-				const cacheResult = await this.cache.getById(table, id)
-				if (cacheResult.hit && cacheResult.element) {
-					logger.debug(options.ctx, 'Found element after table iteration', {
-						slug: cacheResult.element.slug,
-						type: cacheResult.element.type,
-						table
-					})
-
-					return cacheResult.element
-				}
+			const cacheResult = await this.cache.getById(table, id)
+			if (cacheResult.hit) {
+				return cacheResult.element
 			}
 		}
 
-		for (const table of ALL_BUCKETS) {
-			if (this.cache) {
-				const cacheResult = await this.cache.getById(table, id)
-				if (cacheResult.hit && !cacheResult.element) {
-					continue
-				}
-			}
+		const result = await getElementByIdFromTable(this, table, id, options.ctx)
 
-			const result = await getElementByIdFromTable(this, table, id, options.ctx)
+		if (this.cache) {
 			if (result) {
-				if (this.cache) {
-					await this.cache.set(table, result)
-				}
-
-				logger.debug(options.ctx, 'Found element after table iteration', {
-					slug: result.slug,
-					type: result.type,
-					table
-				})
-
-				return result
-			}
-
-			if (this.cache) {
+				await this.cache.set(table, result)
+			} else {
 				await this.cache.setMissingId(table, id)
 			}
 		}
 
-		return null
+		return result
 	}
 
 	/**
@@ -1027,8 +981,8 @@ module.exports = class Backend {
    * @private
    *
    * @param {String} slug - slug
-	 * @param {Object} [options] - options
-	 * @param {String} [options.type] - element type
+	 * @param {Object} options - options
+	 * @param {String} options.type - element type
 	 * @param {Object} [options.ctx] - execution context
    * @returns {(Object|Null)} element
    *
@@ -1042,84 +996,38 @@ module.exports = class Backend {
    *   data: 'foo'
    * })
    *
-   * const element = await backend.getElementBySlug('hello')
+	 * const element = await backend.getElementBySlug('hello', {
+	 *   type: 'card'
+	 * })
    *
    * console.log(element.data)
    * > 'foo'
    */
 	async getElementBySlug (slug, options = {}) {
-		if (options.type) {
-			const table = getBucketForType(options.type)
-
-			if (this.cache) {
-				const cacheResult = await this.cache.getBySlug(table, slug)
-				if (cacheResult.hit) {
-					return cacheResult.element
-				}
-			}
-
-			const result = await getElementBySlugFromTable(this, table, slug, options.ctx)
-
-			if (this.cache) {
-				if (result) {
-					await this.cache.set(table, result)
-				} else {
-					await this.cache.setMissingSlug(table, slug)
-				}
-			}
-
-			return result
+		if (!options.type) {
+			throw new errors.JellyfishNoIdentifier(`No type when getting element by slug: ${slug}`)
 		}
 
-		logger.debug(options.ctx, 'Looping through all tables to find an element by slug', {
-			slug,
-			database: this.database
-		})
+		const table = getBucketForType(options.type)
 
 		if (this.cache) {
-			for (const table of ALL_BUCKETS) {
-				const cacheResult = await this.cache.getBySlug(table, slug)
-				if (cacheResult.hit && cacheResult.element) {
-					logger.debug(options.ctx, 'Found element after table iteration', {
-						slug: cacheResult.element.slug,
-						type: cacheResult.element.type,
-						table
-					})
-
-					return cacheResult.element
-				}
+			const cacheResult = await this.cache.getBySlug(table, slug)
+			if (cacheResult.hit) {
+				return cacheResult.element
 			}
 		}
 
-		for (const table of ALL_BUCKETS) {
-			if (this.cache) {
-				const cacheResult = await this.cache.getBySlug(table, slug)
-				if (cacheResult.hit && !cacheResult.element) {
-					continue
-				}
-			}
+		const result = await getElementBySlugFromTable(this, table, slug, options.ctx)
 
-			const result = await getElementBySlugFromTable(this, table, slug, options.ctx)
+		if (this.cache) {
 			if (result) {
-				if (this.cache) {
-					await this.cache.set(table, result)
-				}
-
-				logger.debug(options.ctx, 'Found element after table iteration', {
-					slug: result.slug,
-					type: result.type,
-					table
-				})
-
-				return result
-			}
-
-			if (this.cache) {
+				await this.cache.set(table, result)
+			} else {
 				await this.cache.setMissingSlug(table, slug)
 			}
 		}
 
-		return null
+		return result
 	}
 
 	/**
@@ -1182,15 +1090,35 @@ module.exports = class Backend {
 			}
 
 			if (schema.properties.id && schema.properties.id.const) {
-				element = await this.getElementById(schema.properties.id.const, {
-					ctx: options.ctx,
-					type
-				})
+				if (options.type) {
+					element = await this.getElementById(schema.properties.id.const, {
+						ctx: options.ctx,
+						type
+					})
+				} else {
+					for (const table of ALL_BUCKETS) {
+						element = await getElementByIdFromTable(
+							this, table, schema.properties.id.const, options.ctx)
+						if (element) {
+							break
+						}
+					}
+				}
 			} else if (schema.properties.slug && schema.properties.slug.const) {
-				element = await this.getElementBySlug(schema.properties.slug.const, {
-					ctx: options.ctx,
-					type
-				})
+				if (options.type) {
+					element = await this.getElementBySlug(schema.properties.slug.const, {
+						ctx: options.ctx,
+						type
+					})
+				} else {
+					for (const table of ALL_BUCKETS) {
+						element = await getElementBySlugFromTable(
+							this, table, schema.properties.slug.const, options.ctx)
+						if (element) {
+							break
+						}
+					}
+				}
 			}
 
 			if (!element) {

--- a/test/unit/core/backend.spec.js
+++ b/test/unit/core/backend.spec.js
@@ -41,49 +41,72 @@ ava('.disconnect() should gracefully close streams', async (test) => {
 })
 
 ava('.getElementById() should return null if the element id is not present', async (test) => {
-	await test.context.backend.createTable('test')
-	const result = await test.context.backend.getElementById('test', '4a962ad9-20b5-4dd8-a707-bf819593cc84')
+	const result = await test.context.backend.getElementById('4a962ad9-20b5-4dd8-a707-bf819593cc84', {
+		type: 'card'
+	})
+
 	test.deepEqual(result, null)
 })
 
 ava('.getElementById() should not break the cache if trying to query a valid slug with it', async (test) => {
 	const element = await test.context.backend.upsertElement({
 		slug: 'example',
+		type: 'card',
 		test: 'foo'
 	})
 
-	const result1 = await test.context.backend.getElementById('example')
+	const result1 = await test.context.backend.getElementById('example', {
+		type: 'card'
+	})
+
 	test.deepEqual(result1, null)
 
-	const result2 = await test.context.backend.getElementBySlug('example')
+	const result2 = await test.context.backend.getElementBySlug('example', {
+		type: 'card'
+	})
+
 	test.deepEqual(result2, element)
 })
 
 ava('.getElementBySlug() should not break the cache if trying to query a valid id with it', async (test) => {
 	const element = await test.context.backend.upsertElement({
 		slug: 'example',
+		type: 'card',
 		test: 'foo'
 	})
 
-	const result1 = await test.context.backend.getElementBySlug(element.id)
+	const result1 = await test.context.backend.getElementBySlug(element.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(result1, null)
 
-	const result2 = await test.context.backend.getElementById(element.id)
+	const result2 = await test.context.backend.getElementById(element.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(result2, element)
 })
 
 ava('.getElementBySlug() should return null if the element slug is not present', async (test) => {
-	const result = await test.context.backend.getElementBySlug('foo')
+	const result = await test.context.backend.getElementBySlug('foo', {
+		type: 'card'
+	})
+
 	test.deepEqual(result, null)
 })
 
 ava('.getElementBySlug() should fetch an element given its slug', async (test) => {
 	const element = await test.context.backend.upsertElement({
 		slug: 'example',
+		type: 'card',
 		test: 'foo'
 	})
 
-	const result = await test.context.backend.getElementBySlug('example')
+	const result = await test.context.backend.getElementBySlug('example', {
+		type: 'card'
+	})
+
 	test.deepEqual(result, element)
 })
 
@@ -109,10 +132,14 @@ ava('.insertElement() should not insert an element without a slug nor an id to a
 
 ava('.insertElement() should insert an element with a non-existent slug', async (test) => {
 	const result = await test.context.backend.insertElement({
-		slug: 'foo'
+		slug: 'foo',
+		type: 'card'
 	})
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element, result)
 })
 
@@ -120,12 +147,16 @@ ava('.insertElement() should not insert an element with a user defined id', asyn
 	const result = await test.context.backend.insertElement({
 		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 		slug: 'foo',
+		type: 'card',
 		foo: 'bar'
 	})
 
 	test.not(result.id, '4a962ad9-20b5-4dd8-a707-bf819593cc84')
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(Object.assign({}, element, {
 		id: result.id
 	}), result)
@@ -135,12 +166,16 @@ ava('.insertElement() should insert an element with a non-existent id and slug',
 	const result = await test.context.backend.insertElement({
 		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 		slug: 'example',
+		type: 'card',
 		foo: 'bar'
 	})
 
 	test.not(result.id, '4a962ad9-20b5-4dd8-a707-bf819593cc84')
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(Object.assign({}, element, {
 		id: result.id
 	}), result)
@@ -155,19 +190,24 @@ ava('.insertElement() should not be able to set any links', async (test) => {
 		}
 	})
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element.links, {})
 })
 
 ava('.insertElement() should not re-use the id when inserting an element with an existent id', async (test) => {
 	const result1 = await test.context.backend.insertElement({
 		slug: 'foo',
+		type: 'card',
 		foo: 'bar'
 	})
 
 	const result2 = await test.context.backend.insertElement({
 		id: result1.id,
 		slug: 'bar',
+		type: 'card',
 		foo: 'baz'
 	})
 
@@ -220,13 +260,17 @@ ava('.upsertElement() should not be able to set links using an id', async (test)
 	const result = await test.context.backend.upsertElement({
 		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 		slug: 'foo',
+		type: 'card',
 		links: {
 			foo: 'bar'
 		},
 		test: 'foo'
 	})
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element.links, {})
 })
 
@@ -255,13 +299,24 @@ ava('.upsertElement() should update linked cards when inserting a link', async (
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: card.id,
-			to: thread.id
+			from: {
+				id: card.id,
+				type: card.type
+			},
+			to: {
+				id: thread.id,
+				type: thread.type
+			}
 		}
 	})
 
-	const updatedCard = await test.context.backend.getElementById(card.id)
-	const updatedThread = await test.context.backend.getElementById(thread.id)
+	const updatedCard = await test.context.backend.getElementById(card.id, {
+		type: 'message'
+	})
+
+	const updatedThread = await test.context.backend.getElementById(thread.id, {
+		type: 'thread'
+	})
 
 	test.deepEqual(updatedCard.links, {
 		'is attached to': [
@@ -287,6 +342,7 @@ ava('.upsertElement() should update linked cards when inserting a link', async (
 ava('.upsertElement() should not be able to set links using both an id and a slug', async (test) => {
 	const result = await test.context.backend.upsertElement({
 		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
 		slug: 'foo-bar',
 		links: {
 			foo: 'bar'
@@ -294,33 +350,44 @@ ava('.upsertElement() should not be able to set links using both an id and a slu
 		test: 'foo'
 	})
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element.links, {})
 })
 
 ava('.upsertElement() should not be able to set links using a slug', async (test) => {
 	const result = await test.context.backend.upsertElement({
 		slug: 'foo-bar',
+		type: 'card',
 		links: {
 			foo: 'bar'
 		},
 		test: 'foo'
 	})
 
-	const element = await test.context.backend.getElementBySlug(result.slug)
+	const element = await test.context.backend.getElementBySlug(result.slug, {
+		type: 'card'
+	})
+
 	test.deepEqual(element.links, {})
 })
 
 ava('.upsertElement() should not be able to set links using no id nor slug', async (test) => {
 	const result = await test.context.backend.upsertElement({
 		slug: 'foo',
+		type: 'card',
 		links: {
 			foo: 'bar'
 		},
 		test: 'foo'
 	})
 
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element.links, {})
 })
 
@@ -344,40 +411,53 @@ ava('.upsertElement() should not be able to change a slug', async (test) => {
 ava('.upsertElement() should insert a card with a slug', async (test) => {
 	const result = await test.context.backend.upsertElement({
 		slug: 'example',
+		type: 'card',
 		test: 'foo'
 	})
 
 	test.not(result.id, 'example')
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element, result)
 })
 
 ava('.upsertElement() should replace an element given the slug but no id', async (test) => {
 	const result1 = await test.context.backend.upsertElement({
 		slug: 'example',
+		type: 'card',
 		test: 'foo',
 		hello: 'world'
 	})
 
 	const result2 = await test.context.backend.upsertElement({
 		slug: 'example',
+		type: 'card',
 		test: 'bar'
 	})
 
 	test.is(result1.id, result2.id)
-	const element = await test.context.backend.getElementById(result1.id)
+	const element = await test.context.backend.getElementById(result1.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element, result2)
 })
 
 ava('.upsertElement() should not let clients pick their own ids', async (test) => {
 	const result = await test.context.backend.upsertElement({
 		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		type: 'card',
 		slug: 'example',
 		test: 'foo'
 	})
 
 	test.not(result.id, '4a962ad9-20b5-4dd8-a707-bf819593cc84')
-	const element = await test.context.backend.getElementById(result.id)
+	const element = await test.context.backend.getElementById(result.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(Object.assign({}, element, {
 		id: result.id
 	}), result)
@@ -415,17 +495,22 @@ ava('.upsertElement() should not consider ids when inserting an element with an 
 
 ava('.upsertElement() should replace an element with an existing id and the slug of the same element', async (test) => {
 	const result1 = await test.context.backend.upsertElement({
+		type: 'card',
 		slug: 'example'
 	})
 
 	const result2 = await test.context.backend.upsertElement({
 		id: result1.id,
+		type: 'card',
 		slug: 'example',
 		test: 'foo'
 	})
 
 	test.is(result1.id, result2.id)
-	const element = await test.context.backend.getElementById(result1.id)
+	const element = await test.context.backend.getElementById(result1.id, {
+		type: 'card'
+	})
+
 	test.deepEqual(element, result2)
 })
 
@@ -1359,8 +1444,14 @@ ava('.query() should be able to query using links', async (test) => {
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: card1.id,
-			to: thread1.id
+			from: {
+				id: card1.id,
+				type: card1.type
+			},
+			to: {
+				id: thread1.id,
+				type: thread1.type
+			}
 		}
 	})
 
@@ -1381,8 +1472,14 @@ ava('.query() should be able to query using links', async (test) => {
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: card2.id,
-			to: thread1.id
+			from: {
+				id: card2.id,
+				type: card2.type
+			},
+			to: {
+				id: thread1.id,
+				type: thread1.type
+			}
 		}
 	})
 
@@ -1403,8 +1500,14 @@ ava('.query() should be able to query using links', async (test) => {
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: card3.id,
-			to: thread2.id
+			from: {
+				id: card3.id,
+				type: card3.type
+			},
+			to: {
+				id: thread2.id,
+				type: thread2.type
+			}
 		}
 	})
 
@@ -1533,8 +1636,14 @@ ava('.query() should be able to query using links when getting an element by id'
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: message.id,
-			to: thread.id
+			from: {
+				id: message.id,
+				type: message.type
+			},
+			to: {
+				id: thread.id,
+				type: thread.type
+			}
 		}
 	})
 
@@ -1618,8 +1727,14 @@ ava('.query() should be able to query using links when getting an element by slu
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: message.id,
-			to: thread.id
+			from: {
+				id: message.id,
+				type: message.type
+			},
+			to: {
+				id: thread.id,
+				type: thread.type
+			}
 		}
 	})
 
@@ -1712,8 +1827,14 @@ ava('.query() should be able to query using links and an inverse name', async (t
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: message1.id,
-			to: thread.id
+			from: {
+				id: message1.id,
+				type: message1.type
+			},
+			to: {
+				id: thread.id,
+				type: thread.type
+			}
 		}
 	})
 
@@ -1724,8 +1845,14 @@ ava('.query() should be able to query using links and an inverse name', async (t
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: message2.id,
-			to: thread.id
+			from: {
+				id: message2.id,
+				type: message2.type
+			},
+			to: {
+				id: thread.id,
+				type: thread.type
+			}
 		}
 	})
 
@@ -1825,8 +1952,14 @@ ava('.query() should omit a result if a link does not match', async (test) => {
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: card1.id,
-			to: thread.id
+			from: {
+				id: card1.id,
+				type: card1.type
+			},
+			to: {
+				id: thread.id,
+				type: thread.type
+			}
 		}
 	})
 
@@ -1846,8 +1979,14 @@ ava('.query() should omit a result if a link does not match', async (test) => {
 		name: 'is attached to',
 		data: {
 			inverseName: 'has attached element',
-			from: card2.id,
-			to: foo.id
+			from: {
+				id: card2.id,
+				type: card2.type
+			},
+			to: {
+				id: foo.id,
+				type: foo.type
+			}
 		}
 	})
 

--- a/test/unit/core/links.spec.js
+++ b/test/unit/core/links.spec.js
@@ -163,7 +163,9 @@ ava('.evaluate(is attached to) should return the declared target properties', as
 		}
 	})
 
-	const linkedInput = await test.context.backend.getElementById(input.id)
+	const linkedInput = await test.context.backend.getElementById(input.id, {
+		type: input.type
+	})
 
 	const results = await links.evaluate(test.context.context, linkedInput, 'is attached to', {
 		type: 'object',
@@ -232,7 +234,9 @@ ava('.evaluate(is attached to) should return the whole target if additionalPrope
 		}
 	})
 
-	const linkedInput = await test.context.backend.getElementById(input.id)
+	const linkedInput = await test.context.backend.getElementById(input.id, {
+		type: input.type
+	})
 
 	const results = await links.evaluate(test.context.context, linkedInput, 'is attached to', {
 		type: 'object',
@@ -376,7 +380,9 @@ ava('.evaluate(has attached element) should return matching elements', async (te
 		}
 	})
 
-	const linkedInput = await test.context.backend.getElementById(input.id)
+	const linkedInput = await test.context.backend.getElementById(input.id, {
+		type: input.type
+	})
 
 	const results = await links.evaluate(test.context.context, linkedInput, 'has attached element', {
 		type: 'object',
@@ -447,7 +453,9 @@ ava('.evaluateCard() should return one link of one type given one match', async 
 		}
 	})
 
-	const linkedInput = await test.context.backend.getElementById(input.id)
+	const linkedInput = await test.context.backend.getElementById(input.id, {
+		type: input.type
+	})
 
 	const results = await links.evaluateCard(test.context.context, linkedInput, {
 		'is attached to': {
@@ -571,7 +579,9 @@ ava('.evaluateCard() should return multiple cards per link', async (test) => {
 		}
 	})
 
-	const linkedInput = await test.context.backend.getElementById(input.id)
+	const linkedInput = await test.context.backend.getElementById(input.id, {
+		type: input.type
+	})
 
 	const results = await links.evaluateCard(test.context.context, linkedInput, {
 		'has attached element': {
@@ -690,7 +700,9 @@ ava('.evaluateCard() should return false if one link is unsatisfied', async (tes
 		}
 	})
 
-	const linkedInput = await test.context.backend.getElementById(input.id)
+	const linkedInput = await test.context.backend.getElementById(input.id, {
+		type: input.type
+	})
 
 	const results = await links.evaluateCard(test.context.context, linkedInput, {
 		'has attached element': {


### PR DESCRIPTION
I found that in all cases where we're using these direct getters, we
always know the type we are expecting in result. Therefore it makes
sense to make it required, simplifying a lot of the logic to traverse
through tables, and to make it very hard to introduce performance
regressions that impact database reads.

Change-type: patch