### PR TITLE
sync: Don't patch Front conversations with status=unassigned

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -232,11 +232,20 @@ module.exports = class FrontIntegration {
 					tags: card.tags
 				})
 
-				await this.front.conversation.update({
+				const updateOptions = {
 					conversation_id: id,
-					status: newStatus,
 					tags: card.tags
-				})
+				}
+
+				if (newStatus === 'unassigned') {
+					// Oddly enough Front doesn't like `status=unassigned`,
+					// and expects this instead.
+					updateOptions.assignee_id = null
+				} else {
+					updateOptions.status = newStatus
+				}
+
+				await this.front.conversation.update(updateOptions)
 
 				return [
 					{


### PR DESCRIPTION
Front doesn't seem to like that, and prefers you to not pass a status at
all.

Change-type: patch