### PR TITLE
queue: Stop keeping track of the queue size

### DIFF
--- a/lib/queue/index.js
+++ b/lib/queue/index.js
@@ -93,7 +93,6 @@ module.exports = class Queue extends EventEmitter {
 		this.context = context
 		this.jellyfish = jellyfish
 		this.session = session
-		this.size = 0
 		this.errors = errors
 	}
 
@@ -109,46 +108,12 @@ module.exports = class Queue extends EventEmitter {
 	 * await queue.initialize(context)
 	 */
 	async initialize (context) {
+		logger.info(context, 'Inserting essential cards')
 		await Bluebird.map(Object.values(CARDS), async (card) => {
 			return this.jellyfish.insertCard(context, this.session, card, {
 				override: true
 			})
 		})
-
-		this.queueStream = await this.jellyfish.stream(
-			context, this.session, {
-				type: 'object',
-				required: [ 'type', 'links' ],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'action-request'
-					},
-					links: {
-						type: 'object',
-						additionalProperties: true
-					}
-				}
-			})
-
-		this.queueStream.once('error', (error) => {
-			this.emit('error', error)
-		})
-
-		// Use a stream to calculate the queue length
-		// based on its deltas
-		this.queueStream.on('data', (change) => {
-			if (change.after.links[LINK_EXECUTE.INVERSE_NAME] &&
-					change.after.links[LINK_EXECUTE.INVERSE_NAME].length > 0) {
-				this.size -= 1
-			} else {
-				this.size += 1
-			}
-		})
-
-		const nonExecutedRequests = await this.jellyfish.query(
-			context, this.session, SCHEMA_NON_EXECUTED_REQUESTS)
-		this.size = nonExecutedRequests.length
 	}
 
 	/**
@@ -161,9 +126,9 @@ module.exports = class Queue extends EventEmitter {
 	 * await queue.initialize(context)
 	 * await queue.destroy()
 	 */
+	// eslint-disable-next-line class-methods-use-this
 	async destroy () {
-		this.queueStream.removeAllListeners()
-		await this.queueStream.close()
+		return Bluebird.resolve()
 	}
 
 	/**
@@ -252,17 +217,6 @@ module.exports = class Queue extends EventEmitter {
 	}
 
 	/**
-	 * @summary Get the length of the queue
-	 * @function
-	 * @public
-	 *
-	 * @returns {Number} length
-	 */
-	async length () {
-		return this.size
-	}
-
-	/**
 	 * @summary Dequeue a request
 	 * @function
 	 * @public
@@ -280,7 +234,6 @@ module.exports = class Queue extends EventEmitter {
 
 		logger.info(actionRequest.data.context, 'Dequeueing request', {
 			actor,
-			length: await this.length(),
 			request: {
 				id: actionRequest.id,
 				card: actionRequest.data.input.id,
@@ -313,7 +266,6 @@ module.exports = class Queue extends EventEmitter {
 	async enqueue (actor, session, options) {
 		logger.info(options.context, 'Enqueueing request', {
 			actor,
-			length: await this.length(),
 			request: {
 				action: options.action,
 				card: options.card,
@@ -375,18 +327,5 @@ module.exports = class Queue extends EventEmitter {
 				}, options.arguments)
 			}
 		})
-	}
-
-	/**
-   * @summary Report status of the queue
-   * @function
-   * @public
-   *
-   * @returns {Object} status
-   */
-	async getStatus () {
-		return {
-			length: await this.length()
-		}
 	}
 }

--- a/lib/server/http/routes.js
+++ b/lib/server/http/routes.js
@@ -61,7 +61,6 @@ module.exports = (application, jellyfish, worker, queue) => {
 
 	application.get('/status', (request, response) => {
 		return Bluebird.props({
-			queue: queue.getStatus(),
 			kernel: jellyfish.getStatus()
 		}).then((status) => {
 			return response.status(200).json(status)

--- a/test/integration/server/index.spec.js
+++ b/test/integration/server/index.spec.js
@@ -51,12 +51,6 @@ ava.serial('The ping endpoint should continuously work', async (test) => {
 	test.false(result3.response.error)
 })
 
-ava.serial('The status endpoint should return numeric queue lengths', async (test) => {
-	const result = await test.context.http('GET', '/status')
-	test.is(result.code, 200)
-	test.true(_.isNumber(result.response.queue.length))
-})
-
 ava.serial('Users should be able to change their own email addresses', async (test) => {
 	const {
 		sdk

--- a/test/unit/queue/index.spec.js
+++ b/test/unit/queue/index.spec.js
@@ -26,64 +26,10 @@ ava.beforeEach(async (test) => {
 
 ava.afterEach(helpers.queue.afterEach)
 
-ava('.length() should be zero by default', async (test) => {
-	const length = await test.context.queue.length()
-	test.is(length, 0)
-})
-
 ava('.dequeue() should return nothing if no requests', async (test) => {
-	const length = await test.context.queue.length()
-	test.is(length, 0)
 	const request = await test.context.queue.dequeue(
 		test.context.context, test.context.queueActor)
 	test.falsy(request)
-})
-
-ava('.dequeue() should not reduce the queue length', async (test) => {
-	const typeCard = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'card')
-	await test.context.queue.enqueue(test.context.queueActor, test.context.session, {
-		action: 'action-create-card',
-		context: test.context.context,
-		card: typeCard.id,
-		type: typeCard.type,
-		arguments: {
-			properties: {
-				slug: 'foo',
-				version: '1.0.0',
-				data: {
-					foo: 1
-				}
-			}
-		}
-	})
-
-	await test.context.queue.dequeue(
-		test.context.context, test.context.queueActor)
-	const length = await test.context.queue.length()
-	test.is(length, 1)
-})
-
-ava('.enqueue() should increment the queue length by one', async (test) => {
-	const typeCard = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'card')
-	await test.context.queue.enqueue(test.context.queueActor, test.context.session, {
-		action: 'action-create-card',
-		context: test.context.context,
-		card: typeCard.id,
-		type: typeCard.type,
-		arguments: {
-			properties: {
-				version: '1.0.0',
-				data: {
-					foo: 'bar'
-				}
-			}
-		}
-	})
-
-	const length = await test.context.queue.length()
-	test.is(length, 1)
 })
 
 ava('.enqueue() should include the actor from the passed session', async (test) => {


### PR DESCRIPTION
Turns out the current approach is incredibly expensive on a real-world
database with a lot of data. There are better ways to do it which we can
explore in the future, but for now we can give up on it (we only use it
for runtime metrics purposes) so the application is at least not down.

Change-type: minor