### PR TITLE
jsonschema2sql: Use the @> operator when possible

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -166,7 +166,7 @@ const getFilterExpression = (operator, property, value, schema, root, options) =
 			return getTypeExpression(property, value, options)
 		}
 		case 'const': {
-			return `${getRowFromProperty(property, true)} = ${format(JSON.stringify(value))}::jsonb`
+			return `${getRowFromProperty(property, true)} @> ${format(JSON.stringify(value))}::jsonb`
 		}
 		case 'pattern': {
 			const patternMatchRow = property.length === 1 ? getRootJSONB(property) : row
@@ -317,7 +317,7 @@ const getFilterExpression = (operator, property, value, schema, root, options) =
 		case 'enum': {
 			row = getRowFromProperty(property, true)
 			const cases = value.map((item) => {
-				return `${row} = ${format(JSON.stringify(item))}::jsonb`
+				return `${row} @> ${format(JSON.stringify(item))}::jsonb`
 			})
 
 			return `(${cases.join(' OR ')})`


### PR DESCRIPTION
GIN indexes optimize this operator.

Change-type: patch