### PR TITLE
postgres: Keep track of cards_markers view triggers

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -192,7 +192,8 @@ const upsertObject = async (context, backend, object, options) => {
 		})
 
 		await markers.refresh(context, backend.connection, {
-			source: cards.TABLE
+			source: cards.TABLE,
+			trigger: insertedObject
 		})
 	}
 

--- a/lib/core/backend/postgres/markers.js
+++ b/lib/core/backend/postgres/markers.js
@@ -95,6 +95,8 @@ exports.refresh = async (context, connection, options) => {
 	await refreshView(connection, table)
 	const refreshEnd = new Date()
 	logger.info(context, 'Refreshed markers', {
+		type: options.trigger.type,
+		trigger: options.trigger.slug,
 		time: refreshEnd.getTime() - refreshStart.getTime()
 	})
 }


### PR DESCRIPTION
For debugging purposes.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!