### PR TITLE
sync: Add warning log when syncing a single character message

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -128,6 +128,15 @@ const getMessage = async (context, front, sequence, payload, threadId) => {
 			`Not actor id for message ${JSON.stringify(payload)}`)
 	}
 
+	// For debugging purposes
+	if (message.length === 1) {
+		context.log.warn('Single character Front message', {
+			mirrorId,
+			message,
+			payload
+		})
+	}
+
 	const date = utils.getDateFromEpoch(payload.posted_at || payload.created_at)
 	const data = {
 		timestamp: date.toISOString(),


### PR DESCRIPTION
This is a bug I'm tracking down.

Change-type: patch