### PR TITLE
logger: Check the set level before sending a debug message

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -21,6 +21,8 @@ const LoggerNoContext = typedErrors.makeTypedError('LoggerNoContext')
 
 class Logger {
 	constructor (level, filename, transport) {
+		this.level = level
+
 		const moduleName = path
 			.relative(BASE_PATH, filename)
 			.split(path.sep)
@@ -44,6 +46,13 @@ class Logger {
 	}
 
 	debug (context, message, data) {
+		// TODO: Investigate the LogEntries transport,
+		// as it seems like its not obeying the Winston
+		// instance level.
+		if (this.level !== 'debug') {
+			return
+		}
+
 		this.logger.log('debug', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,


### PR DESCRIPTION
Looks like the LogEntries transport will still log debug messages even
when setting a different level. I'll patch it this way for now, and will
look at a proper solution later.

Change-type: patch