### PR TITLE
core: Attempt to speed up non executed action requests query

### DIFF
--- a/lib/core/backend.js
+++ b/lib/core/backend.js
@@ -1291,6 +1291,26 @@ module.exports = class Backend {
 
 		const schema = defaultAdditionalPropertiesFalse(querySchema)
 
+		if (options.limit === 1 &&
+			Object.keys(schema.properties).length === 1 &&
+			schema.properties.type &&
+			schema.properties.type.const && schema.$$links) {
+			const linkProperties = Object.keys(schema.$$links)
+			if (linkProperties.length === 1 && !schema.$$links[linkProperties[0]]) {
+				const cursor = await this.connection
+					.db(this.database)
+					.table(getBucketForType(schema.properties.type.const))
+					.getAll(schema.properties.type.const, {
+						index: 'type'
+					})
+					.filter(this.connection.row('links')(linkProperties[0]).typeOf().eq('NULL').default(true))
+					.skip(options.skip || 0)
+					.limit(options.limit)
+					.run()
+				return cursor
+			}
+		}
+
 		if ((schema.properties.id && schema.properties.id.const) || (schema.properties.slug && schema.properties.slug.const)) {
 			if (options.skip || options.limit === 0) {
 				return []


### PR DESCRIPTION
Querying for an arbitrary number of action requests and slicing client
side to workaround the linking issues is something the production
instance can't seem to be able to handle.

Change-type: patch