### PR TITLE
sync: Use a different error to signal that there is no linked user

### DIFF
--- a/lib/sync/errors.js
+++ b/lib/sync/errors.js
@@ -10,6 +10,7 @@ const typedErrors = require('typed-errors')
 _.each([
 	'SyncNoElement',
 	'SyncOAuthError',
+	'SyncOAuthNoUserError',
 	'SyncNoActor',
 	'SyncRateLimit',
 	'SyncInvalidEvent',

--- a/lib/sync/instance.js
+++ b/lib/sync/instance.js
@@ -88,7 +88,7 @@ const getOAuthUser = async (context, provider, actor, options) => {
 	}
 
 	assert.INTERNAL(null, options.defaultUser,
-		errors.SyncOAuthError,
+		errors.SyncOAuthNoUserError,
 		`No default integrations actor to act as ${actor} for ${provider}`)
 
 	const defaultUserCard = await context.getElementBySlug(
@@ -98,7 +98,7 @@ const getOAuthUser = async (context, provider, actor, options) => {
 		errors.SyncNoActor, `No such actor: ${options.defaultUser}`)
 
 	assert.USER(null, _.has(defaultUserCard, tokenPath),
-		errors.SyncOAuthError,
+		errors.SyncOAuthNoUserError,
 		`Default actor ${options.defaultUser} does not support ${provider}`)
 
 	return defaultUserCard

--- a/lib/sync/integrations/outreach.js
+++ b/lib/sync/integrations/outreach.js
@@ -90,7 +90,7 @@ module.exports = class OutreachIntegration {
 			uri,
 			body
 		}).catch((error) => {
-			if (error.expected && error.name === 'SyncOAuthError') {
+			if (error.expected && error.name === 'SyncOAuthNoUserError') {
 				this.context.log.warn('Could not update prospect', {
 					uri,
 					method,

--- a/test/unit/sync/instance.spec.js
+++ b/test/unit/sync/instance.spec.js
@@ -567,7 +567,7 @@ ava('should throw if actor is not associated with service and there is no defaul
 				return data[object.id]
 			}
 		}
-	}), errors.SyncOAuthError)
+	}), errors.SyncOAuthNoUserError)
 
 	nock.cleanAll()
 })
@@ -697,7 +697,7 @@ ava('should throw if neither the actor nor the default user are associated with 
 				return data[object.id]
 			}
 		}
-	}), errors.SyncOAuthError)
+	}), errors.SyncOAuthNoUserError)
 
 	nock.cleanAll()
 })


### PR DESCRIPTION
Change-type: patch