### PR TITLE
sync: Fix duplicated Front messages

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -5,7 +5,6 @@
  */
 
 const Bluebird = require('bluebird')
-const uuid = require('uuid/v4')
 const _ = require('lodash')
 const Front = require('front-sdk').Front
 const utils = require('./utils')
@@ -157,7 +156,14 @@ const getMessage = async (context, front, sequence, payload, threadId) => {
 	}
 
 	return {
-		slug: `${type}-${uuid()}`,
+		/*
+		 * Encoding the mirror id in the slug ensures that we don't
+		 * try to insert the same event twice when failing to determine
+		 * that there is already an element with the same mirror id
+		 * on the database.
+		 */
+		slug: `${type}-front-${_.last(mirrorId.split('/')).replace(/_/g, '-')}`,
+
 		type,
 		tags: [],
 		links: {},
@@ -301,7 +307,7 @@ const getThread = async (context, front, event) => {
 		markers: [],
 		active: true,
 		type: 'support-thread',
-		slug: `support-thread-${event.data.payload.id.replace(/_/g, '-')}`,
+		slug: `support-thread-front-${_.last(mirrorId.split('/')).replace(/_/g, '-')}`,
 		data: {
 			translateDate: utils.getDateFromEpoch(
 				event.data.payload.conversation.created_at).toISOString(),


### PR DESCRIPTION
When syncing messages, we check that neither the database nor the
sequence we are about to insert mention the mirror id we are dealing
with.

However consider that multiple workers might be trying to create the
same message/whisper. Neither of them reference the mirror id in their
sequences, and they check the database at the same time, so they might
still insert the same thing twice. The slug is the only safe way to
prevent this.

Change-type: patch