### PR TITLE
Making the front handle longer

### DIFF
--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -146,7 +146,7 @@ ava.before(async (test) => {
 			subject: title,
 			body: description,
 			sender: {
-				handle: `jellytest-${uuid().slice(0, 4)}`
+				handle: `jellytest-${uuid()}`
 			}
 		})
 


### PR DESCRIPTION
Making the front handle longer so we are more sure that it won't collide with what's already stored on front

Connects-to: #2662
Change-type: patch
Signed-off-by: Federico Fissore <federico@fissore.org>