### PR TITLE
queue: Add temporary logs on .wait()

### DIFF
--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -223,9 +223,16 @@ exports.wait = async (jellyfish, session, options) => {
 		required: [ 'active', 'type', 'data' ]
 	}
 
+	logger.info(options.ctx, 'Waiting for execute event', options)
 	const stream = await jellyfish.stream(options.ctx, session, schema)
+
+	logger.info(options.ctx, 'Preparing to query before stream')
 	const request = await jellyfish.query(options.ctx, session, schema, {
 		limit: 1
+	})
+
+	logger.info(options.ctx, 'Query before stream', {
+		count: request.length
 	})
 
 	if (request.length > 0) {
@@ -255,20 +262,32 @@ exports.wait = async (jellyfish, session, options) => {
 			resolve(result)
 		})
 
+		logger.info(options.ctx, 'Preparing to query after stream')
+
 		// A couple of retries now that the stream is finally setup
 		jellyfish.query(options.ctx, session, schema, {
 			limit: 1
 		}).then((firstResults) => {
+			logger.info(options.ctx, 'Query after stream', {
+				count: firstResults.length
+			})
+
 			if (firstResults.length > 0) {
 				stream.close()
 				return resolve(firstResults[0])
 			}
+
+			logger.info(options.ctx, 'Starting last retry timeout')
 
 			timeout = setTimeout(() => {
 				logger.warn(options.ctx, 'Last poll retry when waiting for execute event', options)
 				jellyfish.query(options.ctx, session, schema, {
 					limit: 1
 				}).then((secondResults) => {
+					logger.info(options.ctx, 'Last query after stream', {
+						count: secondResults.length
+					})
+
 					if (secondResults.length > 0) {
 						stream.close()
 						return resolve(secondResults[0])
@@ -276,6 +295,7 @@ exports.wait = async (jellyfish, session, options) => {
 
 					throw new Error('Cancelling stream')
 				}).catch((error) => {
+					logger.error(options.ctx, 'Error on last query after stream', error)
 					stream.close()
 					return reject(error)
 				})
@@ -283,6 +303,7 @@ exports.wait = async (jellyfish, session, options) => {
 
 			return timeout
 		}).catch((error) => {
+			logger.error(options.ctx, 'Error on first query after stream', error)
 			stream.close()
 			clearTimeout(timeout)
 			return reject(error)


### PR DESCRIPTION
For debugging purposes. Should probably be reverted or reduced
afterwards.

Change-type: patch