### PR TITLE
logger: Stop LogEntries from swallowing warnings/errors

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -40,6 +40,7 @@ class Logger {
 			path.basename(moduleName, path.extname(moduleName)))
 
 		this.logger = winston.createLogger({
+			levels: winston.config.syslog.levels,
 			format: winston.format.combine(
 				winston.format.timestamp(),
 				winston.format.json()),
@@ -51,7 +52,7 @@ class Logger {
 	}
 
 	debug (context, message, data) {
-		this.logger.debug(message, {
+		this.logger.log('debug', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
 			context,
@@ -60,7 +61,7 @@ class Logger {
 	}
 
 	error (context, message, data) {
-		this.logger.error(message, {
+		this.logger.log('crit', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
 			context,
@@ -69,7 +70,7 @@ class Logger {
 	}
 
 	warn (context, message, data) {
-		this.logger.warn(message, {
+		this.logger.log('warning', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
 			context,
@@ -78,7 +79,7 @@ class Logger {
 	}
 
 	info (context, message, data) {
-		this.logger.info(message, {
+		this.logger.log('info', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
 			context,


### PR DESCRIPTION
I couldn't figure out why, but it seems that LogEntries is plainly
swallowing any message with a "warn" or "error" level. After some
experimentation, if we manually set levels to match syslog, I replaced
"warn" with "warning", and "error" with "crit" (as "error" would still
be ignored).

Change-type: patch