### PR TITLE
ui: Get actor without timeline if null

### DIFF
--- a/lib/ui/core/store/actioncreators.js
+++ b/lib/ui/core/store/actioncreators.js
@@ -244,7 +244,8 @@ export default class ActionCreator {
 			if (cachedCard) {
 				actor = cachedCard
 			} else {
-				actor = await this.sdk.card.getWithTimeline(id)
+				actor = await this.sdk.card.getWithTimeline(id) ||
+					await this.sdk.card.get(id)
 
 				dispatch({
 					type: actions.SET_ACTOR,


### PR DESCRIPTION
This is a hot fix. For some reason
`sdk.card.get('84e2b286-fbc2-4ade-b093-dfdaa11a0ae6')` succeeds but
`sdk.card.getWithTimeline('84e2b286-fbc2-4ade-b093-dfdaa11a0ae6')`
returns `null`, causing an issue when dispatching the action right
below (`SET ACTOR`).

Change-type: patch