### PR TITLE
jsonschema2sql: Use top level SQL columns when possible

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -31,6 +31,13 @@ const CARD_TOP_LEVEL_OPTIONAL_FIELD_TYPES = {
 	name: 'string'
 }
 
+const CARD_COLUMNS = _.pick(CARD_TOP_LEVEL_REQUIRED_FIELD_TYPES, [
+	'id',
+	'slug',
+	'type',
+	'active'
+])
+
 const isExcludedKeyword = (options, keyword) => {
 	return _.includes(options.exclude, keyword)
 }
@@ -181,6 +188,13 @@ const getFilterExpression = (operator, property, value, schema, root, options) =
 			return getTypeExpression(property, value, options)
 		}
 		case 'const': {
+			if (options.assumeValidCard &&
+					property.length === 2 &&
+					property[0][0] === 'data' &&
+					CARD_COLUMNS[property[1]]) {
+				return `${property[1]} = ${format(value)}`
+			}
+
 			return `${getRowFromProperty(property, true)} @> ${format(JSON.stringify(value))}::jsonb`
 		}
 		case 'pattern': {
@@ -195,6 +209,10 @@ const getFilterExpression = (operator, property, value, schema, root, options) =
 						CARD_TOP_LEVEL_OPTIONAL_FIELD_TYPES[property[1]]) {
 					if (CARD_TOP_LEVEL_REQUIRED_FIELD_TYPES[property[1]] === 'string' ||
 							CARD_TOP_LEVEL_OPTIONAL_FIELD_TYPES[property[1]] === 'string') {
+						if (CARD_COLUMNS[property[1]]) {
+							return `(${property[1]} ~* ${format(value)})`
+						}
+
 						return `(${matcher})`
 					}
 


### PR DESCRIPTION
Change-type: patch