### PR TITLE
deployment: Increase failureThreshold retries

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -29,6 +29,7 @@ spec:
             port: 8000
           initialDelaySeconds: 2
           periodSeconds: 2
+          failureThreshold: 30
         env:
         - name: DB_HOST
           value: rethinkdb


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Michael Angelos Simos <michalis@balena.io>

The previous value of failureThreshold retries was 3 (default)