### PR TITLE
SDK: Omit links object when updating a card

### DIFF
--- a/lib/sdk/card.js
+++ b/lib/sdk/card.js
@@ -244,7 +244,7 @@ class CardSdk {
 			type: card.type,
 			action: 'action-update-card',
 			arguments: {
-				properties: _.omit(card, [ 'type', 'id' ])
+				properties: _.omit(card, [ 'type', 'id', 'links' ])
 			}
 		})
 	}


### PR DESCRIPTION
This avoids situations where you can accidentally send the links object
and hit a 413 error due to the payload being too large.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>