### PR TITLE
Better error stack trace in worker tests

### DIFF
--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -7,6 +7,7 @@
 const Bluebird = require('bluebird')
 const Worker = require('../../../lib/worker')
 const helpers = require('../queue/helpers')
+const errio = require('errio')
 
 exports.jellyfish = {
 	beforeEach: async (test) => {
@@ -77,7 +78,9 @@ exports.worker = {
 					test.context.jellyfish.errors[result.data.name] ||
 					Error
 
-				throw new Constructor(result.data.message)
+				const error = new Constructor(result.data.message)
+				error.stack = errio.fromObject(result.data).stack
+				throw error
 			}
 
 			await test.context.flush(session, expect - 1)


### PR DESCRIPTION
In #2637 I supposed the problem was more widespread but I was wrong, it was only related to worker tests, so the fix is easy