### PR TITLE
server: Add status endpoint that reports the size of the action queues

### DIFF
--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -349,6 +349,34 @@ exports.bindRoutes = (jellyfish, worker, app, socketServer) => {
 		})
 	})
 
+	app.get('/status', (request, response) => {
+		const currentDate = new Date()
+		return worker.length().then(async (length) => {
+			return response.status(200).json({
+				workers: [
+					{
+						queue: length
+					}
+				]
+			})
+		}).catch((error) => {
+			const errorObject = errio.toObject(error, {
+				stack: true
+			})
+
+			logger.error(request.ctx, 'Status error', {
+				error: errorObject
+			})
+
+			errorReporter.reportException(request.ctx, error)
+			return response.status(500).json({
+				error: true,
+				timestamp: currentDate.toISOString(),
+				data: errorObject
+			})
+		})
+	})
+
 	/*
 	* Health-Check endpoint
 	*/

--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -52,6 +52,14 @@ ava.serial('The ping endpoint should continuously work', async (test) => {
 	test.false(result3.response.error)
 })
 
+ava.serial('The status endpoint should return numeric queue lengths', async (test) => {
+	const result = await test.context.http('GET', '/status')
+	test.is(result.code, 200)
+	test.true(_.every(result.response.workers, (worker) => {
+		return _.isNumber(worker.queue)
+	}))
+})
+
 ava.serial('Users should be able to change their own email addresses', async (test) => {
 	const {
 		sdk


### PR DESCRIPTION
We can plug this into something like Prometheus to get a historical view
about the workers queues.

Change-type: patch