### PR TITLE
postgres: Don't refresh card_markers on user changes

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -181,10 +181,9 @@ const upsertObject = async (context, backend, object, options) => {
 	/*
 	 * Only update the markers view if needed, for performance reasons.
 	 */
-	if (insertedObject.type === 'user' || insertedObject.type === 'org' ||
-			(insertedObject.type === 'link' &&
-				(insertedObject.data.from.type === 'org' ||
-					insertedObject.data.to.type === 'org'))) {
+	if (insertedObject.type === 'link' &&
+			((insertedObject.data.from.type === 'org' && insertedObject.data.to.type === 'user') ||
+			(insertedObject.data.to.type === 'org' && insertedObject.data.from.type === 'user'))) {
 		logger.info(context, 'Triggering markers refresh', {
 			type: insertedObject.type,
 			slug: insertedObject.slug,


### PR DESCRIPTION
Changes to a user card can never change the set of markers they are
associated with.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!