### PR TITLE
core/ui: Refactor code that is not parseable by Esprima

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -384,20 +384,15 @@ exports.getQuery = async (context, backend, session, schema, options) => {
 	if (schema) {
 		const finalSchema = schema.type === (await CARDS.view).slug ? exports.getViewSchema(schema) : schema
 		const evaledSchema = evalFn(finalSchema)
-		const {
-			anyOf,
-			...values
-		} = evaledSchema
-
-		if (anyOf) {
+		if (evaledSchema.anyOf) {
 			compiledSchema.allOf = [
 				{
-					anyOf
+					anyOf: evaledSchema.anyOf
 				}
 			]
 		}
 
-		Object.assign(compiledSchema, values)
+		Object.assign(compiledSchema, _.omit(evaledSchema, [ 'anyOf' ]))
 	}
 
 	// The admin user can access all cards regardless of markers, allowing the

--- a/lib/ui/components/CardActions.tsx
+++ b/lib/ui/components/CardActions.tsx
@@ -102,7 +102,7 @@ class Base extends React.Component<
 	}
 
 	public updateEntry = () => {
-		const updatedEntry = removeUndefinedArrayItems(_.assign({}
+		const updatedEntry = removeUndefinedArrayItems(_.assign({},
 			this.props.card,
 			this.state.editModel,
 		));


### PR DESCRIPTION
Looks like the `...` operator in objects is not recognized by Esprima
at all (maybe its very cutting edge?)

Change-type: patch