### PR TITLE
core: Add test to query all cards linked to a card with no properties

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -69,7 +69,8 @@ module.exports = (table, schema, options = {}) => {
 	const linkedCard = link ? `linked_card__${link.slug}` : null
 
 	if (link && link.schema) {
-		query.push(`, array_agg(to_jsonb(${linkedCard})) AS "links.${link.slug}"`)
+		const prefix = schema.additionalProperties ? ', ' : ''
+		query.push(`${prefix}array_agg(to_jsonb(${linkedCard})) AS "links.${link.slug}"`)
 	}
 
 	query.push(`FROM ${table}`)
@@ -160,7 +161,13 @@ module.exports = (table, schema, options = {}) => {
 			topLevelKeys.push(property.join('.'))
 		}
 
-		query.unshift(topLevelKeys.join(',\n'))
+		if (topLevelKeys.length !== 0) {
+			query.unshift(topLevelKeys.join(',\n'))
+		}
+
+		if (!query[1].startsWith('FROM')) {
+			query[0] = `${query[0]}, `
+		}
 	}
 
 	query.unshift('SELECT')


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!