### PR TITLE
sdk: Don't throw if executing .refreshToken() multiple times

### DIFF
--- a/lib/sdk/auth.js
+++ b/lib/sdk/auth.js
@@ -5,6 +5,7 @@
  */
 
 const Bluebird = require('bluebird')
+const uuid = require('uuid/v4')
 
 // A regex used to test that a string contains only alphanumeric characters and
 // dashes and is at least 5 characters long
@@ -218,7 +219,7 @@ class AuthSdk {
 				expirationDate.setDate(expirationDate.getDate() + 7)
 
 				return this.sdk.card.create({
-					slug: `session-${user.slug}-${Date.now()}`,
+					slug: `session-ui-${user.slug}-${Date.now()}-${uuid()}`,
 					type: 'session',
 					data: {
 						actor: user.id,

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -1135,6 +1135,25 @@ ava.serial('.auth.loginWithToken() should refresh your session token', async (te
 	await test.notThrowsAsync(sdk.auth.whoami())
 })
 
+ava.serial('.auth.refreshToken() should not throw if called multiple times in a row', async (test) => {
+	test.context.sdk.setAuthToken(test.context.session)
+
+	await test.notThrowsAsync(async () => {
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+		await test.context.sdk.auth.refreshToken()
+	})
+})
+
 ava.serial('should broadcast github issue links', async (test) => {
 	test.context.sdk.setAuthToken(test.context.session)
 


### PR DESCRIPTION
I added a "ui" suffix in the slug so that we know that these are UI
created sessions (just for convenience when skimming through logs)

Change-type: patch
Fixes: https://sentry.io/share/issue/e649e2d5cec545d3aceb7b73dbc1fc93/