### PR TITLE
sync: Correctly recap thread tags

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -279,12 +279,9 @@ const getThreadDeltaFromEvent = (event) => {
 		delta.data.status = 'open'
 	}
 
-	if (event.data.payload.type === 'tag' ||
-		event.data.payload.type === 'untag') {
-		delta.tags = event.data.payload.conversation.tags.map((tag) => {
-			return tag.name
-		})
-	}
+	delta.tags = event.data.payload.conversation.tags.map((tag) => {
+		return tag.name
+	})
 
 	return delta
 }

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/01.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/01.json
@@ -1,0 +1,158 @@
+{
+  "headers": {
+    "accept": "application/json",
+    "user-agent": "Needle/1.3.0 (Node.js v9.11.1; linux x64)",
+    "x-front-signature": "9KamRS6K60khSeAQE7V7oG9VcWw=",
+    "content-length": "2637",
+    "content-type": "application/json; charset=utf-8",
+    "host": "073911ac.ngrok.io",
+    "connection": "close",
+    "x-forwarded-proto": "https",
+    "x-forwarded-for": "63.33.206.132"
+  },
+  "payload": {
+    "_links": {
+      "self": "https://api2.frontapp.com/events/evt_56hprai"
+    },
+    "id": "evt_56hprai",
+    "type": "inbound",
+    "emitted_at": 1547829291.902,
+    "conversation": {
+      "_links": {
+        "self": "https://api2.frontapp.com/conversations/cnv_183bv6i",
+        "related": {
+          "events": "https://api2.frontapp.com/conversations/cnv_183bv6i/events",
+          "followers": "https://api2.frontapp.com/conversations/cnv_183bv6i/followers",
+          "messages": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages",
+          "comments": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments",
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+        }
+      },
+      "id": "cnv_183bv6i",
+      "subject": "Tag Backsync Test",
+      "status": "unassigned",
+      "assignee": null,
+      "recipient": {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@balena.io",
+        "role": "from"
+      },
+      "tags": [],
+      "last_message": {
+        "_links": {
+          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
+          }
+        },
+        "id": "msg_28s4nei",
+        "type": "email",
+        "is_inbound": true,
+        "created_at": 1547829291.902,
+        "blurb": " Foo ",
+        "body": "<div>Foo</div>\n",
+        "text": "Foo\n",
+        "is_draft": false,
+        "error_type": null,
+        "metadata": {},
+        "author": null,
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": null
+              }
+            },
+            "handle": "juan@balena.io",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+              }
+            },
+            "handle": "26ww-resin_io_dev@in.frontapp.com",
+            "role": "to"
+          }
+        ],
+        "attachments": []
+      },
+      "created_at": 1547829293.073,
+      "is_private": false
+    },
+    "source": {
+      "_meta": {
+        "type": "inboxes"
+      },
+      "data": [
+        {
+          "_links": {
+            "self": "https://api2.frontapp.com/inboxes/inb_2bcq",
+            "related": {
+              "channels": "https://api2.frontapp.com/inboxes/inb_2bcq/channels",
+              "conversations": "https://api2.frontapp.com/inboxes/inb_2bcq/conversations",
+              "teammates": "https://api2.frontapp.com/inboxes/inb_2bcq/teammates",
+              "owner": "https://api2.frontapp.com/teams/tim_mua"
+            }
+          },
+          "id": "inb_2bcq",
+          "name": "Demo Inbox",
+          "is_private": false,
+          "address": "26ww-resin_io_dev@in.frontapp.com",
+          "send_as": "26ww-resin_io_dev@in.frontapp.com",
+          "type": "smtp"
+        }
+      ]
+    },
+    "target": {
+      "_meta": {
+        "type": "message"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
+          }
+        },
+        "id": "msg_28s4nei",
+        "type": "email",
+        "is_inbound": true,
+        "created_at": 1547829291.902,
+        "blurb": " Foo ",
+        "body": "<div>Foo</div>\n",
+        "text": "Foo\n",
+        "is_draft": false,
+        "error_type": null,
+        "metadata": {},
+        "author": null,
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": null
+              }
+            },
+            "handle": "juan@balena.io",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+              }
+            },
+            "handle": "26ww-resin_io_dev@in.frontapp.com",
+            "role": "to"
+          }
+        ],
+        "attachments": []
+      }
+    }
+  }
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/02.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/02.json
@@ -1,0 +1,141 @@
+{
+  "headers": {
+    "accept": "application/json",
+    "user-agent": "Needle/1.3.0 (Node.js v9.11.1; linux x64)",
+    "x-front-signature": "ufoD9MJEdm5hsWweeeUGk0W8hys=",
+    "content-length": "2434",
+    "content-type": "application/json; charset=utf-8",
+    "host": "073911ac.ngrok.io",
+    "connection": "close",
+    "x-forwarded-proto": "https",
+    "x-forwarded-for": "52.50.117.217"
+  },
+  "payload": {
+    "_links": {
+      "self": "https://api2.frontapp.com/events/evt_56hpu9u"
+    },
+    "id": "evt_56hpu9u",
+    "type": "tag",
+    "emitted_at": 1547829305.795,
+    "conversation": {
+      "_links": {
+        "self": "https://api2.frontapp.com/conversations/cnv_183bv6i",
+        "related": {
+          "events": "https://api2.frontapp.com/conversations/cnv_183bv6i/events",
+          "followers": "https://api2.frontapp.com/conversations/cnv_183bv6i/followers",
+          "messages": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages",
+          "comments": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments",
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+        }
+      },
+      "id": "cnv_183bv6i",
+      "subject": "Tag Backsync Test",
+      "status": "unassigned",
+      "assignee": null,
+      "recipient": {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@balena.io",
+        "role": "from"
+      },
+      "tags": [
+        {
+          "_links": {
+            "self": "https://api2.frontapp.com/tags/tag_n7sq",
+            "related": {
+              "conversations": "https://api2.frontapp.com/tags/tag_n7sq/conversations",
+              "owner": "https://api2.frontapp.com/teams/tim_mua"
+            }
+          },
+          "id": "tag_n7sq",
+          "name": "testTag",
+          "is_private": false
+        }
+      ],
+      "last_message": {
+        "_links": {
+          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
+          }
+        },
+        "id": "msg_28s4nei",
+        "type": "email",
+        "is_inbound": true,
+        "created_at": 1547829291.902,
+        "blurb": " Foo ",
+        "body": "<div>Foo</div>\n",
+        "text": "Foo\n",
+        "is_draft": false,
+        "error_type": null,
+        "metadata": {},
+        "author": null,
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": null
+              }
+            },
+            "handle": "juan@balena.io",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+              }
+            },
+            "handle": "26ww-resin_io_dev@in.frontapp.com",
+            "role": "to"
+          }
+        ],
+        "attachments": []
+      },
+      "created_at": 1547829293.073,
+      "is_private": false
+    },
+    "source": {
+      "_meta": {
+        "type": "teammate"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_1zq0",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_1zq0/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_1zq0/conversations"
+          }
+        },
+        "id": "tea_1zq0",
+        "email": "accounts+front-dev@resin.io",
+        "username": "accounts_front_dev",
+        "first_name": "balena",
+        "last_name": "dev team",
+        "is_admin": true,
+        "is_available": true,
+        "is_blocked": false
+      }
+    },
+    "target": {
+      "_meta": {
+        "type": "tag"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/tags/tag_n7sq",
+          "related": {
+            "conversations": "https://api2.frontapp.com/tags/tag_n7sq/conversations",
+            "owner": "https://api2.frontapp.com/teams/tim_mua"
+          }
+        },
+        "id": "tag_n7sq",
+        "name": "testTag",
+        "is_private": false
+      }
+    }
+  }
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/03.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/03.json
@@ -1,0 +1,158 @@
+{
+  "headers": {
+    "accept": "application/json",
+    "user-agent": "Needle/1.3.0 (Node.js v9.11.1; linux x64)",
+    "x-front-signature": "smOJhvQEcJZfm6XqbvYsOw7ot0g=",
+    "content-length": "2887",
+    "content-type": "application/json; charset=utf-8",
+    "host": "073911ac.ngrok.io",
+    "connection": "close",
+    "x-forwarded-proto": "https",
+    "x-forwarded-for": "52.50.117.217"
+  },
+  "payload": {
+    "_links": {
+      "self": "https://api2.frontapp.com/events/evt_56hpxtu"
+    },
+    "id": "evt_56hpxtu",
+    "type": "comment",
+    "emitted_at": 1547829318.368,
+    "conversation": {
+      "_links": {
+        "self": "https://api2.frontapp.com/conversations/cnv_183bv6i",
+        "related": {
+          "events": "https://api2.frontapp.com/conversations/cnv_183bv6i/events",
+          "followers": "https://api2.frontapp.com/conversations/cnv_183bv6i/followers",
+          "messages": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages",
+          "comments": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments",
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+        }
+      },
+      "id": "cnv_183bv6i",
+      "subject": "Tag Backsync Test",
+      "status": "unassigned",
+      "assignee": null,
+      "recipient": {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@balena.io",
+        "role": "from"
+      },
+      "tags": [
+        {
+          "_links": {
+            "self": "https://api2.frontapp.com/tags/tag_n7sq",
+            "related": {
+              "conversations": "https://api2.frontapp.com/tags/tag_n7sq/conversations",
+              "owner": "https://api2.frontapp.com/teams/tim_mua"
+            }
+          },
+          "id": "tag_n7sq",
+          "name": "testTag",
+          "is_private": false
+        }
+      ],
+      "last_message": {
+        "_links": {
+          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
+          }
+        },
+        "id": "msg_28s4nei",
+        "type": "email",
+        "is_inbound": true,
+        "created_at": 1547829291.902,
+        "blurb": " Foo ",
+        "body": "<div>Foo</div>\n",
+        "text": "Foo\n",
+        "is_draft": false,
+        "error_type": null,
+        "metadata": {},
+        "author": null,
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": null
+              }
+            },
+            "handle": "juan@balena.io",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+              }
+            },
+            "handle": "26ww-resin_io_dev@in.frontapp.com",
+            "role": "to"
+          }
+        ],
+        "attachments": []
+      },
+      "created_at": 1547829293.073,
+      "is_private": false
+    },
+    "source": {
+      "_meta": {
+        "type": "teammate"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_1zq0",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_1zq0/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_1zq0/conversations"
+          }
+        },
+        "id": "tea_1zq0",
+        "email": "accounts+front-dev@resin.io",
+        "username": "accounts_front_dev",
+        "first_name": "balena",
+        "last_name": "dev team",
+        "is_admin": true,
+        "is_available": true,
+        "is_blocked": false
+      }
+    },
+    "target": {
+      "_meta": {
+        "type": "comment"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/comments/com_25mft6",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i",
+            "mentions": "https://api2.frontapp.com/comments/com_25mft6/mentions"
+          }
+        },
+        "id": "com_25mft6",
+        "body": "hello",
+        "posted_at": 1547829318.193,
+        "author": {
+          "_links": {
+            "self": "https://api2.frontapp.com/teammates/tea_1zq0",
+            "related": {
+              "inboxes": "https://api2.frontapp.com/teammates/tea_1zq0/inboxes",
+              "conversations": "https://api2.frontapp.com/teammates/tea_1zq0/conversations"
+            }
+          },
+          "id": "tea_1zq0",
+          "email": "accounts+front-dev@resin.io",
+          "username": "accounts_front_dev",
+          "first_name": "balena",
+          "last_name": "dev team",
+          "is_admin": true,
+          "is_available": true,
+          "is_blocked": false
+        }
+      }
+    }
+  }
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/expected.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/expected.json
@@ -1,0 +1,159 @@
+{
+  "head": {
+    "name": "Tag Backsync Test",
+    "type": "support-thread",
+    "version": "1.0.0",
+    "active": true,
+    "tags": [ "testTag" ],
+    "requires": [],
+    "capabilities": [],
+    "data": {
+      "environment": "production",
+      "inbox": "Demo Inbox",
+      "mirrors": [
+        "https://api2.frontapp.com/conversations/cnv_183bv6i"
+      ],
+      "mentionsUser": [],
+      "alertsUser": [],
+      "description": "",
+      "status": "open"
+    }
+  },
+  "tail": [
+    {
+      "type": "create",
+      "active": true,
+      "version": "1.0.0",
+      "tags": [],
+      "requires": [],
+      "capabilities": [],
+      "data": {
+        "timestamp": "2019-01-18T16:34:53.073Z",
+        "payload": {
+          "name": "Tag Backsync Test",
+          "type": "support-thread",
+          "active": true,
+          "version": "1.0.0",
+          "tags": [],
+          "requires": [],
+          "capabilities": [],
+          "data": {
+            "environment": "production",
+            "inbox": "Demo Inbox",
+            "mirrors": [
+              "https://api2.frontapp.com/conversations/cnv_183bv6i"
+            ],
+            "mentionsUser": [],
+            "alertsUser": [],
+            "description": "",
+            "status": "open"
+          }
+        }
+      }
+    },
+    {
+      "active": true,
+      "capabilities": [],
+      "data": {
+        "payload": {
+          "active": true,
+          "capabilities": [],
+          "data": {
+            "alertsUser": [],
+            "description": "",
+            "environment": "production",
+            "inbox": "Demo Inbox",
+            "mentionsUser": [],
+            "mirrors": [
+              "https://api2.frontapp.com/conversations/cnv_183bv6i"
+            ],
+            "status": "open"
+          },
+          "name": "Tag Backsync Test",
+          "requires": [],
+          "tags": [
+            "testTag"
+          ],
+          "type": "support-thread",
+          "version": "1.0.0"
+        },
+        "timestamp": "2019-01-18T16:35:05.795Z"
+      },
+      "requires": [],
+      "tags": [],
+      "type": "update",
+      "version": "1.0.0"
+    },
+    {
+      "type": "message",
+      "active": true,
+      "version": "1.0.0",
+      "tags": [],
+      "requires": [],
+      "capabilities": [],
+      "data": {
+        "mirrors": [
+          "https://api2.frontapp.com/messages/msg_28s4nei"
+        ],
+        "timestamp": "2019-01-18T16:34:51.902Z",
+        "payload": {
+          "mentionsUser": [],
+          "alertsUser": [],
+          "message": "Foo"
+        }
+      }
+    },
+    {
+      "type": "whisper",
+      "active": true,
+      "version": "1.0.0",
+      "tags": [],
+      "requires": [],
+      "capabilities": [],
+      "data": {
+        "mirrors": [
+          "https://api2.frontapp.com/comments/com_25mft6"
+        ],
+        "timestamp": "2019-01-18T16:35:18.193Z",
+        "payload": {
+          "mentionsUser": [],
+          "alertsUser": [],
+          "message": "hello"
+        }
+      }
+    },
+    {
+      "active": true,
+      "capabilities": [],
+      "data": {
+        "payload": {
+          "active": true,
+          "capabilities": [],
+          "data": {
+            "alertsUser": [],
+            "description": "",
+            "environment": "production",
+            "inbox": "Demo Inbox",
+            "mentionsUser": [],
+            "mirrors": [
+              "https://api2.frontapp.com/conversations/cnv_183bv6i"
+            ],
+            "status": "open"
+          },
+          "name": "Tag Backsync Test",
+          "requires": [],
+          "tags": [
+            "testTag"
+          ],
+          "type": "support-thread",
+          "version": "1.0.0"
+        },
+        "timestamp": "2019-01-18T16:35:18.368Z"
+      },
+      "requires": [],
+      "tags": [],
+      "type": "update",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/1/conversations-cnv-183-bv-6-i-comments.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/1/conversations-cnv-183-bv-6-i-comments.json
@@ -1,0 +1,10 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments"
+  },
+  "_results": []
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/1/conversations-cnv-183-bv-6-i-inboxes.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/1/conversations-cnv-183-bv-6-i-inboxes.json
@@ -1,0 +1,28 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+  },
+  "_results": [
+    {
+      "_links": {
+        "self": "https://api2.frontapp.com/inboxes/inb_2bcq",
+        "related": {
+          "channels": "https://api2.frontapp.com/inboxes/inb_2bcq/channels",
+          "conversations": "https://api2.frontapp.com/inboxes/inb_2bcq/conversations",
+          "teammates": "https://api2.frontapp.com/inboxes/inb_2bcq/teammates",
+          "owner": "https://api2.frontapp.com/teams/tim_mua"
+        }
+      },
+      "id": "inb_2bcq",
+      "name": "Demo Inbox",
+      "is_private": false,
+      "address": "26ww-resin_io_dev@in.frontapp.com",
+      "send_as": "26ww-resin_io_dev@in.frontapp.com",
+      "type": "smtp"
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/1/conversations-cnv-183-bv-6-i-messages-limit-100.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/1/conversations-cnv-183-bv-6-i-messages-limit-100.json
@@ -1,0 +1,51 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages?"
+  },
+  "_results": [
+    {
+      "_links": {
+        "self": "https://api2.frontapp.com/messages/msg_28s4nei",
+        "related": {
+          "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
+        }
+      },
+      "id": "msg_28s4nei",
+      "type": "email",
+      "is_inbound": true,
+      "created_at": 1547829291.902,
+      "blurb": " Foo ",
+      "body": "<div>Foo</div>\n",
+      "text": "Foo\n",
+      "is_draft": false,
+      "error_type": null,
+      "metadata": {},
+      "author": null,
+      "recipients": [
+        {
+          "_links": {
+            "related": {
+              "contact": null
+            }
+          },
+          "handle": "juan@balena.io",
+          "role": "from"
+        },
+        {
+          "_links": {
+            "related": {
+              "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+            }
+          },
+          "handle": "26ww-resin_io_dev@in.frontapp.com",
+          "role": "to"
+        }
+      ],
+      "attachments": []
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/2/conversations-cnv-183-bv-6-i-comments.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/2/conversations-cnv-183-bv-6-i-comments.json
@@ -1,0 +1,10 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments"
+  },
+  "_results": []
+}

--- a/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/3/conversations-cnv-183-bv-6-i-comments.json
+++ b/test/integration/sync/webhooks/front/inbound-tag-comment/stubs/3/conversations-cnv-183-bv-6-i-comments.json
@@ -1,0 +1,40 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments"
+  },
+  "_results": [
+    {
+      "_links": {
+        "self": "https://api2.frontapp.com/comments/com_25mft6",
+        "related": {
+          "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i",
+          "mentions": "https://api2.frontapp.com/comments/com_25mft6/mentions"
+        }
+      },
+      "id": "com_25mft6",
+      "body": "hello",
+      "posted_at": 1547829318.193,
+      "author": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_1zq0",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_1zq0/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_1zq0/conversations"
+          }
+        },
+        "id": "tea_1zq0",
+        "email": "accounts+front-dev@resin.io",
+        "username": "accounts_front_dev",
+        "first_name": "balena",
+        "last_name": "dev team",
+        "is_admin": true,
+        "is_available": true,
+        "is_blocked": false
+      }
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/index.js
+++ b/test/integration/sync/webhooks/front/index.js
@@ -15,6 +15,14 @@
  */
 
 module.exports = {
+	'inbound-tag-comment': {
+		expected: require('./inbound-tag-comment/expected.json'),
+		steps: [
+			require('./inbound-tag-comment/01.json'),
+			require('./inbound-tag-comment/02.json'),
+			require('./inbound-tag-comment/03.json')
+		]
+	},
 	'intercom-recap': {
 		expected: require('./intercom-recap/expected.json'),
 		steps: [

--- a/test/integration/sync/webhooks/front/intercom-inbound-archive/expected.json
+++ b/test/integration/sync/webhooks/front/intercom-inbound-archive/expected.json
@@ -134,7 +134,7 @@
           "type": "support-thread",
           "version": "1.0.0",
           "active": true,
-          "tags": [],
+          "tags": [ "Needs audit" ],
           "requires": [],
           "capabilities": [],
           "data": {

--- a/test/integration/sync/webhooks/front/intercom-unknown-inbound-message-archive/expected.json
+++ b/test/integration/sync/webhooks/front/intercom-unknown-inbound-message-archive/expected.json
@@ -4,7 +4,7 @@
     "type": "support-thread",
     "version": "1.0.0",
     "active": true,
-    "tags": [],
+    "tags": [ "Needs audit" ],
     "requires": [],
     "capabilities": [],
     "data": {
@@ -134,7 +134,7 @@
           "type": "support-thread",
           "version": "1.0.0",
           "active": true,
-          "tags": [],
+          "tags": [ "Needs audit" ],
           "requires": [],
           "capabilities": [],
           "data": {

--- a/test/integration/sync/webhooks/front/reminder/expected.json
+++ b/test/integration/sync/webhooks/front/reminder/expected.json
@@ -79,7 +79,7 @@
           "type": "support-thread",
           "version": "1.0.0",
           "active": true,
-          "tags": [],
+          "tags": [ "Needs audit" ],
           "requires": [],
           "capabilities": [],
           "data": {


### PR DESCRIPTION
At the moment, we would only recap tags if the external event was of
type `tag` or `untag`.

Change-type: patch