### PR TITLE
circleci: Don't run Docker Compose on build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,13 +57,6 @@ jobs:
           name: No Unstaged Files
           command: ./scripts/ci/unstaged.sh
 
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - run:
-          name: Docker Compose
-          command: make compose-build
-
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!