### PR TITLE
do not assume Notifications framework is available

### DIFF
--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -19,9 +19,9 @@ const sound = new Howl({
 	src: '/audio/dustyroom_cartoon_bubble_pop.mp3'
 })
 
-let canUseNotifications = Notification.permission === 'granted'
+let canUseNotifications = window.Notification && Notification.permission === 'granted'
 
-if (Notification && Notification.permission !== 'denied') {
+if (window.Notification && Notification.permission !== 'denied') {
 	Notification.requestPermission((status) => {
 		// Status is "granted", if accepted by user
 		canUseNotifications = status === 'granted'


### PR DESCRIPTION
Connects-to: #2597
Signed-off-by: Will Boyce \<will@balena.io\>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
