### PR TITLE
Revert "deploy-templates: Remove Outreach secrets"

### DIFF
--- a/deploy-templates/staging/v1.0.0/kubernetes/config-manifest.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/config-manifest.yml
@@ -55,3 +55,7 @@ properties:
       type: string
   - INTEGRATION_DISCOURSE_SIGNATURE_KEY:
       type: string
+  - INTEGRATION_OUTREACH_APP_ID:
+      type: string
+  - INTEGRATION_OUTREACH_APP_SECRET:
+      type: string

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/action-server-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/action-server-deployment.tpl.yml
@@ -74,6 +74,10 @@ spec:
           value: {{{INTEGRATION_DISCOURSE_USERNAME}}}
         - name: INTEGRATION_DISCOURSE_SIGNATURE_KEY
           value: {{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}
+        - name: INTEGRATION_OUTREACH_APP_ID
+          value: {{{INTEGRATION_OUTREACH_APP_ID}}}
+        - name: INTEGRATION_OUTREACH_APP_SECRET
+          value: {{{INTEGRATION_OUTREACH_APP_SECRET}}}
 
       imagePullSecrets:
         - name: com.docker.hub.travisciresin

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/jellyfish-deployment.tpl.yml
@@ -86,6 +86,10 @@ spec:
           value: {{{INTEGRATION_DISCOURSE_USERNAME}}}
         - name: INTEGRATION_DISCOURSE_SIGNATURE_KEY
           value: {{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}
+        - name: INTEGRATION_OUTREACH_APP_ID
+          value: {{{INTEGRATION_OUTREACH_APP_ID}}}
+        - name: INTEGRATION_OUTREACH_APP_SECRET
+          value: {{{INTEGRATION_OUTREACH_APP_SECRET}}}
         ports:
         - containerPort: 8000
           name: jellyfish-api

--- a/deploy-templates/staging/v1.0.0/kubernetes/templates/tick-server-deployment.tpl.yml
+++ b/deploy-templates/staging/v1.0.0/kubernetes/templates/tick-server-deployment.tpl.yml
@@ -68,6 +68,10 @@ spec:
           value: {{{INTEGRATION_DISCOURSE_USERNAME}}}
         - name: INTEGRATION_DISCOURSE_SIGNATURE_KEY
           value: {{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}
+        - name: INTEGRATION_OUTREACH_APP_ID
+          value: {{{INTEGRATION_OUTREACH_APP_ID}}}
+        - name: INTEGRATION_OUTREACH_APP_SECRET
+          value: {{{INTEGRATION_OUTREACH_APP_SECRET}}}
 
       imagePullSecrets:
         - name: com.docker.hub.travisciresin


### PR DESCRIPTION
This reverts commit 6a969fe71bc6277f211397b0018b4aa668e8250d.

Change-type: patch