### PR TITLE
deployment: Increase healthcheck timeout

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -22,13 +22,15 @@ spec:
             path: /ping
             port: 8000
           initialDelaySeconds: 8
-          periodSeconds: 6
+          periodSeconds: 10
+          timeoutSeconds: 4
         readinessProbe:
           httpGet:
             path: /ping
             port: 8000
           initialDelaySeconds: 8
           periodSeconds: 10
+          timeoutSeconds: 4
           failureThreshold: 30
         env:
         - name: DB_HOST


### PR DESCRIPTION
Default timeout value is `1`
Change-type: patch
Signed-off-by: Michael Angelos Simos <michalis@balena.io>