### PR TITLE
core: Parallelize index creation on .connect()

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -770,7 +770,7 @@ module.exports = class Backend {
 			}
 		}
 
-		for (const table of ALL_BUCKETS) {
+		await Bluebird.map(ALL_BUCKETS, async (table) => {
 			await this.createTable(context, table)
 
 			logger.debug(context, 'Creating table indexes', {
@@ -811,7 +811,9 @@ module.exports = class Backend {
 						.run()
 				}
 			}
-		}
+		}, {
+			concurrency: 4
+		})
 
 		if (this.cache) {
 			await this.cache.connect(context)
@@ -882,11 +884,12 @@ module.exports = class Backend {
 	 *   console.log(table)
 	 * }
    */
-	getTables (context) {
+	async getTables (context) {
 		logger.debug(context, 'Listing tables', {
 			database: this.database
 		})
 
+		await waitForDBCreation(this.connection, this.database)
 		return this.connection
 			.db(this.database)
 			.tableList()
@@ -938,6 +941,7 @@ module.exports = class Backend {
 				database: this.database
 			})
 
+			await waitForDBCreation(this.connection, this.database)
 			await this.connection
 				.db(this.database)
 				.tableCreate(name, {


### PR DESCRIPTION
We create the indexes sequentially, which makes the `Backend#connect()`
method take up to 5 seconds to complete, which makes unit tests pretty
slow. Doing them in parallel cuts the time in half.

Change-type: patch