### PR TITLE
deploy-templates: Scale out jellyfish-api, enabling affinity

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -19,14 +19,14 @@ spec:
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
-            path: /ping
+            path: /status
             port: 8000
           initialDelaySeconds: 20
           periodSeconds: 10
           timeoutSeconds: 8
         readinessProbe:
           httpGet:
-            path: /ping
+            path: /status
             port: 8000
           initialDelaySeconds: 20
           periodSeconds: 10

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-service.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-service.tpl.yml
@@ -11,3 +11,4 @@ spec:
   ports:
   - port: 8000
     name: jellyfish-api
+  sessionAffinity: ClientIP


### PR DESCRIPTION
ClientIP sessionAffinity at service level is used for mitigating
ws protocol issues.

Change-type: minor
Signed-off-by: Michael Angelos Simos <michalis@balena.io>