### PR TITLE
circleci: Run unit and integration tests multiple times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
                 - dist
                 - node_modules
 
-  unit_tests:
+  unit_tests: &unit_tests
     <<: *job_defaults
 
     steps:
@@ -80,7 +80,7 @@ jobs:
           paths:
             - .nyc_output/*.json
 
-  integration_tests:
+  integration_tests: &integration_tests
     <<: *job_defaults
 
     steps:
@@ -108,7 +108,7 @@ jobs:
           paths:
             - .nyc_output/*.json
 
-  integration_tests_prod:
+  integration_tests_production:
     <<: *job_defaults
 
     steps:
@@ -135,6 +135,16 @@ jobs:
           root: .
           paths:
             - .nyc_output/*.json
+
+  # To attempt to detect flaky tests
+  unit_tests2:
+    <<: *unit_tests
+  unit_tests3:
+    <<: *unit_tests
+  integration_tests2:
+    <<: *integration_tests
+  integration_tests3:
+    <<: *integration_tests
 
   stress_tests:
     <<: *job_defaults
@@ -205,13 +215,29 @@ workflows:
                 requires:
                     - build
                 <<: *workflow_filter
+            - unit_tests2:
+                requires:
+                    - build
+                <<: *workflow_filter
+            - unit_tests3:
+                requires:
+                    - build
+                <<: *workflow_filter
 
             - integration_tests:
                 requires:
                     - build
                 <<: *workflow_filter
+            - integration_tests2:
+                requires:
+                    - build
+                <<: *workflow_filter
+            - integration_tests3:
+                requires:
+                    - build
+                <<: *workflow_filter
 
-            - integration_tests_prod:
+            - integration_tests_production:
                 requires:
                     - build
                 <<: *workflow_filter
@@ -224,8 +250,12 @@ workflows:
             - results:
                 requires:
                   - unit_tests
+                  - unit_tests2
+                  - unit_tests3
                   - integration_tests
-                  - integration_tests_prod
+                  - integration_tests2
+                  - integration_tests3
+                  - integration_tests_production
                 <<: *workflow_filter
 
             - eslint_jellyfish:


### PR DESCRIPTION
This should be a good enough solution to prevent us from inserting flaky
tests or flaky components that make the tests sporadically fail. It is
more computational wasteful, but I think its a fair tradeoff given the
amount of time we're spending dealing with sporadic CI failures (when
debugging them or trying to merge something else).

If it becomes a problem, then we can probably get more Circle CI
parallel jobs in our plan.

Change-type: patch