### PR TITLE
default-cards: Don't constraint issue valid repositories

### DIFF
--- a/default-cards/contrib/issue.json
+++ b/default-cards/contrib/issue.json
@@ -27,18 +27,7 @@
           "type": "object",
           "properties": {
             "repository": {
-              "type": "string",
-              "enum": [
-                "balena-io/jellyfish-test-github",
-                "balena-io/balena-demo",
-                "balena-io/resin-api-demo",
-                "balena-io/resin-ui-demo",
-                "balena-io/jellyfish",
-                "resin-io/balena-demo",
-                "resin-io/resin-api-demo",
-                "resin-io/resin-ui-demo",
-                "resin-io/jellyfish"
-              ]
+              "type": "string"
             },
             "mentionsUser": {
               "type": "array",

--- a/default-cards/contrib/support-thread.json
+++ b/default-cards/contrib/support-thread.json
@@ -12,8 +12,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "pattern": "^.*\\S.*$"
+          "type": "string"
         },
         "tags": {
           "type": "array",


### PR DESCRIPTION
Right now, any issue that is not from those repositories is discarded by
our integrations.

Change-type: patch