### PR TITLE
sync: Don't attempt to recap Front messages from events and the API

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -179,54 +179,6 @@ const getMessage = async (context, front, sequence, payload, threadId) => {
 }
 
 /**
- * @summary Get the last message from a conversation
- * @function
- * @private
- *
- * @param {Object} context - execution context
- * @param {Object} front - front instance
- * @param {Array} sequence - current upsert sequence
- * @param {Object} event - external event
- * @param {Object} targetCard - partial target card
- * @returns {Array} new sequence upserts
- */
-const getConversationLastMessage = async (context, front, sequence, event, targetCard) => {
-	if (!event.data.payload.conversation || !event.data.payload.conversation.last_message) {
-		return []
-	}
-
-	const root = event.data.payload.conversation.last_message
-	const message = await getMessage(context, front, sequence, root, targetCard.id)
-	return utils.postEvent(sequence, message, targetCard, {
-		actor: message ? message.data.actor : null
-	})
-}
-
-/**
- * @summary Get the message from an event
- * @function
- * @private
- *
- * @param {Object} context - execution context
- * @param {Object} front - front instance
- * @param {Array} sequence - current upsert sequence
- * @param {Object} event - external event
- * @param {Object} targetCard - partial target card
- * @returns {Array} new sequence upserts
- */
-const getEventMessage = async (context, front, sequence, event, targetCard) => {
-	if (!event.data.payload.target) {
-		return []
-	}
-
-	const root = event.data.payload.target.data
-	const message = await getMessage(context, front, sequence, root, targetCard.id)
-	return utils.postEvent(sequence, message, targetCard, {
-		actor: message ? message.data.actor : null
-	})
-}
-
-/**
  * @summary Get the inbox an event belongs to
  * @function
  * @private
@@ -439,15 +391,6 @@ module.exports = class FrontIntegration {
 				actor: comment ? comment.data.actor : null
 			}))
 		}
-
-		// We still extract any message mentioned in the event itself,
-		// just in case the API is not updated by the time we query
-		const eventMessage = await getEventMessage(
-			this.context, this.front, cards, event, threadCard)
-		cards.push(...eventMessage)
-		const lastMessage = await getConversationLastMessage(
-			this.context, this.front, cards, event, threadCard)
-		cards.push(...lastMessage)
 
 		const date = utils.getDateFromEpoch(event.data.payload.emitted_at)
 		const delta = getThreadDeltaFromEvent(event)


### PR DESCRIPTION
We will rely on only one of them (the API in this case, as the events
will always have a subset of that information).

Change-type: patch