### PR TITLE
core: Group get operations when traversing links

### DIFF
--- a/lib/core/links.js
+++ b/lib/core/links.js
@@ -66,7 +66,7 @@ exports.evaluate = async (context, card, name, linkSchema) => {
 		? totalLinks.slice(totalLinks.length - LINK_MAX)
 		: totalLinks
 
-	return Bluebird.reduce(links, async (accumulator, link) => {
+	const references = await Bluebird.reduce(links, async (accumulator, link) => {
 		const linkCard = await context.getElementById(link.$link, {
 			type: 'link'
 		})
@@ -78,25 +78,42 @@ exports.evaluate = async (context, card, name, linkSchema) => {
 		const type = name === linkCard.name
 			? linkCard.data.to.type
 			: linkCard.data.from.type
-		const linkResult = await context.getElementById(link.id, {
+
+		accumulator.push({
+			[LINK_ORIGIN_PROPERTY]: link[LINK_ORIGIN_PROPERTY],
+			id: link.id,
 			type
 		})
 
-		const filteredResult = jsonSchema.filter(linkSchema, linkResult)
-		if (!filteredResult) {
-			return accumulator
-		}
-
-		filteredResult[LINK_ORIGIN_PROPERTY] = link[LINK_ORIGIN_PROPERTY]
-
-		// Don't resolve sub-links, at least for now
-		if (filteredResult.links) {
-			filteredResult.links = {}
-		}
-
-		accumulator.push(filteredResult)
 		return accumulator
 	}, [])
+
+	const cards = await Bluebird.map(references, async (reference) => {
+		const result = await context.getElementById(reference.id, {
+			type: reference.type
+		})
+
+		if (result) {
+			result[LINK_ORIGIN_PROPERTY] = reference[LINK_ORIGIN_PROPERTY]
+
+			// Don't resolve sub-links, at least for now
+			if (result.links) {
+				result.links = {}
+			}
+		}
+
+		return result
+	}, {
+		concurrency: 5
+	})
+
+	if (linkSchema.properties) {
+		linkSchema.properties[LINK_ORIGIN_PROPERTY] = {
+			type: 'string'
+		}
+	}
+
+	return jsonSchema.filter(linkSchema, cards) || []
 }
 
 /**


### PR DESCRIPTION
This makes us only run JSON Schema filtering once for the final array,
and makes it trivial to refactor the code to use batch getters.

Change-type: patch