### PR TITLE
core: Debounce materializing the queue view

### DIFF
--- a/lib/core/backend/postgres/queue.js
+++ b/lib/core/backend/postgres/queue.js
@@ -5,6 +5,8 @@
  */
 
 const _ = require('lodash')
+const debouncePromise = require('debounce-promise')
+const logger = require('../../../logger').getLogger(__filename)
 const LINK_TYPE = 'is executed by'
 
 exports.getTable = (source) => {
@@ -71,14 +73,24 @@ exports.setup = async (context, connection, options = {}) => {
 	}
 }
 
+const refreshView = debouncePromise((connection, view) => {
+	/*
+	 * The "CONCURRENTLY" option allows the database to serve other
+	 * queries on the materialized view while we update it.
+	 */
+	return connection.any(`REFRESH MATERIALIZED VIEW CONCURRENTLY ${view}`)
+}, 500, {
+	leading: true
+})
+
 exports.refresh = async (context, connection, options) => {
 	const table = exports.getTable(options.source)
-
-	/*
-	 * We are aware of the "CONCURRENTLY" option, but we found that
-	 * in practice, omitting it speeds up the materialisation.
-	 */
-	await connection.any(`REFRESH MATERIALIZED VIEW ${table}`)
+	const refreshStart = new Date()
+	await refreshView(connection, table)
+	const refreshEnd = new Date()
+	logger.info(context, 'Refreshed queue', {
+		time: refreshEnd.getTime() - refreshStart.getTime()
+	})
 }
 
 exports.getElements = async (context, connection, options = {}) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11108,6 +11108,11 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "debounce-promise": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.0.tgz",
+      "integrity": "sha1-JQNfS0UBe9Uae++LO9n2QB3EdCM="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "compression": "^1.7.2",
     "copy-to-clipboard": "^3.0.8",
     "core-js": "^2.6.4",
+    "debounce-promise": "^3.1.0",
     "errio": "^1.2.2",
     "esprima": "^4.0.0",
     "express": "^4.16.2",


### PR DESCRIPTION
For performance reasons, otherwise we're refreshing way too often and
blocking other stuff in vain.

Change-type: patch