### PR TITLE
Update action card schemas

### DIFF
--- a/lib/action-library/actions/action-create-card.js
+++ b/lib/action-library/actions/action-create-card.js
@@ -44,11 +44,25 @@ module.exports = {
 						pattern: '^[a-z0-9-]+$'
 					},
 					name: {
-						type: 'string',
-						pattern: '^.*\\S.*$'
+						type: 'string'
 					},
 					active: {
 						type: 'boolean'
+					},
+					created_at: {
+						type: 'string',
+						format: 'date-time'
+					},
+					updated_at: {
+						anyOf: [
+							{
+								type: 'string',
+								format: 'date-time'
+							},
+							{
+								type: 'null'
+							}
+						]
 					},
 					markers: {
 						type: 'array',

--- a/lib/action-library/actions/action-update-card.js
+++ b/lib/action-library/actions/action-update-card.js
@@ -45,8 +45,7 @@ module.exports = {
 						]
 					},
 					name: {
-						type: [ 'string', 'null' ],
-						pattern: '^.*\\S.*$'
+						type: [ 'string', 'null' ]
 					},
 					markers: {
 						type: 'array',


### PR DESCRIPTION
- Support names that are empty strings
- Add `created_at` field
- Add `updated_at` field

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>