### PR TITLE
server/worker: Improve how errors look like in logs

### DIFF
--- a/lib/server/error-reporter.js
+++ b/lib/server/error-reporter.js
@@ -36,7 +36,11 @@ class Reporter {
 
 	reportException (error) {
 		logger.error('Reporting server exception', {
-			error
+			error: {
+				message: error.message,
+				name: error.name,
+				stack: error.stack
+			}
 		})
 
 		if (!this.initialized) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -10,7 +10,11 @@ const {
 createServer()
 	.catch((error) => {
 		logger.error(ctx, 'Server error', {
-			error
+			error: {
+				message: error.message,
+				name: error.name,
+				stack: error.stack
+			}
 		})
 
 		reportException(error)

--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -311,7 +311,11 @@ exports.bindRoutes = (jellyfish, worker, app, socketServer) => {
 		}).catch((error) => {
 			const currentDate = new Date()
 			logger.error(ctx, 'HTTP unexpected error', {
-				error
+				error: {
+					message: error.message,
+					name: error.name,
+					stack: error.stack
+				}
 			})
 
 			return response.status(500).json({

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -448,7 +448,11 @@ module.exports = class Worker {
 			}
 		}).catch((error) => {
 			logger.error(ctx, 'Execute error', {
-				error
+				error: {
+					message: error.message,
+					name: error.name,
+					stack: error.stack
+				}
 			})
 
 			return {


### PR DESCRIPTION
Otherwise we just see `error: {}`.

Change-type: patch