### PR TITLE
Add actor information in github integration tests

### DIFF
--- a/test/integration/sync/github-translate.spec.js
+++ b/test/integration/sync/github-translate.spec.js
@@ -18,7 +18,6 @@ const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 scenario.run(avaTest, {
 	integration: require('../../../lib/sync/integrations/github'),
 	scenarios: require('./webhooks/github'),
-	slices: _.range(0, 3),
 	baseUrl: 'https://api.github.com',
 	stubRegex: /.*/,
 	source: 'github',

--- a/test/integration/sync/scenario.js
+++ b/test/integration/sync/scenario.js
@@ -265,12 +265,6 @@ const webhookScenario = async (test, testCase, integration, stub) => {
 		card.id = _.get(actualTail, [ index, 'id' ])
 		card.name = _.get(actualTail, [ index, 'name' ])
 
-		// TODO: This shouldn't be necessary anymore
-		if (integration.source === 'github') {
-			card.data.actor = _.get(actualTail, [ index, 'data', 'actor' ])
-			card.data.timestamp = _.get(actualTail, [ index, 'data', 'timestamp' ])
-		}
-
 		card.data.target = head.id
 
 		// If we have to ignore the update events, then we can't also

--- a/test/integration/sync/webhooks/github/index.js
+++ b/test/integration/sync/webhooks/github/index.js
@@ -32,7 +32,7 @@ module.exports = {
 		]
 	},
 	'open-pr-and-create-repos': {
-		expected: require('./pr-open-close/expected-1.json'),
+		expected: require('./open-pr-and-create-repos/expected.json'),
 		headIndex: 1,
 		steps: [
 			require('./pr-open-close/01-pr-opened.json')

--- a/test/integration/sync/webhooks/github/issue-close-comment/expected.json
+++ b/test/integration/sync/webhooks/github/issue-close-comment/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-26T17:54:37.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Comment on closed issue",
           "type": "issue",
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-26T17:56:59.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",
@@ -81,6 +89,10 @@
           "https://github.com/resin-io/jellyfish/issues/722#issuecomment-424811824"
         ],
         "timestamp": "2018-09-26T17:58:16.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-close-label-toggle/expected.json
+++ b/test/integration/sync/webhooks/github/issue-close-label-toggle/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T14:29:09.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue close label toggle",
           "type": "issue",
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T14:30:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",
@@ -78,6 +86,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T14:31:38.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "add",
@@ -96,6 +108,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T14:32:50.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "remove",

--- a/test/integration/sync/webhooks/github/issue-closed-with-comment/expected.json
+++ b/test/integration/sync/webhooks/github/issue-closed-with-comment/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:27:24.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue closed with comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/713#issuecomment-423286402"
         ],
         "timestamp": "2018-09-20T18:28:35.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -79,6 +87,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:28:35.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/issue-comment-edit-with-missing-ref/expected.json
+++ b/test/integration/sync/webhooks/github/issue-comment-edit-with-missing-ref/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:23:16.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue comment edit",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/712#issuecomment-423285064"
         ],
         "timestamp": "2018-09-20T18:25:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-comment-edit/expected.json
+++ b/test/integration/sync/webhooks/github/issue-comment-edit/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:23:16.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue comment edit",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/712#issuecomment-423285064"
         ],
         "timestamp": "2018-09-20T18:25:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-delete-comment-with-missing-ref-which-is-still-returned/expected.json
+++ b/test/integration/sync/webhooks/github/issue-delete-comment-with-missing-ref-which-is-still-returned/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-26T13:47:13.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue delete second comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/721#issuecomment-424722054"
         ],
         "timestamp": "2018-09-26T13:48:51.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -82,6 +90,10 @@
           "https://github.com/resin-io/jellyfish/issues/721#issuecomment-424722576"
         ],
         "timestamp": "2018-09-26T13:50:15.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-delete-comment-with-missing-ref/expected.json
+++ b/test/integration/sync/webhooks/github/issue-delete-comment-with-missing-ref/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:30:59.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue delete comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/714#issuecomment-423287504"
         ],
         "timestamp": "2018-09-20T18:32:15.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-delete-comment/expected.json
+++ b/test/integration/sync/webhooks/github/issue-delete-comment/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:30:59.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue delete comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/714#issuecomment-423287504"
         ],
         "timestamp": "2018-09-20T18:32:15.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-delete-second-comment-with-missing-ref/expected.json
+++ b/test/integration/sync/webhooks/github/issue-delete-second-comment-with-missing-ref/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-26T13:47:13.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue delete second comment",
           "version": "1.0.0",
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/721#issuecomment-424722054"
         ],
         "timestamp": "2018-09-26T13:48:51.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -82,6 +90,10 @@
           "https://github.com/resin-io/jellyfish/issues/721#issuecomment-424722576"
         ],
         "timestamp": "2018-09-26T13:50:15.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-delete-second-comment/expected.json
+++ b/test/integration/sync/webhooks/github/issue-delete-second-comment/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-26T13:47:13.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue delete second comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/721#issuecomment-424722054"
         ],
         "timestamp": "2018-09-26T13:48:51.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -82,6 +90,10 @@
           "https://github.com/resin-io/jellyfish/issues/721#issuecomment-424722576"
         ],
         "timestamp": "2018-09-26T13:50:15.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-edit-body/expected.json
+++ b/test/integration/sync/webhooks/github/issue-edit-body/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:19:14.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue body edits",
           "active": true,
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:20:28.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/issue-edit-second-comment-with-missing-ref/expected.json
+++ b/test/integration/sync/webhooks/github/issue-edit-second-comment-with-missing-ref/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-25T17:19:51.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue with edition in second comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/719#issuecomment-424428899"
         ],
         "timestamp": "2018-09-25T17:20:36.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -82,6 +90,10 @@
           "https://github.com/resin-io/jellyfish/issues/719#issuecomment-424429646"
         ],
         "timestamp": "2018-09-25T17:24:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-edit-second-comment/expected.json
+++ b/test/integration/sync/webhooks/github/issue-edit-second-comment/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-25T17:19:51.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue with edition in second comment",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/719#issuecomment-424428899"
         ],
         "timestamp": "2018-09-25T17:20:36.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -82,6 +90,10 @@
           "https://github.com/resin-io/jellyfish/issues/719#issuecomment-424429646"
         ],
         "timestamp": "2018-09-25T17:24:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-edit-title/expected.json
+++ b/test/integration/sync/webhooks/github/issue-edit-title/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:16:56.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue title edit",
           "active": true,
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:18:10.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/issue-open-close-open/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-close-open/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T15:46:26.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue re-open",
           "active": true,
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T15:47:33.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",
@@ -78,6 +86,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T15:48:47.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/issue-open-close/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-close/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T17:59:02.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Test Issue",
           "active": true,
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T17:59:57.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/issue-open-label-toggle/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-label-toggle/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T13:47:52.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue label removal",
           "active": true,
@@ -60,6 +64,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T13:49:06.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "add",
@@ -78,6 +86,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-27T13:50:48.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "remove",

--- a/test/integration/sync/webhooks/github/issue-open-with-assignee/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-with-assignee/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:03:27.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue with assignee",
           "version": "1.0.0",

--- a/test/integration/sync/webhooks/github/issue-open-with-comments/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-with-comments/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:11:56.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue with comments",
           "active": true,
@@ -63,6 +67,10 @@
           "https://github.com/resin-io/jellyfish/issues/709#issuecomment-423281663"
         ],
         "timestamp": "2018-09-20T18:13:29.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],
@@ -82,6 +90,10 @@
           "https://github.com/resin-io/jellyfish/issues/709#issuecomment-423282158"
         ],
         "timestamp": "2018-09-20T18:15:20.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/issue-open-with-labels/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-with-labels/expected.json
@@ -32,6 +32,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:01:54.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue with labels",
           "active": true,

--- a/test/integration/sync/webhooks/github/issue-open-without-body-lowercase-headers/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-without-body-lowercase-headers/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:10:42.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue without body",
           "active": true,

--- a/test/integration/sync/webhooks/github/issue-open-without-body/expected.json
+++ b/test/integration/sync/webhooks/github/issue-open-without-body/expected.json
@@ -29,6 +29,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-09-20T18:10:42.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Issue without body",
           "active": true,

--- a/test/integration/sync/webhooks/github/open-pr-and-create-repos/expected.json
+++ b/test/integration/sync/webhooks/github/open-pr-and-create-repos/expected.json
@@ -15,6 +15,7 @@
     "tags": [ ],
     "version":  "1.0.0"
   },
+
   "tail": [
     {
       "type": "create",
@@ -24,7 +25,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:09:36.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
+        "timestamp": "2018-02-26T15:58:55.000Z",
         "payload": {
           "name":  "resin-io/jellyfish",
           "type":  "repository",

--- a/test/integration/sync/webhooks/github/pr-approve-merge/expected.json
+++ b/test/integration/sync/webhooks/github/pr-approve-merge/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:34:00.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Test PR",
           "type": "pull-request",
@@ -76,6 +80,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:44:15.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/pr-changes-requested/expected.json
+++ b/test/integration/sync/webhooks/github/pr-changes-requested/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:04:00.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Open close PR",
           "type": "pull-request",

--- a/test/integration/sync/webhooks/github/pr-comment/expected.json
+++ b/test/integration/sync/webhooks/github/pr-comment/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T09:17:00.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "PR comment",
           "active": true,
@@ -79,6 +83,10 @@
           "https://github.com/resin-io/jellyfish/pull/773#issuecomment-428505538"
         ],
         "timestamp": "2018-10-10T09:35:37.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "mentionsUser": [],
           "alertsUser": [],

--- a/test/integration/sync/webhooks/github/pr-inline-comment/expected.json
+++ b/test/integration/sync/webhooks/github/pr-inline-comment/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T09:56:17.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "PR line comment",
           "version": "1.0.0",

--- a/test/integration/sync/webhooks/github/pr-label/expected.json
+++ b/test/integration/sync/webhooks/github/pr-label/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:08:50.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "PR labels",
           "active": true,
@@ -76,6 +80,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:10:16.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "add",
@@ -94,6 +102,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:11:48.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "remove",

--- a/test/integration/sync/webhooks/github/pr-open-close/expected.json
+++ b/test/integration/sync/webhooks/github/pr-open-close/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T09:09:36.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "Open close PR",
           "active": true,
@@ -76,6 +80,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T09:11:51.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/pr-open-from-fork/expected.json
+++ b/test/integration/sync/webhooks/github/pr-open-from-fork/expected.json
@@ -36,7 +36,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:09:36Z",
+        "timestamp": "2018-12-18T10:30:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": {
           "name": "test external",
           "active": true,
@@ -75,7 +79,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:11:51Z",
+        "timestamp": "2018-12-18T10:34:55.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/pr-review-request/expected.json
+++ b/test/integration/sync/webhooks/github/pr-review-request/expected.json
@@ -37,6 +37,10 @@
       "capabilities": [],
       "data": {
         "timestamp": "2018-10-10T10:13:06.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
         "payload": {
           "name": "PR review request",
           "active": true,

--- a/test/integration/sync/webhooks/github/push-to-master/expected.json
+++ b/test/integration/sync/webhooks/github/push-to-master/expected.json
@@ -73,7 +73,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T10:13:06Z",
+        "timestamp": "2018-12-18T11:57:31.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": {
           "type": "gh-push",
           "active": true,

--- a/test/integration/sync/webhooks/github/push-to-new-branch/expected.json
+++ b/test/integration/sync/webhooks/github/push-to-new-branch/expected.json
@@ -48,7 +48,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T10:13:06Z",
+        "timestamp": "2018-12-18T11:57:31.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": {
           "type": "gh-push",
           "active": true,

--- a/test/integration/sync/webhooks/github/push-to-open-pr-from-fork/expected.json
+++ b/test/integration/sync/webhooks/github/push-to-open-pr-from-fork/expected.json
@@ -36,7 +36,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:09:36.000Z",
+        "timestamp": "2018-12-18T10:30:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": {
           "name": "test external",
           "active": true,
@@ -75,7 +79,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:11:51.000Z",
+        "timestamp": "2018-12-18T11:11:16.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": [
           {
             "op": "replace",

--- a/test/integration/sync/webhooks/github/push-to-open-pr/expected.json
+++ b/test/integration/sync/webhooks/github/push-to-open-pr/expected.json
@@ -36,7 +36,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:09:36.000Z",
+        "timestamp": "2018-12-18T11:08:45.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": {
           "name": "Update readme",
           "active": true,
@@ -75,7 +79,11 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:11:51.000Z",
+        "timestamp": "2018-12-18T11:09:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
         "payload": [
           {
             "op": "replace",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
