### PR TITLE
discourse: Retry requests some times if Discourse is down

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -68,6 +68,22 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 			context, integrationOptions, method, url, options, retries - 1)
 	}
 
+	// Discourse may be unavailable, so at least try a couple
+	// of times before giving up.
+	if (result.code === 503) {
+		assert.USER(null, retries > 0,
+			integrationOptions.errors.SyncExternalRequestError,
+			`Discourse unavailable ${summary}: ${description}`)
+
+		context.log.warn('Discourse unavailable retry', {
+			retries
+		})
+
+		await Bluebird.delay(5000)
+		return httpDiscourse(
+			context, integrationOptions, method, url, options, retries - 1)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
Just as an extra way to cope with any weird issues, eventually throwing
a user error if needed.

Change-type: patch