### PR TITLE
sync: Fix Cannot read property 'toLowerCase' of null in Front

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -858,7 +858,9 @@ module.exports = class FrontIntegration {
 						contact_id: _.last(_.split(url, '/'))
 					})
 
-					return this.context.getActorId('account', contact.name)
+					if (contact) {
+						return this.context.getActorId('account', contact.name)
+					}
 				}
 
 				if (event.data.payload.conversation.recipient.handle &&


### PR DESCRIPTION
```
Cannot read property 'toLowerCase' of null
	at Object.getActorId (/usr/src/app/lib/action-library/sync-context.js:34:37)
	at FrontIntegration.getThreadActor (/usr/src/app/lib/sync/integrations/front.js:861:26)
```

Change-type: patch