### PR TITLE
sync: Don't throw if card strings contain json-e interpolations

### DIFF
--- a/lib/sync/pipeline.js
+++ b/lib/sync/pipeline.js
@@ -74,15 +74,38 @@ const runIntegration = async (integration, options, fn, card) => {
  * > }
  */
 const evaluateObject = (object, environment) => {
-	try {
-		return jsone(object, environment)
-	} catch (error) {
-		if (error.name === 'InterpreterError') {
+	if (!object) {
+		return object
+	}
+
+	if (object.$eval) {
+		try {
+			return jsone(object, environment)
+		} catch (error) {
+			if (error.name === 'InterpreterError') {
+				return null
+			}
+
+			throw error
+		}
+	}
+
+	for (const key of Object.keys(object)) {
+		// For performance reasons
+		// eslint-disable-next-line lodash/prefer-lodash-typecheck
+		if (typeof object[key] !== 'object' || object[key] === null) {
+			continue
+		}
+
+		const result = evaluateObject(object[key], environment)
+		if (!result) {
 			return null
 		}
 
-		throw error
+		object[key] = result
 	}
+
+	return object
 }
 
 /**

--- a/test/integration/sync/pipeline.spec.js
+++ b/test/integration/sync/pipeline.spec.js
@@ -295,6 +295,38 @@ ava('.importCards() should import dependent cards', async (test) => {
 	])
 })
 
+ava('.importCards() should not throw given string interpolation', async (test) => {
+	const results = await pipeline.importCards(test.context.syncContext, [
+		{
+			time: new Date(),
+			actor: test.context.actor.id,
+			card: {
+				type: 'card',
+				slug: 'bar',
+				version: '1.0.0',
+				data: {
+					// eslint-disable-next-line no-template-curly-in-string
+					foo: 'Hello ${world}:$foo #{bar}'
+				}
+			}
+		}
+	])
+
+	test.deepEqual(results, [
+		test.context.jellyfish.defaults({
+			id: results[0].id,
+			slug: 'bar',
+			created_at: results[0].created_at,
+			name: null,
+			type: 'card',
+			data: {
+				// eslint-disable-next-line no-template-curly-in-string
+				foo: 'Hello ${world}:$foo #{bar}'
+			}
+		})
+	])
+})
+
 ava('.importCards() should throw if a template does not evaluate', async (test) => {
 	await test.throwsAsync(pipeline.importCards(test.context.syncContext, [
 		{


### PR DESCRIPTION
If a synced message contains a string property with something like
`${foo}`, then JSON-e will think it should try to resolve it, fail, and
make the worker crash. We really only want JSON-e to kick in on `$eval`
keywords.

Change-type: patch