### PR TITLE
test: Don't tear down core instances on stream closing

### DIFF
--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -3656,10 +3656,21 @@ ava.cb('.stream() should report back new elements that match a certain type', (t
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		await Bluebird.all([
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = Bluebird.all([
 			test.context.backend.insertElement(test.context.context, {
 				type: 'foo',
 				version: '1.0.0',
@@ -3782,10 +3793,21 @@ ava.cb('.stream() should report back changes to certain elements', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return test.context.backend.upsertElement(test.context.context, {
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = test.context.backend.upsertElement(test.context.context, {
 			slug: 'hello',
 			version: '1.0.0',
 			tags: [],
@@ -3894,10 +3916,21 @@ ava.cb('.stream() should report back changes to large elements', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return test.context.backend.upsertElement(test.context.context, {
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = test.context.backend.upsertElement(test.context.context, {
 			slug: 'hello',
 			active: true,
 			version: '1.0.0',
@@ -3988,10 +4021,21 @@ ava.cb('.stream() should set "before" to null if it previously did not match the
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return test.context.backend.upsertElement(test.context.context, {
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = test.context.backend.upsertElement(test.context.context, {
 			slug: 'foobarbaz',
 			active: true,
 			links: {},
@@ -4091,10 +4135,21 @@ ava.cb('.stream() should filter the "before" section of a change', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return test.context.backend.upsertElement(test.context.context, {
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = test.context.backend.upsertElement(test.context.context, {
 			slug: 'hello',
 			version: '1.0.0',
 			tags: [],

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -2246,10 +2246,21 @@ ava.cb('.stream() should include data if additionalProperties true', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return test.context.kernel.insertCard(
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = test.context.kernel.insertCard(
 			test.context.context, test.context.kernel.sessions.admin, {
 				slug: 'card-foo-bar-baz',
 				type: 'card',
@@ -2308,10 +2319,21 @@ ava.cb('.stream() should report back new elements that match a certain slug', (t
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return Bluebird.all([
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = Bluebird.all([
 			test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 				slug: 'card-foo',
 				type: 'card',
@@ -2355,6 +2377,8 @@ ava.cb('.stream() should report back elements of a certain type', (test) => {
 		},
 		required: [ 'type' ]
 	}).then((emitter) => {
+		let promise = Bluebird.resolve()
+
 		emitter.on('data', (change) => {
 			test.deepEqual(change.before, null)
 			test.deepEqual(_.omit(change.after, [ 'id' ]), {
@@ -2368,10 +2392,19 @@ ava.cb('.stream() should report back elements of a certain type', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
 
-		return Bluebird.all([
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = Bluebird.all([
 			test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 				slug: 'card-foo',
 				type: 'card',
@@ -2522,10 +2555,21 @@ ava.cb('.stream() should report back action requests', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return Bluebird.all([
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = Bluebird.all([
 			test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 				type: 'action-request',
 				slug: test.context.generateRandomSlug({
@@ -2598,10 +2642,21 @@ ava.cb('.stream() should report back inactive elements', (test) => {
 			emitter.close()
 		})
 
-		emitter.on('error', test.end)
-		emitter.on('closed', test.end)
+		let promise = Promise.resolve()
 
-		return test.context.kernel.insertCard(
+		emitter.on('error', (error) => {
+			promise.then(() => {
+				test.end(error)
+			}).catch(test.end)
+		})
+
+		emitter.on('closed', () => {
+			promise.then(() => {
+				test.end()
+			}).catch(test.end)
+		})
+
+		promise = test.context.kernel.insertCard(
 			test.context.context, test.context.kernel.sessions.admin, {
 				slug: 'card-bar',
 				active: false,


### PR DESCRIPTION
There may be in-flight requests, so we also need to wait for the actions
we execute to resolve first.

Change-type: patch