### PR TITLE
core: Remove action request from queue given an execute event

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -149,6 +149,10 @@ const upsertObject = async (context, backend, object, options) => {
 		})
 	}
 
+	/*
+	 * Manually maintain the pending action request queue
+	 * when an action request is inserted or executed.
+	 */
 	if (insertedObject.type === 'action-request' &&
 		insertedObject.active &&
 		!options.replace) {
@@ -169,6 +173,11 @@ const upsertObject = async (context, backend, object, options) => {
 					table: 'requests'
 				})
 		}
+	} else if (insertedObject.type === 'execute') {
+		await queue.remove(
+			context, backend.connection, insertedObject.data.target, {
+				table: 'requests'
+			})
 	}
 
 	/*

--- a/lib/queue/index.js
+++ b/lib/queue/index.js
@@ -43,6 +43,18 @@ const linkExecuteEvent = (jellyfish, context, session, eventCard, actionRequest)
 	})
 }
 
+// Re-post execute event in order to tell the core about the fact
+// that this request has already been executed, so it gets removed
+// from the queue and prevents workers from spinning on it in vain.
+const repostExecuteEvent = async (context, jellyfish, session, executeCard, request) => {
+	const newExecuteCard = _.cloneDeep(executeCard)
+	Reflect.deleteProperty(newExecuteCard, 'id')
+	const suffix = await uuid.random()
+	newExecuteCard.slug = `execute-nudge-${request.id}-${suffix}`
+	return jellyfish.insertCard(
+		context, session, newExecuteCard)
+}
+
 const claimRequest = async (context, instance, actor, request) => {
 	assert.INTERNAL(context, request.slug,
 		errors.QueueInvalidRequest,
@@ -79,11 +91,8 @@ const claimRequest = async (context, instance, actor, request) => {
 			execute: executeCard.slug
 		})
 
-		// TODO: Somehow "nudge" the core about the fact that this
-		// request has already been executed, so it gets removed
-		// from the queue and prevents workers from spinning on it
-		// in vain.
-
+		await repostExecuteEvent(
+			context, instance.jellyfish, instance.session, executeCard, request)
 		await instance.jellyfish.unlock(
 			context, instance.session, actor, request)
 		return null
@@ -101,11 +110,8 @@ const claimRequest = async (context, instance, actor, request) => {
 			link: executeLink.slug
 		})
 
-		// TODO: Somehow "nudge" the core about the fact that this
-		// request has already been executed, so it gets removed
-		// from the queue and prevents workers from spinning on it
-		// in vain.
-
+		await repostExecuteEvent(
+			context, instance.jellyfish, instance.session, executeCard, request)
 		await instance.jellyfish.unlock(
 			context, instance.session, actor, request)
 		return null

--- a/lib/queue/index.js
+++ b/lib/queue/index.js
@@ -43,7 +43,7 @@ const linkExecuteEvent = (jellyfish, context, session, eventCard, actionRequest)
 	})
 }
 
-const claimRequest = async (context, jellyfish, session, actor, request) => {
+const claimRequest = async (context, instance, actor, request) => {
 	assert.INTERNAL(context, request.slug,
 		errors.QueueInvalidRequest,
 		`Request has no slug: ${JSON.stringify(request, null, 2)}`)
@@ -52,7 +52,8 @@ const claimRequest = async (context, jellyfish, session, actor, request) => {
 		slug: request.slug
 	})
 
-	if (!await jellyfish.lock(context, session, actor, request)) {
+	if (!await instance.jellyfish.lock(
+		context, instance.session, actor, request)) {
 		return null
 	}
 
@@ -68,8 +69,8 @@ const claimRequest = async (context, jellyfish, session, actor, request) => {
 	 * until materialized view is refreshed, which is eventually
 	 * consistent.
 	 */
-	const executeCard = await jellyfish.getCardBySlug(
-		context, session, events.getExecuteEventSlug(request), {
+	const executeCard = await instance.jellyfish.getCardBySlug(
+		context, instance.session, events.getExecuteEventSlug(request), {
 			type: 'execute'
 		})
 	if (executeCard) {
@@ -78,14 +79,20 @@ const claimRequest = async (context, jellyfish, session, actor, request) => {
 			execute: executeCard.slug
 		})
 
-		await jellyfish.unlock(context, session, actor, request)
+		// TODO: Somehow "nudge" the core about the fact that this
+		// request has already been executed, so it gets removed
+		// from the queue and prevents workers from spinning on it
+		// in vain.
+
+		await instance.jellyfish.unlock(
+			context, instance.session, actor, request)
 		return null
 	}
 
 	// Also check the link cards as a last resort,
 	// just in case the materialization failed
-	const executeLink = await jellyfish.getCardBySlug(
-		context, session, getExecuteLinkSlug(request), {
+	const executeLink = await instance.jellyfish.getCardBySlug(
+		context, instance.session, getExecuteLinkSlug(request), {
 			type: 'link'
 		})
 	if (executeLink) {
@@ -94,7 +101,13 @@ const claimRequest = async (context, jellyfish, session, actor, request) => {
 			link: executeLink.slug
 		})
 
-		await jellyfish.unlock(context, session, actor, request)
+		// TODO: Somehow "nudge" the core about the fact that this
+		// request has already been executed, so it gets removed
+		// from the queue and prevents workers from spinning on it
+		// in vain.
+
+		await instance.jellyfish.unlock(
+			context, instance.session, actor, request)
 		return null
 	}
 
@@ -166,7 +179,7 @@ const pickNextUnexecutedRequest = async (instance, context, actor, skip = 0) => 
 	// worker locking conflicts
 	for (const actionRequest of _.shuffle(results)) {
 		const result = await claimRequest(
-			context, instance.jellyfish, instance.session, actor, actionRequest)
+			context, instance, actor, actionRequest)
 
 		/*
 		 * We need to manually maintain the priority buffer.


### PR DESCRIPTION
Faster than waiting for the link card between an execute event and the
action request.

Change-type: patch