### PR TITLE
Hotfix: Temporarily disable tag highlighting in messages

### DIFF
--- a/lib/ui/components/Event.jsx
+++ b/lib/ui/components/Event.jsx
@@ -227,10 +227,6 @@ class Event extends React.Component {
 		return !circularDeepEqual(nextState, this.state) || !circularDeepEqual(nextProps, this.props)
 	}
 
-	componentDidMount () {
-		this.processText()
-	}
-
 	downloadAttachment ({
 		slug,
 		name,


### PR DESCRIPTION
On large messages/threads of messages, tag highlighting can cause 100% CPU usage
and freeze the UI

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>