### PR TITLE
Add JELLYFISH_API_HOST dnsname support for the API

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/config-manifest.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/config-manifest.yml
@@ -2,6 +2,8 @@
 properties:
   - JELLYFISH_HOST:
       type: hostname
+  - JELLYFISH_API_HOST:
+      type: hostname
   - POSTGRES_DATABASE:
       type: string
   - POSTGRES_USER:

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-api-service.tpl.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: jellyfish-api
+  namespace: jellyfish
+  name: jellyfish-api
+spec:
+  selector:
+    app: jellyfish
+  ports:
+  - port: 8000
+    name: jellyfish-api

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-ingress.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-ingress.tpl.yml
@@ -11,6 +11,7 @@ spec:
       secretName: jellyfish-tls
       hosts:
         - {{{JELLYFISH_HOST}}}
+        - {{{JELLYFISH_API_HOST}}}
   rules:
     -
       host: {{{JELLYFISH_HOST}}}
@@ -21,4 +22,13 @@ spec:
             backend:
               serviceName: jellyfish
               servicePort: 8000 
+    -
+      host: {{{JELLYFISH_API_HOST}}}
+      http:
+        paths:
+          -
+            path: /
+            backend:
+              serviceName: jellyfish-api
+              servicePort: 8000
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Michael Angelos Simos <michalis@balena.io>