### PR TITLE
chat-widget: Take token as an unexported JELLYFISH_TOKEN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,6 @@ export INTEGRATION_OUTREACH_APP_SECRET
 INTEGRATION_OUTREACH_SIGNATURE_KEY ?=
 export INTEGRATION_OUTREACH_SIGNATURE_KEY
 
-# Temporary token for chat widget
-CHAT_WIDGET_JELLYFISH_TOKEN ?=
-export CHAT_WIDGET_JELLYFISH_TOKEN
-
 # -----------------------------------------------
 # Test Runtime Configuration
 # -----------------------------------------------
@@ -268,12 +264,12 @@ build-chat-widget:
 	./node_modules/.bin/nyc instrument $(NYC_OPTS) apps/chat-widget $(NYC_TMP_DIR)/apps/chat-widget
 	NODE_ENV=test \
 		SENTRY_DSN_UI=$(SENTRY_DSN_UI) API_URL=$(SERVER_HOST):$(SERVER_PORT) \
-		CHAT_WIDGET_JELLYFISH_TOKEN=$(CHAT_WIDGET_JELLYFISH_TOKEN) \
+		JELLYFISH_TOKEN=$(JELLYFISH_TOKEN) \
 		./node_modules/.bin/webpack --config=./apps/chat-widget/webpack.config.js
 else
 build-chat-widget:
 	SENTRY_DSN_UI=$(SENTRY_DSN_UI) API_URL=$(SERVER_HOST):$(SERVER_PORT) \
-	CHAT_WIDGET_JELLYFISH_TOKEN=$(CHAT_WIDGET_JELLYFISH_TOKEN) \
+	JELLYFISH_TOKEN=$(JELLYFISH_TOKEN) \
 		./node_modules/.bin/webpack --config=./apps/chat-widget/webpack.config.js
 endif
 
@@ -366,7 +362,7 @@ dev-ui:
 
 dev-chat-widget: NODE_ENV = development
 dev-chat-widget:
-	CHAT_WIDGET_JELLYFISH_TOKEN=$(CHAT_WIDGET_JELLYFISH_TOKEN) \
+	JELLYFISH_TOKEN=$(JELLYFISH_TOKEN) \
 	./node_modules/.bin/webpack-dev-server --config=./apps/chat-widget/webpack.config.js --color
 
 dev-storybook:

--- a/apps/chat-widget/environment.js
+++ b/apps/chat-widget/environment.js
@@ -10,7 +10,7 @@
 export const api = {
 	prefix: process.env.API_PREFIX || 'api/v2',
 	url: process.env.API_URL || window.location.origin,
-	token: process.env.CHAT_WIDGET_JELLYFISH_TOKEN
+	token: process.env.JELLYFISH_TOKEN
 }
 
 export const analytics = {

--- a/apps/chat-widget/webpack.config.js
+++ b/apps/chat-widget/webpack.config.js
@@ -51,7 +51,7 @@ const config = mergeConfig(baseConfig, {
 				NODE_ENV: JSON.stringify(process.env.NODE_ENV),
 				SENTRY_DSN_UI: JSON.stringify(process.env.SENTRY_DSN_UI),
 				MIXPANEL_TOKEN_UI: JSON.stringify(process.env.MIXPANEL_TOKEN_UI),
-				CHAT_WIDGET_JELLYFISH_TOKEN: JSON.stringify(process.env.CHAT_WIDGET_JELLYFISH_TOKEN),
+				JELLYFISH_TOKEN: JSON.stringify(process.env.JELLYFISH_TOKEN),
 
 				// So that it matches git tags
 				VERSION: JSON.stringify(`v${packageJSON.version}`)
@@ -66,7 +66,7 @@ if (process.env.NODE_ENV !== 'production') {
 	config.plugins.push(
 		new BundleAnalyzerPlugin({
 			analyzerMode: 'static',
-			reportFilename: path.resolve(outDir, 'webpack-bundle-report.chat-widget.html'),
+			reportFilename: path.resolve(outDir, 'webpack-bundle-report.html'),
 			openAnalyzer: false
 		})
 	)


### PR DESCRIPTION
- There is no need to export the env var in the Makefile, as its passed
to Webpack directly
- The `CHAT_WIDGET_` prefix is implicit based on where its being used

Change-type: patch