### PR TITLE
deploy-templates: Wait significantly for server to start

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -21,14 +21,14 @@ spec:
           httpGet:
             path: /ping
             port: 8000
-          initialDelaySeconds: 8
+          initialDelaySeconds: 45
           periodSeconds: 10
           timeoutSeconds: 4
         readinessProbe:
           httpGet:
             path: /ping
             port: 8000
-          initialDelaySeconds: 8
+          initialDelaySeconds: 45
           periodSeconds: 10
           timeoutSeconds: 4
           failureThreshold: 30


### PR DESCRIPTION
We were previously binding the port way before the application was
ready, so now all healtchecks seem to fail, as the app doesn't start in
8 seconds anymore.

Change-type: patch