### PR TITLE
core: Fix JSON-e error when including $ prefixed properties

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -303,23 +303,27 @@ const createMarkersQuery = (markers) => {
 	}
 }
 
-const evalSchema = (user, schema) => {
-	// If json-e encounters a property that starts with more than one
-	// dollar sign, then it will remove one for some reason. The
-	// only way I found to workaround this is to double escape before
-	// calling json-e, so that the resulting key remains accurate.
-	if (schema.$$sort) {
-		schema.$$$sort = schema.$$sort
-		Reflect.deleteProperty(schema, '$$sort')
-	}
-	if (schema.$$links) {
-		schema.$$$links = schema.$$links
-		Reflect.deleteProperty(schema, '$$links')
+// Only consider objects with $eval
+const evalSchema = (object, context) => {
+	if (object.$eval) {
+		return jsone(object, context)
 	}
 
-	return jsone(schema, {
-		user
-	})
+	if (object.$id) {
+		Reflect.deleteProperty(object, '$id')
+	}
+
+	for (const key of Object.keys(object)) {
+		// For performance reasons
+		// eslint-disable-next-line lodash/prefer-lodash-typecheck
+		if (typeof object[key] !== 'object') {
+			continue
+		}
+
+		object[key] = evalSchema(object[key], context)
+	}
+
+	return object
 }
 
 /**
@@ -350,7 +354,11 @@ const evalSchema = (user, schema) => {
 exports.getQuery = async (context, backend, session, schema, options) => {
 	const user = await exports.getSessionUser(context, backend, session)
 
-	const evalFn = _.partial(evalSchema, user)
+	const evalFn = (object) => {
+		return evalSchema(object, {
+			user
+		})
+	}
 
 	const permissionFilters = await getRoleViews(context, backend, user, {
 		writeMode: options.writeMode

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -363,6 +363,10 @@ module.exports = class Worker {
 			})
 		})
 
+		if (!cards.session) {
+			throw new errors.WorkerNoElement(`No such session: ${session}`, execCtx)
+		}
+
 		if (!cards.action) {
 			throw new errors.WorkerInvalidAction(`No such action: ${options.action}`, execCtx)
 		}


### PR DESCRIPTION
Otherwise you will get:

```
$<identifier> is reserved; use $$<identifier>
```

Change-type: patch
Fixes: #1073