### PR TITLE
tests: add polledTest for dynamic test timing

### DIFF
--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -217,14 +217,12 @@ ava.serial('Users should be able to mark all messages as read from their inbox',
 
 	await macros.waitForThenClickSelector(incognitoPage, '[data-test="inbox__mark-all-as-read"]')
 
-	// Leave a small delay for the message to be marked as read and for the change
-	// to be propogated to the UI
-	await Bluebird.delay(4000)
-
-	const messages = await incognitoPage.$$('[data-test="event-card__message"]')
-
-	// Assert that there are no longer messages in the inbox
-	test.is(messages.length, 0)
+	await helpers.pollTest(
+		test,
+		async () => { return (await incognitoPage.$$('[data-test="event-card__message"]')).length === 0 },
+		10,
+		1000
+	)
 })
 
 ava.serial('Users should be able to create private conversations', async (test) => {


### PR DESCRIPTION
Some tests require some wait before they succeed. A fixed sleep is previously used, but that doesn't allow for faster or slower test environments (such as the connected PR, running tests in balenaOS). Add a helper to create a more dynamic testing setup for such cases.

Connects-to: #2650
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
