### PR TITLE
Removing mentions to new_{created,updated}_at columns/fields

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -40,21 +40,17 @@ exports.setup = async (context, connection, database, options = {}) => {
 			name TEXT,
 			tags TEXT[] NOT NULL,
 			markers TEXT[] NOT NULL,
-			created_at TEXT NOT NULL,
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 			links JSONB NOT NULL,
 			requires JSONB[] NOT NULL,
 			capabilities JSONB[] NOT NULL,
 			data JSONB NOT NULL,
-			updated_at TEXT,
-			linked_at JSONB NOT NULL,
-			new_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-			new_updated_at TIMESTAMP WITH TIME ZONE
+			updated_at TIMESTAMP WITH TIME ZONE,
+			linked_at JSONB NOT NULL
 		);
 
-		ALTER TABLE ${table} ADD IF NOT EXISTS updated_at TEXT;
+		ALTER TABLE ${table} ADD IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE;
 		ALTER TABLE ${table} ADD IF NOT EXISTS linked_at JSONB;
-		ALTER TABLE ${table} ADD IF NOT EXISTS new_created_at TIMESTAMP WITH TIME ZONE;
-		ALTER TABLE ${table} ADD IF NOT EXISTS new_updated_at TIMESTAMP WITH TIME ZONE;
 		`)
 
 	if (options.noIndexes) {
@@ -243,15 +239,13 @@ exports.upsert = async (context, errors, connection, object, options) => {
 			: null,
 		insertedObject.tags,
 		insertedObject.markers,
-		insertedObject.created_at,
+		new Date(insertedObject.created_at),
 		insertedObject.links,
 		insertedObject.requires,
 		insertedObject.capabilities,
 		insertedObject.data,
-		insertedObject.updated_at,
-		{},
-		new Date(insertedObject.created_at),
-		insertedObject.updated_at ? new Date(insertedObject.updated_at) : null
+		insertedObject.updated_at ? new Date(insertedObject.updated_at) : null,
+		{}
 	]
 
 	let results = null
@@ -266,11 +260,11 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active, version, name, tags, markers,
 					created_at, links, requires, capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at)
+					linked_at)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, NULL,
-					$15, $16, NULL)
+					$15)
 				ON CONFLICT (slug) DO UPDATE SET
 					id = ${table}.id,
 					active = $4,
@@ -284,9 +278,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 					capabilities = $12,
 					data = $13,
 					updated_at = $14,
-					linked_at = ${table}.linked_at,
-					new_created_at = ${table}.new_created_at,
-					new_updated_at = $17
+					linked_at = ${table}.linked_at
 				RETURNING *`
 
 			results = await connection.any({
@@ -299,11 +291,11 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active, version, name, tags, markers,
 					created_at, links, requires, capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at)
+					linked_at)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, $14,
-					$15, $16, $17)
+					$15)
 				RETURNING *`
 			results = await connection.any({
 				name: `cards-upsert-insert-${table}`,

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -50,10 +50,6 @@ exports.convertDatesToISOString = (row) => {
 		row.updated_at = new Date(row.updated_at).toISOString()
 	}
 
-	// FIXME remove references to new_* columns
-	Reflect.deleteProperty(row, 'new_created_at')
-	Reflect.deleteProperty(row, 'new_updated_at')
-
 	return row
 }
 

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -27,9 +27,7 @@ const patchCard = (card, patch, options = {}) => {
 			operation.path.startsWith('/links') ||
 			operation.path.startsWith('/linked_at') ||
 			operation.path.startsWith('/created_at') ||
-			operation.path.startsWith('/updated_at') ||
-			operation.path.startsWith('/new_created_at') ||
-			operation.path.startsWith('/new_updated_at')) {
+			operation.path.startsWith('/updated_at')) {
 			return accumulator
 		}
 


### PR DESCRIPTION
Removing mentions to new_{created,updated}_at columns/fields, as the db migration is over

Don't merge until having run the last migration statements [as described here](https://github.com/balena-io/jellyfish/issues/2710#issuecomment-552793063)

Connects-to: #2710
Change-type: minor
Signed-off-by: Federico Fissore <federico@fissore.org>
