### PR TITLE
discourse: Assert that there is a user id in event payload

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -479,6 +479,10 @@ const getActor = async (context, actor, options, baseUrl, payload) => {
 		_.get(payload, [ 'topic', 'created_by', 'id' ]) ||
 		_.get(payload, [ 'details', 'created_by', 'id' ])
 
+	assert.INTERNAL(null, userId,
+		options.errors.SyncNoActor,
+		`No user id in payload: ${JSON.stringify(payload, null, 2)}`)
+
 	const remoteUser = await getDiscourseUserById(
 		context, actor, options, baseUrl, userId)
 


### PR DESCRIPTION
Will help for debugging purposes. We have a case where `userId` is
`undefined`, but its proving hard to track down without more info. We'll
know more next time.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!