### PR TITLE
worker: Fix create/update event sync race condition

### DIFF
--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -96,7 +96,7 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 			epoch: time.valueOf(),
 			arguments: {
 				name: options.reason,
-				type: current ? 'update' : 'create',
+				type: options.eventType,
 				payload: options.eventPayload,
 				tags: []
 			}
@@ -324,6 +324,7 @@ exports.insertCard = async (context, jellyfish, session, typeCard, options, obje
 	}
 
 	options.eventPayload = _.omit(object, [ 'id' ])
+	options.eventType = 'create'
 
 	return commit(context, jellyfish, session, typeCard, card, options, async () => {
 		return jellyfish.insertCard(context, session, object)
@@ -341,7 +342,6 @@ exports.replaceCard = async (context, jellyfish, session, typeCard, options, obj
 	})
 
 	object.type = typeCard.slug
-	options.eventPayload = _.omit(object, [ 'id' ])
 
 	let card = null
 	if (object.slug) {
@@ -355,6 +355,13 @@ exports.replaceCard = async (context, jellyfish, session, typeCard, options, obj
 
 	if (typeof object.name !== 'string') {
 		Reflect.deleteProperty(object, 'name')
+	}
+
+	if (card) {
+		options.attachEvents = false
+	} else {
+		options.eventPayload = _.omit(object, [ 'id' ])
+		options.eventType = 'create'
 	}
 
 	return commit(context, jellyfish, session, typeCard, card, options, async () => {
@@ -380,6 +387,7 @@ exports.patchCard = async (context, jellyfish, session, typeCard, options, objec
 	})
 
 	options.eventPayload = patch
+	options.eventType = 'update'
 
 	return commit(context, jellyfish, session, typeCard, object, options, async () => {
 		return jellyfish.patchCardBySlug(


### PR DESCRIPTION
Consider a piece of code that checks whether a card exists in order to
call the `.insertCard()` or `.patchCard()` worker method. If the outcome
is to insert, but the card gets inserted in the mean-time, then by the
time the executor runs, it will check again in order to decide if it
should post a `create` or an `update` event, which means we can end up
with a `create` event that has the payload of an `update` event.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!