### PR TITLE
default-cards: Stop restricting card tags

### DIFF
--- a/default-cards/partials/tags.json
+++ b/default-cards/partials/tags.json
@@ -1,7 +1,6 @@
 {
   "type": "array",
   "items": {
-    "type": "string",
-    "pattern": "^[a-zA-Z0-9-_/][a-zA-Z0-9-_/\\s:]+[a-zA-Z0-9-_/]$"
+    "type": "string"
   }
 }

--- a/test/unit/core/kernel.spec.js
+++ b/test/unit/core/kernel.spec.js
@@ -105,6 +105,21 @@ ava('.insertCard() should be able to set a tag with a colon', async (test) => {
 	test.deepEqual(element, card)
 })
 
+ava('.insertCard() should be able to set a tag with a space and a slash', async (test) => {
+	const card = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
+		slug: 'hello-world',
+		tags: [ 'CUSTOM HARDWARE/OS' ],
+		type: 'card',
+		version: '1.0.0',
+		data: {
+			foo: 'bar'
+		}
+	})
+
+	const element = await test.context.kernel.getCardById(test.context.context, test.context.kernel.sessions.admin, card.id)
+	test.deepEqual(element, card)
+})
+
 ava('.insertCard() should use defaults if required keys are missing', async (test) => {
 	const card = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 		slug: 'hello-world',


### PR DESCRIPTION
They should be free form, and we keep having runtime schema mismatches
errors because of this.

Change-type: minor