### PR TITLE
core: Stop doing an incredibly inefficient query to find created_at

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -87,33 +87,6 @@ const getElementCreatedTime = async (context, backend, card) => {
 		return card.created_at
 	}
 
-	// If the card doesn't have a `created_at` field then it is an old card and
-	// the related `create` card needs to be queried.
-	const [ createCard ] = await backend.query(context, {
-		type: 'object',
-		properties: {
-			type: {
-				type: 'string',
-				const: 'create'
-			},
-			data: {
-				type: 'object',
-				properties: {
-					target: {
-						type: 'string',
-						const: card.id
-					}
-				},
-				required: [ 'target' ]
-			}
-		},
-		required: [ 'type', 'data' ]
-	})
-
-	if (createCard && createCard.data.timestamp) {
-		return createCard.data.timestamp
-	}
-
 	// If a timestamp can't be resolved, create a new one
 	return new Date().toISOString()
 }


### PR DESCRIPTION
80% of startup time seems to be taken by this query.

Change-type: patch