### PR TITLE
UI improvement when doing support

### DIFF
--- a/apps/ui/lens/list/SupportThreads.jsx
+++ b/apps/ui/lens/list/SupportThreads.jsx
@@ -240,7 +240,7 @@ export class SupportThreads extends React.Component {
 				>
 					{segments.map((segment) => {
 						return (
-							<Tab key={segment.name} title={segment.name}>
+							<Tab key={segment.name} title={`${segment.name} (${segment.cards.length})`}>
 								<InfiniteList
 									key={segment.name}
 									onScrollEnding={this.handleScrollEnding}

--- a/lib/sdk/auth.js
+++ b/lib/sdk/auth.js
@@ -4,7 +4,6 @@
  * Proprietary and confidential.
  */
 
-const Bluebird = require('bluebird')
 const uuid = require('uuid/v4')
 
 // A regex used to test that a string contains only alphanumeric characters and
@@ -38,23 +37,32 @@ class AuthSdk {
      * 		console.log(user)
      * 	})
      */
-	whoami () {
-		return Bluebird.try(() => {
-			const session = this.sdk.getAuthToken()
-			if (!session) {
-				throw new Error('No session token found')
-			}
-			return this.sdk.card.get(session, {
-				type: 'session'
-			})
-				.then((result) => {
-					if (!result) {
-						throw new Error('Could not retrieve session data')
-					}
-					return this.sdk.card.get(result.data.actor, {
-						type: 'user'
-					})
-				})
+	async whoami () {
+		const session = this.sdk.getAuthToken()
+		if (!session) {
+			throw new Error('No session token found')
+		}
+		const result = await this.sdk.card.get(session, {
+			type: 'session'
+		})
+		if (!result) {
+			throw new Error('Could not retrieve session data')
+		}
+
+		// Try and load the user with attached org data, otherwise load them
+		// without it.
+		// TODO: Fix our broken queries so that we can optionally get linked
+		// data
+		const user = await this.sdk.card.getWithLinks(result.data.actor, [ 'is member of' ], {
+			type: 'user'
+		})
+
+		if (user) {
+			return user
+		}
+
+		return this.sdk.card.get(result.data.actor, {
+			type: 'user'
 		})
 	}
 

--- a/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
@@ -21,7 +21,23 @@ import {
 const AUTOCOMPLETE_DEBOUNCE = 250
 
 const getUsers = async (value) => {
+	const user = selectors.getCurrentUser(store.getState())
+
+	// Get the current user's organisations
+	const orgs = _.map(user.links['is member of'], 'slug')
+
+	// Return all matching users in the same organisation(s)
 	const results = await sdk.query({
+		$$links: {
+			'is member of': {
+				type: 'object',
+				properties: {
+					slug: {
+						enum: orgs
+					}
+				}
+			}
+		},
 		type: 'object',
 		properties: {
 			type: {


### PR DESCRIPTION
- Show number of support threads in each tab
- Restrict username autocomplete to users in your org

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
