### PR TITLE
core: Don't set Redis password options if its null

### DIFF
--- a/lib/core/cache.js
+++ b/lib/core/cache.js
@@ -30,6 +30,11 @@ module.exports = class Cache {
 	 */
 	constructor (options) {
 		this.options = options
+
+		if (!this.options.password) {
+			Reflect.deleteProperty(this.options, 'password')
+		}
+
 		this.tables = new Set()
 	}
 


### PR DESCRIPTION
Otherwise we get:

```
node_redis: Deprecated: The AUTH command contains a "null" argument.
```

This is just a warning, but its good to get rid of it.

Change-type: patch