### PR TITLE
action-library: Support login with both PBKDF and Bcrypt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
 
       - run:
           name: Sync Tests
-          command: make test FILES=./test/e2e/sync/github-*.spec.js COVERAGE=1
+          command: make test FILES=./test/e2e/sync/github-*.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY
       - run:
           name: Sync End To End Tests Without Tokens
           command: make test FILES=./test/e2e/sync/github-*.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=
@@ -159,7 +159,7 @@ jobs:
 
       - run:
           name: Sync Tests
-          command: make test FILES=./test/e2e/sync/front-*.spec.js COVERAGE=1
+          command: make test FILES=./test/e2e/sync/front-*.spec.js COVERAGE=1 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN
       - run:
           name: Sync End To End Tests Without Tokens
           command: make test FILES=./test/e2e/sync/front-*.spec.js COVERAGE=1 INTEGRATION_FRONT_TOKEN=
@@ -187,7 +187,7 @@ jobs:
 
       - run:
           name: Sync Tests
-          command: make test FILES=./test/e2e/sync/discourse-*.spec.js COVERAGE=1
+          command: make test FILES=./test/e2e/sync/discourse-*.spec.js COVERAGE=1 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME
       - run:
           name: Sync End To End Tests Without Tokens
           command: make test FILES=./test/e2e/sync/discourse-*.spec.js COVERAGE=1 INTEGRATION_DISCOURSE_TOKEN=
@@ -215,7 +215,7 @@ jobs:
 
       - run:
           name: Sync Tests
-          command: make test FILES=./test/e2e/sync/balena-api-*.spec.js COVERAGE=1
+          command: make test FILES=./test/e2e/sync/balena-api-*.spec.js COVERAGE=1 INTEGRATION_BALENA_API_TOKEN=$BALENA_API_TOKEN INTEGRATION_BALENA_API_PUBLIC_KEY=$BALENA_API_PUBLIC_KEY INTEGRATION_BALENA_API_PRIVATE_KEY=$BALENA_API_PRIVATE_KEY
       - run:
           name: Sync End To End Tests Without Tokens
           command: make test FILES=./test/e2e/sync/balena-api-*.spec.js COVERAGE=1 INTEGRATION_BALENA_API_TOKEN=
@@ -365,7 +365,7 @@ jobs:
 
       - run:
           name: Post PR Summary
-          command: GITHUB_TOKEN=$INTEGRATION_GITHUB_TOKEN node scripts/ci/github-pr-summary.js $CIRCLE_PULL_REQUEST ./SUMMARY
+          command: GITHUB_TOKEN=$GITHUB_TOKEN node scripts/ci/github-pr-summary.js $CIRCLE_PULL_REQUEST ./SUMMARY
 
   eslint_jellyfish:
     <<: *job_defaults

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -8,6 +8,7 @@ const Bluebird = require('bluebird')
 const crypto = require('crypto')
 const _ = require('lodash')
 const skhema = require('skhema')
+const bcrypt = require('bcrypt')
 const syncContext = require('./sync-context')
 const sync = require('../sync')
 const environment = require('../environment')
@@ -23,21 +24,6 @@ const slugify = (string) => {
 const isUUID = (string) => {
 	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 		.test(string)
-}
-
-// Based on https://stackoverflow.com/a/17201493/1641422
-const DEFAULT_ITERATIONS = 10000
-const DEFAULT_KEY_LENGTH = 64
-const DEFAULT_DIGEST = 'sha512'
-const hashPBKDF = (options) => {
-	const key = crypto.pbkdf2Sync(
-		options.string,
-		options.salt,
-		DEFAULT_ITERATIONS,
-		DEFAULT_KEY_LENGTH,
-		DEFAULT_DIGEST)
-
-	return key.toString('hex')
 }
 
 const mirror = async (type, session, context, card, request) => {
@@ -354,27 +340,57 @@ module.exports = {
 					type: userCard.type
 				})
 
-			if (!fullUser.data.password || !fullUser.data.password.hash) {
+			if ((!fullUser.data.password || !fullUser.data.password.hash) &&
+				!fullUser.data.hash) {
 				const error = new context.errors.WorkerAuthenticationError(
 					'Login disallowed', request.context)
 				error.expected = true
 				throw error
 			}
 
-			// Convert the plaintext password into a hash so that
-			// we don't have a plain password stored in the DB
-			request.arguments.password = hashPBKDF({
-				string: request.arguments.password,
-				salt: userCard.slug
-			})
+			/*
+			 * Support the old PBKDF hashing method for
+			 * backwards compatibility purposes.
+			 * TODO: Delete this conditional block once
+			 * we migrate all the users to Bcrypt.
+			 */
+			if (!fullUser.data.hash) {
+				// Based on https://stackoverflow.com/a/17201493/1641422
+				const DEFAULT_ITERATIONS = 10000
+				const DEFAULT_KEY_LENGTH = 64
+				const DEFAULT_DIGEST = 'sha512'
+				const key = crypto.pbkdf2Sync(
+					request.arguments.password,
+					userCard.slug,
+					DEFAULT_ITERATIONS,
+					DEFAULT_KEY_LENGTH,
+					DEFAULT_DIGEST)
 
-			// Check the hash before enqueuing the request
-			if (request.arguments.password !== fullUser.data.password.hash) {
+				request.arguments.password = key.toString('hex')
+
+				if (request.arguments.password !== fullUser.data.password.hash) {
+					const error = new context.errors.WorkerAuthenticationError(
+						'Invalid password', request.context)
+					error.expected = true
+					throw error
+				}
+
+				return request.arguments
+			}
+
+			const matches = await bcrypt.compare(
+				request.arguments.password,
+				fullUser.data.hash)
+			if (!matches) {
 				const error = new context.errors.WorkerAuthenticationError(
 					'Invalid password', request.context)
 				error.expected = true
 				throw error
 			}
+
+			// Don't store the plain text password in the
+			// action request as we don't need it anymore.
+			request.arguments.password = 'CHECKED IN PRE HOOK'
 
 			return request.arguments
 		},
@@ -391,7 +407,8 @@ module.exports = {
 				throw error
 			}
 
-			if (!user.data.password || !user.data.password.hash) {
+			if ((!user.data.password || !user.data.password.hash) &&
+				!user.data.hash) {
 				const error = new context.errors.WorkerAuthenticationError(
 					'Login disallowed')
 				error.expected = true
@@ -444,10 +461,9 @@ module.exports = {
 		pre: async (session, context, request) => {
 			// Convert the plaintext password into a hash so that we don't have
 			// a plain password stored in the DB
-			request.arguments.password = hashPBKDF({
-				string: request.arguments.password,
-				salt: request.arguments.username
-			})
+			const SALTROUNDS = 12
+			request.arguments.password = await bcrypt.hash(
+				request.arguments.password, SALTROUNDS)
 
 			return request.arguments
 		},
@@ -465,9 +481,7 @@ module.exports = {
 					data: {
 						email: request.arguments.email,
 						roles: [ 'user-community' ],
-						password: {
-							hash: request.arguments.password
-						}
+						hash: request.arguments.password
 					}
 				})
 

--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -35,6 +35,12 @@ module.exports = {
 							type: 'string',
 							format: 'email'
 						},
+						hash: {
+							type: 'string'
+						},
+
+						// TODO: Remove this property once we completely
+						// moved all the user hashes to Bcrypt
 						password: {
 							type: 'object',
 							properties: {
@@ -47,6 +53,7 @@ module.exports = {
 								'hash'
 							]
 						},
+
 						roles: {
 							type: 'array',
 							items: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5833,8 +5833,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -6160,8 +6159,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "archy": {
       "version": "1.0.0",
@@ -6173,7 +6171,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.6"
@@ -8514,8 +8511,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "balena-temen": {
       "version": "0.5.6",
@@ -8625,6 +8621,22 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
+    },
+    "bcrypt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-3.0.6.tgz",
+      "integrity": "sha512-taA5bCTfXe7FUjKroKky9EXpdhkVvhE5owfxfLYodbrAR1Ul3juLmIQmIQBK4L9a5BuUcE6cqmwT+Da20lF9tg==",
+      "requires": {
+        "nan": "2.13.2",
+        "node-pre-gyp": "0.12.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+        }
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -8823,7 +8835,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -10646,8 +10657,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codependency": {
       "version": "0.1.4",
@@ -10874,8 +10884,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -10947,8 +10956,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -12185,8 +12193,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depcheck": {
       "version": "0.7.2",
@@ -12421,6 +12428,11 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-node": {
       "version": "2.0.4",
@@ -15743,6 +15755,14 @@
         }
       }
     },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -15764,8 +15784,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -16329,7 +16348,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
       "requires": {
         "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
@@ -16345,7 +16363,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -16354,7 +16371,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -16469,7 +16485,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -16915,8 +16930,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -17960,6 +17974,14 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -18126,7 +18148,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -18140,8 +18161,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -18445,8 +18465,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
       "version": "2.0.1",
@@ -20870,7 +20889,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -20888,6 +20906,30 @@
       "requires": {
         "arrify": "1.0.1",
         "is-plain-obj": "1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "2.3.5"
       }
     },
     "mississippi": {
@@ -21152,6 +21194,31 @@
         }
       }
     },
+    "needle": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "requires": {
+        "debug": "3.2.6",
+        "iconv-lite": "0.4.19",
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -21361,6 +21428,34 @@
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
+    "node-pre-gyp": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.4.0",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.4.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar": "4.4.9"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        }
+      }
+    },
     "node-releases": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.3.tgz",
@@ -21485,6 +21580,20 @@
       "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
       "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA=="
     },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+    },
+    "npm-packlist": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.6"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -21497,7 +21606,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.5",
         "console-control-strings": "1.1.0",
@@ -22090,7 +22198,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -22226,8 +22333,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -22252,8 +22358,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "output-file-sync": {
       "version": "2.0.1",
@@ -22510,8 +22624,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -23519,7 +23632,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "0.6.0",
         "ini": "1.3.5",
@@ -23530,14 +23642,12 @@
         "deep-extend": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -25400,7 +25510,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.3"
       }
@@ -25768,8 +25877,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -26627,7 +26735,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -26636,14 +26743,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -26774,7 +26879,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -26837,8 +26941,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-loader": {
       "version": "0.23.1",
@@ -27186,6 +27289,32 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
       "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
       "dev": true
+    },
+    "tar": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.9.tgz",
+      "integrity": "sha512-xisFa7Q2i3HOgfn+nmnWLGHD6Tm23hxjkx6wwGmgxkJFr6wxwXnJOdJYcZjL453PSdF0+bemO03+flAzkIdLBQ==",
+      "requires": {
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.6",
+        "minipass": "2.3.5",
+        "minizlib": "1.2.1",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "temp": {
       "version": "0.8.3",
@@ -30417,7 +30546,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
       "requires": {
         "string-width": "2.1.1"
       }
@@ -30602,8 +30730,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "ajv-keywords": "^3.4.0",
     "aws-sdk": "^2.289.0",
     "axios": "^0.18.0",
+    "bcrypt": "^3.0.6",
     "bluebird": "^3.5.1",
     "blueimp-md5": "^2.10.0",
     "body-parser": "^1.18.2",

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -530,7 +530,7 @@ ava.serial('When updating a user, inaccessible fields should not be removed', as
 	await sdk.card.update(
 		user.id,
 		_.merge(
-			_.omit(user, [ 'data', 'password' ]),
+			_.omit(user, [ 'data', 'hash' ]),
 			{
 				type: user.type,
 				data: {
@@ -547,7 +547,7 @@ ava.serial('When updating a user, inaccessible fields should not be removed', as
 
 	test.is(rawUserCard.data.email, 'test@example.com')
 	test.is(_.has(rawUserCard, [ 'data', 'roles' ]), true)
-	test.is(_.has(rawUserCard, [ 'data', 'password', 'hash' ]), true)
+	test.is(_.has(rawUserCard, [ 'data', 'hash' ]), true)
 })
 
 ava.serial('Users should not be able to login as the core admin user', async (test) => {
@@ -1008,7 +1008,7 @@ ava.serial('should apply permissions on resolved links', async (test) => {
 					Object.assign({}, targetUser, {
 						links: results[0].links['is attached to'][0].links,
 						linked_at: results[0].links['is attached to'][0].linked_at,
-						data: _.omit(targetUser.data, [ 'password', 'roles' ])
+						data: _.omit(targetUser.data, [ 'hash', 'roles' ])
 					})
 				]
 			},


### PR DESCRIPTION
For backwards compatibility reasons. New users use Bcrypt and
`action-create-session` will prefer to Bcrypt hash, but will fallback to
PBKDF.

Change-type: minor