### PR TITLE
 outreach/server/action-library: Support multiple emails in contacts

### DIFF
--- a/apps/server/default-cards/contrib/contact.json
+++ b/apps/server/default-cards/contrib/contact.json
@@ -35,8 +35,14 @@
               "type": "object",
               "properties": {
                 "email": {
-                  "type": "string",
-                  "format": "email"
+                  "type": [ "string", "array" ],
+                  "format": "email",
+                  "uniqueItems": true,
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "format": "email"
+                  }
                 },
                 "company": {
                   "type": "string"

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -1064,8 +1064,9 @@ module.exports = {
 				}
 			}
 
+			const gravatarEmail = Array.isArray(email) ? email[0] : email
 			const GRAVATAR_URL = 'https://www.gravatar.com/avatar/'
-			const avatarUrl = `${GRAVATAR_URL + md5(card.data.email.trim())}?d=404`
+			const avatarUrl = `${GRAVATAR_URL + md5(gravatarEmail.trim())}?d=404`
 
 			const patch = []
 

--- a/lib/sync/integrations/outreach.js
+++ b/lib/sync/integrations/outreach.js
@@ -65,7 +65,9 @@ const getProspectAttributes = (contact) => {
 		// As we may still have users around with these
 		// auto-generated emails that Outreach doesn't
 		// like as it claims they were taken already.
-		emails: [ contact.data.profile && contact.data.profile.email ].filter((email) => {
+		emails: _.flatten([
+			contact.data.profile && contact.data.profile.email
+		]).filter((email) => {
 			return email && !email.endsWith('@change.me')
 		}),
 

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -1171,3 +1171,73 @@ ava.serial('should create a contact for a user with plenty of info', async (test
 		}
 	})
 })
+
+ava.serial('should create a contact for a user with multiple emails', async (test) => {
+	const slug = test.context.generateRandomSlug({
+		prefix: 'user'
+	})
+
+	const userCard = await test.context.sdk.card.create({
+		slug,
+		type: 'user',
+		data: {
+			email: [ 'johndoe@example.com', 'johndoe@gmail.com' ],
+			roles: [ 'user-community' ],
+			profile: {
+				company: 'Balena.io',
+				title: 'Senior Directory of the Jellyfish Task Force',
+				type: 'professional',
+				country: 'Republic of Balena',
+				city: 'Contractshire',
+				name: {
+					first: 'John',
+					last: 'Doe'
+				}
+			}
+		}
+	})
+
+	const result = await test.context.http(
+		'POST', '/api/v2/action', {
+			card: userCard.id,
+			type: userCard.type,
+			action: 'action-maintain-contact',
+			arguments: {}
+		}, {
+			Authorization: `Bearer ${test.context.token}`
+		})
+
+	test.false(result.response.error)
+	const contactCard = await test.context.sdk.card.get(result.response.data.slug)
+
+	test.deepEqual(contactCard, {
+		id: contactCard.id,
+		slug: contactCard.slug.replace('user-', 'contact-'),
+		name: '',
+		tags: [],
+		type: 'contact',
+		links: {},
+		active: true,
+		markers: [],
+		version: '1.0.0',
+		requires: [],
+		capabilities: [],
+		linked_at: contactCard.linked_at,
+		created_at: contactCard.created_at,
+		updated_at: contactCard.updated_at,
+		data: {
+			profile: {
+				email: [ 'johndoe@example.com', 'johndoe@gmail.com' ],
+				company: 'Balena.io',
+				title: 'Senior Directory of the Jellyfish Task Force',
+				country: 'Republic of Balena',
+				city: 'Contractshire',
+				type: 'professional',
+				name: {
+					first: 'John',
+					last: 'Doe'
+				}
+			}
+		}
+	})
+})


### PR DESCRIPTION
***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!