### PR TITLE
core: Don't sort by data.timestamp by default

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -46,8 +46,6 @@ const queryTable = async (context, backend, table, schema, options) => {
 
 	const preProcessingStartDate = new Date()
 	const config = _.defaults(options, {
-		sortBy: [ 'data', 'timestamp' ],
-
 		// Exclude converting additionalProperties to SQL, as its used for field
 		// filtering rather than record selection and will typically break the
 		// generated SQL query, causing no results to be returned

--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -120,8 +120,6 @@ exports.post = async (context, jellyfish, session, options, results) => {
  * }
  */
 exports.getLastExecutionEvent = async (context, jellyfish, session, originator) => {
-	// The .query() function automatically sorts by data.timestamp, so
-	// we don't have to manually specify any sorting in this case.
 	const events = await jellyfish.query(context, session, {
 		type: 'object',
 		required: [ 'active', 'type', 'data' ],
@@ -148,6 +146,7 @@ exports.getLastExecutionEvent = async (context, jellyfish, session, originator) 
 			}
 		}
 	}, {
+		sortBy: 'created_at',
 		limit: 1
 	})
 

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -257,6 +257,7 @@ ava.serial('.query() should accept a "limit" option', async (test) => {
 		},
 		additionalProperties: true
 	}, {
+		sortBy: 'created_at',
 		limit
 	})
 
@@ -356,6 +357,7 @@ ava.serial('.query() should accept a "skip" option', async (test) => {
 		},
 		additionalProperties: true
 	}, {
+		sortBy: 'created_at',
 		limit,
 		skip
 	})

--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -1396,6 +1396,7 @@ ava('.query() should be able to limit the results', async (test) => {
 		},
 		required: [ 'type' ]
 	}, {
+		sortBy: 'created_at',
 		limit: 2
 	})
 
@@ -1471,6 +1472,7 @@ ava('.query() should be able to skip the results', async (test) => {
 		},
 		required: [ 'type' ]
 	}, {
+		sortBy: 'created_at',
 		skip: 2
 	})
 

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -1802,6 +1802,7 @@ ava('.query() should be able to limit the results', async (test) => {
 		},
 		required: [ 'type' ]
 	}, {
+		sortBy: 'created_at',
 		limit: 2
 	})
 
@@ -1850,6 +1851,7 @@ ava('.query() should be able to skip the results', async (test) => {
 		},
 		required: [ 'type' ]
 	}, {
+		sortBy: 'created_at',
 		skip: 2
 	})
 

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -3136,6 +3136,8 @@ ava('should add an update event if updating a card', async (test) => {
 				}
 			}
 		}
+	}, {
+		sortBy: 'created_at'
 	})
 
 	test.deepEqual(timeline, [


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't ssafely do this without a solid
test suite!