### PR TITLE
action-library: Replace square brackets in sync user slugs

### DIFF
--- a/lib/action-library/sync-context.js
+++ b/lib/action-library/sync-context.js
@@ -41,7 +41,7 @@ exports.fromWorkerContext = (workerContext, context, session) => {
 				return null
 			}
 
-			const slug = `${type}-${username.toLowerCase().replace(/[@|._]/g, '-')}`
+			const slug = `${type}-${username.toLowerCase().replace(/[@|._\\[\\]]/g, '-')}`
 			const actorCard = await workerContext.getCardBySlug(session, slug, {
 				type
 			})


### PR DESCRIPTION
Otherwise the GitHub integration fails when trying to create
`wafflebot[bot]`.

Change-type: patch