### PR TITLE
sync: Handle intercom e-mails from Front contacts

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -549,6 +549,10 @@ module.exports = class FrontIntegration {
 	}
 }
 
+const isEmail = (string) => {
+	return /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(string)
+}
+
 module.exports.getLocalUser = async (event, options) => {
 	// eslint-disable-next-line no-underscore-dangle
 	if (event.data.payload.source._meta.type === 'teammate') {
@@ -581,7 +585,7 @@ module.exports.getLocalUser = async (event, options) => {
 
 	const front = new Front(options.token.api)
 
-	if (/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(from.handle)) {
+	if (isEmail(from.handle)) {
 		return {
 			type: 'account',
 			email: from.handle
@@ -605,9 +609,20 @@ module.exports.getLocalUser = async (event, options) => {
 		contact_id: _.last(_.split(from._links.related.contact, '/'))
 	})
 
+	if (isEmail(contact.name)) {
+		return {
+			type: 'account',
+			email: contact.email
+		}
+	}
+
+	const name = contact.name
+		.replace(/[^a-z0-9-]/g, '-')
+		.replace(/-{1,}/g, '-')
+
 	return {
 		type: 'account',
-		email: contact.name
+		email: `${name}@intercom.io`
 	}
 }
 

--- a/test/integration/sync/front-translate.spec.js
+++ b/test/integration/sync/front-translate.spec.js
@@ -28,7 +28,7 @@ helpers.translate.scenario(TOKEN ? ava : ava.skip, {
 	scenarios: require('./webhooks/front'),
 	slices: _.range(0, 2),
 	baseUrl: 'https://api2.frontapp.com',
-	stubRegex: /^\/conversations\/.+\/(messages|inboxes)$/,
+	stubRegex: /^\/(conversations|contacts)\/.+(\/(messages|inboxes))?$/,
 	source: 'front',
 	options: {
 		token: TOKEN

--- a/test/integration/sync/webhooks/front/index.js
+++ b/test/integration/sync/webhooks/front/index.js
@@ -15,6 +15,12 @@
  */
 
 module.exports = {
+	'intercom-no-author': {
+		expected: require('./intercom-no-author/expected.json'),
+		steps: [
+			require('./intercom-no-author/01.json')
+		]
+	},
 	'discourse-topic-message': {
 		expected: require('./discourse-topic-message/expected.json'),
 		steps: [

--- a/test/integration/sync/webhooks/front/intercom-no-author/01.json
+++ b/test/integration/sync/webhooks/front/intercom-no-author/01.json
@@ -1,0 +1,172 @@
+{
+  "headers": {
+    "accept": "application/json",
+    "connection": "close",
+    "content-length": "8237",
+    "content-type": "application/json; charset=utf-8",
+    "host": "jel.ly.fish",
+    "user-agent": "Needle/1.3.0 (Node.js v9.11.1; linux x64)",
+    "x-forwarded-for": "54.67.1.220",
+    "x-forwarded-host": "jel.ly.fish",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https",
+    "x-front-signature": "WZR6qgT67y8EvimrfUDTixSb1M0=",
+    "x-original-uri": "/api/v2/hooks/front/",
+    "x-real-ip": "54.67.1.220",
+    "x-scheme": "https"
+  },
+  "payload": {
+    "_links": {
+      "self": "https://api2.frontapp.com/events/evt_5c2a47n"
+    },
+    "conversation": {
+      "_links": {
+        "related": {
+          "comments": "https://api2.frontapp.com/conversations/cnv_16ax9l7/comments",
+          "events": "https://api2.frontapp.com/conversations/cnv_16ax9l7/events",
+          "followers": "https://api2.frontapp.com/conversations/cnv_16ax9l7/followers",
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_16ax9l7/inboxes",
+          "messages": "https://api2.frontapp.com/conversations/cnv_16ax9l7/messages"
+        },
+        "self": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+      },
+      "assignee": null,
+      "created_at": 1546464991.639,
+      "id": "cnv_16ax9l7",
+      "is_private": false,
+      "last_message": {
+        "_links": {
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+          },
+          "self": "https://api2.frontapp.com/messages/msg_284xm4z"
+        },
+        "attachments": [],
+        "author": null,
+        "blurb": "",
+        "body": "<p>Hi dt-rush,<br />To run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script.  So they are running from the shell using the Command::new() portion of std::process::Command from Rust.  </p>\n<p>For some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:</p>\n<p>---Snip---<br />FROM balenalib/amd64-ubuntu</p>\n<p>ENV INITSYSTEM on</p>\n<p>RUN apt-get update</p>\n<p>RUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\<br />    &amp;&amp; systemctl mask NetworkManager.service \\<br />    &amp;&amp; apt-get clean \\<br />    &amp;&amp; rm -rf /var/lib/apt/lists/*<br />---Snip---</p>\n<p>The rest is just some application specific stuff to put files in the container and run it.</p>\n<p>Ill look into the systemd service idea today.  One issue I am assuming I&#39;d need to solve is bringing up the new wifi interface before I reboot, I&#39;m not sure if NM will allow me to do that if the balena tunnel is running on another device however.  If you have any other suggestions or details around that approach I&#39;m listening.</p>\n<p>Thanks,<br />Brant</p>\n<a href=\"https://www.balena-cloud.com?hidden=reply&source=flowdock&flow=rulemotion/public-s-community&thread=TAz9aNXmYye6c4FeZGg-7MmHznc&hmac=d430d2534f80fa099bd2556deb1facc82d5dff927a1d6bec08e33a33e81466fc\" target=\"_blank\" rel=\"noopener noreferrer\"></a>",
+        "created_at": 1546612197.276,
+        "error_type": null,
+        "id": "msg_284xm4z",
+        "is_draft": false,
+        "is_inbound": false,
+        "metadata": {
+          "headers": {
+            "in_reply_to": "287f6fb565446cd6c9255a5bb1c6e3c9@frontapp.com"
+          }
+        },
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_2yqwmh"
+              }
+            },
+            "handle": "423a0f350b6f1102",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_8rhkb7"
+              }
+            },
+            "handle": "BrantR",
+            "role": "to"
+          }
+        ],
+        "text": "Hi dt-rush,\nTo run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script. So they are running from the shell using the Command::new() portion of std::process::Command from Rust. \nFor some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:\n---Snip---\nFROM balenalib/amd64-ubuntu\nENV INITSYSTEM on\nRUN apt-get update\nRUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\\n&& systemctl mask NetworkManager.service \\\n&& apt-get clean \\\n&& rm -rf /var/lib/apt/lists/*\n---Snip---\nThe rest is just some application specific stuff to put files in the container and run it.\nIll look into the systemd service idea today. One issue I am assuming I'd need to solve is bringing up the new wifi interface before I reboot, I'm not sure if NM will allow me to do that if the balena tunnel is running on another device however. If you have any other suggestions or details around that approach I'm listening.\nThanks,\nBrant",
+        "type": "custom"
+      },
+      "recipient": {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_8rhkb7"
+          }
+        },
+        "handle": "BrantR",
+        "role": "to"
+      },
+      "status": "unassigned",
+      "subject": "Reconfiguration of wifi adapter settings for static IP not sticking",
+      "tags": []
+    },
+    "emitted_at": 1546612197.276,
+    "id": "evt_5c2a47n",
+    "source": {
+      "_meta": {
+        "type": "inboxes"
+      },
+      "data": [
+        {
+          "_links": {
+            "related": {
+              "channels": "https://api2.frontapp.com/inboxes/inb_23sp/channels",
+              "conversations": "https://api2.frontapp.com/inboxes/inb_23sp/conversations",
+              "owner": "https://api2.frontapp.com/teams/tim_qh",
+              "teammates": "https://api2.frontapp.com/inboxes/inb_23sp/teammates"
+            },
+            "self": "https://api2.frontapp.com/inboxes/inb_23sp"
+          },
+          "address": "423a0f350b6f1102",
+          "id": "inb_23sp",
+          "is_private": false,
+          "name": "S/Forums",
+          "send_as": "423a0f350b6f1102",
+          "type": "custom"
+        }
+      ]
+    },
+    "target": {
+      "_meta": {
+        "type": "message"
+      },
+      "data": {
+        "_links": {
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+          },
+          "self": "https://api2.frontapp.com/messages/msg_284xm4z"
+        },
+        "attachments": [],
+        "author": null,
+        "blurb": "",
+        "body": "<p>Hi dt-rush,<br />To run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script.  So they are running from the shell using the Command::new() portion of std::process::Command from Rust.  </p>\n<p>For some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:</p>\n<p>---Snip---<br />FROM balenalib/amd64-ubuntu</p>\n<p>ENV INITSYSTEM on</p>\n<p>RUN apt-get update</p>\n<p>RUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\<br />    &amp;&amp; systemctl mask NetworkManager.service \\<br />    &amp;&amp; apt-get clean \\<br />    &amp;&amp; rm -rf /var/lib/apt/lists/*<br />---Snip---</p>\n<p>The rest is just some application specific stuff to put files in the container and run it.</p>\n<p>Ill look into the systemd service idea today.  One issue I am assuming I&#39;d need to solve is bringing up the new wifi interface before I reboot, I&#39;m not sure if NM will allow me to do that if the balena tunnel is running on another device however.  If you have any other suggestions or details around that approach I&#39;m listening.</p>\n<p>Thanks,<br />Brant</p>\n<a href=\"https://www.balena-cloud.com?hidden=reply&source=flowdock&flow=rulemotion/public-s-community&thread=TAz9aNXmYye6c4FeZGg-7MmHznc&hmac=d430d2534f80fa099bd2556deb1facc82d5dff927a1d6bec08e33a33e81466fc\" target=\"_blank\" rel=\"noopener noreferrer\"></a>",
+        "created_at": 1546612197.276,
+        "error_type": null,
+        "id": "msg_284xm4z",
+        "is_draft": false,
+        "is_inbound": false,
+        "metadata": {
+          "headers": {
+            "in_reply_to": "287f6fb565446cd6c9255a5bb1c6e3c9@frontapp.com"
+          }
+        },
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_2yqwmh"
+              }
+            },
+            "handle": "423a0f350b6f1102",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_8rhkb7"
+              }
+            },
+            "handle": "BrantR",
+            "role": "to"
+          }
+        ],
+        "text": "Hi dt-rush,\nTo run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script. So they are running from the shell using the Command::new() portion of std::process::Command from Rust. \nFor some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:\n---Snip---\nFROM balenalib/amd64-ubuntu\nENV INITSYSTEM on\nRUN apt-get update\nRUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\\n&& systemctl mask NetworkManager.service \\\n&& apt-get clean \\\n&& rm -rf /var/lib/apt/lists/*\n---Snip---\nThe rest is just some application specific stuff to put files in the container and run it.\nIll look into the systemd service idea today. One issue I am assuming I'd need to solve is bringing up the new wifi interface before I reboot, I'm not sure if NM will allow me to do that if the balena tunnel is running on another device however. If you have any other suggestions or details around that approach I'm listening.\nThanks,\nBrant",
+        "type": "custom"
+      }
+    },
+    "type": "out_reply"
+  },
+  "source": "front"
+}

--- a/test/integration/sync/webhooks/front/intercom-no-author/expected.json
+++ b/test/integration/sync/webhooks/front/intercom-no-author/expected.json
@@ -1,0 +1,75 @@
+{
+  "head": {
+    "name": "Reconfiguration of wifi adapter settings for static IP not sticking",
+    "type": "support-thread",
+    "version": "1.0.0",
+    "active": true,
+    "tags": [],
+    "requires": [],
+    "capabilities": [],
+    "data": {
+      "environment": "production",
+      "inbox": "S/Forums",
+      "mirrors": [
+        "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+      ],
+      "mentionsUser": [],
+      "alertsUser": [],
+      "description": "",
+      "status": "open"
+    }
+  },
+  "tail": [
+    {
+      "active": true,
+      "capabilities": [],
+      "data": {
+        "payload": {
+          "active": true,
+          "capabilities": [],
+          "data": {
+            "alertsUser": [],
+            "description": "",
+            "environment": "production",
+            "inbox": "S/Forums",
+            "mentionsUser": [],
+            "mirrors": [
+              "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+            ],
+            "status": "open"
+          },
+          "name": "Reconfiguration of wifi adapter settings for static IP not sticking",
+          "requires": [],
+          "tags": [],
+          "type": "support-thread",
+          "version": "1.0.0"
+        },
+        "timestamp": "2019-01-02T21:36:31.639Z"
+      },
+      "requires": [],
+      "tags": [],
+      "type": "create",
+      "version": "1.0.0"
+    },
+    {
+      "version": "1.0.0",
+      "tags": [],
+      "capabilities": [],
+      "type": "message",
+      "active": true,
+      "requires": [],
+      "data": {
+        "target": "70ac6348-5c4f-46e4-9499-d8e74c0b6ad7",
+        "timestamp": "2019-01-04T14:29:57.276Z",
+        "mirrors": [
+          "https://api2.frontapp.com/messages/msg_284xm4z"
+        ],
+        "payload": {
+          "alertsUser": [],
+          "mentionsUser": [],
+          "message": "Hi dt-rush,\nTo run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script. So they are running from the shell using the Command::new() portion of std::process::Command from Rust. \nFor some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:\n---Snip---\nFROM balenalib/amd64-ubuntu\nENV INITSYSTEM on\nRUN apt-get update\nRUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\\n&& systemctl mask NetworkManager.service \\\n&& apt-get clean \\\n&& rm -rf /var/lib/apt/lists/*\n---Snip---\nThe rest is just some application specific stuff to put files in the container and run it.\nIll look into the systemd service idea today. One issue I am assuming I'd need to solve is bringing up the new wifi interface before I reboot, I'm not sure if NM will allow me to do that if the balena tunnel is running on another device however. If you have any other suggestions or details around that approach I'm listening.\nThanks,\nBrant"
+        }
+      }
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/intercom-no-author/slice-0/contacts-crd-2-yqwmh.json
+++ b/test/integration/sync/webhooks/front/intercom-no-author/slice-0/contacts-crd-2-yqwmh.json
@@ -1,0 +1,25 @@
+{
+  "_links": {
+    "self": "https://api2.frontapp.com/contacts/crd_2yqwmh",
+    "related": {
+      "notes": "https://api2.frontapp.com/contacts/crd_2yqwmh/notes",
+      "conversations": "https://api2.frontapp.com/contacts/crd_2yqwmh/conversations",
+      "owner": "https://api2.frontapp.com/teams/tim_qh"
+    }
+  },
+  "id": "crd_2yqwmh",
+  "name": "S/Community_Custom",
+  "description": "",
+  "avatar_url": null,
+  "links": [],
+  "handles": [
+    {
+      "source": "custom",
+      "handle": "423a0f350b6f1102"
+    }
+  ],
+  "groups": [],
+  "updated_at": 1497605988,
+  "custom_fields": {},
+  "is_private": false
+}


### PR DESCRIPTION
The original error looks like this:

```
[worker/index.js] [\u001b[31merror\u001b[39m] [MISSING-TRANSACTION]: Execute error [{\"error\":{\"message\":\"Invalid object:\\n\\n{\\n \\\"active\\\": true,\\n \\\"version\\\": \\\"1.0.0\\\",\\n \\\"tags\\\": [],\\n \\\"markers\\\": [],\\n \\\"links\\\": {},\\n \\\"requires\\\": [],\\n \\\"capabilities\\\": [],\\n \\\"data\\\": {\\n \\\"email\\\": \\\"S/Community_Custom\\\"\\n },\\n \\\"slug\\\": \\\"account-S/Community_Custom\\\",\\n \\\"type\\\": \\\"account\\\",\\n \\\"created_at\\\": \\\"2019-01-04T14:29:59.429Z\\\"\\n}\\n\\n- data.slug should match pattern \\\"^[a-z0-9-]+$\\\"\",\"name\":\"JellyfishSchemaMismatch\",\"stack\":\"JellyfishSchemaMismatch: Invalid object:\\n\\n{\\n \\\"active\\\": true,\\n \\\"version\\\": \\\"1.0.0\\\",\\n \\\"tags\\\": [],\\n \\\"markers\\\": [],\\n \\\"links\\\": {},\\n \\\"requires\\\": [],\\n \\\"capabilities\\\": [],\\n \\\"data\\\": {\\n \\\"email\\\": \\\"S/Community_Custom\\\"\\n },\\n \\\"slug\\\": \\\"account-S/Community_Custom\\\",\\n \\\"type\\\": \\\"account\\\",\\n \\\"created_at\\\": \\\"2019-01-04T14:29:59.429Z\\\"\\n}\\n\\n- data.slug should match pattern \\\"^[a-z0-9-]+$\\\"\\n at new TypedError (/usr/src/app/node_modules/typed-errors/src/make-typed-error.js:8:19)\\n at Object.exports.validate (/usr/src/app/node_modules/skhema/lib/index.js:497:9)\\n at Kernel.insertCard (/usr/src/app/lib/core/kernel.js:439:14)\\n at process._tickCallback (internal/process/next_tick.js:68:7)\"}}]
```

The problem is that given an inbount Intercom message delivered through
Front, the author will be "S/Community_Custom", which is not a valid
e-mail.

Change-type: patch