### PR TITLE
core: Always set user's data.hash

### DIFF
--- a/apps/server/bootstrap.js
+++ b/apps/server/bootstrap.js
@@ -81,6 +81,7 @@ module.exports = async (context) => {
 			active: true,
 			data: {
 				email: 'test@jel.ly.fish',
+				hash: 'PASSWORDLESS',
 				roles: [ environment.test.user.role ]
 			}
 		})

--- a/apps/server/default-cards/contrib/user-guest.json
+++ b/apps/server/default-cards/contrib/user-guest.json
@@ -9,6 +9,7 @@
   "active": true,
   "data": {
     "email": "accounts+jellyfish@resin.io",
+    "hash": "PASSWORDLESS",
     "roles": []
   },
   "requires": [],

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -19,6 +19,9 @@ const assert = require('../assert')
 
 const BCRYPT_SALT_ROUNDS = 12
 
+// See https://github.com/balena-io/jellyfish/issues/2011
+const PASSWORDLESS_USER_HASH = 'PASSWORDLESS'
+
 const slugify = (string) => {
 	return string
 		.toLowerCase()
@@ -565,7 +568,10 @@ module.exports = {
 		pre: async (session, context, request) => {
 			const card = await context.getCardById(context.privilegedSession, request.card)
 			const isFirstTimePassword =
-				card && card.data && !card.data.hash && !request.arguments.currentPassword
+				card &&
+				card.data &&
+				card.data.hash === PASSWORDLESS_USER_HASH &&
+				!request.arguments.currentPassword
 
 			const loginResult = isFirstTimePassword
 				? {

--- a/lib/core/cards/user-admin.js
+++ b/lib/core/cards/user-admin.js
@@ -15,6 +15,7 @@ module.exports = {
 	active: true,
 	data: {
 		email: 'accounts+jellyfish@resin.io',
+		hash: 'PASSWORDLESS',
 		roles: []
 	},
 	requires: [],

--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -42,7 +42,8 @@ module.exports = {
 							}
 						},
 						hash: {
-							type: 'string'
+							type: 'string',
+							minLength: 1
 						},
 						avatar: {
 							type: [

--- a/lib/sync/instance.js
+++ b/lib/sync/instance.js
@@ -274,6 +274,10 @@ exports.run = async (integration, token, fn, options) => {
 				}
 
 				const data = {
+					// A hash that can never occur in the real-world
+					// See https://github.com/balena-io/jellyfish/issues/2011
+					hash: 'PASSWORDLESS',
+
 					roles: [],
 					profile
 				}

--- a/lib/sync/integrations/balena-api.js
+++ b/lib/sync/integrations/balena-api.js
@@ -153,7 +153,10 @@ module.exports = class BalenaAPIIntegration {
 			markers: [],
 			active: true,
 			data: {
-				roles: [ 'user-community' ]
+				roles: [ 'user-community' ],
+
+				// See  https://github.com/balena-io/jellyfish/issues/2011
+				hash: 'PASSWORDLESS'
 			}
 		}
 

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -36,6 +36,7 @@ ava.serial('should elevate external event source', async (test) => {
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ],
 			origin: event.id,
 			profile: {
@@ -101,6 +102,7 @@ ava.serial('should prettify name when creating user contact', async (test) => {
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				name: {
 					first: 'john   ',
@@ -161,7 +163,8 @@ ava.serial('should link the contact to the user', async (test) => {
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
-			roles: [ 'user-community' ]
+			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS'
 		}
 	})
 
@@ -235,6 +238,7 @@ ava.serial('should be able to sync updates to user first names', async (test) =>
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				title: 'Frontend Engineer',
 				name: {
@@ -329,6 +333,7 @@ ava.serial('should apply a user patch to a contact that diverged', async (test) 
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				title: 'Frontend Engineer'
 			}
@@ -438,6 +443,7 @@ ava.serial('should update the name of existing contact', async (test) => {
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				title: 'Frontend Engineer'
 			}
@@ -527,6 +533,7 @@ ava.serial('should delete an existing contact if the user is deleted', async (te
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				title: 'Frontend Engineer'
 			}
@@ -616,6 +623,7 @@ ava.serial('should replace a property from an existing linked contact', async (t
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				title: 'Frontend Engineer'
 			}
@@ -705,6 +713,7 @@ ava.serial('should not remove a property from an existing linked contact', async
 		data: {
 			email: 'johndoe@example.com',
 			roles: [ 'user-community' ],
+			hash: 'PASSWORDLESS',
 			profile: {
 				title: 'Frontend Engineer'
 			}
@@ -792,6 +801,7 @@ ava.serial('should merge and relink a diverging contact with a matching slug', a
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			profile: {
 				company: 'Balena'
 			},
@@ -866,6 +876,7 @@ ava.serial('should add a property to an existing linked contact', async (test) =
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -957,6 +968,7 @@ ava.serial('should create a contact for a user with little profile info', async 
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -1009,6 +1021,7 @@ ava.serial('should use the user name when creating a contact', async (test) => {
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -1061,6 +1074,7 @@ ava.serial('should create an inactive contact given an inactive user', async (te
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -1112,6 +1126,7 @@ ava.serial('should create a contact for a user with plenty of info', async (test
 		type: 'user',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ],
 			profile: {
 				company: 'Balena.io',
@@ -1182,6 +1197,7 @@ ava.serial('should create a contact for a user with multiple emails', async (tes
 		type: 'user',
 		data: {
 			email: [ 'johndoe@example.com', 'johndoe@gmail.com' ],
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ],
 			profile: {
 				company: 'Balena.io',

--- a/test/e2e/server/security.spec.js
+++ b/test/e2e/server/security.spec.js
@@ -279,6 +279,7 @@ ava.serial('a community user should not be able to set a first time password to 
 		type: 'user',
 		data: {
 			email: newUserDetails.email,
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -286,6 +287,7 @@ ava.serial('a community user should not be able to set a first time password to 
 	const newUserCard = await test.context.sdk.card.get(newUser.id)
 	test.deepEqual(newUserCard.data, {
 		email: newUserDetails.email,
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		avatar: null
 	})
@@ -311,6 +313,7 @@ ava.serial('a community user should not be able to set a first time password to 
 
 	test.deepEqual(newUserAfter.data, {
 		email: newUserDetails.email,
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		avatar: null
 	})

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -488,6 +488,7 @@ ava('.patchCardBySlug() should not break the type schema', async (test) => {
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -644,6 +645,7 @@ ava('.patchCardBySlug() should be able to patch cards hidden to the user', async
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -744,6 +746,7 @@ ava('.patchCardBySlug() should not allow updates in hidden fields', async (test)
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -1576,6 +1579,7 @@ ava('.insertCard() read access on a property should not allow to write other pro
 		version: '1.0.0',
 		data: {
 			email: 'johndoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	})
@@ -1586,6 +1590,7 @@ ava('.insertCard() read access on a property should not allow to write other pro
 		version: '1.0.0',
 		data: {
 			email: 'janedoe@example.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	})
@@ -1608,6 +1613,7 @@ ava('.insertCard() read access on a property should not allow to write other pro
 		version: '1.0.0',
 		data: {
 			email: 'pwned@example.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	}), errors.JellyfishSchemaMismatch)
@@ -3852,6 +3858,7 @@ ava('.lock() should not let a user lock a card it does not have access to', asyn
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -3942,6 +3949,7 @@ ava('.unlock() should not let a user unlock an unlocked card it does not have ac
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -4032,6 +4040,7 @@ ava('.unlock() should not let a user unlock a locked card it does not have acces
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -4371,6 +4380,7 @@ ava('.insertCard() should create a user with two email addressses', async (test)
 			version: '1.0.0',
 			data: {
 				email: [ 'johndoe@example.com', 'johndoe@gmail.com' ],
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -4386,6 +4396,7 @@ ava('.insertCard() should not create a user with an empty email list', async (te
 			version: '1.0.0',
 			data: {
 				email: [],
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		}), errors.JellyfishSchemaMismatch)
@@ -4399,6 +4410,7 @@ ava('.insertCard() should not create a user with an invalid email', async (test)
 			version: '1.0.0',
 			data: {
 				email: [ 'foo' ],
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		}), errors.JellyfishSchemaMismatch)
@@ -4412,6 +4424,7 @@ ava('.insertCard() should not create a user with an invalid and a valid email', 
 			version: '1.0.0',
 			data: {
 				email: [ 'johndoe@example.com', 'foo' ],
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		}), errors.JellyfishSchemaMismatch)
@@ -4425,6 +4438,7 @@ ava('.insertCard() should not create a user with duplicated emails', async (test
 			version: '1.0.0',
 			data: {
 				email: [ 'johndoe@example.com', 'johndoe@example.com' ],
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		}), errors.JellyfishSchemaMismatch)

--- a/test/integration/core/permission-filter.spec.js
+++ b/test/integration/core/permission-filter.spec.js
@@ -40,15 +40,17 @@ ava('.getSessionUser() should throw if the session actor is invalid', async (tes
 })
 
 ava('.getSessionUser() should get the session user given the session did not expire', async (test) => {
-	const result = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'user-johndoe',
-		type: 'user',
-		version: '1.0.0',
-		data: {
-			email: 'johndoe@example.com',
-			roles: [ 'foo', 'bar' ]
-		}
-	})
+	const result = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'user-johndoe',
+			type: 'user',
+			version: '1.0.0',
+			data: {
+				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
+				roles: [ 'foo', 'bar' ]
+			}
+		})
 
 	const date = new Date()
 	date.setDate(date.getDate() + 1)
@@ -76,15 +78,17 @@ ava('.getSessionUser() should get the session user given the session did not exp
 })
 
 ava('.getSessionUser() should throw if the session expired', async (test) => {
-	const user = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'user-johndoe',
-		type: 'user',
-		version: '1.0.0',
-		data: {
-			email: 'johndoe@example.com',
-			roles: [ 'foo', 'bar' ]
-		}
-	})
+	const user = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'user-johndoe',
+			type: 'user',
+			version: '1.0.0',
+			data: {
+				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
+				roles: [ 'foo', 'bar' ]
+			}
+		})
 
 	const date = new Date()
 	date.setDate(date.getDate() - 1)

--- a/test/integration/server/oauth.spec.js
+++ b/test/integration/server/oauth.spec.js
@@ -33,6 +33,7 @@ outreachTest('should be able to associate a user with Outreach', async (test) =>
 		version: '1.0.0',
 		data: {
 			email: 'test@jellysync.io',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -102,6 +103,7 @@ outreachTest('should not be able to associate a user with Outreach given the wro
 		version: '1.0.0',
 		data: {
 			email: 'test@jellysync.io',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -164,6 +166,7 @@ outreachTest('should not be able to associate a user with Outreach given no stat
 		version: '1.0.0',
 		data: {
 			email: 'test@jellysync.io',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})
@@ -216,6 +219,7 @@ outreachTest('should not be able to associate a user with Outreach given an inva
 		version: '1.0.0',
 		data: {
 			email: 'test@jellysync.io',
+			hash: 'PASSWORDLESS',
 			roles: [ 'user-community' ]
 		}
 	})

--- a/test/integration/sync/balena-api-translate.spec.js
+++ b/test/integration/sync/balena-api-translate.spec.js
@@ -56,6 +56,7 @@ avaTest('should change the remote username to an existing unsynced user', async 
 			version: '1.0.0',
 			data: {
 				email: 'foo@bar.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -133,6 +134,7 @@ avaTest('should change the remote username to an existing unsynced user', async 
 	test.true(johnDoe.active)
 	test.deepEqual(johnDoe.data, {
 		email: 'jane@balena.io',
+		hash: 'PASSWORDLESS',
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [],
 		origin: johnDoe.data.origin,
@@ -145,6 +147,7 @@ avaTest('should change the remote username to an existing unsynced user', async 
 	test.false(janeDoe.active)
 	test.deepEqual(janeDoe.data, {
 		email: 'jane@balena.io',
+		hash: 'PASSWORDLESS',
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
@@ -249,6 +252,7 @@ avaTest('should change the remote username to an existing user', async (test) =>
 	test.deepEqual(johnDoe.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		email: 'jane@balena.io',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(124)' ],
@@ -261,6 +265,7 @@ avaTest('should change the remote username to an existing user', async (test) =>
 	test.deepEqual(janeDoe.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		email: 'jane@balena.io',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [],
@@ -362,6 +367,7 @@ avaTest('should change the remote username to an existing user while removing ex
 	test.deepEqual(johnDoe.data, {
 		translateDate: '2019-04-17T15:26:49.231Z',
 		email: 'john@souvlakitek.com',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(124)' ],
@@ -377,6 +383,7 @@ avaTest('should change the remote username to an existing user while removing ex
 	test.false(janeDoe.active)
 	test.deepEqual(janeDoe.data, {
 		translateDate: '2019-04-17T15:26:49.231Z',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [],
@@ -483,6 +490,7 @@ avaTest('should change the remote username to an existing user and add a name', 
 	test.deepEqual(johnDoe.data, {
 		email: 'john@souvlakitek.com',
 		translateDate: '2019-04-17T15:26:49.231Z',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(124)' ],
@@ -500,6 +508,7 @@ avaTest('should change the remote username to an existing user and add a name', 
 		translateDate: '2019-04-17T15:26:49.231Z',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
+		hash: 'PASSWORDLESS',
 		mirrors: [],
 		profile: {
 			name: {
@@ -604,6 +613,7 @@ avaTest('should change the remote username to an existing user while removing th
 		email: 'john@souvlakitek.com',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
+		hash: 'PASSWORDLESS',
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(124)' ],
 		profile: {
 			company: 'Souvlaki Tek',
@@ -618,6 +628,7 @@ avaTest('should change the remote username to an existing user while removing th
 	test.deepEqual(janeDoe.data, {
 		translateDate: '2019-04-17T15:26:49.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: johnDoe.data.origin,
 		mirrors: []
 	})
@@ -722,6 +733,7 @@ avaTest('should change the remote username to an existing user while removing th
 	test.deepEqual(johnDoe.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		email: 'john@souvlakitek.com',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(124)' ],
@@ -738,6 +750,7 @@ avaTest('should change the remote username to an existing user while removing th
 	test.deepEqual(janeDoe.data, {
 		email: 'jane@balena.io',
 		translateDate: '2019-04-17T15:26:45.231Z',
+		hash: 'PASSWORDLESS',
 		roles: [ 'user-community' ],
 		origin: johnDoe.data.origin,
 		mirrors: [],
@@ -852,6 +865,7 @@ avaTest('should change the remote username to an existing user with a name', asy
 		email: 'jane@balena.io',
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: johnDoe.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(124)' ],
 		profile: {
@@ -868,6 +882,7 @@ avaTest('should change the remote username to an existing user with a name', asy
 		email: 'jane@balena.io',
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: johnDoe.data.origin,
 		mirrors: [],
 		profile: {
@@ -955,6 +970,7 @@ avaTest('should change the remote username', async (test) => {
 		email: 'admin@souvlakitek.com',
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: oldUsername.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
 		profile: {
@@ -1036,6 +1052,7 @@ avaTest('should change the remote username while filling in the company', async 
 	test.deepEqual(oldUsername.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: oldUsername.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
 		profile: {
@@ -1117,6 +1134,7 @@ avaTest('should change the remote username while filling in the first name', asy
 	test.deepEqual(oldUsername.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: oldUsername.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
 		profile: {
@@ -1200,6 +1218,7 @@ avaTest('should change the remote username while filling in the last name', asyn
 	test.deepEqual(oldUsername.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: oldUsername.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
 		profile: {
@@ -1282,6 +1301,7 @@ avaTest('should change the remote username while not changing anything else', as
 	test.deepEqual(oldUsername.data, {
 		translateDate: '2019-04-17T15:26:45.231Z',
 		roles: [ 'user-community' ],
+		hash: 'PASSWORDLESS',
 		origin: oldUsername.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ]
 	})
@@ -1297,6 +1317,7 @@ avaTest('should add a company and email to an existing user', async (test) => {
 		version: '1.0.0',
 		data: {
 			email: 'foo@bar.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	})
@@ -1363,6 +1384,7 @@ avaTest('should add a company and email to an existing user', async (test) => {
 	test.deepEqual(updatedCard.data, {
 		email: 'admin@souvlakitek.com',
 		translateDate: '2019-04-17T15:25:45.231Z',
+		hash: 'PASSWORDLESS',
 		roles: [],
 		origin: updatedCard.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
@@ -1380,6 +1402,7 @@ avaTest('should add a first name to an existing user', async (test) => {
 		version: '1.0.0',
 		data: {
 			email: 'foo@bar.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	})
@@ -1445,6 +1468,7 @@ avaTest('should add a first name to an existing user', async (test) => {
 	test.deepEqual(updatedCard.data, {
 		email: 'foo@bar.com',
 		roles: [],
+		hash: 'PASSWORDLESS',
 		translateDate: '2019-04-17T15:25:45.231Z',
 		origin: updatedCard.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
@@ -1464,6 +1488,7 @@ avaTest('should add a last name to an existing user', async (test) => {
 		version: '1.0.0',
 		data: {
 			email: 'foo@bar.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	})
@@ -1529,6 +1554,7 @@ avaTest('should add a last name to an existing user', async (test) => {
 	test.deepEqual(updatedCard.data, {
 		email: 'foo@bar.com',
 		roles: [],
+		hash: 'PASSWORDLESS',
 		translateDate: '2019-04-17T15:25:45.231Z',
 		origin: updatedCard.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ],
@@ -1548,6 +1574,7 @@ avaTest('should link an existing user by adding no data', async (test) => {
 		version: '1.0.0',
 		data: {
 			email: 'foo@bar.com',
+			hash: 'PASSWORDLESS',
 			roles: []
 		}
 	})
@@ -1613,6 +1640,7 @@ avaTest('should link an existing user by adding no data', async (test) => {
 		email: 'foo@bar.com',
 		translateDate: '2019-04-17T15:25:45.231Z',
 		roles: [],
+		hash: 'PASSWORDLESS',
 		origin: updatedCard.data.origin,
 		mirrors: [ 'https://api.balena-cloud.com/v5/user(123)' ]
 	})

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -27,6 +27,7 @@ avaTest('should not change the same user email', async (test) => {
 			version: '1.0.0',
 			data: {
 				email: 'juan@resin.io',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -94,6 +95,7 @@ avaTest('should not change the same user email', async (test) => {
 	test.true(user.active)
 	test.deepEqual(user.data, {
 		email: 'juan@resin.io',
+		hash: 'PASSWORDLESS',
 		roles: [],
 		profile: {
 			title: 'Software Engineer',
@@ -112,6 +114,7 @@ avaTest('should add a new e-mail to a user', async (test) => {
 			version: '1.0.0',
 			data: {
 				email: 'foo@bar.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -180,6 +183,7 @@ avaTest('should add a new e-mail to a user', async (test) => {
 	test.deepEqual(user.data, {
 		email: [ 'foo@bar.com', 'juan@resin.io' ],
 		roles: [],
+		hash: 'PASSWORDLESS',
 		profile: {
 			title: 'Software Engineer',
 			name: {

--- a/test/integration/sync/webhooks/balena-api/new-user-delete/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-delete/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [],
       "profile": {
         "type": "professional",
@@ -46,6 +47,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-invalid-slug/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-invalid-slug/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -48,6 +49,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-ip/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-ip/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -50,6 +51,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-no-data-add-company/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-no-data-add-company/expected.json
@@ -10,6 +10,7 @@
     "capabilities": [],
     "data": {
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -41,6 +42,7 @@
           "capabilities": [],
           "data": {
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ]

--- a/test/integration/sync/webhooks/balena-api/new-user-no-email/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-no-email/expected.json
@@ -10,6 +10,7 @@
     "capabilities": [],
     "data": {
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -46,6 +47,7 @@
           "capabilities": [],
           "data": {
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-no-info/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-no-info/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ]
@@ -40,6 +41,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ]

--- a/test/integration/sync/webhooks/balena-api/new-user-no-last-name/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-no-last-name/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -47,6 +48,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-no-name-add-name/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-no-name-add-name/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -48,6 +49,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-remove-company/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-remove-company/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -47,6 +48,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-remove-email/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-remove-email/expected.json
@@ -10,6 +10,7 @@
     "capabilities": [],
     "data": {
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -47,6 +48,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user-update-email/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user-update-email/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "ceo@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -47,6 +48,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/sync/webhooks/balena-api/new-user/expected.json
+++ b/test/integration/sync/webhooks/balena-api/new-user/expected.json
@@ -11,6 +11,7 @@
     "data": {
       "email": "johndoe@souvlakitek.com",
       "roles": [ "user-community" ],
+      "hash": "PASSWORDLESS",
       "mirrors": [
         "https://api.balena-cloud.com/v5/user(999)"
       ],
@@ -48,6 +49,7 @@
           "data": {
             "email": "johndoe@souvlakitek.com",
             "roles": [ "user-community" ],
+            "hash": "PASSWORDLESS",
             "mirrors": [
               "https://api.balena-cloud.com/v5/user(999)"
             ],

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -311,6 +311,7 @@ ava('should not store the passwords when using action-set-password on a first ti
 			type: 'user',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: [ 'user-community' ]
 			}
 		})
@@ -345,6 +346,7 @@ ava('should not change the password of a password-less user given a password', a
 			type: 'user',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: [ 'user-community' ]
 			}
 		})
@@ -368,6 +370,7 @@ ava('should change the password of a password-less user given no password', asyn
 			type: 'user',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: [ 'user-community' ]
 			}
 		})
@@ -2523,6 +2526,7 @@ ava('should not be able to login as a password-less user', async (test) => {
 			slug: 'user-johndoe',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -2549,6 +2553,7 @@ ava('should not be able to login as a password-less user given a random password
 			slug: 'user-johndoe',
 			data: {
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -2573,6 +2578,7 @@ ava('should not be able to login as a password-less non-disallowed user', async 
 			data: {
 				disallowLogin: false,
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -2600,6 +2606,7 @@ ava('should not be able to login as a password-less disallowed user', async (tes
 			data: {
 				disallowLogin: true,
 				email: 'johndoe@example.com',
+				hash: 'PASSWORDLESS',
 				roles: []
 			}
 		})
@@ -3320,33 +3327,17 @@ ava('should post an error execute event if logging in as a disallowed user', asy
 	const adminCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'user-admin@latest')
 
-	const loginRequest = await test.context.queue.enqueue(test.context.worker.getId(), test.context.session, {
-		action: 'action-create-session',
-		context: test.context.context,
-		card: adminCard.id,
-		type: adminCard.type,
-		arguments: {
-			password: 'foobarbaz'
-		}
-	})
-
 	await test.throwsAsync(
-		test.context.flush(test.context.session, 1),
-		test.context.worker.errors.WorkerAuthenticationError)
-
-	const loginResult = await test.context.queue.waitResults(
-		test.context.context, loginRequest)
-	test.deepEqual(loginResult, {
-		error: true,
-		timestamp: loginResult.timestamp,
-		data: {
-			expected: true,
+		test.context.worker.pre(test.context.session, {
+			action: 'action-create-session',
 			context: test.context.context,
-			message: 'Login disallowed',
-			name: 'WorkerAuthenticationError',
-			stack: loginResult.data.stack
-		}
-	})
+			card: adminCard.id,
+			type: adminCard.type,
+			arguments: {
+				password: 'foobarbaz'
+			}
+		}),
+		test.context.worker.errors.WorkerAuthenticationError)
 })
 
 ava('action-create-event should create a link card', async (test) => {
@@ -4316,6 +4307,7 @@ ava('should broadcast the same message twice given different actors', async (tes
 			slug: 'user-admin-fake-test',
 			data: {
 				email: 'accounts+jellyfish@resin.io',
+				hash: 'PASSWORDLESS',
 				roles: [ 'user-community' ]
 			}
 		})


### PR DESCRIPTION
Change-type: minor
Fixes: https://github.com/balena-io/jellyfish/issues/2011


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!