### PR TITLE
core: Don't traverse links when doing streaming

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -742,15 +742,7 @@ module.exports = class PostgresBackend {
 			schemaOnly: true
 		})
 
-		return streams.attach(context, this.streamClient, schema, {
-			// TODO: This is an abomination. These types of sub
-			// queries and links injections passed to the streams
-			// module shouldn't happen.
-			links,
-			subquery: (subcontext, ids, suboptions) => {
-				return this.getElementsById(subcontext, ids, suboptions)
-			}
-		})
+		return streams.attach(context, this.streamClient, schema)
 	}
 
 	/*

--- a/lib/core/backend/postgres/streams/index.js
+++ b/lib/core/backend/postgres/streams/index.js
@@ -11,8 +11,6 @@ const EventEmitter = require('events').EventEmitter
 const PGLiveSelect = require('./pg-live-select')
 const logger = require('../../../../logger').getLogger(__filename)
 
-const LINK_KEY = '$$links'
-
 const filter = (schema, element) => {
 	const result = skhema.filter(schema, element)
 
@@ -33,28 +31,6 @@ const filter = (schema, element) => {
 	}
 
 	return result
-}
-
-const resolveLinks = async (context, subqueryFn, schema, options, card, links) => {
-	const result = await links.evaluateCard({
-		getElementsById: (ids, subqueryOptions) => {
-			if (options.subquery) {
-				return options.subquery(context, ids, subqueryOptions)
-			}
-
-			return subqueryFn(context, ids, subqueryOptions)
-		}
-	}, card, schema[LINK_KEY] || {})
-	if (!result) {
-		return null
-	}
-
-	if (!_.isEmpty(result)) {
-		// Object.assign is used so that only resolved verbs are modified
-		Object.assign(card.links, result)
-	}
-
-	return card
 }
 
 const mergeStreams = async (keys, createFunction) => {
@@ -162,7 +138,7 @@ exports.teardown = async (context, connection, instance) => {
 	return null
 }
 
-exports.attach = async (context, instance, schema, options) => {
+exports.attach = async (context, instance, schema) => {
 	/*
 	 * Create a new emitter instance and register it in the
 	 * list of opens stream the instance keeps track of.
@@ -189,16 +165,6 @@ exports.attach = async (context, instance, schema, options) => {
 		}
 		if (_.isEmpty(oldMatch)) {
 			oldMatch = null
-		}
-
-		if (newMatch) {
-			newMatch = await resolveLinks(
-				context, options.subquery, schema, {}, newMatch, options.links)
-		}
-
-		if (oldMatch) {
-			oldMatch = await resolveLinks(
-				context, options.subquery, schema, {}, oldMatch, options.links)
 		}
 
 		if (newMatch || oldMatch) {

--- a/lib/ui/core/reducers/core.ts
+++ b/lib/ui/core/reducers/core.ts
@@ -190,12 +190,6 @@ export const actionCreators = {
 			config: sdk.getConfig(),
 			stream: sdk.stream({
 				type: 'object',
-				$$links: {
-					'has attached element': {
-						type: 'object',
-						additionalProperties: true,
-					},
-				},
 				additionalProperties: true,
 			}),
 		})


### PR DESCRIPTION
We are re-working the stream system, and its going to be really hard to
support links resolution while streaming in a way that leverages the DB.

Change-type: minor