### PR TITLE
Preserve stack traces when serializing error objects

### DIFF
--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -321,15 +321,19 @@ exports.bindRoutes = (jellyfish, worker, app, socketServer) => {
 			return response.status(code).json(results)
 		}).catch((error) => {
 			const currentDate = new Date()
+			const errorObject = errio.toObject(error, {
+				stack: true
+			})
+
 			logger.error(ctx, 'HTTP unexpected error', {
-				error: errio.toObject(error)
+				error: errorObject
 			})
 
 			errorReporter.reportException(error)
 			return response.status(500).json({
 				error: true,
 				timestamp: currentDate.toISOString(),
-				data: errio.toObject(error)
+				data: errorObject
 			})
 		})
 	})

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -455,13 +455,17 @@ module.exports = class Worker {
 				data
 			}
 		}).catch((error) => {
+			const errorObject = errio.toObject(error, {
+				stack: true
+			})
+
 			logger.error(logger.context.systemContext, 'Execute error', {
-				error: errio.toObject(error)
+				error: errorObject
 			})
 
 			return {
 				error: true,
-				data: errio.toObject(error)
+				data: errorObject
 			}
 		})
 

--- a/test/unit/worker/index.spec.js
+++ b/test/unit/worker/index.spec.js
@@ -2427,7 +2427,8 @@ ava('should post an error execute event if logging in as a disallowed user', asy
 		timestamp: loginResult.timestamp,
 		data: {
 			message: 'Login disallowed',
-			name: 'WorkerAuthenticationError'
+			name: 'WorkerAuthenticationError',
+			stack: loginResult.data.stack
 		}
 	})
 })


### PR DESCRIPTION
Turns out `errio` didn't do it by default.

Change-type: patch