### PR TITLE
UI: Remove unnecessary checks for test environment

### DIFF
--- a/lib/ui/core/common.ts
+++ b/lib/ui/core/common.ts
@@ -40,11 +40,3 @@ export const getDefaultState = (): StoreState => ({
 		activeView: null,
 	},
 });
-
-export const ifNotInTestEnv = (fn: (...args: any[]) => any) => (...args: any[]) => {
-	if (process.env.NODE_ENV === 'test') {
-		return;
-	}
-
-	return fn.call(fn, ...args);
-};

--- a/lib/ui/core/index.ts
+++ b/lib/ui/core/index.ts
@@ -7,7 +7,7 @@ import {
 	setChannelsFromPath,
 	setPathFromState,
 } from '../services/url-manager';
-import { getDefaultState, ifNotInTestEnv } from './common';
+import { getDefaultState } from './common';
 import { STORAGE_KEY } from './constants';
 import { sdk as jellyfishSdk } from './sdk';
 import { actionCreators, actions, createJellyfishStore, selectors, StoreState } from './store';
@@ -19,7 +19,7 @@ export const analytics = new Analytics({
 	token: ANALYTICS_TOKEN,
 });
 
-const load = () => Bluebird.try(ifNotInTestEnv(() => {
+const load = () => Bluebird.try(() => {
 	debug('LOADING STATE FROM STORAGE');
 	return localForage.getItem<StoreState>(STORAGE_KEY)
 
@@ -55,7 +55,7 @@ const load = () => Bluebird.try(ifNotInTestEnv(() => {
 			store.subscribe(() => setPathFromState(store.getState()));
 		}
 	});
-}));
+});
 
 load()
 	.then(() => {

--- a/lib/ui/core/store.ts
+++ b/lib/ui/core/store.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { applyMiddleware, combineReducers, createStore, Middleware } from 'redux';
 import thunk from 'redux-thunk';
 import { debug } from '../services/helpers';
-import { Action, getDefaultState, ifNotInTestEnv } from './common';
+import { Action, getDefaultState } from './common';
 import { STORAGE_KEY } from './constants';
 import {
 	core,
@@ -31,11 +31,11 @@ export interface StoreState {
 // In memory storage should be used as a fallback if localStorage isn't
 // available for some reason. This functionality is waiting on:
 // https://github.com/localForage/localForage/pull/721
-ifNotInTestEnv(() => localForage.setDriver(localForage.LOCALSTORAGE))();
+localForage.setDriver(localForage.LOCALSTORAGE);
 
-const save = ifNotInTestEnv((state: StoreState) => {
+const save = (state: StoreState) => {
 	localForage.setItem(STORAGE_KEY, state);
-});
+};
 
 const rootReducer = combineReducers<StoreState>({
 	core,


### PR DESCRIPTION
The checks were legacy code for when UI integrations tests used JSDom

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>