### PR TITLE
Makefile: Support flamegraph generation with 0x

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -3,5 +3,6 @@
 --ignore-dir=.nyc_output
 --ignore-dir=coverage
 --ignore-dir=dist
+--ignore-dir=match:/.0x$/
 --ignore-dir=.cache-loader
 --ignore-file=is:webpack-bundle-report.html

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ jellyfish-files
 dist/
 .cache-loader/
 webpack-bundle-report.html
+*.0x
 
 # End of https://www.gitignore.io/api/node
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,12 @@ NODE_DEBUG_ARGS = $(NODE_ARGS) \
 ifeq ($(NODE_ENV),production)
 NODE_EXEC="node"
 else
+ifeq ($(NODE_ENV),profile)
+# See https://github.com/davidmarkclements/0x
+NODE_EXEC=0x --open -- node
+else
 NODE_EXEC="./node_modules/.bin/supervisor"
+endif
 endif
 
 # User parameters
@@ -171,6 +176,7 @@ endif
 
 clean:
 	rm -rf \
+		*.0x \
 		dump.rdb \
 		.nyc_output \
 		coverage \


### PR DESCRIPTION
You will automatically get a nice flamegraph if you run any of the entry
points using `NODE_ENV=profile`.

Change-type: patch