### PR TITLE
core: Allow queries to express negated links

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -422,6 +422,29 @@ const getTablesSafe = async (connection, database, retries = 10) => {
 	}
 }
 
+const createTableSafe = async (connection, database, name, retries = 10) => {
+	if (retries === 0) {
+		throw new errors.JellyfishDatabaseError(
+			`Could not create table ${name} after multiple retries`)
+	}
+
+	try {
+		return await connection
+			.db(database)
+			.tableCreate(name, {
+				primaryKey: 'slug'
+			})
+			.run()
+	} catch (error) {
+		if (error.name === 'ReqlOpFailedError' &&
+				error.msg === `Database \`${database}\` does not exist.`) {
+			await Bluebird.delay(100)
+			return createTableSafe(connection, database, name, retries - 1)
+		}
+
+		throw error
+	}
+}
 const upsertObject = async (context, backend, table, object, options) => {
 	if (!object.slug) {
 		throw new errors.JellyfishDatabaseError('Missing primary key')
@@ -968,14 +991,7 @@ module.exports = class Backend {
 				database: this.database
 			})
 
-			await waitForDBCreation(this.connection, this.database)
-			await this.connection
-				.db(this.database)
-				.tableCreate(name, {
-					primaryKey: 'slug'
-				})
-				.run()
-
+			await createTableSafe(this.connection, this.database, name)
 			logger.debug(context, 'Waiting for table', {
 				table: name,
 				database: this.database

--- a/lib/core/links.js
+++ b/lib/core/links.js
@@ -118,8 +118,12 @@ exports.evaluateCard = async (context, card, schema) => {
 	for (const name of Object.keys(schema)) {
 		result[name] = await exports.evaluate(context, card, name, schema[name])
 
-		// Abort at the first link evaluation error
-		if (result[name].length === 0) {
+		if (result[name].length === 0 && schema[name]) {
+			return null
+		}
+
+		// Negated link, but we found results
+		if (result[name].length !== 0 && !schema[name]) {
 			return null
 		}
 	}

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -305,6 +305,10 @@ const createMarkersQuery = (markers) => {
 
 // Only consider objects with $eval
 const evalSchema = (object, context) => {
+	if (!object) {
+		return object
+	}
+
 	if (object.$eval) {
 		return jsone(object, context)
 	}


### PR DESCRIPTION
This means that you can query for cards that are *not* associated with a
certain type of link.

Change-type: minor