### PR TITLE
permissions: Ensure values are unique in markers query

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -294,7 +294,7 @@ const createMarkersQuery = (markers) => {
 							pattern: `(^|\\+)(${markers.join('|')})($|\\+)`
 						},
 						{
-							enum: markers
+							enum: _.uniq(markers)
 						}
 					]
 				}


### PR DESCRIPTION
This prevents the permission filter from generating an illegal json
schema (where enum contains duplicate values). This can happen if the
user somehow gets two links to an org.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>