### PR TITLE
sync: Keep more than one email in actors if needed

### DIFF
--- a/lib/sync/instance.js
+++ b/lib/sync/instance.js
@@ -62,7 +62,16 @@ const getOrCreate = async (context, object) => {
 	const card = await context.getElementBySlug(
 		`${object.slug}@${object.version}`)
 	if (card) {
-		setProperty(card, object, [ 'data', 'email' ])
+		// Set union of all known e-mails
+		const emailPropertyPath = [ 'data', 'email' ]
+		if (_.has(object, emailPropertyPath)) {
+			const emails = _.sortBy(_.compact(_.union(
+				_.castArray(_.get(card, emailPropertyPath)),
+				_.castArray(_.get(object, emailPropertyPath)))))
+			_.set(card, emailPropertyPath,
+				emails.length === 1 ? _.first(emails) : emails)
+		}
+
 		setProperty(card, object, [ 'data', 'profile', 'company' ])
 		setProperty(card, object, [ 'data', 'profile', 'name', 'first' ])
 		setProperty(card, object, [ 'data', 'profile', 'name', 'last' ])

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -7,6 +7,8 @@
 const ava = require('ava')
 const querystring = require('querystring')
 const _ = require('lodash')
+const nock = require('nock')
+const uuid = require('uuid/v4')
 const url = require('url')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
@@ -16,6 +18,176 @@ ava.beforeEach(scenario.beforeEach)
 ava.afterEach(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
+
+avaTest('should not change the same user email', async (test) => {
+	await test.context.jellyfish.insertCard(
+		test.context.context, test.context.session, {
+			slug: 'user-jviotti',
+			type: 'user',
+			version: '1.0.0',
+			data: {
+				email: 'juan@resin.io',
+				roles: []
+			}
+		})
+
+	nock('https://forums.balena.io')
+		.get('/admin/users/4.json')
+		.query({
+			api_key: TOKEN.api,
+			api_username: TOKEN.username
+		})
+		.reply(200,
+			require('./webhooks/discourse/inbound-tag-tag/stubs/1/admin-users-4-json.json'))
+
+	nock('https://forums.balena.io')
+		.get('/t/6061.json')
+		.query({
+			api_key: TOKEN.api,
+			api_username: TOKEN.username,
+			print: true
+		})
+		.reply(200,
+			require('./webhooks/discourse/inbound-tag-tag/stubs/1/t-6061-json-print-true.json'))
+
+	nock('https://forums.balena.io')
+		.get('/categories.json')
+		.query({
+			api_key: TOKEN.api,
+			api_username: TOKEN.username
+		})
+		.reply(200,
+			require('./webhooks/discourse/inbound-tag-tag/stubs/1/categories-json.json'))
+
+	for (const externalEvent of [
+		Object.assign({}, require('./webhooks/discourse/inbound-tag-tag/01.json'), {
+			source: 'discourse'
+		})
+	]) {
+		const event = await test.context.jellyfish.insertCard(test.context.context,
+			test.context.session, {
+				type: 'external-event',
+				slug: `external-event-${uuid()}`,
+				version: '1.0.0',
+				data: externalEvent
+			})
+
+		const request = await test.context.queue.enqueue(
+			test.context.worker.getId(),
+			test.context.session, {
+				context: test.context.context,
+				action: 'action-integration-import-event',
+				card: event.id,
+				type: event.type,
+				arguments: {}
+			})
+
+		await test.context.flush(test.context.session, 1)
+		const result = await test.context.queue.waitResults(
+			test.context.context, request)
+		test.false(result.error)
+	}
+
+	const user = await test.context.jellyfish.getCardBySlug(
+		test.context.context, test.context.session, 'user-jviotti@latest')
+
+	test.true(user.active)
+	test.deepEqual(user.data, {
+		email: 'juan@resin.io',
+		roles: [],
+		profile: {
+			title: 'Software Engineer',
+			name: {
+				first: 'Juan'
+			}
+		}
+	})
+})
+
+avaTest('should add a new e-mail to a user', async (test) => {
+	await test.context.jellyfish.insertCard(
+		test.context.context, test.context.session, {
+			slug: 'user-jviotti',
+			type: 'user',
+			version: '1.0.0',
+			data: {
+				email: 'foo@bar.com',
+				roles: []
+			}
+		})
+
+	nock('https://forums.balena.io')
+		.get('/admin/users/4.json')
+		.query({
+			api_key: TOKEN.api,
+			api_username: TOKEN.username
+		})
+		.reply(200,
+			require('./webhooks/discourse/inbound-tag-tag/stubs/1/admin-users-4-json.json'))
+
+	nock('https://forums.balena.io')
+		.get('/t/6061.json')
+		.query({
+			api_key: TOKEN.api,
+			api_username: TOKEN.username,
+			print: true
+		})
+		.reply(200,
+			require('./webhooks/discourse/inbound-tag-tag/stubs/1/t-6061-json-print-true.json'))
+
+	nock('https://forums.balena.io')
+		.get('/categories.json')
+		.query({
+			api_key: TOKEN.api,
+			api_username: TOKEN.username
+		})
+		.reply(200,
+			require('./webhooks/discourse/inbound-tag-tag/stubs/1/categories-json.json'))
+
+	for (const externalEvent of [
+		Object.assign({}, require('./webhooks/discourse/inbound-tag-tag/01.json'), {
+			source: 'discourse'
+		})
+	]) {
+		const event = await test.context.jellyfish.insertCard(test.context.context,
+			test.context.session, {
+				type: 'external-event',
+				slug: `external-event-${uuid()}`,
+				version: '1.0.0',
+				data: externalEvent
+			})
+
+		const request = await test.context.queue.enqueue(
+			test.context.worker.getId(),
+			test.context.session, {
+				context: test.context.context,
+				action: 'action-integration-import-event',
+				card: event.id,
+				type: event.type,
+				arguments: {}
+			})
+
+		await test.context.flush(test.context.session, 1)
+		const result = await test.context.queue.waitResults(
+			test.context.context, request)
+		test.false(result.error)
+	}
+
+	const user = await test.context.jellyfish.getCardBySlug(
+		test.context.context, test.context.session, 'user-jviotti@latest')
+
+	test.true(user.active)
+	test.deepEqual(user.data, {
+		email: [ 'foo@bar.com', 'juan@resin.io' ],
+		roles: [],
+		profile: {
+			title: 'Software Engineer',
+			name: {
+				first: 'Juan'
+			}
+		}
+	})
+})
 
 scenario.run(avaTest, {
 	integration: require('../../../lib/sync/integrations/discourse'),


### PR DESCRIPTION
To avoid tons of update events defining a different e-mail for a user.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!