### PR TITLE
Attempts to speed up circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
               - dist
               - node_modules
 
-  unit_tests: &unit_tests
+  unit_and_sync_tests: &unit_and_sync_tests
     <<: *job_defaults
 
     steps:
@@ -76,8 +76,43 @@ jobs:
           at: .
 
       - run:
+          name: Start PostgreSQL
+          command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
+      - run:
+          name: Start Redis
+          command: service redis-server start
+
+      - run:
           name: Unit Tests
           command: make test-unit COVERAGE=1
+
+      - run:
+          name: Sync Tests Outreach Translate
+          command: make test FILES=./test/integration/sync/outreach-translate.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY
+      - run:
+          name: Sync Tests Outreach Translate Without Tokens
+          command: make test FILES=./test/integration/sync/outreach-translate.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID= INTEGRATION_OUTREACH_APP_SECRET= INTEGRATION_OUTREACH_SIGNATURE_KEY=
+
+      - run:
+          name: Sync Tests Outreach Mirror
+          command: make test FILES=./test/integration/server/outreach-mirror.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY
+      - run:
+          name: Sync Tests Outreach Mirror Without Tokens
+          command: make test FILES=./test/integration/server/outreach-mirror.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID= INTEGRATION_OUTREACH_APP_SECRET= INTEGRATION_OUTREACH_SIGNATURE_KEY=
+
+      - run:
+          name: Sync Tests Balena API Translate
+          command: make test FILES=./test/integration/sync/balena-api-translate.spec.js COVERAGE=1 INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION=$BALENA_API_PUBLIC_KEY_PRODUCTION INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING=$BALENA_API_PUBLIC_KEY_STAGING INTEGRATION_BALENA_API_PRIVATE_KEY=$BALENA_API_PRIVATE_KEY
+      - run:
+          name: Sync Tests Balena API Translate Without Tokens
+          command: make test FILES=./test/integration/sync/balena-api-translate.spec.js COVERAGE=1 INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION= INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING= INTEGRATION_BALENA_API_PRIVATE_KEY=
+
+      - run:
+          name: Sync Tests Github Translate
+          command: make test FILES=./test/integration/sync/github-translate.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY
+      - run:
+          name: Sync Tests Github Translate Without Tokens
+          command: make test FILES=./test/integration/sync/github-translate.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=
 
       - persist_to_workspace:
           root: .
@@ -103,37 +138,6 @@ jobs:
       - run:
           name: Integration Tests
           command: make test-integration-core test-integration-queue test-integration-sync test-integration-worker COVERAGE=1 && make test-integration-server COVERAGE=1 INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
-      - run:
-          name: Integration Tests (with debug logs)
-          command: make test-integration COVERAGE=1 LOGLEVEL=debug
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .nyc_output/*.json
-
-  sync_tests_github_translate:
-    <<: *job_defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: .
-
-      - run:
-          name: Start PostgreSQL
-          command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
-
-      - run:
-          name: Sync Tests
-          command: make test FILES=./test/integration/sync/github-translate.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY
-      - run:
-          name: Sync End To End Tests Without Tokens
-          command: make test FILES=./test/integration/sync/github-translate.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=
 
       - persist_to_workspace:
           root: .
@@ -244,63 +248,6 @@ jobs:
           paths:
             - .nyc_output/*.json
 
-  sync_tests_outreach_translate:
-    <<: *job_defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: .
-
-      - run:
-          name: Start PostgreSQL
-          command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
-
-      - run:
-          name: Sync Tests
-          command: make test FILES=./test/integration/sync/outreach-translate.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY
-
-      - run:
-          name: Sync End To End Tests Without Tokens
-          command: make test FILES=./test/integration/sync/outreach-translate.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID= INTEGRATION_OUTREACH_APP_SECRET= INTEGRATION_OUTREACH_SIGNATURE_KEY=
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .nyc_output/*.json
-
-  sync_tests_outreach_mirror:
-    <<: *job_defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: .
-
-      - run:
-          name: Start PostgreSQL
-          command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
-
-      - run:
-          name: Sync Tests
-          command: make test FILES=./test/integration/server/outreach-mirror.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY
-      - run:
-          name: Sync End To End Tests Without Tokens
-          command: make test FILES=./test/integration/server/outreach-mirror.spec.js COVERAGE=1 INTEGRATION_OUTREACH_APP_ID= INTEGRATION_OUTREACH_APP_SECRET= INTEGRATION_OUTREACH_SIGNATURE_KEY=
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .nyc_output/*.json
-
   sync_tests_discourse_translate:
     <<: *job_defaults
 
@@ -361,34 +308,6 @@ jobs:
       - run:
           name: Copy Code Coverage Reports
           command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .nyc_output/*.json
-
-  sync_tests_balena_api_translate:
-    <<: *job_defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: .
-
-      - run:
-          name: Start PostgreSQL
-          command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
-
-      - run:
-          name: Sync Tests
-          command: make test FILES=./test/integration/sync/balena-api-translate.spec.js COVERAGE=1 INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION=$BALENA_API_PUBLIC_KEY_PRODUCTION INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING=$BALENA_API_PUBLIC_KEY_STAGING INTEGRATION_BALENA_API_PRIVATE_KEY=$BALENA_API_PRIVATE_KEY
-      - run:
-          name: Sync End To End Tests Without Tokens
-          command: make test FILES=./test/integration/sync/balena-api-translate.spec.js COVERAGE=1 INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION= INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING= INTEGRATION_BALENA_API_PRIVATE_KEY=
 
       - persist_to_workspace:
           root: .
@@ -551,7 +470,7 @@ workflows:
             - build:
                 <<: *workflow_filter
 
-            - unit_tests:
+            - unit_and_sync_tests:
                 requires:
                     - build
                 <<: *workflow_filter
@@ -576,32 +495,12 @@ workflows:
                     - build
                 <<: *workflow_filter
 
-            - sync_tests_outreach_translate:
-                requires:
-                    - build
-                <<: *workflow_filter
-
             - sync_tests_discourse_translate:
                 requires:
                     - build
                 <<: *workflow_filter
 
-            - sync_tests_balena_api_translate:
-                requires:
-                    - build
-                <<: *workflow_filter
-
-            - sync_tests_github_translate:
-                requires:
-                    - build
-                <<: *workflow_filter
-
             - sync_tests_front_mirror:
-                requires:
-                    - build
-                <<: *workflow_filter
-
-            - sync_tests_outreach_mirror:
                 requires:
                     - build
                 <<: *workflow_filter
@@ -618,17 +517,13 @@ workflows:
 
             - results:
                 requires:
-                  - unit_tests
+                  - unit_and_sync_tests
                   - integration_tests
                   - e2e_tests
                   - e2e_tests_previous_dump
                   - sync_tests_front_translate
-                  - sync_tests_outreach_translate
                   - sync_tests_discourse_translate
-                  - sync_tests_balena_api_translate
-                  - sync_tests_github_translate
                   - sync_tests_front_mirror
-                  - sync_tests_outreach_mirror
                   - sync_tests_discourse_mirror
                   - sync_tests_github_mirror
                 <<: *workflow_filter


### PR DESCRIPTION
Attempt to speed circleci by:
 - grouping together Unit Tests, Sync Tests Outreach Translate, Sync Tests Outreach Mirror, Sync Tests Balena API Translate, Sync Tests Github Translate
 - removing Integration Tests (with debug logs)
 - ~turning simple sql queries to prepared statements~ (this was moved to #2708)