### PR TITLE
sync: Pass the Front message text representation correctly

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -876,22 +876,23 @@ module.exports = class FrontIntegration {
 				this.context.log.info('Creating front message', {
 					conversation,
 					author: author.id,
-					body: message,
-
-					/*
-					 * Front seems to mess up back ticks by replacing them
-					 * with "<br>\n", but for some reason it doesn't mangle
-					 * the data if we also pass a plain text version of the
-					 * message (?)
-					 */
-					text: message
+					body: message
 				})
 
 				const createResponse = await handleRateLimit(this.context, () => {
 					return this.front.message.reply({
 						conversation_id: conversation,
 						author_id: author.id,
-						body: card.data.payload.message,
+						body: message,
+
+						/*
+						 * Front seems to mess up back ticks by replacing them
+						 * with "<br>\n", but for some reason it doesn't mangle
+						 * the data if we also pass a plain text version of the
+						 * message (?)
+						 */
+						text: message,
+
 						options: {
 							archive: false
 						}

--- a/test/unit/sync/integrations/utils.spec.js
+++ b/test/unit/sync/integrations/utils.spec.js
@@ -31,3 +31,10 @@ ava('.parseHTML() should parse <p>\\n correctly', (test) => {
 	const result = utils.parseHTML(string)
 	test.is(result, expected)
 })
+
+ava('.parseHTML() should parse <code> correctly', (test) => {
+	const string = '<div><p>Foo <code>bar</code> baz</p>\n</div>'
+	const expected = 'Foo `bar` baz'
+	const result = utils.parseHTML(string)
+	test.is(result, expected)
+})


### PR DESCRIPTION
Change-type: patch
Fixes: https://github.com/balena-io/jellyfish/issues/1660
Fixes: https://github.com/balena-io/jellyfish/issues/1772