### PR TITLE
deploy-templates: Even greater initial delay

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -21,14 +21,14 @@ spec:
           httpGet:
             path: /ping
             port: 8000
-          initialDelaySeconds: 300
+          initialDelaySeconds: 600
           periodSeconds: 10
           timeoutSeconds: 4
         readinessProbe:
           httpGet:
             path: /ping
             port: 8000
-          initialDelaySeconds: 300
+          initialDelaySeconds: 600
           periodSeconds: 10
           timeoutSeconds: 4
           failureThreshold: 30


### PR DESCRIPTION
Looks like RethinkDB is randomly hanging for a very long time on
listening indexes, or waiting for them.

Change-type: patch