### PR TITLE
worker/action-library: Move duplicate update logic to executor.insertCard()

### DIFF
--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -136,18 +136,31 @@ exports.insertCard = async (jellyfish, session, typeCard, options, object, execu
 	}
 
 	object.type = typeCard.slug
-
-	const hasCard = options.attachEvents && await utils.hasCard(jellyfish, session, object, {
+	const getOptions = {
 		writeMode: true,
 		type: object.type,
 		ctx: executionContext
-	})
+	}
 
+	let card = null
+	if (object.slug) {
+		card = await jellyfish.getCardBySlug(session, object.slug, getOptions)
+	}
+	if (!card && object.id) {
+		card = await jellyfish.getCardById(session, object.id, getOptions)
+	}
+
+	const hasCard = options.attachEvents && card
 	const evaluationResult = jellyscript.evaluateObject(typeCard.data.schema, object)
+
 	const insertedCard = await jellyfish.insertCard(session, evaluationResult, {
 		override: options.override,
 		ctx: executionContext
 	})
+
+	if (_.isEqual(insertedCard, card)) {
+		return null
+	}
 
 	if (options.attachEvents) {
 		const eventName = options.override && hasCard ? 'update' : 'create'

--- a/test/unit/worker/executor.spec.js
+++ b/test/unit/worker/executor.spec.js
@@ -223,6 +223,28 @@ ava('.insertCard() should be able to set a name', async (test) => {
 	test.is(card.name, 'Hello')
 })
 
+ava('.insertCard() should not upsert if no changes were made', async (test) => {
+	await test.context.jellyfish.insertCard(test.context.session, {
+		slug: 'foo-bar-baz',
+		type: 'card',
+		version: '1.0.0'
+	})
+
+	const typeCard = await test.context.jellyfish.getCardBySlug(test.context.session, 'card')
+	await executor.insertCard(test.context.jellyfish, test.context.session, typeCard, {
+		currentTime: new Date(),
+		override: true,
+		attachEvents: true,
+		executeAction: test.context.executeAction
+	}, {
+		version: '1.0.0',
+		slug: 'foo-bar-baz',
+		active: true
+	})
+
+	test.deepEqual(test.context.queue, [])
+})
+
 ava('.insertCard() should override if the override option is true', async (test) => {
 	const previousCard = await test.context.jellyfish.insertCard(test.context.session, {
 		slug: 'foo-bar-baz',


### PR DESCRIPTION
Otherwise if something else goes through `executor.insertCard()` rather
than through `action-update-card` (like sync integrations), then you
might end up with duplicate update events.

Change-type: patch