### PR TITLE
core/worker/action-library: Expose core cards from kernel library

### DIFF
--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -19,20 +19,12 @@ const uuid = require('uuid/v4')
 const skhema = require('skhema')
 const syncContext = require('./sync-context')
 const sync = require('../sync')
-const CARDS = require('../core/cards')
 const logger = require('../logger')
 
 const slugify = (string) => {
 	return string
 		.replace(/[^a-z0-9-]/g, '-')
 		.replace(/-{1,}/g, '-')
-}
-
-const assertNotEvent = async (card) => {
-	const event = await CARDS.event
-	if (skhema.isValid(event.data.schema, card)) {
-		throw new Error('You may not use card actions to create an event')
-	}
 }
 
 module.exports = {
@@ -64,7 +56,9 @@ module.exports = {
 		})
 	},
 	'action-create-card': async (session, context, card, request) => {
-		await assertNotEvent(request.arguments.properties)
+		if (skhema.isValid(context.cards.event.data.schema, request.arguments.properties)) {
+			throw new Error('You may not use card actions to create an event')
+		}
 
 		if (!request.arguments.properties.slug) {
 			// Auto-generate a slug by joining the type, the name, and a uuid

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -141,6 +141,7 @@ module.exports = class Kernel {
 	constructor (backend) {
 		this.backend = backend
 		this.errors = errors
+		this.cards = {}
 	}
 
 	/**
@@ -187,6 +188,10 @@ module.exports = class Kernel {
 		}
 
 		// Built-in cards
+
+		for (const key of Object.keys(CARDS)) {
+			this.cards[key] = await CARDS[key]
+		}
 
 		logger.debug(context, 'Upserting minimal required cards')
 		const unsafeUpsert = (card) => {

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -67,6 +67,7 @@ module.exports = class Worker {
 			}, this),
 			privilegedSession: session,
 			insertCard: this.insertCard.bind(this),
+			cards: this.jellyfish.cards,
 			execContext
 		}
 	}

--- a/test/unit/worker/executor.spec.js
+++ b/test/unit/worker/executor.spec.js
@@ -30,6 +30,7 @@ ava.beforeEach(async (test) => {
 	}
 
 	test.context.context = {
+		cards: test.context.jellyfish.cards,
 		getCardById: test.context.jellyfish.getCardById,
 		getCardBySlug: test.context.jellyfish.getCardBySlug,
 		setTriggers: (triggers) => {


### PR DESCRIPTION
This removes the hard coupling between the action library and the event
JSON card.

Change-type: patch