### PR TITLE
sync: Upgrade front-sdk to v0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfish",
-  "version": "12.11.0",
+  "version": "12.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8974,9 +8974,9 @@
       }
     },
     "front-sdk": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/front-sdk/-/front-sdk-0.3.4.tgz",
-      "integrity": "sha512-2Ph9NLmpornnSB/2bQv5r7uzLfzCONel4uZ6tAi+2KyrpkicqV3fZKIvzgGT/LJ650Z7DwKnJtz5m1G477ENmg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/front-sdk/-/front-sdk-0.3.5.tgz",
+      "integrity": "sha512-PPvfSSpt+5zq0s3iuxpMQ/syheGU/cnLLEgGO75kOfyFurwEAZxumZSVTIYVFH34rIp2wcdX3nrSAfd5DLCjXg==",
       "requires": {
         "@types/bluebird-global": "3.5.9",
         "@types/body-parser": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "express": "^4.16.2",
     "fast-equals": "^1.5.3",
     "formulajs": "^1.0.8",
-    "front-sdk": "^0.3.4",
+    "front-sdk": "^0.3.5",
     "history": "^4.7.2",
     "howler": "^2.0.12",
     "isobj": "^1.0.0",


### PR DESCRIPTION
This version contains a fix to make sure we get extra debugging
information out of Front HTTP errors.

Change-type: patch