### PR TITLE
Makefile: Get rid of the "supervisor" auto-reload module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,15 +118,11 @@ NODE_DEBUG_ARGS = $(NODE_ARGS) \
 									--stack_trace_on_illegal \
 									--abort_on_stack_or_string_length_overflow
 
-ifeq ($(NODE_ENV),production)
-NODE_EXEC="node"
-else
 ifeq ($(NODE_ENV),profile)
 # See https://github.com/davidmarkclements/0x
-NODE_EXEC=0x --open -- node
+NODE = 0x --open -- node
 else
-NODE_EXEC="./node_modules/.bin/supervisor"
-endif
+NODE = "node"
 endif
 
 # User parameters
@@ -259,15 +255,15 @@ node:
 
 start-server: LOGLEVEL = info
 start-server:
-	$(NODE_EXEC) $(NODE_ARGS) apps/server/index.js
+	$(NODE) $(NODE_ARGS) apps/server/index.js
 
 start-worker: LOGLEVEL = info
 start-worker:
-	$(NODE_EXEC) $(NODE_ARGS) apps/action-server/worker.js
+	$(NODE) $(NODE_ARGS) apps/action-server/worker.js
 
 start-tick: LOGLEVEL = info
 start-tick:
-	$(NODE_EXEC) $(NODE_ARGS) apps/action-server/tick.js
+	$(NODE) $(NODE_ARGS) apps/action-server/tick.js
 
 start-redis:
 	redis-server --port $(REDIS_PORT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26756,12 +26756,6 @@
         }
       }
     },
-    "supervisor": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/supervisor/-/supervisor-0.12.0.tgz",
-      "integrity": "sha1-3n5jNwFbKRhRwQ81OMSn8EkX7ME=",
-      "dev": true
-    },
     "supports-color": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "percentile": "^1.2.1",
     "puppeteer": "1.13.0",
     "request": "^2.88.0",
-    "supervisor": "^0.12.0",
     "webpack": "^4.1.1",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "^2.0.12",


### PR DESCRIPTION
Turns out this tool can easily eat 100% CPU just checking if the process
should be reloaded or not.

Change-type: patch