### PR TITLE
deploy-templates: Add cookie affinity to API ingress

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-api-ingress.tpl.yml
@@ -1,10 +1,14 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: jellyfish
+  name: jellyfish-api
   namespace: jellyfish
   annotations:
     kubernetes.io/tls-acme: 'true'
+    ingress.kubernetes.io/affinity: "cookie"
+    ingress.kubernetes.io/session-cookie-name: "jellyfishAPI"
+    ingress.kubernetes.io/session-cookie-expires: "172800"
+    ingress.kubernetes.io/session-cookie-max-age: "172800"
 spec:
   tls:
     - secretName: jellyfish-api-tls


### PR DESCRIPTION
This addition should ensure affinity in the `ingress load balancer <--> ingress`  route.
Change-type: patch
Signed-off-by: Michael Angelos Simos <michalis@balena.io>