### PR TITLE
core: Don't crash on string queries on the UUID column

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/keywords.js
+++ b/lib/core/backend/postgres/jsonschema2sql/keywords.js
@@ -125,7 +125,7 @@ exports.regexp = (value, path, walk, schema, context, keys) => {
 			keys,
 			filter: builder.or(
 				builder.isNotOfType(path, 'string'),
-				`${selector} ${operator} ${builder.valueToPostgres(pattern)}`)
+				`${selector}::text ${operator} ${builder.valueToPostgres(pattern)}`)
 		}
 	}
 

--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -910,6 +910,26 @@ ava('.upsertElement() should not insert an element with a non-matching id nor sl
 	}), errors.JellyfishDatabaseError)
 })
 
+ava('.query() should correctly take string contraints on the uuid', async (test) => {
+	const results = await test.context.backend.query(
+		test.context.context, {
+			type: 'object',
+			additionalProperties: true,
+			required: [ 'id' ],
+			properties: {
+				id: {
+					type: 'string',
+					regexp: {
+						pattern: 'assume',
+						flags: 'i'
+					}
+				}
+			}
+		})
+
+	test.deepEqual(results, [])
+})
+
 ava('.query() should query the database using JSON schema', async (test) => {
 	const result1 = await test.context.backend.upsertElement(test.context.context, {
 		type: 'example',


### PR DESCRIPTION
Change-type: patch
Fixes: https://github.com/balena-io/jellyfish/issues/2748


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!