### PR TITLE
package.json: Remove unused portfinder dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfish",
-  "version": "12.21.22",
+  "version": "12.22.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21175,6 +21175,7 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
       "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+      "dev": true,
       "requires": {
         "async": "1.5.2",
         "debug": "2.6.9",
@@ -21184,12 +21185,14 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "moment": "^2.22.1",
     "multer": "^1.3.1",
     "object-hash": "^1.3.0",
-    "portfinder": "^1.0.20",
     "proper-lockfile": "^3.2.0",
     "randomstring": "^1.1.5",
     "react": "^16.2.0",


### PR DESCRIPTION
See: https://github.com/balena-io/jellyfish/pull/1350/files#r249357439
Change-type: patch