### PR TITLE
queue: Use a predictable execute event slug based on the request

### DIFF
--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -15,7 +15,6 @@
  */
 
 const Bluebird = require('bluebird')
-const uuid = require('uuid/v4')
 
 /**
  * @summary The execution event card type slug
@@ -77,7 +76,7 @@ exports.post = async (jellyfish, session, options, results, ctx) => {
 
 	const contents = {
 		type: EXECUTION_EVENT_TYPE,
-		slug: `${EXECUTION_EVENT_TYPE}-${data.actor}-${uuid()}`,
+		slug: `${EXECUTION_EVENT_TYPE}-${data.actor}-${options.id}`,
 		version: '1.0.0',
 		active: true,
 		links: {},
@@ -179,7 +178,12 @@ exports.wait = async (jellyfish, session, options) => {
 	const schema = {
 		type: 'object',
 		additionalProperties: true,
+		required: [ 'slug', 'active', 'type' ],
 		properties: {
+			slug: {
+				type: 'string',
+				const: `${EXECUTION_EVENT_TYPE}-${options.actor}-${options.id}`
+			},
 			active: {
 				type: 'boolean',
 				const: true
@@ -187,39 +191,8 @@ exports.wait = async (jellyfish, session, options) => {
 			type: {
 				type: 'string',
 				const: EXECUTION_EVENT_TYPE
-			},
-			data: {
-				type: 'object',
-				additionalProperties: true,
-				required: [ 'target', 'actor', 'payload' ],
-				properties: {
-					target: {
-						type: 'string',
-						const: options.action
-					},
-					actor: {
-						type: 'string',
-						const: options.actor
-					},
-					payload: {
-						type: 'object',
-						additionalProperties: true,
-						required: [ 'id', 'card' ],
-						properties: {
-							id: {
-								type: 'string',
-								const: options.id
-							},
-							card: {
-								type: 'string',
-								const: options.card
-							}
-						}
-					}
-				}
 			}
-		},
-		required: [ 'active', 'type', 'data' ]
+		}
 	}
 
 	const stream = await jellyfish.stream(options.ctx, session, schema)


### PR DESCRIPTION
This means that we don't have to do a full blown unoptimized query, but
just a constant get by slug operation.

Change-type: patch