### PR TITLE
logger: Setup a native LogEntries integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,15 @@ NODE_DEBUG_ARGS = $(NODE_ARGS) \
 									--stack_trace_on_illegal \
 									--abort_on_stack_or_string_length_overflow
 
+# Default to warn on tests
+ifdef CI
+LOGLEVEL ?= warn
+endif
+ifdef AVA_PATH
+LOGLEVEL ?= warn
+endif
 LOGLEVEL ?= info
+
 API_URL ?= http://localhost:8000/
 DB_HOST ?= localhost
 DB_PORT ?= 28015
@@ -27,6 +35,7 @@ NODE_DEBUG ?= 'jellyfish:*'
 NODE_ENV ?= test
 COVERAGE ?= 1
 DISABLE_CACHE ?=
+LOGENTRIES_TOKEN ?=
 SENTRY_DSN_SERVER ?=
 SENTRY_DSN_UI ?=
 
@@ -183,6 +192,7 @@ start-server:
 	DB_HOST=$(DB_HOST) \
 	DB_PORT=$(DB_PORT) \
 	LOGLEVEL=$(LOGLEVEL) \
+	LOGENTRIES_TOKEN=$(LOGENTRIES_TOKEN) \
 	SENTRY_DSN_SERVER=$(SENTRY_DSN_SERVER) \
 	INTEGRATION_GITHUB_TOKEN=$(INTEGRATION_GITHUB_TOKEN) \
 	INTEGRATION_GITHUB_SIGNATURE_KEY=$(INTEGRATION_GITHUB_SIGNATURE_KEY) \

--- a/deploy-templates/staging/v1.0.0/kubernetes/config-manifest.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/config-manifest.yml
@@ -22,6 +22,8 @@ properties:
       type: string
   - SENTRY_DSN_UI:
       type: string
+  - LOGENTRIES_TOKEN:
+      type: string
   - INTEGRATION_FRONT_TOKEN:
       type: string
   - INTEGRATION_GITHUB_TOKEN:

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -54,6 +54,8 @@ spec:
           value: {{{SENTRY_DSN_SERVER}}}
         - name: SENTRY_DSN_UI
           value: {{{SENTRY_DSN_UI}}}
+        - name: LOGENTRIES_TOKEN
+          value: {{{LOGENTRIES_TOKEN}}}
         - name: INTEGRATION_FRONT_TOKEN
           value: {{{INTEGRATION_FRONT_TOKEN}}}
         - name: INTEGRATION_GITHUB_TOKEN

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -31,22 +31,6 @@ exports.isProduction = () => {
 }
 
 /**
- * @summary Check if the code is running in a test environment
- * @function
- * @public
- *
- * @returns {Boolean} Whether the environment is test
- *
- * @example
- * if (environment.isTest()) {
- *   console.log('Testing!!')
- * }
- */
-exports.isTest = () => {
-	return process.env.CI || process.env.AVA_PATH
-}
-
-/**
  * @summary Get the log level
  * @function
  * @public

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -14,73 +14,71 @@
  * limitations under the License.
  */
 
-const _ = require('lodash')
 const path = require('path')
+const _ = require('lodash')
 const winston = require('winston')
 const loggerContext = require('./context')
 const environment = require('../environment')
 const packageJSON = require('../../package.json')
 const BASE_PATH = path.join(__dirname, '..', '..')
 
-const config = {
-	logLevel: {}
-}
+// Adds winston.transports.Logentries
+require('le_node')
 
-const {
-	combine,
-	timestamp
-} = winston.format
+class Logger {
+	constructor (level, filename, transport) {
+		this.namespace = path
+			.relative(BASE_PATH, filename)
+			.split(path.sep)
+			.slice(1)
+			.join(path.sep)
 
-class LogWrapper {
-	constructor (logger) {
-		this.logger = logger
+		this.logger = winston.createLogger({
+			format: winston.format.combine(
+				winston.format.timestamp(),
+				winston.format.json()),
+			transports: [ transport ],
+			exceptionHandlers: [ transport ],
+			exitOnError: false,
+			level
+		})
+
+		this.context = loggerContext
 	}
 
-	debug (context, message, ...data) {
-		this.logger.debug({
-			message,
-			ctx: context,
-			additionalArgs: data
+	debug (context, message, data) {
+		this.logger.debug(message, {
+			namespace: this.namespace,
+			version: packageJSON.version,
+			context,
+			data
 		})
 	}
 
-	error (context, message, ...data) {
-		this.logger.error({
-			message,
-			ctx: context,
-			additionalArgs: data
+	error (context, message, data) {
+		this.logger.error(message, {
+			namespace: this.namespace,
+			version: packageJSON.version,
+			context,
+			data
 		})
 	}
 
-	warn (context, message, ...data) {
-		this.logger.warn({
-			message,
-			ctx: context,
-			additionalArgs: data
+	warn (context, message, data) {
+		this.logger.warn(message, {
+			namespace: this.namespace,
+			version: packageJSON.version,
+			context,
+			data
 		})
 	}
 
-	info (context, message, ...data) {
-		this.logger.info({
-			message,
-			ctx: context,
-			additionalArgs: data
-		})
-	}
-
-	verbose (context, message, ...data) {
-		this.logger.verbose({
-			message,
-			ctx: context,
-			additionalArgs: data
-		})
-	}
-
-	silly (context, message, ...data) {
-		this.logger.silly({
-			message,
-			ctx: context,
-			additionalArgs: data
+	info (context, message, data) {
+		this.logger.info(message, {
+			namespace: this.namespace,
+			version: packageJSON.version,
+			context,
+			data
 		})
 	}
 }
@@ -88,49 +86,25 @@ class LogWrapper {
 module.exports.context = loggerContext
 
 module.exports.getLogger = _.memoize((filename) => {
-	const name = path
-		.relative(BASE_PATH, filename)
-		.split(path.sep)
-		.slice(1)
-		.join(path.sep)
+	const transport = environment.isProduction() && process.env.LOGENTRIES_TOKEN
+		? new winston.transports.Logentries({
+			token: process.env.LOGENTRIES_TOKEN
+		})
+		: new winston.transports.Console({
+			format: winston.format.combine(
+				winston.format.colorize(),
+				winston.format.printf((info) => {
+					const context = info.context || {}
+					const transaction = context.id || 'MISSING-TRANSACTION'
+					const id = context.workerid ? `${transaction} - ${context.workerid}` : transaction
+					const prefix = `(${info.version}) ${info.timestamp} [${info.namespace}] [${info.level}] [${id}]:`
+					if (info.data) {
+						return `${prefix} ${info.message} ${JSON.stringify(info.data)}`
+					}
 
-	const loglevel = environment.isTest()
-		? 'warn'
-		: (config.logLevel[name] || environment.getLogLevel())
-	const myFormat = winston.format.printf((info) => {
-		const additionalArgs = info.additionalArgs
-		const id = _.get(info, [ 'ctx', 'id' ], 'MISSING-TRANSACTION')
+					return `${prefix} ${info.message}`
+				}))
+		})
 
-		let idField = `${id}`
-		const workerid = _.get(info, [ 'ctx', 'workerid' ])
-		if (!_.isNil(workerid)) {
-			idField = `${idField} - ${workerid}`
-		}
-
-		const line = `(${packageJSON.version}) ${info.timestamp} [${name}] [${info.level}] [${idField}]: ${info.message}`
-		if (!_.isEmpty(additionalArgs)) {
-			return `${line} ${JSON.stringify(additionalArgs)}`
-		}
-
-		return line
-	})
-
-	const instance = new LogWrapper(winston.createLogger({
-		format: combine(
-			winston.format.colorize(),
-			timestamp(),
-			myFormat
-		),
-		transports: [
-			new winston.transports.Console()
-		],
-		exceptionHandlers: [
-			new winston.transports.Console()
-		],
-		exitOnError: false,
-		level: loglevel
-	}))
-
-	instance.context = loggerContext
-	return instance
+	return new Logger(environment.getLogLevel(), filename, transport)
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfish",
-  "version": "12.13.5",
+  "version": "12.13.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4079,6 +4079,14 @@
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2.3"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -5123,6 +5131,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "codependency": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/codependency/-/codependency-0.1.4.tgz",
+      "integrity": "sha1-0XY6tyZL1wyR2WJumIYtN5K/jUo=",
+      "requires": {
+        "semver": "5.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.1.tgz",
+          "integrity": "sha1-n7P0AE+QDYPEeWj+QvdYPgWDLMk="
+        }
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -11901,6 +11924,44 @@
         "invert-kv": "1.0.0"
       }
     },
+    "le_node": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/le_node/-/le_node-1.8.0.tgz",
+      "integrity": "sha512-NXzjxBskZ4QawTNwlGdRG05jYU0LhV2nxxmP3x7sRMHyROV0jPdyyikO9at+uYrWX3VFt0Y/am11oKITedx0iw==",
+      "requires": {
+        "babel-runtime": "6.6.1",
+        "codependency": "0.1.4",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.11",
+        "reconnect-core": "1.3.0",
+        "semver": "5.1.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
+          "integrity": "sha1-eIuUtvY04luRvWxd9y1GdFevsAA=",
+          "requires": {
+            "core-js": "2.6.1"
+          }
+        },
+        "core-js": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
+          "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "semver": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
+        }
+      }
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -16158,6 +16219,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16921,6 +16987,14 @@
         "fbjs": "0.8.16",
         "hoist-non-react-statics": "2.5.0",
         "symbol-observable": "1.2.0"
+      }
+    },
+    "reconnect-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-1.3.0.tgz",
+      "integrity": "sha1-+65SkZp4d9hE4yRtAaLyZwHIM8g=",
+      "requires": {
+        "backoff": "2.5.0"
       }
     },
     "redis": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "isobj": "^1.0.0",
     "json-e": "^2.6.0",
     "json-schema-ref-parser": "^6.0.2",
+    "le_node": "^1.8.0",
     "localforage": "^1.6.0",
     "lodash": "^4.17.5",
     "mark.js": "^8.11.1",


### PR DESCRIPTION
I refactored the logger module to take a LogEntries token, and if that's
available, it will send the logs directly to LogEntries (preserving
object structure) and NOT output to `stdout`, which should also give us
a small boost on production, as we don't have to stringify huge objects,
etc.

Everything behaves as usual if such token is not set.

Change-type: minor