### PR TITLE
Stop showing changelog in a modal

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash')
 const Bluebird = require('bluebird')
-const fs = require('fs')
 const errio = require('errio')
 const multer = require('multer')
 const Storage = require('./file-storage')
@@ -23,30 +22,6 @@ const fileStore = new Storage({
 const upload = multer({
 	storage: multer.memoryStorage()
 })
-
-// Finds the nthIndex of a pattern in a string
-const nthIndex = (source, pattern, nth) => {
-	let target = nth
-	const length = source.length
-	let index = -1
-	while (target-- && index++ < length) {
-		index = source.indexOf(pattern, index)
-		if (index < 0) {
-			break
-		}
-	}
-	return index
-}
-
-// Changelog
-const rawChangelog = fs.readFileSync('./CHANGELOG.md', 'utf8')
-
-// Strip the semantic version header from the changelog, and only use the last
-// 10 version bumps
-const changelog = rawChangelog.slice(
-	rawChangelog.indexOf('# v'),
-	nthIndex(rawChangelog, '# v', 20)
-)
 
 const sendHTTPError = (request, response, error) => {
 	// Add more debugging information in case we pass an invalid object
@@ -84,7 +59,6 @@ const sendHTTPError = (request, response, error) => {
 module.exports = (application, jellyfish, worker, queue) => {
 	application.get('/api/v2/config', (request, response) => {
 		response.send({
-			changelog,
 			codename: packageJSON.codename,
 			version: packageJSON.version
 		})

--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -13,9 +13,7 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
-	Flex,
-	Modal,
-	Txt
+	Flex
 } from 'rendition'
 import {
 	Form
@@ -26,9 +24,6 @@ import {
 import {
 	MermaidWidget
 } from 'rendition/dist/extra/Form/mermaid'
-import {
-	Markdown
-} from 'rendition/dist/extra/Markdown'
 import {
 	saveAs
 } from 'file-saver'
@@ -97,29 +92,8 @@ class JellyfishUI extends React.Component {
 			saveAs(blob, `jellyfish-ui-dump__${new Date().toISOString()}.json`)
 		}
 
-		this.state = {
-			showChangelog: null
-		}
-
-		this.hideChangelog = () => {
-			this.setState({
-				showChangelog: null
-			})
-		}
-
 		this.handleChatWidgetClose = () => {
 			this.props.actions.setChatWidgetOpen(false)
-		}
-	}
-
-	componentDidUpdate (prevProps) {
-		if (
-			prevProps.version && this.props.version &&
-			prevProps.version !== this.props.version
-		) {
-			this.setState({
-				showChangelog: prevProps.version
-			})
 		}
 	}
 
@@ -143,18 +117,6 @@ class JellyfishUI extends React.Component {
 			<React.Fragment>
 				{isLegacyPath(path) && (
 					<Redirect to={transformLegacyPath(path)} />
-				)}
-
-				{this.state.showChangelog && (
-					<Modal
-						title={`Whats new in v${this.props.version}`}
-						done={this.hideChangelog}
-					>
-						<Txt pb={3}>There have been a few changes since you were last here:</Txt>
-						<Markdown>
-							{this.props.changelog.split(`# v${this.state.showChangelog}`)[0]}
-						</Markdown>
-					</Modal>
 				)}
 
 				<Flex flex="1" style={{
@@ -186,7 +148,6 @@ const mapStateToProps = (state) => {
 		channels: selectors.getChannels(state),
 		status: selectors.getStatus(state),
 		version: selectors.getAppVersion(state),
-		changelog: selectors.getChangelog(state),
 		isChatWidgetOpen: selectors.getChatWidgetOpen(state)
 	}
 }

--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -119,7 +119,6 @@ export const selectors = {
 	getOrgs: (state) => { return state.core.orgs },
 	getAppVersion: (state) => { return _.get(state.core, [ 'config', 'version' ]) || null },
 	getAppCodename: (state) => { return _.get(state.core, [ 'config', 'codename' ]) || null },
-	getChangelog: (state) => { return _.get(state.core, [ 'config', 'changelog' ]) || null },
 	getChannels: (state) => { return state.core.channels },
 	getCurrentUser: (state) => { return _.get(state.core, [ 'session', 'user' ]) || null },
 	getNotifications: (state) => { return state.core.notifications || [] },


### PR DESCRIPTION
Displaying changelog items to end users is not meaningful as many of the
changes don't have any bearing on users of the UI.

Change-type: minor
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
