### PR TITLE
core: Refactor and simplify permission filter code

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -4,44 +4,22 @@
  * Proprietary and confidential.
  */
 
-const _ = require('lodash')
 const jsone = require('json-e')
+const _ = require('lodash')
 const jsonSchema = require('./json-schema')
 const errors = require('./errors')
 const CARDS = require('./cards')
 const assert = require('../assert')
 
-const applyMarkersToSchema = (schema, user, markersQuery) => {
-	// The admin user can access all cards regardless of markers, allowing the
-	// admin user to insert cards that have markers already set. As such, the
-	// markers query should not be added if the user-admin is running the query.
-	// TODO: Find a way to implement this logic without hardcoding the user-admin
-	// slug
-	if (user.slug !== 'user-admin') {
-		// The markers must match
-		if (schema.properties && schema.properties.markers) {
-			if (!schema.allOf) {
-				schema.allOf = []
-			}
-			schema.allOf.push(markersQuery)
-		} else {
-			schema.properties = schema.properties || {}
-			schema.properties.markers = markersQuery.properties.markers
-		}
-	}
-
-	return schema
-}
-
-const getMarkers = async (context, backend, user) => {
-	// We don't care about admin's markers as we treat this
-	// as a special case anyways.
-	if (user.slug === 'user-admin') {
-		return []
+const applyMarkers = async (context, backend, user, schema) => {
+	// TODO: Find a way to implement this logic without
+	// hardcoding the admin user
+	if (user.slug === CARDS['user-admin'].slug) {
+		return schema
 	}
 
 	/*
-	 * Be careful if modifying this schema as is has been
+	 * Be careful if modifying this schema as it has been
 	 * written so that the backend can be smart about it
 	 * and execute it really fast.
 	 */
@@ -75,49 +53,51 @@ const getMarkers = async (context, backend, user) => {
 		}
 	})
 
-	return orgs.reduce((accumulator, org) => {
-		accumulator.push(org.slug)
-		return accumulator
-	}, [ user.slug ])
-}
+	const markers = _.uniq([ user, ...orgs ].map((card) => {
+		return card.slug
+	}))
 
-const createMarkersQuery = async (context, backend, user) => {
-	const markers = await getMarkers(context, backend, user)
+	const markersQuery = markers.length === 0
+		// If there are no markers provided, only elements with
+		// no markers are valid
+		? {
+			type: 'array',
+			maxItems: 0
+		}
+		: {
+			type: 'array',
+			items: {
+				type: 'string',
+				anyOf: [
+					{
+						enum: markers
+					},
 
-	// If there are no markers provided, only elements with no markers are valid
-	if (markers.length === 0) {
-		return {
+					// Use pattern matching to allow content using compound markers
+					// (markers join with a + symbol)
+					{
+						pattern: `(^|\\+)(${markers.join('|')})($|\\+)`
+					}
+				]
+			}
+		}
+
+	// The markers must match
+	if (schema.properties && schema.properties.markers) {
+		schema.allOf = schema.allOf || []
+		schema.allOf.push({
 			type: 'object',
+			required: [ 'markers' ],
 			properties: {
-				markers: {
-					type: 'array',
-					maxItems: 0
-				}
+				markers: markersQuery
 			}
-		}
+		})
+	} else {
+		schema.properties = schema.properties || {}
+		schema.properties.markers = markersQuery
 	}
 
-	return {
-		type: 'object',
-		properties: {
-			markers: {
-				type: 'array',
-				items: {
-					type: 'string',
-					anyOf: [
-						// Use pattern matching to allow content using compound markers
-						// (markers join with a + symbol)
-						{
-							pattern: `(^|\\+)(${markers.join('|')})($|\\+)`
-						},
-						{
-							enum: _.uniq(markers)
-						}
-					]
-				}
-			}
-		}
-	}
+	return schema
 }
 
 /**
@@ -181,9 +161,10 @@ exports.getSessionUser = async (context, backend, session) => {
 		errors.JellyfishSessionExpired,
 		`Session expired at: ${sessionCard.data.expiration}`)
 
-	const actor = await backend.getElementById(context, sessionCard.data.actor, {
-		type: 'user'
-	})
+	const actor = await backend.getElementById(
+		context, sessionCard.data.actor, {
+			type: 'user'
+		})
 
 	assert.INTERNAL(context, actor, errors.JellyfishNoElement,
 		`Invalid actor: ${sessionCard.data.actor}`)
@@ -255,6 +236,20 @@ const evalSchema = (object, context) => {
 	return object
 }
 
+const getUserMask = async (context, backend, user) => {
+	const permissionFilters = await getRoleViews(context, backend, user)
+	return applyMarkers(context, backend, user, {
+		type: 'object',
+
+		// At least one permission must match
+		anyOf: permissionFilters.map((object) => {
+			return evalSchema(object, {
+				user
+			})
+		})
+	})
+}
+
 /**
  * @summary Get the permissions mask for a user
  * @function
@@ -266,22 +261,8 @@ const evalSchema = (object, context) => {
  * @returns {Object} mask
  */
 exports.getMask = async (context, backend, session) => {
-	const user = await exports.getSessionUser(context, backend, session)
-	const [ permissionFilters, markersQuery ] = await Promise.all([
-		getRoleViews(context, backend, user),
-		createMarkersQuery(context, backend, user)
-	])
-
-	return applyMarkersToSchema({
-		type: 'object',
-
-		// At least one permission must match
-		anyOf: permissionFilters.map((object) => {
-			return evalSchema(object, {
-				user
-			})
-		})
-	}, user, markersQuery)
+	return getUserMask(context, backend,
+		await exports.getSessionUser(context, backend, session))
 }
 
 /**
@@ -297,47 +278,21 @@ exports.getMask = async (context, backend, session) => {
  */
 exports.getQuery = async (context, backend, session, schema) => {
 	const user = await exports.getSessionUser(context, backend, session)
-	const [ permissionFilters, markersQuery ] = await Promise.all([
-		getRoleViews(context, backend, user),
-		createMarkersQuery(context, backend, user)
-	])
+	const mask = await getUserMask(context, backend, user)
 
-	const compiledSchema = {
-		type: 'object',
-
-		// At least one permission must match
-		anyOf: permissionFilters.map((object) => {
-			return evalSchema(object, {
-				user
-			})
-		})
-	}
-
+	// Apply permission mask to links
 	if (schema.$$links) {
 		const linkName = Object.keys(schema.$$links)[0]
-
 		if (schema.$$links[linkName]) {
-			schema.$$links[linkName] = jsonSchema.merge([
-				schema.$$links[linkName],
-				compiledSchema
-			])
-
-			applyMarkersToSchema(schema.$$links[linkName], user, markersQuery)
+			schema.$$links[linkName] =
+				jsonSchema.merge([ mask, schema.$$links[linkName] ])
 		}
 	}
 
-	const evaledSchema = evalSchema(schema, {
-		user
-	})
-
-	if (evaledSchema.anyOf) {
-		compiledSchema.allOf = [
-			{
-				anyOf: evaledSchema.anyOf
-			}
-		]
-	}
-	Object.assign(compiledSchema, _.omit(evaledSchema, [ 'anyOf' ]))
-
-	return applyMarkersToSchema(compiledSchema, user, markersQuery)
+	return jsonSchema.merge([
+		mask,
+		evalSchema(schema, {
+			user
+		})
+	])
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15167,9 +15167,9 @@
       }
     },
     "skhema": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.2.5.tgz",
-      "integrity": "sha512-3xsY7kb4digjml8kXSN3o8wWLh5Wq5I3xty/buhjsKeXsYmNkTlwuD6Xp5WWNT6GSuDBjL68YQaMHIhxOlEXhg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.2.6.tgz",
+      "integrity": "sha512-qkmxDI6xNx/KJF36bVO1scJXqm1nlVBZtmAuWfx8FHrQ4dNm7PMm/MrZvIyN6+WfCGh80GoFuvkr9/hosN8lxA==",
       "requires": {
         "@types/json-schema": "^6.0.1",
         "ajv": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "rendition": "^11.25.0",
     "request-promise": "^4.2.2",
     "response-time": "^2.3.2",
-    "skhema": "^5.2.5",
+    "skhema": "^5.2.6",
     "socket.io": "^2.1.0",
     "socket.io-client": "^2.2.0",
     "socket.io-redis": "^5.2.0",

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -51,6 +51,7 @@ ava.serial('.action() should be able to successfully create a new card', async (
 
 	const results = await sdk.query({
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			name: {
 				type: 'string',
@@ -66,7 +67,6 @@ ava.serial('.action() should be able to successfully create a new card', async (
 
 	test.deepEqual(results, [
 		{
-			markers: [],
 			type: 'card',
 			name
 		}
@@ -858,6 +858,7 @@ ava.serial('.card.create() should create a new card', async (test) => {
 
 	const results = await sdk.query({
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			slug: {
 				type: 'string',
@@ -872,7 +873,6 @@ ava.serial('.card.create() should create a new card', async (test) => {
 	})
 
 	test.deepEqual(_.first(results), {
-		markers: [],
 		type: 'card',
 		slug
 	})
@@ -1000,6 +1000,7 @@ ava.serial.cb('.stream() should stream new cards', (test) => {
 
 	sdk.stream({
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			slug: {
 				type: 'string',
@@ -1028,7 +1029,6 @@ ava.serial.cb('.stream() should stream new cards', (test) => {
 				test.is(update.data.before, null)
 				test.deepEqual(_.omit(update.data.after, [ 'id' ]), {
 					slug: slug1,
-					markers: [],
 					data: {
 						test: 1
 					}

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -220,7 +220,6 @@ ava.serial('should link the contact to the user', async (test) => {
 	test.deepEqual(results[0].links['has contact'], [
 		{
 			id: result.response.data.id,
-			markers: [],
 			slug: result.response.data.slug,
 			type: result.response.data.type
 		}

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -406,7 +406,8 @@ ava.serial('should be able to resolve links', async (test) => {
 			}
 		},
 		type: 'object',
-		required: [ 'type', 'links' ],
+		required: [ 'type', 'links', 'data', 'slug' ],
+		additionalProperties: true,
 		properties: {
 			type: {
 				type: 'string',
@@ -427,15 +428,24 @@ ava.serial('should be able to resolve links', async (test) => {
 
 	test.deepEqual(results, [
 		{
+			id: message.id,
+			active: true,
 			slug: message.slug,
 			type: 'message',
+			version: '1.0.0',
+			name: null,
+			updated_at: null,
+			created_at: message.created_at,
+			linked_at: message.linked_at,
+			requires: [],
+			capabilities: [],
+			tags: [],
 			markers: [],
 			links: {
 				'is attached to': [
 					{
 						id: thread.id,
 						type: 'thread',
-						markers: [],
 						data: {
 							uuid: id
 						}

--- a/test/e2e/server/security.spec.js
+++ b/test/e2e/server/security.spec.js
@@ -1242,7 +1242,7 @@ ava.serial('should apply permissions on resolved links', async (test) => {
 			}
 		},
 		type: 'object',
-		required: [ 'type', 'links', 'data' ],
+		required: [ 'id', 'type', 'links', 'data', 'slug' ],
 		properties: {
 			id: {
 				type: 'string'
@@ -1283,6 +1283,15 @@ ava.serial('should apply permissions on resolved links', async (test) => {
 			id: message.id,
 			slug: message.slug,
 			type: 'message',
+			version: '1.0.0',
+			updated_at: null,
+			linked_at: message.linked_at,
+			created_at: message.created_at,
+			name: null,
+			active: true,
+			tags: [],
+			requires: [],
+			capabilities: [],
 			markers: [],
 			links: {
 				'is attached to': [

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -1955,49 +1955,53 @@ ava('.query() should be able to limit and skip the results', async (test) => {
 })
 
 ava('.query() should return the cards that match a schema', async (test) => {
-	const result1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'johndoe',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			email: 'johndoe@example.io'
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'johnsmith',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			email: 'johnsmith@example.io'
-		}
-	})
-
-	const results = await test.context.kernel.query(test.context.context, test.context.kernel.sessions.admin, {
-		type: 'object',
-		properties: {
-			id: {
-				type: 'string'
-			},
-			slug: {
-				type: 'string',
-				pattern: 'doe$'
-			},
-			type: {
-				type: 'string'
-			},
+	const result1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'johndoe',
+			type: 'card',
+			version: '1.0.0',
 			data: {
-				type: 'object',
-				properties: {
-					email: {
-						type: 'string'
-					}
-				},
-				required: [ 'email' ]
+				email: 'johndoe@example.io'
 			}
-		},
-		required: [ 'id', 'slug', 'type', 'data' ]
-	})
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'johnsmith',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				email: 'johnsmith@example.io'
+			}
+		})
+
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				id: {
+					type: 'string'
+				},
+				slug: {
+					type: 'string',
+					pattern: 'doe$'
+				},
+				type: {
+					type: 'string'
+				},
+				data: {
+					type: 'object',
+					properties: {
+						email: {
+							type: 'string'
+						}
+					},
+					required: [ 'email' ]
+				}
+			},
+			required: [ 'id', 'slug', 'type', 'data' ]
+		})
 
 	test.deepEqual(results, [
 		{
@@ -2036,6 +2040,7 @@ ava('.query() should work if passing an $id top level property', async (test) =>
 		test.context.context, test.context.kernel.sessions.admin, {
 			$id: 'foobar',
 			type: 'object',
+			additionalProperties: false,
 			properties: {
 				id: {
 					type: 'string'
@@ -2115,77 +2120,87 @@ ava('.query() should be able to describe a property that starts with $', async (
 })
 
 ava('.query() should take roles into account', async (test) => {
-	const actor = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'johndoe',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			email: 'johndoe@example.io',
-			roles: [ 'foo' ]
-		}
-	})
+	const actor = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'johndoe',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				email: 'johndoe@example.io',
+				roles: [ 'foo' ]
+			}
+		})
 
-	const session = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: test.context.generateRandomSlug({
-			prefix: 'session'
-		}),
-		type: 'session',
-		version: '1.0.0',
-		data: {
-			actor: actor.id
-		}
-	})
+	const session = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'session'
+			}),
+			type: 'session',
+			version: '1.0.0',
+			data: {
+				actor: actor.id
+			}
+		})
 
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'role-foo',
-		type: 'role',
-		version: '1.0.0',
-		data: {
-			read: {
-				type: 'object',
-				required: [ 'type', 'data' ],
-				properties: {
-					type: {
-						type: 'string',
-						const: 'type'
-					},
-					data: {
-						type: 'object',
-						required: [ 'schema' ],
-						properties: {
-							schema: {
-								type: 'object',
-								additionalProperties: true
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'role-foo',
+			type: 'role',
+			version: '1.0.0',
+			data: {
+				read: {
+					type: 'object',
+					required: [ 'type', 'data' ],
+					properties: {
+						type: {
+							type: 'string',
+							const: 'type'
+						},
+						data: {
+							type: 'object',
+							required: [ 'schema' ],
+							properties: {
+								schema: {
+									type: 'object',
+									additionalProperties: true
+								}
 							}
 						}
 					}
 				}
 			}
-		}
-	})
+		})
 
-	const results = await test.context.kernel.query(test.context.context, session.id, {
-		type: 'object',
-		required: [ 'type', 'slug', 'active', 'data' ],
-		properties: {
-			type: {
-				type: 'string'
-			},
-			slug: {
-				type: 'string',
-				pattern: '^user'
-			},
-			active: {
-				type: 'boolean'
-			},
-			data: {
-				type: 'object'
+	const results = await test.context.kernel.query(
+		test.context.context, session.id, {
+			type: 'object',
+			required: [ 'type', 'slug', 'active', 'data' ],
+			additionalProperties: false,
+			properties: {
+				type: {
+					type: 'string'
+				},
+				slug: {
+					type: 'string',
+					pattern: '^user'
+				},
+				active: {
+					type: 'boolean'
+				},
+				data: {
+					type: 'object'
+				}
 			}
-		}
-	})
+		})
 
 	test.deepEqual(results, [
-		_.pick(await CARDS.user, [ 'type', 'slug', 'active', 'data', 'markers' ])
+		_.pick(await CARDS.user, [
+			'type',
+			'slug',
+			'active',
+			'data'
+		])
 	])
 })
 
@@ -2251,7 +2266,8 @@ ava('.query() should ignore queries to properties not whitelisted by a role', as
 	test.deepEqual(results, [
 		{
 			type: 'type',
-			slug: 'user'
+			slug: 'user',
+			markers: []
 		}
 	])
 })
@@ -2324,6 +2340,7 @@ ava('.query() should ignore $id properties in roles', async (test) => {
 	test.deepEqual(results, [
 		{
 			type: 'type',
+			markers: [],
 			slug: 'user'
 		}
 	])
@@ -2391,6 +2408,7 @@ ava('.query() should ignore queries to disallowed properties with additionalProp
 
 	test.deepEqual(results, [
 		{
+			markers: [],
 			type: 'type',
 			slug: 'user'
 		}
@@ -2439,22 +2457,25 @@ ava('.query() should return all action request cards', async (test) => {
 		}
 	}
 
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, request)
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, request)
 
-	const results = await test.context.kernel.query(test.context.context, test.context.kernel.sessions.admin, {
-		type: 'object',
-		properties: {
-			type: {
-				type: 'string',
-				const: 'action-request'
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				type: {
+					type: 'string',
+					const: 'action-request'
+				},
+				data: {
+					type: 'object',
+					additionalProperties: true
+				}
 			},
-			data: {
-				type: 'object',
-				additionalProperties: true
-			}
-		},
-		required: [ 'type', 'data' ]
-	})
+			required: [ 'type', 'data' ]
+		})
 
 	test.deepEqual(results, [
 		{
@@ -2535,27 +2556,30 @@ ava('.query() should be able to return both action requests and other cards', as
 })
 
 ava('.query() should return inactive cards', async (test) => {
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'johnsmith',
-		type: 'card',
-		version: '1.0.0',
-		active: false,
-		data: {
-			email: 'johnsmith@example.io',
-			roles: []
-		}
-	})
-
-	const results = await test.context.kernel.query(test.context.context, test.context.kernel.sessions.admin, {
-		type: 'object',
-		properties: {
-			slug: {
-				type: 'string',
-				pattern: 'smith$'
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'johnsmith',
+			type: 'card',
+			version: '1.0.0',
+			active: false,
+			data: {
+				email: 'johnsmith@example.io',
+				roles: []
 			}
-		},
-		required: [ 'slug' ]
-	})
+		})
+
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: 'smith$'
+				}
+			},
+			required: [ 'slug' ]
+		})
 
 	test.deepEqual(results, [
 		{
@@ -2636,7 +2660,9 @@ ava('.query() should take a view card with two filters', async (test) => {
 			}
 		})
 
-	test.deepEqual(results, [
+	test.deepEqual(results.map((element) => {
+		return _.pick(element, [ 'tags', 'data' ])
+	}), [
 		{
 			tags: [ 'foo' ],
 			data: {
@@ -2801,6 +2827,7 @@ ava('.query() should take into account newly inserted links when processing null
 	const results1 = await test.context.kernel.query(
 		test.context.context, test.context.kernel.sessions.admin, {
 			type: 'object',
+			additionalProperties: false,
 			required: [ 'slug', 'type', 'data' ],
 			$$links: {
 				'has appended element': null
@@ -2891,82 +2918,88 @@ ava('.query() should take into account newly inserted links when processing null
 })
 
 ava('.query() should be able to query for cards without a certain type of link', async (test) => {
-	const parent1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'foo',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 1
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'bar',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 2
-		}
-	})
-
-	const card1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'baz',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: false,
-			count: 1
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: `link-${card1.slug}-is-appended-to-${parent1.slug}`,
-		type: 'link',
-		version: '1.0.0',
-		name: 'is appended to',
-		active: true,
-		data: {
-			inverseName: 'has appended element',
-			from: {
-				id: card1.id,
-				type: card1.type
-			},
-			to: {
-				id: parent1.id,
-				type: parent1.type
-			}
-		}
-	})
-
-	const results = await test.context.kernel.query(test.context.context, test.context.kernel.sessions.admin, {
-		type: 'object',
-		required: [ 'slug', 'type', 'data' ],
-		$$links: {
-			'has appended element': null
-		},
-		properties: {
-			slug: {
-				type: 'string'
-			},
-			type: {
-				type: 'string',
-				const: 'card'
-			},
+	const parent1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foo',
+			type: 'card',
+			version: '1.0.0',
 			data: {
-				type: 'object',
-				required: [ 'thread' ],
-				additionalProperties: true,
-				properties: {
-					thread: {
-						type: 'boolean',
-						const: true
+				thread: true,
+				number: 1
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'bar',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: true,
+				number: 2
+			}
+		})
+
+	const card1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'baz',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: false,
+				count: 1
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: `link-${card1.slug}-is-appended-to-${parent1.slug}`,
+			type: 'link',
+			version: '1.0.0',
+			name: 'is appended to',
+			active: true,
+			data: {
+				inverseName: 'has appended element',
+				from: {
+					id: card1.id,
+					type: card1.type
+				},
+				to: {
+					id: parent1.id,
+					type: parent1.type
+				}
+			}
+		})
+
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: false,
+			required: [ 'slug', 'type', 'data' ],
+			$$links: {
+				'has appended element': null
+			},
+			properties: {
+				slug: {
+					type: 'string'
+				},
+				type: {
+					type: 'string',
+					const: 'card'
+				},
+				data: {
+					type: 'object',
+					required: [ 'thread' ],
+					additionalProperties: true,
+					properties: {
+						thread: {
+							type: 'boolean',
+							const: true
+						}
 					}
 				}
 			}
-		}
-	})
+		})
 
 	test.deepEqual(results, [
 		{
@@ -2981,129 +3014,137 @@ ava('.query() should be able to query for cards without a certain type of link',
 })
 
 ava('.query() should not consider inactive links', async (test) => {
-	const parent1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'foo',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 1
-		}
-	})
-
-	const parent2 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'bar',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 2
-		}
-	})
-
-	const card1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'baz',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: false,
-			count: 1
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: `link-${card1.slug}-is-attached-to-${parent1.slug}`,
-		type: 'link',
-		version: '1.0.0',
-		name: 'is attached to',
-		active: false,
-		data: {
-			inverseName: 'has attached element',
-			from: {
-				id: card1.id,
-				type: card1.type
-			},
-			to: {
-				id: parent1.id,
-				type: parent1.type
-			}
-		}
-	})
-
-	const card2 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'qux',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: false,
-			count: 2
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: `link-${card2.slug}-is-attached-to-${parent2.slug}`,
-		type: 'link',
-		version: '1.0.0',
-		name: 'is attached to',
-		data: {
-			inverseName: 'has attached element',
-			from: {
-				id: card2.id,
-				type: card2.type
-			},
-			to: {
-				id: parent2.id,
-				type: parent2.type
-			}
-		}
-	})
-
-	const results = await test.context.kernel.query(test.context.context, test.context.kernel.sessions.admin, {
-		type: 'object',
-		required: [ 'type', 'links', 'data' ],
-		$$links: {
-			'is attached to': {
-				type: 'object',
-				required: [ 'id', 'data' ],
-				properties: {
-					id: {
-						type: 'string'
-					},
-					data: {
-						type: 'object',
-						required: [ 'thread' ],
-						properties: {
-							thread: {
-								type: 'boolean'
-							}
-						},
-						additionalProperties: false
-					}
-				},
-				additionalProperties: false
-			}
-		},
-		properties: {
-			type: {
-				type: 'string',
-				const: 'card'
-			},
-			links: {
-				type: 'object',
-				additionalProperties: true
-			},
+	const parent1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foo',
+			type: 'card',
+			version: '1.0.0',
 			data: {
-				type: 'object',
-				required: [ 'count' ],
-				properties: {
-					count: {
-						type: 'number'
-					}
-				},
-				additionalProperties: true
+				thread: true,
+				number: 1
 			}
-		}
-	})
+		})
+
+	const parent2 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'bar',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: true,
+				number: 2
+			}
+		})
+
+	const card1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'baz',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: false,
+				count: 1
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: `link-${card1.slug}-is-attached-to-${parent1.slug}`,
+			type: 'link',
+			version: '1.0.0',
+			name: 'is attached to',
+			active: false,
+			data: {
+				inverseName: 'has attached element',
+				from: {
+					id: card1.id,
+					type: card1.type
+				},
+				to: {
+					id: parent1.id,
+					type: parent1.type
+				}
+			}
+		})
+
+	const card2 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'qux',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: false,
+				count: 2
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: `link-${card2.slug}-is-attached-to-${parent2.slug}`,
+			type: 'link',
+			version: '1.0.0',
+			name: 'is attached to',
+			data: {
+				inverseName: 'has attached element',
+				from: {
+					id: card2.id,
+					type: card2.type
+				},
+				to: {
+					id: parent2.id,
+					type: parent2.type
+				}
+			}
+		})
+
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: false,
+			required: [ 'type', 'links', 'data' ],
+			$$links: {
+				'is attached to': {
+					type: 'object',
+					required: [ 'id', 'data' ],
+					properties: {
+						id: {
+							type: 'string'
+						},
+						data: {
+							type: 'object',
+							required: [ 'thread' ],
+							properties: {
+								thread: {
+									type: 'boolean'
+								}
+							},
+							additionalProperties: false
+						}
+					},
+					additionalProperties: false
+				}
+			},
+			properties: {
+				type: {
+					type: 'string',
+					const: 'card'
+				},
+				links: {
+					type: 'object',
+					additionalProperties: true
+				},
+				data: {
+					type: 'object',
+					required: [ 'count' ],
+					properties: {
+						count: {
+							type: 'number'
+						}
+					},
+					additionalProperties: true
+				}
+			}
+		})
 
 	test.deepEqual(results, [
 		{
@@ -3127,169 +3168,180 @@ ava('.query() should not consider inactive links', async (test) => {
 })
 
 ava('.query() should be able to query using links', async (test) => {
-	const parent1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'foo',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 1
-		}
-	})
-
-	const parent2 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'bar',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 2
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'baz',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: true,
-			number: 3
-		}
-	})
-
-	const card1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'qux',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: false,
-			count: 1
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: `link-${card1.slug}-is-attached-to-${parent1.slug}`,
-		type: 'link',
-		version: '1.0.0',
-		name: 'is attached to',
-		data: {
-			inverseName: 'has attached element',
-			from: {
-				id: card1.id,
-				type: card1.type
-			},
-			to: {
-				id: parent1.id,
-				type: parent1.type
-			}
-		}
-	})
-
-	const card2 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'tux',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: false,
-			count: 2
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: `link-${card2.slug}-is-attached-to-${parent1.slug}`,
-		type: 'link',
-		version: '1.0.0',
-		name: 'is attached to',
-		data: {
-			inverseName: 'has attached element',
-			from: {
-				id: card2.id,
-				type: card2.type
-			},
-			to: {
-				id: parent1.id,
-				type: parent1.type
-			}
-		}
-	})
-
-	const card3 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'fux',
-		type: 'card',
-		version: '1.0.0',
-		data: {
-			thread: false,
-			count: 3
-		}
-	})
-
-	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: `link-${card3.slug}-is-attached-to-${parent2.slug}`,
-		type: 'link',
-		version: '1.0.0',
-		name: 'is attached to',
-		data: {
-			inverseName: 'has attached element',
-			from: {
-				id: card3.id,
-				type: card3.type
-			},
-			to: {
-				id: parent2.id,
-				type: parent2.type
-			}
-		}
-	})
-
-	const results = await test.context.kernel.query(test.context.context, test.context.kernel.sessions.admin, {
-		type: 'object',
-		required: [ 'type', 'links', 'data' ],
-		$$links: {
-			'is attached to': {
-				type: 'object',
-				required: [ 'id', 'data' ],
-				properties: {
-					id: {
-						type: 'string'
-					},
-					data: {
-						type: 'object',
-						required: [ 'thread' ],
-						properties: {
-							thread: {
-								type: 'boolean',
-								const: true
-							}
-						},
-						additionalProperties: false
-					}
-				},
-				additionalProperties: false
-			}
-		},
-		properties: {
-			type: {
-				type: 'string',
-				const: 'card'
-			},
-			links: {
-				type: 'object',
-				additionalProperties: true
-			},
+	const parent1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foo',
+			type: 'card',
+			version: '1.0.0',
 			data: {
-				type: 'object',
-				required: [ 'count' ],
-				properties: {
-					count: {
-						type: 'number'
-					}
-				},
-				additionalProperties: false
+				thread: true,
+				number: 1
 			}
-		}
-	}, {
-		sortBy: [ 'data', 'count' ]
-	})
+		})
+
+	const parent2 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'bar',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: true,
+				number: 2
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'baz',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: true,
+				number: 3
+			}
+		})
+
+	const card1 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'qux',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: false,
+				count: 1
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: `link-${card1.slug}-is-attached-to-${parent1.slug}`,
+			type: 'link',
+			version: '1.0.0',
+			name: 'is attached to',
+			data: {
+				inverseName: 'has attached element',
+				from: {
+					id: card1.id,
+					type: card1.type
+				},
+				to: {
+					id: parent1.id,
+					type: parent1.type
+				}
+			}
+		})
+
+	const card2 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'tux',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: false,
+				count: 2
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: `link-${card2.slug}-is-attached-to-${parent1.slug}`,
+			type: 'link',
+			version: '1.0.0',
+			name: 'is attached to',
+			data: {
+				inverseName: 'has attached element',
+				from: {
+					id: card2.id,
+					type: card2.type
+				},
+				to: {
+					id: parent1.id,
+					type: parent1.type
+				}
+			}
+		})
+
+	const card3 = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'fux',
+			type: 'card',
+			version: '1.0.0',
+			data: {
+				thread: false,
+				count: 3
+			}
+		})
+
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: `link-${card3.slug}-is-attached-to-${parent2.slug}`,
+			type: 'link',
+			version: '1.0.0',
+			name: 'is attached to',
+			data: {
+				inverseName: 'has attached element',
+				from: {
+					id: card3.id,
+					type: card3.type
+				},
+				to: {
+					id: parent2.id,
+					type: parent2.type
+				}
+			}
+		})
+
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: false,
+			required: [ 'type', 'links', 'data' ],
+			$$links: {
+				'is attached to': {
+					type: 'object',
+					required: [ 'id', 'data' ],
+					properties: {
+						id: {
+							type: 'string'
+						},
+						data: {
+							type: 'object',
+							required: [ 'thread' ],
+							properties: {
+								thread: {
+									type: 'boolean',
+									const: true
+								}
+							},
+							additionalProperties: false
+						}
+					},
+					additionalProperties: false
+				}
+			},
+			properties: {
+				type: {
+					type: 'string',
+					const: 'card'
+				},
+				links: {
+					type: 'object',
+					additionalProperties: true
+				},
+				data: {
+					type: 'object',
+					required: [ 'count' ],
+					properties: {
+						count: {
+							type: 'number'
+						}
+					},
+					additionalProperties: false
+				}
+			}
+		}, {
+			sortBy: [ 'data', 'count' ]
+		})
 
 	test.deepEqual(results, [
 		{
@@ -3420,6 +3472,7 @@ ava.cb('.stream() should include data if additionalProperties true', (test) => {
 ava.cb('.stream() should report back new elements that match a certain slug', (test) => {
 	test.context.kernel.stream(test.context.context, test.context.kernel.sessions.admin, {
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			type: {
 				type: 'string'
@@ -3502,6 +3555,7 @@ ava.cb('.stream() should report back new elements that match a certain slug', (t
 ava.cb('.stream() should report back elements of a certain type', (test) => {
 	test.context.kernel.stream(test.context.context, test.context.kernel.sessions.admin, {
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			slug: {
 				type: 'string'
@@ -3573,6 +3627,7 @@ ava.cb('.stream() should report back elements of a certain type', (test) => {
 ava.cb('.stream() should be able to attach a large number of streams', (test) => {
 	const schema = {
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			slug: {
 				type: 'string'
@@ -3653,6 +3708,7 @@ ava.cb('.stream() should be able to attach a large number of streams', (test) =>
 ava.cb('.stream() should report back action requests', (test) => {
 	test.context.kernel.stream(test.context.context, test.context.kernel.sessions.admin, {
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			type: {
 				type: 'string',
@@ -3766,6 +3822,7 @@ ava.cb('.stream() should close without finding anything', (test) => {
 ava.cb('.stream() should report back inactive elements', (test) => {
 	test.context.kernel.stream(test.context.context, test.context.kernel.sessions.admin, {
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			slug: {
 				type: 'string'

--- a/test/integration/core/views.spec.js
+++ b/test/integration/core/views.spec.js
@@ -121,6 +121,7 @@ ava('.getSchema() should return a schema given a view card with two conjunctions
 
 	test.deepEqual(schema, {
 		type: 'object',
+		additionalProperties: true,
 		properties: {
 			foo: {
 				type: 'string',
@@ -171,6 +172,7 @@ ava('.getSchema() should return a schema given a view card with two conjunctions
 
 	test.deepEqual(schema, {
 		type: 'object',
+		additionalProperties: true,
 		properties: {
 			foo: {
 				type: 'string',
@@ -220,6 +222,7 @@ ava('.getSchema() should return a schema given a view card with two disjunctions
 
 	test.deepEqual(schema, {
 		type: 'object',
+		additionalProperties: true,
 		anyOf: [
 			{
 				type: 'object',
@@ -284,6 +287,7 @@ ava('.getSchema() should return a schema given a view card with two disjunctions
 
 	test.deepEqual(schema, {
 		type: 'object',
+		additionalProperties: true,
 		anyOf: [
 			{
 				type: 'object',
@@ -375,6 +379,7 @@ ava('.getSchema() should return a schema given a view card with two disjunctions
 
 	test.deepEqual(schema, {
 		type: 'object',
+		additionalProperties: true,
 		properties: {
 			foo: {
 				type: 'string',


### PR DESCRIPTION
Most of these test changes are caused by the fact that we are replacing
a custom "merge" logic set of statements with the more proper
`skhema.merge()` function, which highlighted some semantic issues.

As far as I can tell, these changes to how we use `additionalProperties`
are correct, while the previous ones were ambiguous in some cases.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!