### PR TITLE
UI: Do a better job of detecting backsynced events

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -444,7 +444,8 @@ export default class Event extends React.Component {
 
 		const attachments = getAttachments(card)
 
-		const timestamp = _.get(card, [ 'data', 'timestamp' ]) || card.created_at
+		const timestamp = helpers.getTrueEventTimestamp(card)
+
 		const messageOverflows = this.state.messageHeight >= MESSAGE_COLLAPSED_HEIGHT
 
 		return (

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -340,7 +340,8 @@ class Timeline extends React.Component {
 		} = this.state
 
 		// Due to a bug in syncing, sometimes there can be duplicate cards in tail
-		const sortedTail = _.uniqBy(_.sortBy(tail, 'data.timestamp'), 'id')
+		const sortedTail = _.uniqBy(
+			_.sortBy(tail, helpers.getTrueEventTimestamp), 'id')
 
 		// Remove non-message and non-whisper cards and update cards that don't have
 		// a "name" field. Update cards with a "name" field provide a human readable

--- a/lib/ui/lens/list/SupportThreads.jsx
+++ b/lib/ui/lens/list/SupportThreads.jsx
@@ -44,7 +44,7 @@ const timestampSort = (cards) => {
 	return _.sortBy(cards, (element) => {
 		const timestamps = _.map(
 			_.get(element.links, [ 'has attached element' ], []),
-			'data.timestamp'
+			helpers.getTrueEventTimestamp
 		)
 		timestamps.sort()
 		return _.last(timestamps)
@@ -103,12 +103,7 @@ export class SupportThreads extends React.Component {
 			 *    for a response
 			 */
 
-			// Sort the timeline by timestamp rathern than created_at as they might
-			// not be the same value if the card was backsynced
-			const timeline = _.sortBy(
-				_.get(card.links, [ 'has attached element' ], []),
-				'data.timestamp'
-			)
+			const timeline = _.sortBy(tail, helpers.getTrueEventTimestamp)
 
 			// If the card contains a message/whisper tagged as a discussion, move it to the discussion tab
 			for (const event of timeline) {

--- a/lib/ui/services/helpers.js
+++ b/lib/ui/services/helpers.js
@@ -405,3 +405,13 @@ export const patchPath = (card, keyPath, value) => {
 
 	return patch
 }
+
+// Get an events timestamp, whilst allowing for the potential of backsyncing
+// from integrations
+export const getTrueEventTimestamp = (card) => {
+	// If the timestamp is earlier than the created_at stamp then the event
+	// was created via back-syncing, so the earlier timestamp should be
+	// respected
+	const timestamp = _.get(card, [ 'data', 'timestamp' ])
+	return card.created_at > timestamp ? timestamp : card.created_at
+}


### PR DESCRIPTION
Only use data.timestamp for sorting if it is an earlier date than
created_at. This prevents issues where sync can overwrite
data.timestamp with a later date (I.E Front)

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>