### PR TITLE
server: Make data.payload.message required in whispers/messages

### DIFF
--- a/apps/server/default-cards/contrib/message.json
+++ b/apps/server/default-cards/contrib/message.json
@@ -24,6 +24,7 @@
             },
             "payload": {
               "type": "object",
+              "required": [ "message" ],
               "properties": {
                 "mentionsUser": {
                   "type": "array",

--- a/apps/server/default-cards/contrib/whisper.json
+++ b/apps/server/default-cards/contrib/whisper.json
@@ -28,6 +28,7 @@
             },
             "payload": {
               "type": "object",
+              "required": [ "message" ],
               "properties": {
                 "mentionsUser": {
                   "type": "array",

--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -951,7 +951,7 @@ module.exports = class FrontIntegration {
 
 			if (card.type === 'whisper') {
 				const conversation = _.last(threadFrontUrl.split('/'))
-				const message = card.data.payload.message
+				const message = card.data.payload.message || '[Empty content]'
 
 				this.context.log.info('Creating front whisper', {
 					conversation,

--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -248,6 +248,10 @@ module.exports = class GitHubIntegration {
 				return []
 			}
 
+			if (!issue.data.repository) {
+				return []
+			}
+
 			const [ owner, repository ] = issue.data.repository.split('/')
 
 			if (!githubUrl) {

--- a/lib/ui/components/Event.jsx
+++ b/lib/ui/components/Event.jsx
@@ -94,6 +94,10 @@ const getMessage = (card) => {
 		return `![Attached image](https://app.frontapp.com${message.slice(1, -1)})`
 	}
 
+	if (_.startsWith(message, '[](#jellyfish-hidden)')) {
+		return ''
+	}
+
 	return message
 }
 

--- a/lib/ui/lens/Timeline.jsx
+++ b/lib/ui/lens/Timeline.jsx
@@ -31,11 +31,20 @@ import {
 	selectors
 } from '../core'
 import helpers from '../services/helpers'
+import {
+	createPermaLink
+} from '../services/url-manager'
 import AutocompleteTextarea from '../shame/AutocompleteTextarea'
 import Column from '../shame/Column'
 import Icon from '../shame/Icon'
 
 const messageSymbolRE = /^\s*%\s*/
+
+/*
+ * This message text is used when uploading a file so that syncing can be done
+ * effectively without have to sync the entire file
+ */
+const FILE_PROXY_MESSAGE = '[](#jellyfish-hidden)A file has been uploaded using Jellyfish:'
 
 const TypingNotice = styled.div `
 	background: white;
@@ -124,7 +133,8 @@ class TimelineRenderer extends React.Component {
 			tags: [],
 			type,
 			payload: {
-				file
+				file,
+				message: `${FILE_PROXY_MESSAGE} ${createPermaLink(this.props.card)}`
 			}
 		}
 

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -893,6 +893,7 @@ ava.serial('.event.create() should create a new event', async (test) => {
 		target: card,
 		type: 'message',
 		payload: {
+			message: 'Foo',
 			test: 1
 		}
 	}
@@ -940,6 +941,7 @@ ava.serial('.event.create() should create a new event', async (test) => {
 	test.deepEqual(result.data, {
 		target: card.id,
 		payload: {
+			message: 'Foo',
 			test: 1
 		}
 	})

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -721,7 +721,8 @@ ava('.execute() should be able to AGGREGATE based on the card timeline', async (
 		arguments: {
 			type: 'message',
 			payload: {
-				mentions: [ 'johndoe' ]
+				mentions: [ 'johndoe' ],
+				message: 'Hello'
 			}
 		}
 	})
@@ -734,7 +735,8 @@ ava('.execute() should be able to AGGREGATE based on the card timeline', async (
 		arguments: {
 			type: 'message',
 			payload: {
-				mentions: [ 'janedoe', 'johnsmith' ]
+				mentions: [ 'janedoe', 'johnsmith' ],
+				message: 'Hello'
 			}
 		}
 	})
@@ -825,7 +827,8 @@ ava('.execute() AGGREGATE should create a property on the target if it does not 
 			type: 'message',
 			tags: [],
 			payload: {
-				mentions: [ 'johndoe' ]
+				mentions: [ 'johndoe' ],
+				message: 'Hello'
 			}
 		}
 	})
@@ -915,7 +918,8 @@ ava('.execute() AGGREGATE should work with $$ prefixed properties', async (test)
 			type: 'message',
 			tags: [],
 			payload: {
-				$$mentions: [ 'johndoe' ]
+				$$mentions: [ 'johndoe' ],
+				message: 'Hello'
 			}
 		}
 	})
@@ -993,7 +997,8 @@ ava('.execute() should create a message with tags', async (test) => {
 			type: 'message',
 			tags: [ 'testtag' ],
 			payload: {
-				$$mentions: [ 'johndoe' ]
+				$$mentions: [ 'johndoe' ],
+				message: 'Hello'
 			}
 		}
 	})


### PR DESCRIPTION
Otherwise we can't sync them to third party services.

Change-type: patch