### PR TITLE
github: Don't use underscores in GitHub links slugs

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -879,7 +879,7 @@ module.exports = class GitHubIntegration {
 		return result.concat([
 			makeCard({
 				name: 'refers to',
-				slug: `link-gh-push-${afterSHA}-to-${repo.repoInfo.slug}`,
+				slug: `link-gh-push-${afterSHA}-to-${repo.repoInfo.slug.replace(/_/g, '-')}`,
 				type: 'link',
 				data: {
 					inverseName: 'is referenced by',


### PR DESCRIPTION
For example:

```
link-gh-push-12ca7ff3b56cdac73f555fcc8bcf0791248f3c61-to-repository-balena-io-modules-cloudwatch_exporter
```

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!