### PR TITLE
discourse: Retry API requests on 5xx

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -48,10 +48,6 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 	const summary = `${result.code} ${method} ${url}`
 	const description = JSON.stringify(result.body, null, 2)
 
-	assert.INTERNAL(null, result.code < 500,
-		integrationOptions.errors.SyncExternalRequestError,
-		`Discourse API error ${summary}: ${description}`)
-
 	if (result.code === 429) {
 		assert.INTERNAL(null, retries > 0,
 			integrationOptions.errors.SyncRateLimit,
@@ -70,7 +66,7 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 
 	// Discourse may be unavailable, so at least try a couple
 	// of times before giving up.
-	if (result.code === 503) {
+	if (result.code >= 500) {
 		assert.USER(null, retries > 0,
 			integrationOptions.errors.SyncExternalRequestError,
 			`Discourse unavailable ${summary}: ${description}`)


### PR DESCRIPTION
We logged some sporadic 502 responses in production. Lets just retry on
any 5xx code rather than complicating the conditionals.

Change-type: patch