### PR TITLE
core: Ensure pg-live-select survives parallel installations

### DIFF
--- a/lib/core/backend/postgres/streams/pg-live-select/index.js
+++ b/lib/core/backend/postgres/streams/pg-live-select/index.js
@@ -32,6 +32,15 @@ const _ = require('lodash')
 const createTriggerSQL = require('./trigger-sql')
 const payload = require('./payload')
 
+/*
+ * Because Postgres doesn't allow us to run CREATE OR REPLACE FUNCTION
+ * concurrently. This "random" big int is a key between clients to
+ * synchronize themselves when creating the functions and triggers.
+ *
+ * See https://vladmihalcea.com/how-do-postgresql-advisory-locks-work/
+ */
+const TRANSACTION_ADVISORY_LOCK_KEY = 2142043989439426746
+
 module.exports = class LivePg extends EventEmitter {
 	constructor (client, channel, table) {
 		super()
@@ -47,17 +56,12 @@ module.exports = class LivePg extends EventEmitter {
 	}
 
 	async select () {
-		await this.client.query([
-			'BEGIN',
-			`DROP TRIGGER IF EXISTS "${this.triggerName}" ON "${this.table}"`,
-			[
-				`CREATE TRIGGER "${this.triggerName}"`,
-				`AFTER INSERT OR UPDATE OR DELETE ON "${this.table}"`,
-				`FOR EACH ROW EXECUTE PROCEDURE "${this.triggerProcedure}"()`
-			].join(' '),
-			'COMMIT'
-		].join('; '))
-
+		await this.client.query(createTriggerSQL(
+			TRANSACTION_ADVISORY_LOCK_KEY,
+			this.triggerProcedure,
+			this.triggerName,
+			this.table,
+			this.channel))
 		await this.client.query(`LISTEN "${this.channel}"`)
 
 		this.client.on('notification', (info) => {
@@ -80,9 +84,6 @@ module.exports = class LivePg extends EventEmitter {
 	}
 
 	async start () {
-		await this.client.query(
-			createTriggerSQL(this.triggerProcedure, this.channel))
-
 		// Periodically send a spoof query to keep the client open
 		this.interval = setInterval(() => {
 			this.client.query('SELECT TRUE').catch((error) => {
@@ -96,6 +97,7 @@ module.exports = class LivePg extends EventEmitter {
 
 		await this.client.query([
 			'BEGIN',
+			`SELECT pg_advisory_xact_lock(${TRANSACTION_ADVISORY_LOCK_KEY})`,
 			`DROP TRIGGER IF EXISTS "${this.triggerName}" ON ${this.table}`,
 			`DROP FUNCTION IF EXISTS "${this.triggerProcedure}"() CASCADE`,
 			'COMMIT'

--- a/lib/core/backend/postgres/streams/pg-live-select/trigger-sql.js
+++ b/lib/core/backend/postgres/streams/pg-live-select/trigger-sql.js
@@ -36,11 +36,8 @@ const FULL_MESSAGE_PAGINATED_SIZE = 7800
 
 /*
  * Template for trigger function to send row changes over notification
- * Accepts 2 arguments:
- * funName: name of function to create/replace
- * channel: NOTIFY channel on which to broadcast changes
  */
-module.exports = (triggerFunction, channel) => {
+module.exports = (lockKey, triggerProcedure, triggerName, table, channel) => {
 	/*
 	 * This function chunks the "before" and "after" payload so that we
 	 * can workaround the 8000 bytes NOTIFY limitation.
@@ -61,6 +58,9 @@ module.exports = (triggerFunction, channel) => {
 	 *   logical characters we need to extract
 	 */
 	return `
+	BEGIN;
+	SELECT pg_advisory_xact_lock(${lockKey});
+
   CREATE OR REPLACE FUNCTION is_valid_utf8_bytea(buffer BYTEA) RETURNS boolean AS $$
   BEGIN
     PERFORM length(buffer, 'UTF8');
@@ -70,7 +70,7 @@ module.exports = (triggerFunction, channel) => {
   END;
   $$ LANGUAGE plpgsql;
 
-  CREATE OR REPLACE FUNCTION "${triggerFunction}"() RETURNS trigger AS $$
+  CREATE OR REPLACE FUNCTION "${triggerProcedure}"() RETURNS trigger AS $$
   DECLARE
     row_data           RECORD;
     full_msg_binary    BYTEA;
@@ -141,5 +141,11 @@ module.exports = (triggerFunction, channel) => {
     END LOOP;
     RETURN NULL;
   END;
-$$ LANGUAGE plpgsql;`
+	$$ LANGUAGE plpgsql;
+
+	DROP TRIGGER IF EXISTS "${triggerName}" ON "${table}";
+	CREATE TRIGGER "${triggerName}" AFTER INSERT OR UPDATE OR DELETE ON "${table}"
+	FOR EACH ROW EXECUTE PROCEDURE "${triggerProcedure}"();
+
+	COMMIT;`
 }

--- a/test/integration/core/backend/postgres/streams/index.spec.js
+++ b/test/integration/core/backend/postgres/streams/index.spec.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const _ = require('lodash')
+const Bluebird = require('bluebird')
+const uuid = require('uuid/v4')
+const pgp = require('pg-promise')()
+const streams = require('../../../../../../lib/core/backend/postgres/streams')
+const environment = require('../../../../../../lib/environment')
+
+ava.beforeEach(async (test) => {
+	const id = uuid()
+
+	test.context.table = 'test_table'
+	test.context.database = `test_streams_${id.replace(/-/g, '')}`
+
+	test.context.context = {
+		id: `TEST-STREAMS-${id}`
+	}
+
+	const bootstrapConnection = pgp({
+		user: environment.postgres.user,
+		password: environment.postgres.password,
+		database: 'postgres',
+		port: environment.postgres.port
+	})
+
+	await bootstrapConnection.any(`
+		CREATE DATABASE ${test.context.database}
+		OWNER = ${environment.postgres.user}`)
+
+	await bootstrapConnection.$pool.end()
+	await bootstrapConnection.$destroy()
+
+	test.context.createConnection = async () => {
+		return pgp({
+			user: environment.postgres.user,
+			database: test.context.database,
+			password: environment.postgres.password,
+			port: environment.postgres.port
+		})
+	}
+
+	test.context.destroyConnection = async (connection) => {
+		await connection.$pool.end()
+		await connection.$destroy()
+	}
+
+	test.context.connection = await test.context.createConnection()
+	await test.context.connection.any(`
+		CREATE TABLE IF NOT EXISTS ${test.context.table} (
+			id UUID PRIMARY KEY NOT NULL,
+			slug VARCHAR (255) UNIQUE NOT NULL
+		)`)
+})
+
+ava.afterEach(async (test) => {
+	await test.context.destroyConnection(test.context.connection)
+	test.context.connection = null
+})
+
+ava('should be able to setup and teardown', async (test) => {
+	await test.notThrowsAsync(async () => {
+		const instance = await streams.setup(
+			test.context.context, test.context.connection, test.context.table)
+		await streams.teardown(
+			test.context.context, test.context.connection, instance)
+	})
+})
+
+ava('should be able to create two instances on the same connection', async (test) => {
+	await test.notThrowsAsync(async () => {
+		const instance1 = await streams.setup(
+			test.context.context, test.context.connection, test.context.table)
+		const instance2 = await streams.setup(
+			test.context.context, test.context.connection, test.context.table)
+		await streams.teardown(
+			test.context.context, test.context.connection, instance1)
+		await streams.teardown(
+			test.context.context, test.context.connection, instance2)
+	})
+})
+
+ava('should be able to create two instances different connections', async (test) => {
+	const connection1 = await test.context.createConnection()
+	const connection2 = await test.context.createConnection()
+
+	await test.notThrowsAsync(async () => {
+		const instance1 = await streams.setup(
+			test.context.context, connection1, test.context.table)
+		const instance2 = await streams.setup(
+			test.context.context, connection2, test.context.table)
+		await streams.teardown(
+			test.context.context, connection1, instance1)
+		await streams.teardown(
+			test.context.context, connection2, instance2)
+	})
+
+	await test.context.destroyConnection(connection1)
+	await test.context.destroyConnection(connection2)
+})
+
+ava('should survive parallel setups', async (test) => {
+	const run = async () => {
+		await Bluebird.delay(_.random(0, 1000))
+		const connection = await test.context.createConnection()
+		const instance = await streams.setup(
+			test.context.context, connection, test.context.table)
+		await Bluebird.delay(_.random(0, 1000))
+		await streams.teardown(
+			test.context.context, connection, instance)
+		await Bluebird.delay(_.random(0, 1000))
+		await test.context.destroyConnection(connection)
+	}
+
+	await test.notThrowsAsync(async () => {
+		await Bluebird.all([
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run(),
+			run()
+		])
+	})
+})


### PR DESCRIPTION
This commit tests and fixes the dreaded:

```
ERROR:  deadlock detected
DETAIL:  Process 6227 waits for AccessExclusiveLock on object 76992 of class 2620 of database 76954; blocked by process 6220.
        Process 6220 waits for AccessExclusiveLock on relation 76955 of database 76954; blocked by process 6229.
        Process 6229 waits for AccessExclusiveLock on object 76992 of class 2620 of database 76954; blocked by process 6227.
        Process 6227: BEGIN; DROP TRIGGER IF EXISTS "megatream-test_table_test_table" ON test_table; DROP FUNCTION IF EXISTS "livepg_megatream-tesnot t_table"() CASCADE; COMMIT
        Process 6220: BEGIN; DROP TRIGGER IF EXISTS "megatream-test_table_test_table" ON test_table; DROP FUNCTION IF EXISTS "livepg_megatream-test_table"() CASCADE; COMMIT
        Process 6229: BEGIN; DROP TRIGGER IF EXISTS "megatream-test_table_test_table" ON test_table; DROP FUNCTION IF EXISTS "livepg_megatream-test_table"() CASCADE; COMMIT
```

Change-type: patch