### PR TITLE
Only run unit tests on resinCI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ COPY --from=base /usr/src/app /usr/src/app
 RUN rethinkdb --version && \
 		rethinkdb --daemon --bind all && \
 		make lint && \
-		make test-unit COVERAGE=0 && \
-		make test-integration COVERAGE=0
+		make test-unit COVERAGE=0
 
 FROM node:dubnium-jessie as runtime
 


### PR DESCRIPTION
We are running the entire test suite already on circleCI, running them
again on resinCI just slows down the testing process

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>