### PR TITLE
test: Remove debug .only from worker unit tests

### DIFF
--- a/test/unit/worker/index.spec.js
+++ b/test/unit/worker/index.spec.js
@@ -2515,7 +2515,7 @@ ava('action-create-event should create a link card', async (test) => {
 	}))
 })
 
-ava.only('events should always inherit their parent\'s markers', async (test) => {
+ava('events should always inherit their parent\'s markers', async (test) => {
 	const {
 		context,
 		jellyfish,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>