### PR TITLE
core: Require an explicit version suffix in Backend#getElementBySlug()

### DIFF
--- a/apps/server/default-cards/contrib/view-read-user-guest.json
+++ b/apps/server/default-cards/contrib/view-read-user-guest.json
@@ -306,6 +306,9 @@
               "not": {
                 "const": "user-admin"
               }
+            },
+            "version": {
+              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -484,6 +484,11 @@ module.exports = class PostgresBackend {
 			this.errors.JellyfishNoIdentifier,
 			`No type when getting element by slug: ${slug}`)
 
+		const version = slug.split('@')[1]
+		assert.INTERNAL(context, version && version !== 'latest',
+			this.errors.JellyfishInvalidVersion,
+			`Missing version suffix in slug: ${slug}`)
+
 		/*
 		 * Lets first check the in-memory cache so we can avoid
 		 * making a full-blown query to the database.

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -13,6 +13,7 @@ _.each([
 	'JellyfishCacheError',
 	'JellyfishInvalidSlug',
 	'JellyfishInvalidId',
+	'JellyfishInvalidVersion',
 	'JellyfishInvalidPatch',
 	'JellyfishInvalidSession',
 	'JellyfishElementAlreadyExists',

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -180,7 +180,9 @@ exports.getViews = async (context, backend, roles) => {
 	const CARD_TYPE = 'view'
 
 	const views = await Promise.all(roles.map((role) => {
-		return backend.getElementBySlug(context, role, {
+		// TODO: We shouldn't be hardcoding the version here,
+		// but pointing to the specific one from the start.
+		return backend.getElementBySlug(context, `${role}@1.0.0`, {
 			type: CARD_TYPE
 		})
 	}))

--- a/lib/worker/errors.js
+++ b/lib/worker/errors.js
@@ -10,6 +10,7 @@ const typedErrors = require('typed-errors')
 _.each([
 	'WorkerNoExecuteEvent',
 	'WorkerNoElement',
+	'WorkerInvalidVersion',
 	'WorkerInvalidAction',
 	'WorkerInvalidActionRequest',
 	'WorkerInvalidTrigger',

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -138,7 +138,7 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 		for (const event of timeline) {
 			if (!fastEquals.deepEqual(event.markers, insertedCard.markers)) {
 				await jellyfish.patchCardBySlug(
-					context, session, event.slug, [
+					context, session, `${event.slug}@${event.version}`, [
 						{
 							op: 'replace',
 							path: '/markers',
@@ -202,15 +202,16 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 		const typeTriggers = await triggers.getTypeTriggers(
 			context, jellyfish, session, insertedCard.slug)
 		await Bluebird.map(typeTriggers, async (trigger) => {
-			await jellyfish.patchCardBySlug(context, session, trigger.slug, [
-				{
-					op: 'replace',
-					path: '/active',
-					value: false
-				}
-			], {
-				type: trigger.type
-			})
+			await jellyfish.patchCardBySlug(
+				context, session, `${trigger.slug}@${trigger.version}`, [
+					{
+						op: 'replace',
+						path: '/active',
+						value: false
+					}
+				], {
+					type: trigger.type
+				})
 
 			// Also from the locally cached triggers
 			_.remove(options.triggers, (element) => {
@@ -366,10 +367,16 @@ exports.replaceCard = async (context, jellyfish, session, typeCard, options, obj
 }
 
 exports.patchCard = async (context, jellyfish, session, typeCard, options, object, patch) => {
+	assert.INTERNAL(context,
+		object.version,
+		errors.WorkerInvalidVersion,
+		`Can't update without a version for: ${object.slug}`)
+
 	options.triggers = options.triggers || []
 
 	logger.debug(context, 'Patching card', {
 		slug: object.slug,
+		version: object.version,
 		type: typeCard.slug,
 		attachEvents: options.attachEvents,
 		operations: patch.length,
@@ -380,7 +387,7 @@ exports.patchCard = async (context, jellyfish, session, typeCard, options, objec
 
 	return commit(context, jellyfish, session, typeCard, object, options, async () => {
 		return jellyfish.patchCardBySlug(
-			context, session, object.slug, patch, {
+			context, session, `${object.slug}@${object.version}`, patch, {
 				type: typeCard.slug
 			})
 	})

--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -181,7 +181,7 @@ ava('.getElementById() should not break the cache if trying to query a valid slu
 	test.deepEqual(result1, null)
 
 	const result2 = await test.context.backend.getElementBySlug(
-		test.context.context, '4a962ad9-20b5-4dd8-a707-bf819593cc84', {
+		test.context.context, '4a962ad9-20b5-4dd8-a707-bf819593cc84@1.0.0', {
 			type: 'card'
 		})
 
@@ -204,23 +204,26 @@ ava('.getElementBySlug() should not break the cache if trying to query a valid i
 		active: true
 	})
 
-	const result1 = await test.context.backend.getElementBySlug(test.context.context, element.id, {
-		type: 'card'
-	})
+	const result1 = await test.context.backend.getElementBySlug(
+		test.context.context, `${element.id}@${element.version}`, {
+			type: 'card'
+		})
 
 	test.deepEqual(result1, null)
 
-	const result2 = await test.context.backend.getElementById(test.context.context, element.id, {
-		type: 'card'
-	})
+	const result2 = await test.context.backend.getElementById(
+		test.context.context, element.id, {
+			type: 'card'
+		})
 
 	test.deepEqual(result2, element)
 })
 
 ava('.getElementBySlug() should return null if the element slug is not present', async (test) => {
-	const result = await test.context.backend.getElementBySlug(test.context.context, 'foo', {
-		type: 'card'
-	})
+	const result = await test.context.backend.getElementBySlug(
+		test.context.context, 'foo@1.0.0', {
+			type: 'card'
+		})
 
 	test.deepEqual(result, null)
 })
@@ -241,20 +244,12 @@ ava('.getElementBySlug() should fetch an element given its slug', async (test) =
 		active: true
 	})
 
-	const result = await test.context.backend.getElementBySlug(test.context.context, 'example', {
-		type: 'card'
-	})
-
-	test.deepEqual(result, element)
-})
-
-ava('.getElementBySlug() should return null if the slug@latest is not present', async (test) => {
 	const result = await test.context.backend.getElementBySlug(
-		test.context.context, 'foo@latest', {
+		test.context.context, 'example@1.0.0', {
 			type: 'card'
 		})
 
-	test.deepEqual(result, null)
+	test.deepEqual(result, element)
 })
 
 ava('.getElementBySlug() should return null given the wrong version', async (test) => {
@@ -299,54 +294,6 @@ ava('.getElementBySlug() should fetch an element given the correct version', asy
 
 	const result = await test.context.backend.getElementBySlug(
 		test.context.context, 'example@1.0.0', {
-			type: 'card'
-		})
-
-	test.deepEqual(result, element)
-})
-
-ava('.getElementBySlug() should fetch the latest version other than 1.0.0 using @latest', async (test) => {
-	const element = await test.context.backend.upsertElement(test.context.context, {
-		slug: 'example',
-		type: 'card',
-		version: '3.0.0',
-		links: {},
-		linked_at: {},
-		data: {},
-		tags: [],
-		markers: [],
-		requires: [],
-		capabilities: [],
-		created_at: new Date().toISOString(),
-		active: true
-	})
-
-	const result = await test.context.backend.getElementBySlug(
-		test.context.context, 'example@latest', {
-			type: 'card'
-		})
-
-	test.deepEqual(result, element)
-})
-
-ava('.getElementBySlug() should fetch an element given its slug@latest', async (test) => {
-	const element = await test.context.backend.upsertElement(test.context.context, {
-		slug: 'example',
-		type: 'card',
-		version: '1.0.0',
-		links: {},
-		linked_at: {},
-		data: {},
-		tags: [],
-		markers: [],
-		requires: [],
-		capabilities: [],
-		created_at: new Date().toISOString(),
-		active: true
-	})
-
-	const result = await test.context.backend.getElementBySlug(
-		test.context.context, 'example@latest', {
 			type: 'card'
 		})
 

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -71,7 +71,7 @@ ava('.disconnect() should gracefully close streams', async (test) => {
 
 ava('.patchCardBySlug() should throw an error if the element does not exist', async (test) => {
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, 'foobarbaz', [
+		test.context.context, test.context.kernel.sessions.admin, 'foobarbaz@1.0.0', [
 			{
 				op: 'replace',
 				path: '/active',
@@ -95,7 +95,8 @@ ava('.patchCardBySlug() should apply a single operation', async (test) => {
 		})
 
 	await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context,
+		test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'replace',
 				path: '/data/foo',
@@ -144,7 +145,8 @@ ava('.patchCardBySlug() should add an element to an array', async (test) => {
 		})
 
 	await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context,
+		test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'add',
 				path: '/markers/0',
@@ -194,7 +196,7 @@ ava('.patchCardBySlug() should delete a property inside data', async (test) => {
 		})
 
 	await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'remove',
 				path: '/data/foo'
@@ -240,7 +242,7 @@ ava('.patchCardBySlug() should apply more than one operation', async (test) => {
 		})
 
 	await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'add',
 				path: '/data/foo',
@@ -302,7 +304,7 @@ ava('.patchCardBySlug() should not be able to delete an id', async (test) => {
 		})
 
 	const patched = await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'remove',
 				path: '/id'
@@ -333,7 +335,7 @@ ava('.patchCardBySlug() should not be able to delete a top level property', asyn
 		})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'remove',
 				path: '/tags'
@@ -363,7 +365,7 @@ ava('.patchCardBySlug() should throw if the patch does not match', async (test) 
 		})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'delete',
 				path: '/data/hello'
@@ -393,7 +395,7 @@ ava('.patchCardBySlug() should throw if adding to non existent property', async 
 		})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'add',
 				path: '/data/hello/world',
@@ -424,7 +426,7 @@ ava('.patchCardBySlug() should throw given an invalid operation', async (test) =
 		})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'bar',
 				path: '/data/foo',
@@ -455,7 +457,7 @@ ava('.patchCardBySlug() should not apply half matching patches', async (test) =>
 		})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'add',
 				path: '/data/test',
@@ -491,7 +493,7 @@ ava('.patchCardBySlug() should not break the type schema', async (test) => {
 		})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'remove',
 				path: '/data/roles'
@@ -521,7 +523,7 @@ ava('.patchCardBySlug() should apply a no-op patch', async (test) => {
 		})
 
 	const patched = await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'replace',
 				path: '/data/foo',
@@ -553,7 +555,7 @@ ava('.patchCardBySlug() should apply an empty set of patches', async (test) => {
 		})
 
 	const patched = await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [], {
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [], {
 			type: card.type
 		})
 
@@ -579,7 +581,7 @@ ava('.patchCardBySlug() should ignore changes to read-only properties', async (t
 		})
 
 	const patched = await test.context.kernel.patchCardBySlug(
-		test.context.context, test.context.kernel.sessions.admin, card.slug, [
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
 			{
 				op: 'add',
 				path: '/links/foo',
@@ -664,7 +666,7 @@ ava('.patchCardBySlug() should be able to patch cards hidden to the user', async
 		}))
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, session.id, userCard.slug, [
+		test.context.context, session.id, `${userCard.slug}@${userCard.version}`, [
 			{
 				op: 'add',
 				path: '/data/foo',
@@ -768,7 +770,7 @@ ava('.patchCardBySlug() should not allow updates in hidden fields', async (test)
 	})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, session.id, userCard.slug, [
+		test.context.context, session.id, `${userCard.slug}@${userCard.version}`, [
 			{
 				op: 'replace',
 				path: '/data/roles',
@@ -873,7 +875,7 @@ ava('.patchCardBySlug() should not return the full card', async (test) => {
 	})
 
 	const patched = await test.context.kernel.patchCardBySlug(
-		test.context.context, session.id, userCard.slug, [
+		test.context.context, session.id, `${userCard.slug}@${userCard.version}`, [
 			{
 				op: 'replace',
 				path: '/data/email',
@@ -990,7 +992,7 @@ ava('.patchCardBySlug() should not allow a patch that makes a card inaccessible'
 	test.deepEqual(filteredCard, randomCard)
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, session.id, randomCard.slug, [
+		test.context.context, session.id, `${randomCard.slug}@${randomCard.version}`, [
 			{
 				op: 'replace',
 				path: '/data/foo',
@@ -1095,7 +1097,7 @@ ava('.patchCardBySlug() should not remove inaccessible fields', async (test) => 
 	})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, session.id, userCard.slug, [
+		test.context.context, session.id, `${userCard.slug}@${userCard.version}`, [
 			{
 				op: 'remove',
 				path: '/data/hash'
@@ -1199,7 +1201,7 @@ ava('.patchCardBySlug() should not add an inaccesible field', async (test) => {
 	})
 
 	await test.throwsAsync(test.context.kernel.patchCardBySlug(
-		test.context.context, session.id, userCard.slug, [
+		test.context.context, session.id, `${userCard.slug}@${userCard.version}`, [
 			{
 				op: 'add',
 				path: '/data/special',

--- a/test/integration/sync/outreach-translate.spec.js
+++ b/test/integration/sync/outreach-translate.spec.js
@@ -34,10 +34,15 @@ scenario.run(avaTest, {
 		token: TOKEN
 	},
 	pre: async (test) => {
+		const userCard = await test.context.jellyfish.getCardBySlug(
+			test.context.context,
+			test.context.jellyfish.sessions.admin,
+			`user-${environment.integration.default.user}`)
+
 		await test.context.jellyfish.patchCardBySlug(
 			test.context.context,
 			test.context.jellyfish.sessions.admin,
-			`user-${environment.integration.default.user}`, [
+			`${userCard.slug}@${userCard.version}`, [
 				{
 					op: 'add',
 					path: '/data/oauth',


### PR DESCRIPTION
As a small step towards moving to a world where all slug references have
a concrete type suffix.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!