### PR TITLE
core: Support version suffixes in Kernel#getCardBySlug()

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -282,35 +282,43 @@ module.exports = class Kernel {
 		assert.INTERNAL(context, slug,
 			errors.JellyfishInvalidSlug, 'Slug is undefined')
 
-		const schema = options.type ? {
-			type: 'object',
-			properties: {
-				slug: {
-					type: 'string',
-					const: slug
-				},
-				type: {
-					type: 'string',
-					const: options.type
-				}
-			},
-			additionalProperties: true,
-			required: [ 'slug', 'type' ]
-		} : {
-			type: 'object',
-			properties: {
-				slug: {
-					type: 'string',
-					const: slug
-				}
-			},
-			additionalProperties: true,
-			required: [ 'slug' ]
+		const [ base, version ] = slug.split('@')
+		const queryOptions = {
+			limit: 1
 		}
 
-		const results = await this.query(context, session, schema, {
-			limit: 1
-		})
+		const schema = {
+			type: 'object',
+			additionalProperties: true,
+			properties: {
+				slug: {
+					type: 'string',
+					const: base
+				}
+			}
+		}
+
+		if (options.type) {
+			schema.properties.type = {
+				type: 'string',
+				const: options.type
+			}
+		}
+
+		if (version && version !== 'latest') {
+			schema.properties.version = {
+				type: 'string',
+				const: version
+			}
+		} else if (version === 'latest') {
+			queryOptions.sortBy = [ 'version' ]
+			queryOptions.sortDir = 'desc'
+		}
+
+		schema.required = Object.keys(schema.properties)
+
+		const results = await this.query(
+			context, session, schema, queryOptions)
 
 		assert.INTERNAL(context, results.length <= 1,
 			errors.JellyfishDatabaseError,

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -1232,6 +1232,26 @@ ava('.insertCard() should throw an error if the element does not adhere to the t
 	}), errors.JellyfishSchemaMismatch)
 })
 
+ava('.insertCard() should throw an error if the slug contains @latest', async (test) => {
+	await test.throwsAsync(test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'test-1@latest',
+			type: 'card',
+			version: '1.0.0',
+			data: {}
+		}), errors.JellyfishSchemaMismatch)
+})
+
+ava('.insertCard() should throw an error if the slug contains a version', async (test) => {
+	await test.throwsAsync(test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'test-1@1.0.0',
+			type: 'card',
+			version: '1.0.0',
+			data: {}
+		}), errors.JellyfishSchemaMismatch)
+})
+
 ava('.insertCard() should throw an error if the card type does not exist', async (test) => {
 	await test.throwsAsync(test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 		slug: 'foo',
@@ -1715,6 +1735,66 @@ ava('.getCardBySlug() should find an active card by its slug', async (test) => {
 	})
 
 	const card = await test.context.kernel.getCardBySlug(test.context.context, test.context.kernel.sessions.admin, 'foo-bar')
+	test.deepEqual(card, result)
+})
+
+ava('.getCardBySlug() should find an active card by its slug and its version', async (test) => {
+	const result = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foo-bar',
+			type: 'card',
+			version: '1.0.0',
+			data: {}
+		})
+
+	const card = await test.context.kernel.getCardBySlug(
+		test.context.context, test.context.kernel.sessions.admin, 'foo-bar@1.0.0', {
+			type: 'card'
+		})
+
+	test.deepEqual(card, result)
+})
+
+ava('.getCardBySlug() should not find an active card by its slug and the wrong version', async (test) => {
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foo-bar',
+			type: 'card',
+			version: '1.0.0',
+			data: {}
+		})
+
+	const card = await test.context.kernel.getCardBySlug(
+		test.context.context, test.context.kernel.sessions.admin, 'foo-bar@1.0.1', {
+			type: 'card'
+		})
+
+	test.falsy(card)
+})
+
+ava('.getCardBySlug() should not find an invalid slug when using @latest', async (test) => {
+	const card = await test.context.kernel.getCardBySlug(
+		test.context.context, test.context.kernel.sessions.admin, 'foo-bar@latest', {
+			type: 'card'
+		})
+
+	test.falsy(card)
+})
+
+ava('.getCardBySlug() should find an active card by its slug using @latest', async (test) => {
+	const result = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foo-bar',
+			type: 'card',
+			version: '1.0.0',
+			data: {}
+		})
+
+	const card = await test.context.kernel.getCardBySlug(
+		test.context.context, test.context.kernel.sessions.admin, 'foo-bar@latest', {
+			type: 'card'
+		})
+
 	test.deepEqual(card, result)
 })
 


### PR DESCRIPTION
It basically converts expressions like `slug@x.y.z` or `slug@latest`
into the right JSON Schemas.

Change-type: minor


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!