### PR TITLE
discourse: Throw a nicer error when post edit is not allowed

### DIFF
--- a/lib/sync/errors.js
+++ b/lib/sync/errors.js
@@ -15,6 +15,7 @@ _.each([
 	'SyncRateLimit',
 	'SyncInvalidEvent',
 	'SyncInvalidType',
+	'SyncPermissionsError',
 	'SyncInvalidRequest',
 	'SyncNoExternalResource',
 	'SyncExternalRequestError',

--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -880,6 +880,13 @@ module.exports = class DiscourseIntegration {
 						}
 					})
 
+				if (editResponse.code === 403) {
+					const error = new this.options.errors.SyncPermissionsError(
+						'You don\'t have permissions to update this post on Discourse')
+					error.expected = true
+					throw error
+				}
+
 				assert.INTERNAL(null, editResponse.code === 200,
 					this.options.errors.SyncExternalRequestError, [
 						`Could not update comment ${topicResponse.id}`,


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!