### PR TITLE
Revert "deployment: Add jellyfish liveness/readiness probes"

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -17,21 +17,6 @@ spec:
       - image: {{{jellyfish-application-image}}}
         name: jellyfish
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 8000
-          initialDelaySeconds: 20
-          periodSeconds: 10
-          timeoutSeconds: 8
-        readinessProbe:
-          httpGet:
-            path: /ping
-            port: 8000
-          initialDelaySeconds: 20
-          periodSeconds: 10
-          timeoutSeconds: 8
-          failureThreshold: 30
         env:
         - name: DB_HOST
           value: rethinkdb


### PR DESCRIPTION
For testing purposes. I suspect there is something else, apart from the
probes, that are killing us. I'll re-apply this commit after my research
finishes.

This reverts commit dc14aeaba4ee9e3b6fc27d2360f933b90abede6a.

Change-type: patch