### PR TITLE
Persist nyc output reports on Docker Compose jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ aliases:
       docker:
         - image: resinci/jellyfish-test
 
-      working_directory: ~/repo
+      # Match the Dockerfile WORKDIR so we can
+      # transparently merge code coverage reports.
+      working_directory: /usr/src/jellyfish
+
       environment:
         DATABASE: postgres
         POSTGRES_USER: postgres
@@ -150,7 +153,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY
+          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY COVERAGE=1
       - run:
           name: Sync Tests
           command: make compose-exec-sidecar COMMAND="make" ARGS="test COVERAGE=0 FILES=./test/e2e/sync/github-mirror.spec.js SCRUB=0 COVERAGE=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY"
@@ -159,13 +162,21 @@ jobs:
           command: make compose-stop
       - run:
           name: Compose Up Without Tokens
-          command: make compose-up DETACH=1
+          command: make compose-up DETACH=1 COVERAGE=1
       - run:
           name: Sync End To End Tests Without Tokens
           command: make compose-exec-sidecar COMMAND="make" ARGS="test COVERAGE=0 FILES=./test/e2e/sync/github-mirror.spec.js SCRUB=0 COVERAGE=0 INTEGRATION_GITHUB_TOKEN="
       - run:
           name: Compose Down
           command: make compose-stop
+      - run:
+          name: Copy Code Coverage Reports
+          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .nyc_output/*.json
 
   sync_tests_front_translate:
     <<: *job_defaults
@@ -208,7 +219,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN
+          command: make compose-up DETACH=1 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN COVERAGE=1
       - run:
           name: Sync Tests
           command: make compose-exec-sidecar COMMAND="make" ARGS="test COVERAGE=0 FILES=./test/e2e/sync/front-mirror.spec.js SCRUB=0 COVERAGE=0 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN"
@@ -217,13 +228,21 @@ jobs:
           command: make compose-stop
       - run:
           name: Compose Up Without Tokens
-          command: make compose-up DETACH=1
+          command: make compose-up DETACH=1 COVERAGE=1
       - run:
           name: Sync End To End Tests Without Tokens
           command: make compose-exec-sidecar COMMAND="make" ARGS="test COVERAGE=0 FILES=./test/e2e/sync/front-mirror.spec.js SCRUB=0 COVERAGE=0 INTEGRATION_FRONT_TOKEN="
       - run:
           name: Compose Down
           command: make compose-stop
+      - run:
+          name: Copy Code Coverage Reports
+          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .nyc_output/*.json
 
   sync_tests_outreach_translate:
     <<: *job_defaults
@@ -323,7 +342,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME
+          command: make compose-up DETACH=1 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME COVERAGE=1
       - run:
           name: Sync Tests
           command: make compose-exec-sidecar COMMAND="make" ARGS="test COVERAGE=0 FILES=./test/e2e/sync/discourse-mirror.spec.js SCRUB=0 COVERAGE=0 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME"
@@ -332,13 +351,21 @@ jobs:
           command: make compose-stop
       - run:
           name: Compose Up Without Tokens
-          command: make compose-up DETACH=1
+          command: make compose-up DETACH=1 COVERAGE=1
       - run:
           name: Sync End To End Tests Without Tokens
           command: make compose-exec-sidecar COMMAND="make" ARGS="test COVERAGE=0 FILES=./test/e2e/sync/discourse-mirror.spec.js SCRUB=0 COVERAGE=0 INTEGRATION_DISCOURSE_TOKEN="
       - run:
           name: Compose Down
           command: make compose-stop
+      - run:
+          name: Copy Code Coverage Reports
+          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .nyc_output/*.json
 
   sync_tests_balena_api_translate:
     <<: *job_defaults
@@ -382,7 +409,7 @@ jobs:
 
       - run:
           name: Docker Compose Up (with integration tokens)
-          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
+          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish COVERAGE=1
       - run:
           name: End To End Tests (Server)
           command: make compose-exec-sidecar COMMAND="make" ARGS="test-e2e-server COVERAGE=0 SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
@@ -391,7 +418,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Docker Compose Up
-          command: make compose-up DETACH=1
+          command: make compose-up DETACH=1 COVERAGE=1
       - run:
           name: End To End Tests (SDK)
           command: make compose-exec-sidecar COMMAND="make" ARGS="test-e2e-sdk COVERAGE=0 SCRUB=0"
@@ -404,6 +431,14 @@ jobs:
       - run:
           name: Docker Compose Down
           command: make compose-stop
+      - run:
+          name: Copy Code Coverage Reports
+          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .nyc_output/*.json
 
   results:
     <<: *job_defaults

--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,10 @@ compose-exec-%:
 		exec $(subst compose-exec-,,$@) $(COMMAND) $(ARGS) \
 		$(DOCKER_COMPOSE_COMMAND_OPTIONS)
 
+compose-up-%:
+	docker-compose $(DOCKER_COMPOSE_OPTIONS) \
+		up $(DOCKER_COMPOSE_COMMAND_OPTIONS) $(subst compose-up-,,$@) $(ARGS)
+
 compose-%:
 	docker-compose $(DOCKER_COMPOSE_OPTIONS) $(subst compose-,,$@) \
 		$(DOCKER_COMPOSE_COMMAND_OPTIONS)

--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -4,18 +4,18 @@
 
 FROM resinci/jellyfish-base:ffea33d27
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/jellyfish
 
 ARG ENABLE_COVERAGE=0
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 ENV COVERAGE ${ENABLE_COVERAGE}
 
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/jellyfish/
 RUN mkdir -p scripts/eslint-plugin-jellyfish
 COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/app/scripts/eslint-plugin-jellyfish
+	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
 RUN npm ci
-COPY . /usr/src/app
+COPY . /usr/src/jellyfish
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-tick >> run.sh && \

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -4,18 +4,18 @@
 
 FROM resinci/jellyfish-base:ffea33d27
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/jellyfish
 
 ARG ENABLE_COVERAGE=0
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 ENV COVERAGE ${ENABLE_COVERAGE}
 
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/jellyfish/
 RUN mkdir -p scripts/eslint-plugin-jellyfish
 COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/app/scripts/eslint-plugin-jellyfish
+	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
 RUN npm ci
-COPY . /usr/src/app
+COPY . /usr/src/jellyfish
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-worker >> run.sh && \

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -4,14 +4,14 @@
 
 FROM resinci/jellyfish-base:ffea33d27 as base
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/jellyfish
 
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/jellyfish/
 RUN mkdir -p scripts/eslint-plugin-jellyfish
 COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/app/scripts/eslint-plugin-jellyfish
+	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
 RUN npm ci
-COPY . /usr/src/app
+COPY . /usr/src/jellyfish
 
 ARG SERVER_HOST=https://api.ly.fish
 ARG SERVER_PORT=443
@@ -27,6 +27,6 @@ RUN make build-livechat \
 ###########################################################
 
 FROM nginx:1.15
-WORKDIR /usr/src/app
-COPY --from=base /usr/src/app/dist/livechat /usr/share/nginx/html
+WORKDIR /usr/src/jellyfish
+COPY --from=base /usr/src/jellyfish/dist/livechat /usr/share/nginx/html
 COPY apps/livechat/conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -4,18 +4,18 @@
 
 FROM resinci/jellyfish-base:ffea33d27
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/jellyfish
 
 ARG ENABLE_COVERAGE=0
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 ENV COVERAGE ${ENABLE_COVERAGE}
 
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/jellyfish/
 RUN mkdir -p scripts/eslint-plugin-jellyfish
 COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/app/scripts/eslint-plugin-jellyfish
+	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
 RUN npm ci
-COPY . /usr/src/app
+COPY . /usr/src/jellyfish
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-server >> run.sh && \

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -4,12 +4,12 @@
 
 FROM resinci/jellyfish-base:ffea33d27
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/jellyfish
 
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/jellyfish/
 RUN mkdir -p scripts/eslint-plugin-jellyfish
 COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/app/scripts/eslint-plugin-jellyfish
+	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
 RUN npm ci
 
 RUN apt-get update && apt-get install -y \
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 	libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0
 
-COPY . /usr/src/app
+COPY . /usr/src/jellyfish
 
 # Sleep forever
 # See: https://stackoverflow.com/a/35770783

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -4,14 +4,14 @@
 
 FROM resinci/jellyfish-base:ffea33d27 as base
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/jellyfish
 
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/jellyfish/
 RUN mkdir -p scripts/eslint-plugin-jellyfish
 COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/app/scripts/eslint-plugin-jellyfish
+	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
 RUN npm ci
-COPY . /usr/src/app
+COPY . /usr/src/jellyfish
 
 ARG SERVER_HOST=https://api.ly.fish
 ARG SERVER_PORT=443
@@ -30,6 +30,6 @@ RUN make build-ui \
 ###########################################################
 
 FROM nginx:1.15
-WORKDIR /usr/src/app
-COPY --from=base /usr/src/app/dist/ui /usr/share/nginx/html
+WORKDIR /usr/src/jellyfish
+COPY --from=base /usr/src/jellyfish/dist/ui /usr/share/nginx/html
 COPY apps/ui/conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,13 @@ services:
       - INTEGRATION_OUTREACH_SIGNATURE_KEY
     ports:
       - "${PORT}:${PORT}"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:${PORT}/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
     volumes:
-      - .nyc_output:/usr/src/app/.nyc_output
+      - .nyc_output:/usr/src/jellyfish/.nyc_output
     depends_on:
       - postgres
       - redis
@@ -121,7 +126,7 @@ services:
       - postgres
       - redis
     volumes:
-      - .nyc_output:/usr/src/app/.nyc_output
+      - .nyc_output:/usr/src/jellyfish/.nyc_output
     links:
       - postgres
       - redis
@@ -167,7 +172,7 @@ services:
       - postgres
       - redis
     volumes:
-      - .nyc_output:/usr/src/app/.nyc_output
+      - .nyc_output:/usr/src/jellyfish/.nyc_output
     links:
       - postgres
       - redis
@@ -219,6 +224,11 @@ services:
       - UI_PORT=80
       - LIVECHAT_HOST=http://livechat
       - LIVECHAT_PORT=80
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://api:${SERVER_PORT}/ping" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
     depends_on:
       - api
       - ui


### PR DESCRIPTION
We will make it an opt-in now that we will add support for it on Docker
Compose.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!