### PR TITLE
front: Correctly handle bad attachments

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -1307,12 +1307,9 @@ module.exports = class FrontIntegration {
 
 			return Buffer.from(response, 'utf8')
 		} catch (error) {
-			// Looks like sometimes Front sends us invalid HTTP responses
-			// when fetching attachments. Not much we can do about it.
-			// See https://github.com/nodejs/node-v0.x-archive/issues/4863
-			assert.USER(null, error.code !== 'HPE_INVALID_CONSTANT',
+			assert.USER(null, error.statusCode !== 500,
 				this.options.errors.SyncExternalRequestError,
-				`Front returned a malformed HTTP response when fetching attachment ${file}`)
+				`Front crashed with ${error.statusCode} when fetching attachment ${file}`)
 
 			// Because the response is a buffer, the error is sent as a buffer as well
 			if (_.isBuffer(error.error)) {


### PR DESCRIPTION
This is an example problematic reponse:

```
GET https://api2.frontapp.com/download/fil_78b47b7

HTTP/1.1 500 Internal Server Error
Connection: keep-alive
Content-Length: 52
Content-Type: application/json; charset=utf-8
Date: Tue, 13 Aug 2019 08:27:58 GMT
ETag: W/"34-zWc8gW+EWeg2mrqPaNjNywdzhTk"
Vary: Accept
X-Front-Time: 1327
content-disposition: attachment; filename="fcfcee30d4feab3f68201478b340e658_05.08.2019_18_11_49+0000.txt"
x-protected-by: Sqreen
x-ratelimit-limit: 200
x-ratelimit-remaining: 177
x-ratelimit-reset: 1565684894.182

{
    "_error": {
        "message": "An internal error occurred."
    }
}
```

Change-type: patch