### PR TITLE
Exclude npm tests from balenaCI

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -17,3 +17,5 @@ docker:
       dockerfile: Dockerfile.ui
       docker_repo: balena/jellyfish-ui
       publish: true
+npm:
+  platforms: []


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>