### PR TITLE
Added support to triggers to work on multiple cards

### DIFF
--- a/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -58,7 +58,7 @@
     "action": "action-update-card",
     "target": {
       "$map": {
-        "$eval": "source.links['issue has attached support thread'][0:].id"
+        "$eval": "source.links['issue has attached support thread'][0:]"
       },
       "each(link)": {
         "$eval": "link.id"

--- a/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -57,7 +57,12 @@
     },
     "action": "action-update-card",
     "target": {
-      "$eval": "source.links['issue has attached support thread'][0].id"
+      "$map": {
+        "$eval": "source.links['issue has attached support thread'][0:].id"
+      },
+      "each(link)": {
+        "$eval": "link.id"
+      }
     },
     "arguments": {
       "reason": "Re-opened because linked issue was closed",

--- a/apps/server/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-reopen.json
@@ -48,7 +48,7 @@
     "action": "action-update-card",
     "target": {
       "$map": {
-        "$eval": "source.links['is attached to'][0:].id"
+        "$eval": "source.links['is attached to'][0:]"
       },
       "each(link)": {
         "$eval": "link.id"

--- a/apps/server/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-reopen.json
@@ -47,7 +47,12 @@
     },
     "action": "action-update-card",
     "target": {
-      "$eval": "source.links['is attached to'][0].id"
+      "$map": {
+        "$eval": "source.links['is attached to'][0:].id"
+      },
+      "each(link)": {
+        "$eval": "link.id"
+      }
     },
     "mode": "insert",
     "arguments": {

--- a/apps/server/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-summary.json
@@ -65,7 +65,12 @@
     },
     "action": "action-update-card",
     "target": {
-      "$eval": "source.links['is attached to'][0].id"
+      "$map": {
+        "$eval": "source.links['is attached to'][0:].id"
+      },
+      "each(link)": {
+        "$eval": "link.id"
+      }
     },
     "arguments": {
       "reason": "Closed with #summary tag",

--- a/apps/server/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-summary.json
@@ -66,7 +66,7 @@
     "action": "action-update-card",
     "target": {
       "$map": {
-        "$eval": "source.links['is attached to'][0:].id"
+        "$eval": "source.links['is attached to'][0:]"
       },
       "each(link)": {
         "$eval": "link.id"

--- a/lib/worker/cards/triggered-action.js
+++ b/lib/worker/cards/triggered-action.js
@@ -49,8 +49,13 @@ module.exports = {
 						target: {
 							type: [
 								'string',
-								'object'
-							]
+								'object',
+								'array'
+							],
+							items: {
+								type: 'string'
+							},
+							uniqueItems: true
 						},
 						arguments: {
 							type: 'object'

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -171,25 +171,32 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 				return null
 			}
 
-			const triggerCard = await getInputCard(
-				context, jellyfish, session, request.card)
-			assert.INTERNAL(context, triggerCard, errors.WorkerNoElement,
-				`No such input card for trigger: ${request.card}`)
+			const identifiers = _.uniq(_.castArray(request.card))
 
-			return options.library[request.action].handler(
-				session, options.context, triggerCard, {
-					card: triggerCard,
-					action: request.action,
-					actor: options.actor,
-					context: request.context,
-					timestamp: request.currentDate.toISOString(),
-					epoch: request.currentDate.valueOf(),
-					arguments: request.arguments,
+			const triggerCards = await Bluebird.map(identifiers, async (identifier) => {
+				const triggerCard = await getInputCard(
+					context, jellyfish, session, identifier)
+				assert.INTERNAL(context, triggerCard, errors.WorkerNoElement,
+					`No such input card for trigger: ${identifier}`)
+				return triggerCard
+			})
 
-					// Carry the old originator if present so we
-					// don't break the chain
-					originator: options.originator || request.originator
-				})
+			return Promise.all(triggerCards.map((triggerCard) => {
+				return options.library[request.action].handler(
+					session, options.context, triggerCard, {
+						card: triggerCard,
+						action: request.action,
+						actor: options.actor,
+						context: request.context,
+						timestamp: request.currentDate.toISOString(),
+						epoch: request.currentDate.valueOf(),
+						arguments: request.arguments,
+
+						// Carry the old originator if present so we
+						// don't break the chain
+						originator: options.originator || request.originator
+					})
+			}))
 		}, {
 			// Triggers can't be processed concurrently as they may modify cards, which
 			// can cause race conditions if they are not done in serial

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -241,8 +241,13 @@ module.exports = class Worker {
 			assert.INTERNAL(context, !trigger.mode || _.isString(trigger.mode),
 				errors.WorkerInvalidTrigger, `Invalid mode: ${trigger.mode}`)
 			assert.INTERNAL(context,
-				trigger.target && (_.isString(trigger.target) || _.isPlainObject(trigger.target)),
+				trigger.target && (_.isString(trigger.target) || _.isPlainObject(trigger.target) || _.isArray(trigger.target)),
 				errors.WorkerInvalidTrigger, `Invalid target: ${trigger.target}`)
+			if (_.isArray(trigger.target)) {
+				assert.INTERNAL(context,
+					trigger.target.length === _.uniq(trigger.target).length,
+					errors.WorkerInvalidTrigger, 'Invalid target: it contains duplicates')
+			}
 			assert.INTERNAL(context,
 				(trigger.interval || trigger.filter) && !(trigger.interval && trigger.filter),
 				errors.WorkerInvalidTrigger, 'Use either a filter or an interval')

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -965,6 +965,280 @@ ava('.execute() should execute a triggered action', async (test) => {
 	test.is(resultCard.data.command, 'foo-bar-baz')
 })
 
+ava('a triggered action can update a dynamic list of cards (ids as array of strings)', async (test) => {
+	const cardIds = []
+	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
+		const card = await test.context.jellyfish.insertCard(
+			test.context.context, test.context.session, {
+				slug: `foo${idx}`,
+				type: 'card',
+				version: '1.0.0',
+				data: {
+					id: `id${idx}`
+				}
+			})
+		cardIds.push(card.id)
+	})
+
+	test.context.worker.setTriggers(test.context.context, [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			filter: {
+				type: 'object',
+				required: [ 'data' ],
+				properties: {
+					data: {
+						type: 'object',
+						required: [ 'cards' ],
+						properties: {
+							cards: {
+								type: 'array',
+								items: {
+									type: 'string'
+								}
+							}
+						}
+					}
+				}
+			},
+			action: 'action-update-card',
+			target: {
+				$eval: 'source.data.cards'
+			},
+			arguments: {
+				reason: null,
+				patch: [
+					{
+						op: 'add',
+						path: '/data/updated',
+						value: true
+					}
+				]
+			}
+		}
+	])
+
+	const typeCard = await test.context.jellyfish.getCardBySlug(
+		test.context.context, test.context.session, 'card@latest')
+	const actionCard = await test.context.jellyfish.getCardBySlug(
+		test.context.context, test.context.session, 'action-create-card@latest')
+
+	const request = await test.context.queue.enqueue(
+		test.context.worker.getId(), test.context.session, {
+			action: actionCard.slug,
+			context: test.context.context,
+			card: typeCard.id,
+			type: typeCard.type,
+			arguments: {
+				reason: null,
+				properties: {
+					data: {
+						cards: cardIds
+					}
+				}
+			}
+		})
+
+	await test.context.flush(test.context.session, 1)
+	const result = await test.context.queue.waitResults(
+		test.context.context, request)
+	test.false(result.error)
+
+	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
+		const card = await test.context.jellyfish.getCardBySlug(
+			test.context.context, test.context.session, `foo${idx}@latest`)
+		test.true(card.data.updated)
+	})
+})
+
+ava('a triggered action can update a dynamic list of cards (ids as array of objects with field id)', async (test) => {
+	const cardsWithId = []
+	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
+		const card = await test.context.jellyfish.insertCard(
+			test.context.context, test.context.session, {
+				slug: `foo${idx}`,
+				type: 'card',
+				version: '1.0.0',
+				data: {
+					id: `id${idx}`
+				}
+			})
+		cardsWithId.push(_.pick(card, 'id'))
+	})
+
+	test.context.worker.setTriggers(test.context.context, [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			filter: {
+				type: 'object',
+				required: [ 'data' ],
+				properties: {
+					data: {
+						type: 'object',
+						required: [ 'cards' ],
+						properties: {
+							cards: {
+								type: 'array',
+								items: {
+									type: 'object',
+									required: [ 'id' ],
+									properties: {
+										id: {
+											type: 'string'
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			action: 'action-update-card',
+			target: {
+				$map: {
+					$eval: 'source.data.cards[0:]'
+				},
+				'each(card)': {
+					$eval: 'card.id'
+				}
+			},
+			arguments: {
+				reason: null,
+				patch: [
+					{
+						op: 'add',
+						path: '/data/updated',
+						value: true
+					}
+				]
+			}
+		}
+	])
+
+	const typeCard = await test.context.jellyfish.getCardBySlug(
+		test.context.context, test.context.session, 'card@latest')
+	const actionCard = await test.context.jellyfish.getCardBySlug(
+		test.context.context, test.context.session, 'action-create-card@latest')
+
+	const request = await test.context.queue.enqueue(
+		test.context.worker.getId(), test.context.session, {
+			action: actionCard.slug,
+			context: test.context.context,
+			card: typeCard.id,
+			type: typeCard.type,
+			arguments: {
+				reason: null,
+				properties: {
+					data: {
+						cards: cardsWithId
+					}
+				}
+			}
+		})
+
+	await test.context.flush(test.context.session, 1)
+	const result = await test.context.queue.waitResults(
+		test.context.context, request)
+	test.false(result.error)
+
+	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
+		const card = await test.context.jellyfish.getCardBySlug(
+			test.context.context, test.context.session, `foo${idx}@latest`)
+		test.true(card.data.updated)
+	})
+})
+
+ava('should fail when attempting to insert a triggered-action card with duplicate targets', async (test) => {
+	const trigger = {
+		id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		type: 'triggered-action',
+		slug: 'triggered-action-12345',
+		data: {
+			filter: {
+				type: 'object',
+				required: [ 'data' ],
+				properties: {
+					data: {
+						type: 'object',
+						required: [ 'command' ],
+						properties: {
+							command: {
+								type: 'string',
+								const: 'foo-bar-baz'
+							}
+						}
+					}
+				}
+			},
+			action: 'action-update-card',
+			target: [ '1', '1', '1' ],
+			arguments: {
+				reason: null,
+				patch: [
+					{
+						op: 'add',
+						path: '/data/updated',
+						value: true
+					}
+				]
+			}
+		}
+	}
+
+	await test.throwsAsync(test.context.jellyfish.insertCard(test.context.context, test.context.session, trigger),
+		test.context.backend.errors.JellyfishSchemaMismatch)
+})
+
+ava('should fail to set a trigger when the list of card ids contains duplicates', async (test) => {
+	const card = await test.context.jellyfish.insertCard(
+		test.context.context, test.context.session, {
+			slug: 'foo1',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				id: 'id1'
+			}
+		})
+
+	const triggers = [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			filter: {
+				type: 'object',
+				required: [ 'data' ],
+				properties: {
+					data: {
+						type: 'object',
+						required: [ 'command' ],
+						properties: {
+							command: {
+								type: 'string',
+								const: 'foo-bar-baz'
+							}
+						}
+					}
+				}
+			},
+			action: 'action-update-card',
+			target: [ card.id, card.id, card.id ],
+			arguments: {
+				reason: null,
+				patch: [
+					{
+						op: 'add',
+						path: '/data/updated',
+						value: true
+					}
+				]
+			}
+		}
+	]
+
+	test.throws(() => {
+		test.context.worker.setTriggers(test.context.context, triggers)
+	}, test.context.worker.errors.WorkerInvalidTrigger)
+})
+
 ava('.execute() should execute a triggered action given a matching mode', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')


### PR DESCRIPTION
Field `card` can now be a json-e template that returns an array of card ids

For example
```js
card: {
  $eval: 'source.data.cards'
}
```
when `source.data.cards` is an array of card ids, or
```js
card: {
  $map: {
    $eval: 'source.data.cards[0:]'
  },
  'each(card)': {
    $eval: 'card.id'
  }
}
```
when `source.data.cards` is an array of objects like `{ id: 123 }`

See https://taskcluster.github.io/json-e/

Connects-to: #2547
Change-type: patch
Signed-off-by: Federico Fissore <federico@fissore.org>