### PR TITLE
sync: Get real forums actor in messages as well

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -60,7 +60,6 @@ const getMessageActor = async (context, front, payload) => {
 		}
 	}
 
-
 	if (payload.author) {
 		return context.getActorId('user', payload.author.username)
 	}

--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -37,6 +37,30 @@ const getMessageActor = async (context, front, payload) => {
 		return null
 	}
 
+	/*
+	 * Handle S/Community_Custom forums actor weirdness.
+	 */
+	if (payload.target &&
+		payload.target.data &&
+		payload.target.data.type === 'custom' &&
+		payload.target.data.recipients.length > 1) {
+		/*
+		 * In forum messages the "from" is really "to" (?)
+		 */
+		const from = _.find(payload.target.data.recipients, {
+			role: 'to'
+		})
+
+		/*
+		 * If this is the case then we can patch the event accordingly.
+		 */
+		if (from) {
+			payload.target.data.recipients = [ from ]
+			payload.target.data.recipients[0].role = 'from'
+		}
+	}
+
+
 	if (payload.author) {
 		return context.getActorId('user', payload.author.username)
 	}
@@ -707,29 +731,6 @@ module.exports = class FrontIntegration {
 				// eslint-disable-next-line no-underscore-dangle
 				event.data.payload.source._meta.type === 'reminder') {
 			return this.context.getActorId('user', 'admin')
-		}
-
-		/*
-		 * Handle S/Community_Custom forums actor weirdness.
-		 */
-		if (event.data.payload.target &&
-			event.data.payload.target.data &&
-			event.data.payload.target.data.type === 'custom' &&
-			event.data.payload.target.data.recipients.length > 1) {
-			/*
-			 * In forum messages the "from" is really "to" (?)
-			 */
-			const from = _.find(event.data.payload.target.data.recipients, {
-				role: 'to'
-			})
-
-			/*
-			 * If this is the case then we can patch the event accordingly.
-			 */
-			if (from) {
-				event.data.payload.target.data.recipients = [ from ]
-				event.data.payload.target.data.recipients[0].role = 'from'
-			}
 		}
 
 		return getMessageActor(

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -160,8 +160,8 @@ exports.insertCard = async (context, jellyfish, session, typeCard, options, obje
 	}
 
 	if (_.isEqual(
-		_.omit(insertedCard, [ 'created_at', 'updated_at', 'links' ]),
-		_.omit(card, [ 'created_at', 'updated_at', 'links' ])
+		_.omit(insertedCard, [ 'created_at', 'updated_at', 'linked_at', 'links' ]),
+		_.omit(card, [ 'created_at', 'updated_at', 'linked_at', 'links' ])
 	)) {
 		logger.debug(context, 'Omitting pointless insertion', {
 			slug: object.slug


### PR DESCRIPTION
We should have elevated the workaround like this from the very
beginning, otherwise it only applies to threads.

Change-type: patch