### PR TITLE
deploy-templates: Add liveness check for rethinkdb service

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -23,14 +23,15 @@ spec:
             port: 8000
           initialDelaySeconds: 600
           periodSeconds: 10
-          timeoutSeconds: 4
+          timeoutSeconds: 5
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /ping
             port: 8000
-          initialDelaySeconds: 600
+          initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 4
+          timeoutSeconds: 5
           failureThreshold: 30
         env:
         - name: DB_HOST

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/rethinkdb-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/rethinkdb-deployment.tpl.yml
@@ -15,6 +15,15 @@ spec:
       containers:
       - image: {{{jellyfish-rethinkdb-image}}}
         name: rethinkdb
+        livenessProbe:
+          exec:
+            command:
+              - /probe.py
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         env:
         - name: DB_PASSWORD
           value: {{{DB_PASSWORD}}}


### PR DESCRIPTION
Also remove readiness check for jellyfish service.

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>