### PR TITLE
discourse: Cache responses from the /emails.json endpoint

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -21,6 +21,7 @@ const CATEGORIES = {}
  * Discourse user cache, for rate limiting purposes.
  */
 const DISCOURSE_USER_CACHE = new LRU(200)
+const DISCOURSE_USER_EMAIL_CACHE = new LRU(200)
 
 const httpDiscourse = async (context, integrationOptions, method, url, options, retries = 15) => {
 	const username = options.username || integrationOptions.token.username
@@ -130,9 +131,19 @@ const getDiscourseResource = async (context, actor, options, baseUrl, path) => {
 // Sometimes the email is not visible on the main user endpoints,
 // but its accessible through this special URL.
 const getDiscourseEmailByUsername = async (context, actor, options, baseUrl, username) => {
+	const cachedEmail = DISCOURSE_USER_EMAIL_CACHE.get(username)
+	if (cachedEmail) {
+		return cachedEmail
+	}
+
 	const response = await getDiscourseResource(
 		context, actor, options, baseUrl, `/u/${username}/emails.json`)
-	return response && response.email
+	if (!response || !response.email) {
+		return null
+	}
+
+	DISCOURSE_USER_EMAIL_CACHE.set(username, response.email)
+	return response.email
 }
 
 /**


### PR DESCRIPTION
For rate limiting purposes.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!