### PR TITLE
test: Sort out sdk test hooks messy situation

### DIFF
--- a/test/e2e/sdk/helpers.js
+++ b/test/e2e/sdk/helpers.js
@@ -11,7 +11,7 @@ const {
 } = require('../../../lib/sdk')
 
 exports.sdk = {
-	beforeEach: async (test) => {
+	before: async (test) => {
 		await helpers.server.beforeEach(test)
 
 		// Since AVA tests are running concurrently, set up an SDK instance that will
@@ -40,9 +40,16 @@ exports.sdk = {
 		}
 	},
 
-	afterEach: async (test) => {
+	after: async (test) => {
+		await helpers.server.afterEach(test)
+	},
+
+	beforeEach: (test) => {
+		test.context.sdk.setAuthToken(test.context.session)
+	},
+
+	afterEach: (test) => {
 		test.context.sdk.cancelAllStreams()
 		test.context.sdk.cancelAllRequests()
-		await helpers.server.afterEach(test)
 	}
 }

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -11,20 +11,21 @@ const uuid = require('uuid/v4')
 const helpers = require('./helpers')
 const environment = require('../../../lib/environment')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
+
+ava.beforeEach(helpers.sdk.beforeEach)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {
 	await test.context.sdk.auth.logout()
+	await helpers.sdk.afterEach(test)
 })
 
 ava.serial('.action() should be able to successfully create a new card', async (test) => {
 	const {
 		sdk
 	} = test.context
-
-	sdk.setAuthToken(test.context.session)
 
 	const name = `test-card-${uuid()}`
 
@@ -74,8 +75,6 @@ ava.serial('.action() should resolve with the slug, id and type of the card', as
 	const {
 		sdk
 	} = test.context
-
-	sdk.setAuthToken(test.context.session)
 
 	const name = `test-card-${uuid()}`
 	const slug = test.context.generateRandomSlug({
@@ -127,8 +126,6 @@ ava.serial('.query() should run a query on the server', async (test) => {
 		tags: [],
 		data: {}
 	})
-
-	sdk.setAuthToken(test.context.session)
 
 	const results = await sdk.query({
 		type: 'object',
@@ -233,8 +230,6 @@ ava.serial('.query() should accept a "limit" option', async (test) => {
 		tags: []
 	})
 
-	sdk.setAuthToken(test.context.session)
-
 	const results = await sdk.query({
 		type: 'object',
 		required: [ 'type', 'data' ],
@@ -332,8 +327,6 @@ ava.serial('.query() should accept a "skip" option', async (test) => {
 		markers: [],
 		tags: []
 	})
-
-	sdk.setAuthToken(test.context.session)
 
 	const results = await sdk.query({
 		type: 'object',
@@ -445,8 +438,6 @@ ava.serial('.query() should accept a "sortBy" option as a single key', async (te
 		tags: []
 	})
 
-	sdk.setAuthToken(test.context.session)
-
 	const results = await sdk.query({
 		type: 'object',
 		required: [ 'type', 'data' ],
@@ -555,8 +546,6 @@ ava.serial('.query() should accept a "sortBy" option as an array of keys', async
 		tags: []
 	})
 
-	sdk.setAuthToken(test.context.session)
-
 	const results = await sdk.query({
 		type: 'object',
 		required: [ 'type', 'data' ],
@@ -628,8 +617,6 @@ ava.serial('.card.get() should return a single element', async (test) => {
 		data: {}
 	})
 
-	sdk.setAuthToken(test.context.session)
-
 	const result = await sdk.card.get(card.id, {
 		type: 'card'
 	})
@@ -678,8 +665,6 @@ ava.serial('.card.get() should work with slugs', async (test) => {
 		tags: [],
 		data: {}
 	})
-
-	sdk.setAuthToken(test.context.session)
 
 	const result = await sdk.card.get(slug, {
 		type: 'card'
@@ -731,8 +716,6 @@ ava.serial('.card.get() should work for ids without a type option', async (test)
 		data: {}
 	})
 
-	sdk.setAuthToken(test.context.session)
-
 	const result = await sdk.card.get(card.id)
 
 	test.deepEqual(result, card)
@@ -780,8 +763,6 @@ ava.serial('.card.get() should work for slugs without a type option', async (tes
 		data: {}
 	})
 
-	sdk.setAuthToken(test.context.session)
-
 	const result = await sdk.card.get(slug)
 
 	test.deepEqual(result, card)
@@ -791,8 +772,6 @@ ava.serial('.card.create() should create a new card', async (test) => {
 	const {
 		sdk
 	} = test.context
-
-	sdk.setAuthToken(test.context.session)
 
 	const slug = test.context.generateRandomSlug({
 		prefix: 'card'
@@ -833,8 +812,6 @@ ava.serial('.card.create() should resolve with the slug, id and type of the crea
 		sdk
 	} = test.context
 
-	sdk.setAuthToken(test.context.session)
-
 	const slug = test.context.generateRandomSlug({
 		prefix: 'card'
 	})
@@ -857,8 +834,6 @@ ava.serial('.card.remove() should be able to delete a card', async (test) => {
 		sdk
 	} = test.context
 
-	sdk.setAuthToken(test.context.session)
-
 	const card = await sdk.card.create({
 		type: 'card',
 		slug: test.context.generateRandomSlug({
@@ -878,8 +853,6 @@ ava.serial('.event.create() should create a new event', async (test) => {
 	const {
 		sdk
 	} = test.context
-
-	sdk.setAuthToken(test.context.session)
 
 	const slug = test.context.generateRandomSlug({
 		prefix: 'card'
@@ -958,7 +931,6 @@ ava.serial.cb('.stream() should stream new cards', (test) => {
 	const slug1 = `test-card-${uuid()}`.toLowerCase()
 	const slug2 = `test-card-${uuid()}`.toLowerCase()
 
-	sdk.setAuthToken(test.context.session)
 	sdk.stream({
 		type: 'object',
 		properties: {
@@ -1025,7 +997,6 @@ ava.serial.cb('.stream() should emit an event using the .type() method', (test) 
 		sdk
 	} = test.context
 
-	sdk.setAuthToken(test.context.session)
 	sdk.stream()
 		.then(async (stream1) => {
 			const stream2 = await sdk.stream()
@@ -1074,8 +1045,6 @@ ava.serial('.auth.signup() should work with a valid token', async (test) => {
 	const {
 		sdk
 	} = test.context
-
-	sdk.setAuthToken(test.context.session)
 
 	const details = {
 		username: `testuser-${uuid()}`,
@@ -1140,8 +1109,6 @@ ava.serial('.auth.loginWithToken() should refresh your session token', async (te
 })
 
 ava.serial('.auth.refreshToken() should not throw if called multiple times in a row', async (test) => {
-	test.context.sdk.setAuthToken(test.context.session)
-
 	await test.notThrowsAsync(async () => {
 		await test.context.sdk.auth.refreshToken()
 		await test.context.sdk.auth.refreshToken()
@@ -1159,8 +1126,6 @@ ava.serial('.auth.refreshToken() should not throw if called multiple times in a 
 })
 
 ava.serial('should broadcast github issue links', async (test) => {
-	test.context.sdk.setAuthToken(test.context.session)
-
 	const issueSlug = test.context.generateRandomSlug({
 		prefix: 'issue'
 	})
@@ -1216,8 +1181,6 @@ ava.serial('should broadcast github issue links', async (test) => {
 })
 
 ava.serial('should link two cards together', async (test) => {
-	test.context.sdk.setAuthToken(test.context.session)
-
 	const issueSlug = test.context.generateRandomSlug({
 		prefix: 'issue'
 	})
@@ -1312,8 +1275,6 @@ ava.serial('should link two cards together', async (test) => {
 })
 
 ava.serial('linking two cards should be idempotent', async (test) => {
-	test.context.sdk.setAuthToken(test.context.session)
-
 	const issueSlug = test.context.generateRandomSlug({
 		prefix: 'issue'
 	})

--- a/test/e2e/server/actions/action-increment-tag.spec.js
+++ b/test/e2e/server/actions/action-increment-tag.spec.js
@@ -9,8 +9,8 @@ const Bluebird = require('bluebird')
 const _ = require('lodash')
 const helpers = require('../../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/actions/action-increment.spec.js
+++ b/test/e2e/server/actions/action-increment.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -8,8 +8,8 @@ const ava = require('ava')
 const uuid = require('uuid/v4')
 const helpers = require('../../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/attachments.spec.js
+++ b/test/e2e/server/attachments.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/hooks.spec.js
+++ b/test/e2e/server/hooks.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -11,8 +11,8 @@ const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 const environment = require('../../../lib/environment')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/integrations.spec.js
+++ b/test/e2e/server/integrations.spec.js
@@ -16,8 +16,8 @@ const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 const environment = require('../../../lib/environment')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/markers.spec.js
+++ b/test/e2e/server/markers.spec.js
@@ -8,8 +8,8 @@ const ava = require('ava')
 const uuid = require('uuid/v4')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/messages.spec.js
+++ b/test/e2e/server/messages.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/oauth.spec.js
+++ b/test/e2e/server/oauth.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/security.spec.js
+++ b/test/e2e/server/security.spec.js
@@ -9,8 +9,8 @@ const uuid = require('uuid/v4')
 const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/sessions.spec.js
+++ b/test/e2e/server/sessions.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/server/users.spec.js
+++ b/test/e2e/server/users.spec.js
@@ -10,8 +10,8 @@ const nock = require('nock')
 const uuid = require('uuid/v4')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.sdk.beforeEach)
-ava.after(helpers.sdk.afterEach)
+ava.before(helpers.sdk.before)
+ava.after(helpers.sdk.after)
 
 // Logout of the SDK after each test
 ava.afterEach(async (test) => {

--- a/test/e2e/sync/helpers.js
+++ b/test/e2e/sync/helpers.js
@@ -416,10 +416,10 @@ exports.translate = {
 
 exports.mirror = {
 	before: async (test) => {
-		await helpers.sdk.beforeEach(test)
+		await helpers.sdk.before(test)
 	},
 	after: async (test) => {
-		await helpers.sdk.afterEach(test)
+		await helpers.sdk.after(test)
 	},
 	beforeEach: async (test, username) => {
 		test.context.username = username


### PR DESCRIPTION
- `beforeEach` and `afterEach` should be `before` and `after`
- We need new `beforeEach` and `afterEach` hooks to keep track of the
SDK session
- Therefore we don't need `sdk.setAuthToken()` in every test case

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!