### PR TITLE
circleci: Generate gitstats report

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -3,7 +3,7 @@ FROM rethinkdb:2.3.6
 RUN apt-get update && apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 # Install node, git and packages required to run headless chrome
-RUN apt-get update && apt-get install -y nodejs build-essential \
+RUN apt-get update && apt-get install -y nodejs gnuplot gitstats build-essential \
 	wget jq git python-pip python-dev libX11-xcb1 libxcomposite1 \
 	libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
 	libgconf2-4 libasound2 libatk1.0-0 libgtk-3-0 shellcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,9 @@ jobs:
       - run:
           name: Store Code Coverage Results
           command: make report-coverage && mkdir -p /tmp/test-results && cp -rf coverage /tmp/test-results
+      - run:
+          name: Git Stats
+          command: gitstats . /tmp/test-results/gitstats
 
       # Store artifacts for debugging purposes
       - store_test_results:


### PR DESCRIPTION
I found this little tool on Hacker News over the weekend. Can generate
some fun/interesting metrics out of git repos, beyond what GitHub gives
you by default on the "Insights" page.

Change-type: patch