### PR TITLE
server: Improve server startup speed

### DIFF
--- a/lib/server/action-server.js
+++ b/lib/server/action-server.js
@@ -170,6 +170,29 @@ const processQueue = (context, jellyfish, worker, queue, session, onError) => {
 	})
 }
 
+const flush = async (context, jellyfish, session, worker, queue) => {
+	logger.info(context, 'Flushing queue')
+	await tickingWorker
+	await processingQueue
+
+	const request = await queue.dequeue(context, worker.getId())
+	if (!request) {
+		return
+	}
+
+	const result = await worker.execute(session, request)
+
+	if (result.error) {
+		const Constructor = worker.errors[result.data.type] ||
+			jellyfish.errors[result.data.type] ||
+			Error
+
+		throw new Constructor(result.data.message)
+	}
+
+	await flush(context, jellyfish, session, worker, queue)
+}
+
 exports.start = async (queue, context, jellyfish, session) => {
 	const worker = new Worker(jellyfish, session, actionLibrary, queue)
 	await worker.initialize(context)
@@ -245,33 +268,9 @@ exports.start = async (queue, context, jellyfish, session) => {
 		triggerStream.removeAllListeners()
 		triggerStream.close()
 		await refreshingTriggers
-		await exports.flush(workerContext, jellyfish, session, worker, queue)
+		await flush(workerContext, jellyfish, session, worker, queue)
 		await Bluebird.delay(1000)
 	}
 
-	await exports.flush(context, jellyfish, session, worker, queue)
 	return worker
-}
-
-exports.flush = async (context, jellyfish, session, worker, queue) => {
-	logger.info(context, 'Flushing queue')
-	await tickingWorker
-	await processingQueue
-
-	const request = await queue.dequeue(context, worker.getId())
-	if (!request) {
-		return
-	}
-
-	const result = await worker.execute(session, request)
-
-	if (result.error) {
-		const Constructor = worker.errors[result.data.type] ||
-			jellyfish.errors[result.data.type] ||
-			Error
-
-		throw new Constructor(result.data.message)
-	}
-
-	await exports.flush(context, jellyfish, session, worker, queue)
 }

--- a/lib/server/card-loader.js
+++ b/lib/server/card-loader.js
@@ -115,7 +115,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 
 		return worker.insertCard(context, session, typeCard, {
 			override: true,
-			attachEvents: true
+			attachEvents: false
 		}, card)
 	})
 

--- a/lib/ui/core/reducers/core.ts
+++ b/lib/ui/core/reducers/core.ts
@@ -96,7 +96,7 @@ export const actionCreators = {
 	loadChannelData: (channel: Channel): JellyThunkSync<void, KnownState> =>
 		function loadChannelData(dispatch, getState): Bluebird<any> {
 			const { target, cardType } = channel.data;
-			const load = (): Bluebird<Card | null> => sdk.card.getWithTimeline(target, {
+			const load = (): Bluebird<Card | null> => sdk.card.get(target, {
 				type: cardType as any,
 			})
 				.then((result) => {


### PR DESCRIPTION
- Don't add create events to default cards during bootstrap (we have the
`created_at` property if needed)

- Don't flush the queue at startup (we don't have pending tasks at that
point, as we don't use the queue)

Change-type: patch