### PR TITLE
docker-compose: Setup 3 worker replicas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -244,7 +244,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -310,7 +310,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -343,7 +343,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -377,7 +377,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -411,7 +411,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -445,7 +445,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -482,7 +482,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -518,7 +518,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -554,7 +554,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .
@@ -590,7 +590,7 @@ jobs:
           command: make compose-stop
       - run:
           name: Copy Code Coverage Reports
-          command: make compose-up-worker DETACH=1 && docker cp jellyfish_worker_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
+          command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
 
       - persist_to_workspace:
           root: .

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -13,7 +13,9 @@ services:
       - postgres
       - redis
       - tick
-      - worker
+      - worker_1
+      - worker_2
+      - worker_3
       - balena-mdns-publisher
     environment:
       - DATABASE={{DATABASE}}
@@ -190,7 +192,95 @@ services:
       NODE_ENV: {{NODE_ENV}}
     networks:
       - internal
-  worker:
+  worker_1:
+    build:
+      args:
+        ENABLE_COVERAGE: ${COVERAGE}
+      context: .
+      dockerfile: apps/action-server/Dockerfile.worker
+    depends_on:
+      - postgres
+      - redis
+      - balena-mdns-publisher
+    environment:
+      - DATABASE={{DATABASE}}
+      - LOGLEVEL={{LOGLEVEL}}
+      - NODE_ENV={{NODE_ENV}}
+      - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_PORT={{POSTGRES_PORT}}
+      - POSTGRES_USER=docker
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=redis
+      - REDIS_PORT={{REDIS_PORT}}
+      - SENTRY_DSN_SERVER
+      - LOGENTRIES_TOKEN
+      - INTEGRATION_BALENA_API_PRIVATE_KEY
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
+      - INTEGRATION_DEFAULT_USER
+      - INTEGRATION_INTERCOM_TOKEN
+      - INTEGRATION_FRONT_TOKEN
+      - INTEGRATION_GITHUB_TOKEN
+      - INTEGRATION_GITHUB_SIGNATURE_KEY
+      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
+      - INTEGRATION_DISCOURSE_TOKEN
+      - INTEGRATION_DISCOURSE_USERNAME
+      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
+      - INTEGRATION_OUTREACH_APP_ID
+      - INTEGRATION_OUTREACH_APP_SECRET
+      - INTEGRATION_OUTREACH_SIGNATURE_KEY
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - nyc_output:/usr/src/jellyfish/.nyc_output:rw
+  worker_2:
+    build:
+      args:
+        ENABLE_COVERAGE: ${COVERAGE}
+      context: .
+      dockerfile: apps/action-server/Dockerfile.worker
+    depends_on:
+      - postgres
+      - redis
+      - balena-mdns-publisher
+    environment:
+      - DATABASE={{DATABASE}}
+      - LOGLEVEL={{LOGLEVEL}}
+      - NODE_ENV={{NODE_ENV}}
+      - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_PORT={{POSTGRES_PORT}}
+      - POSTGRES_USER=docker
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=redis
+      - REDIS_PORT={{REDIS_PORT}}
+      - SENTRY_DSN_SERVER
+      - LOGENTRIES_TOKEN
+      - INTEGRATION_BALENA_API_PRIVATE_KEY
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
+      - INTEGRATION_DEFAULT_USER
+      - INTEGRATION_INTERCOM_TOKEN
+      - INTEGRATION_FRONT_TOKEN
+      - INTEGRATION_GITHUB_TOKEN
+      - INTEGRATION_GITHUB_SIGNATURE_KEY
+      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
+      - INTEGRATION_DISCOURSE_TOKEN
+      - INTEGRATION_DISCOURSE_USERNAME
+      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
+      - INTEGRATION_OUTREACH_APP_ID
+      - INTEGRATION_OUTREACH_APP_SECRET
+      - INTEGRATION_OUTREACH_SIGNATURE_KEY
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - nyc_output:/usr/src/jellyfish/.nyc_output:rw
+  worker_3:
     build:
       args:
         ENABLE_COVERAGE: ${COVERAGE}
@@ -265,7 +355,9 @@ services:
       - /run
       - /sys/fs/cgroup
     depends_on:
-      - worker
+      - worker_1
+      - worker_2
+      - worker_3
       - ui
       - tick
       - sidecar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - postgres
       - redis
       - tick
-      - worker
+      - worker_1
+      - worker_2
+      - worker_3
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres
@@ -190,7 +192,95 @@ services:
       NODE_ENV: test
     networks:
       - internal
-  worker:
+  worker_1:
+    build:
+      args:
+        ENABLE_COVERAGE: ${COVERAGE}
+      context: .
+      dockerfile: apps/action-server/Dockerfile.worker
+    depends_on:
+      - postgres
+      - redis
+      - balena-mdns-publisher
+    environment:
+      - DATABASE=postgres
+      - LOGLEVEL=info
+      - NODE_ENV=test
+      - POSTGRES_DATABASE=jellyfish
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=docker
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=redis
+      - REDIS_PORT=6379
+      - SENTRY_DSN_SERVER
+      - LOGENTRIES_TOKEN
+      - INTEGRATION_BALENA_API_PRIVATE_KEY
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
+      - INTEGRATION_DEFAULT_USER
+      - INTEGRATION_INTERCOM_TOKEN
+      - INTEGRATION_FRONT_TOKEN
+      - INTEGRATION_GITHUB_TOKEN
+      - INTEGRATION_GITHUB_SIGNATURE_KEY
+      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
+      - INTEGRATION_DISCOURSE_TOKEN
+      - INTEGRATION_DISCOURSE_USERNAME
+      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
+      - INTEGRATION_OUTREACH_APP_ID
+      - INTEGRATION_OUTREACH_APP_SECRET
+      - INTEGRATION_OUTREACH_SIGNATURE_KEY
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - nyc_output:/usr/src/jellyfish/.nyc_output:rw
+  worker_2:
+    build:
+      args:
+        ENABLE_COVERAGE: ${COVERAGE}
+      context: .
+      dockerfile: apps/action-server/Dockerfile.worker
+    depends_on:
+      - postgres
+      - redis
+      - balena-mdns-publisher
+    environment:
+      - DATABASE=postgres
+      - LOGLEVEL=info
+      - NODE_ENV=test
+      - POSTGRES_DATABASE=jellyfish
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=docker
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=redis
+      - REDIS_PORT=6379
+      - SENTRY_DSN_SERVER
+      - LOGENTRIES_TOKEN
+      - INTEGRATION_BALENA_API_PRIVATE_KEY
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
+      - INTEGRATION_DEFAULT_USER
+      - INTEGRATION_INTERCOM_TOKEN
+      - INTEGRATION_FRONT_TOKEN
+      - INTEGRATION_GITHUB_TOKEN
+      - INTEGRATION_GITHUB_SIGNATURE_KEY
+      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
+      - INTEGRATION_DISCOURSE_TOKEN
+      - INTEGRATION_DISCOURSE_USERNAME
+      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
+      - INTEGRATION_OUTREACH_APP_ID
+      - INTEGRATION_OUTREACH_APP_SECRET
+      - INTEGRATION_OUTREACH_SIGNATURE_KEY
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - nyc_output:/usr/src/jellyfish/.nyc_output:rw
+  worker_3:
     build:
       args:
         ENABLE_COVERAGE: ${COVERAGE}
@@ -265,7 +355,9 @@ services:
       - /run
       - /sys/fs/cgroup
     depends_on:
-      - worker
+      - worker_1
+      - worker_2
+      - worker_3
       - ui
       - tick
       - sidecar


### PR DESCRIPTION
We have to copy paste the component definition as Balena's Docker
Compose implementation doesn't support the `replicas` keyword.

This change should hopefully speed up the e2e tests.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!