### PR TITLE
core: Avoid fetching user markers for the admin user

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -340,7 +340,11 @@ exports.getQuery = async (context, backend, session, schema, options) => {
 		throw new errors.JellyfishPermissionsError('User must have at least 1 role or permission view')
 	}
 
-	const userMarkers = await backend.getUserMarkers(context, user)
+	// We don't care about admin's markers as we treat this
+	// as a special case anyways.
+	const userMarkers = user.slug === 'user-admin'
+		? []
+		: await backend.getUserMarkers(context, user)
 
 	const markersQuery = createMarkersQuery(userMarkers)
 


### PR DESCRIPTION
The admin user conceptually has all markers anyways.

Change-type: patch