### PR TITLE
JSONSchema2sql: Handle min/maxItems on top level columns

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/keywords.js
+++ b/lib/core/backend/postgres/jsonschema2sql/keywords.js
@@ -217,6 +217,14 @@ exports.properties = (value, path, walk, schema, context, keys) => {
 
 exports.minItems = (value, path, walk, schema, context, keys) => {
 	const postgresValue = builder.valueToPostgres(value)
+
+	if (builder.isColumn(path)) {
+		return {
+			keys,
+			filter: `cardinality(${builder.getProperty(path)}) >= ${postgresValue}`
+		}
+	}
+
 	return {
 		keys,
 		filter: builder.or(
@@ -227,6 +235,14 @@ exports.minItems = (value, path, walk, schema, context, keys) => {
 
 exports.maxItems = (value, path, walk, schema, context, keys) => {
 	const postgresValue = builder.valueToPostgres(value)
+
+	if (builder.isColumn(path)) {
+		return {
+			keys,
+			filter: `cardinality(${builder.getProperty(path)}) <= ${postgresValue}`
+		}
+	}
+
 	return {
 		keys,
 		filter: builder.or(

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -899,3 +899,90 @@ avaTest('jsonb_pattern - pattern keyword should be case sensitive', async (test)
 	test.is(results.length, 1)
 	test.deepEqual(results[0].slug, elements[0].slug)
 })
+
+avaTest('minItems keyword should work on TEXT array columns', async (test) => {
+	const table = 'minitems_text_array'
+
+	const schema = {
+		type: 'object',
+		required: [ 'markers' ],
+		properties: {
+			markers: {
+				type: 'array',
+				minItems: 1
+			}
+		},
+		additionalProperties: true
+	}
+
+	const elements = [
+		{
+			slug: 'test-1',
+			version: '1.0.0',
+			type: 'card',
+			active: true,
+			markers: [ 'foobar' ]
+		},
+		{
+			slug: 'test-2',
+			version: '1.0.0',
+			type: 'card',
+			active: true
+		}
+	]
+
+	const results = await runner({
+		connection: test.context.connection,
+		database: test.context.database,
+		table,
+		elements,
+		schema
+	})
+
+	test.is(results.length, 1)
+	test.deepEqual(results[0].slug, elements[0].slug)
+})
+
+avaTest('maxItems keyword should work on TEXT array columns', async (test) => {
+	const table = 'maxitems_text_array'
+
+	const schema = {
+		type: 'object',
+		required: [ 'markers' ],
+		properties: {
+			markers: {
+				type: 'array',
+				maxItems: 1
+			}
+		},
+		additionalProperties: true
+	}
+
+	const elements = [
+		{
+			slug: 'test-1',
+			version: '1.0.0',
+			type: 'card',
+			active: true,
+			markers: [ 'foobar' ]
+		},
+		{
+			slug: 'test-2',
+			version: '1.0.0',
+			type: 'card',
+			active: true,
+			markers: [ 'foobar', 'bazbuzz' ]
+		}
+	]
+
+	const results = await runner({
+		connection: test.context.connection,
+		database: test.context.database,
+		table,
+		elements,
+		schema
+	})
+
+	test.is(results.length, 1)
+	test.deepEqual(results[0].slug, elements[0].slug)
+})


### PR DESCRIPTION
Fixes #2389

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>