### PR TITLE
Using @> to query array fields

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -84,17 +84,25 @@ exports.setup = async (context, connection, database, options = {}) => {
 	 * This query will give us a list of all the indexes
 	 * on a particular table.
 	 */
-	const indexes = _.map(await connection.any(`
-		SELECT * FROM pg_indexes WHERE tablename = '${table}'`),
-	'indexname')
+	const indexes = _.map(await connection.any(`SELECT * FROM pg_indexes WHERE tablename = '${table}'`), 'indexname')
 
-	await Bluebird.map([
-		'slug',
-		'type',
-		'data',
-		'created_at',
-		'updated_at'
-	], async (secondaryIndex) => {
+	await Bluebird.map([ {
+		column: 'slug'
+	}, {
+		column: 'tags',
+		indexType: 'GIN'
+	}, {
+		column: 'type'
+	}, {
+		column: 'data',
+		indexType: 'GIN',
+		options: 'jsonb_path_ops'
+	}, {
+		column: 'created_at',
+		options: 'DESC'
+	}, {
+		column: 'updated_at'
+	} ], async (secondaryIndex) => {
 		/*
 		 * This is the actual name of the index that we will create
 		 * in Postgres.
@@ -103,7 +111,7 @@ exports.setup = async (context, connection, database, options = {}) => {
 		 * not be able to cleanup older indexes with the older
 		 * name convention.
 		 */
-		const fullyQualifiedIndexName = `${secondaryIndex}_${table}_idx`
+		const fullyQualifiedIndexName = `${secondaryIndex.column}_${table}_idx`
 
 		/*
 		 * Lets not create the index if it already exists.
@@ -115,41 +123,12 @@ exports.setup = async (context, connection, database, options = {}) => {
 		logger.debug(context, 'Creating table index', {
 			table,
 			database,
-			index: secondaryIndex
+			index: secondaryIndex.column
 		})
 
-		/*
-		 * A GIN index on the whole JSON column is known to speed
-		 * up queries that use JSON functions on this column.
-		 */
-		if (secondaryIndex === 'data') {
-			await connection.any(`
-				CREATE INDEX ${fullyQualifiedIndexName} ON ${table}
-				USING GIN (${secondaryIndex} jsonb_path_ops)`)
-			return
-		}
-
-		/*
-		 * We will use this one mainly for sorting in descending order.
-		 * See https://www.postgresql.org/docs/8.3/indexes-ordering.html
-		 */
-		if (secondaryIndex === 'created_at') {
-			await connection.any(`
-				CREATE INDEX ${fullyQualifiedIndexName} ON ${table}
-				USING BTREE (${secondaryIndex} DESC)`)
-			return
-		}
-
-		/*
-		 * This is the point where we actually create the index.
-		 * Notice that all these are indexes on fields inside
-		 * the column that contains the card JSON contents.
-		 *
-		 * The BTREE type is simply the default configuration.
-		 */
 		await connection.any(`
 			CREATE INDEX ${fullyQualifiedIndexName} ON ${table}
-			USING BTREE (${secondaryIndex})`)
+			USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
 	}, {
 		concurrency: 4
 	})

--- a/lib/core/backend/postgres/jsonschema2sql/builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder.js
@@ -311,6 +311,10 @@ exports.noneObject = (property, expression) => {
 
 exports.someArray = (property, schema, walk) => {
 	if (exports.isColumn(property)) {
+		if (schema.const) {
+			return `${exports.getProperty(property)} @> ARRAY[${exports.valueToPostgres(schema.const)}]`
+		}
+
 		const expression = walk(schema, [ null, 'unnest' ], CARD_FIELDS[property[1]])
 		return [
 			`EXISTS (SELECT 1 FROM UNNEST(${exports.getProperty(property)})`,

--- a/lib/core/backend/postgres/jsonschema2sql/builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder.js
@@ -78,6 +78,14 @@ exports.valueToPostgres = (value) => {
 	return pgFormat.literal(value)
 }
 
+exports.valueToPostgresJSONB = (value) => {
+	if (_.isString(value)) {
+		return `'${pgFormat.ident(value)}'`
+	}
+
+	return `'${value}'`
+}
+
 exports.getProperty = (property, options = {}) => {
 	if (property.length < 2) {
 		return null
@@ -336,4 +344,18 @@ exports.everyArray = (property, schema, walk) => {
 
 exports.keys = (property) => {
 	return `ARRAY(SELECT jsonb_object_keys(${exports.getProperty(property)}))`
+}
+
+exports.shortcuts = {}
+
+exports.shortcuts.isJsonArrayContainsStringOrNumber = (property, schema) => {
+	return !exports.isColumn(property) &&
+		schema.type === 'array' &&
+		schema.contains &&
+		(schema.contains.type === 'string' || schema.contains.type === 'number') &&
+		!_.isUndefined(schema.contains.const)
+}
+
+exports.shortcuts.jsonArrayContainsStringOrNumber = (property, schema) => {
+	return `${exports.getProperty(property)} @> ${exports.valueToPostgresJSONB(schema.contains.const)}`
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -36,6 +36,10 @@ const walk = (schema, path, context, keys = new Set()) => {
 		const conjunct = keywords[key](
 			value, path, walk, schema, context, keys)
 		result.push(conjunct.filter)
+
+		if (conjunct.shortcut) {
+			break
+		}
 	}
 
 	return {

--- a/lib/core/backend/postgres/jsonschema2sql/keywords.js
+++ b/lib/core/backend/postgres/jsonschema2sql/keywords.js
@@ -29,6 +29,14 @@ exports.type = (value, path, walk, schema, context, keys) => {
 		}
 	}
 
+	if (builder.shortcuts.isJsonArrayContainsStringOrNumber(path, schema)) {
+		return {
+			keys,
+			filter: builder.shortcuts.jsonArrayContainsStringOrNumber(path, schema),
+			shortcut: true
+		}
+	}
+
 	return {
 		keys,
 		filter: builder.isOfType(path, value)

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -2564,7 +2564,7 @@ ava('.query() should return inactive cards', async (test) => {
 	])
 })
 
-ava('.query() should take a view card with two filters', async (test) => {
+ava.only('.query() should take a view card with two filters', async (test) => {
 	await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {
 			slug: 'foo',

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const jsonschema2sql = require('../../../../../../lib/core/backend/postgres/jsonschema2sql')
+
+ava('schema with type array and string const is translated to a query that uses the @> operator', (test) => {
+	const query = jsonschema2sql('cards', {
+		type: 'object',
+		required: [ 'type', 'data' ],
+		additionalProperties: true,
+		properties:
+			{
+				type: {
+					type: 'string',
+					const: 'support-thread'
+				},
+				data: {
+					type: 'object',
+					required: [ 'mirrors' ],
+					additionalProperties: true,
+					properties: {
+						mirrors: {
+							type: 'array',
+							contains: {
+								type: 'string',
+								const: 'https://api2.frontapp.com/conversations/cnv_2q9efia'
+							}
+						}
+					}
+				}
+			}
+	})
+
+	test.deepEqual(query, `SELECT
+*
+FROM cards
+WHERE
+(cards.type = 'support-thread')
+AND
+((cards.data->'mirrors' IS NOT NULL)
+AND
+((cards.data->'mirrors' IS NULL)
+OR
+(cards.data->'mirrors' @> '"https://api2.frontapp.com/conversations/cnv_2q9efia"')))`)
+})
+
+ava('schema with type array and number const is translated to a query that uses the @> operator', (test) => {
+	const query = jsonschema2sql('cards', {
+		type: 'object',
+		required: [ 'type', 'data' ],
+		additionalProperties: true,
+		properties:
+			{
+				type: {
+					type: 'string',
+					const: 'support-thread'
+				},
+				data: {
+					type: 'object',
+					required: [ 'mirrors' ],
+					additionalProperties: true,
+					properties: {
+						mirrors: {
+							type: 'array',
+							contains: {
+								type: 'number',
+								const: 42
+							}
+						}
+					}
+				}
+			}
+	})
+
+	test.deepEqual(query, `SELECT
+*
+FROM cards
+WHERE
+(cards.type = 'support-thread')
+AND
+((cards.data->'mirrors' IS NOT NULL)
+AND
+((cards.data->'mirrors' IS NULL)
+OR
+(cards.data->'mirrors' @> '42')))`)
+})

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -7,7 +7,7 @@
 const ava = require('ava')
 const jsonschema2sql = require('../../../../../../lib/core/backend/postgres/jsonschema2sql')
 
-ava('schema with type array and string const is translated to a query that uses the @> operator', (test) => {
+ava('when querying for jsonb array field that contains string const we use the @> operator', (test) => {
 	const query = jsonschema2sql('cards', {
 		type: 'object',
 		required: [ 'type', 'data' ],
@@ -48,7 +48,7 @@ OR
 (cards.data->'mirrors' @> '"https://api2.frontapp.com/conversations/cnv_2q9efia"')))`)
 })
 
-ava('schema with type array and number const is translated to a query that uses the @> operator', (test) => {
+ava('when querying for jsonb array field that contains number const we use the @> operator', (test) => {
 	const query = jsonschema2sql('cards', {
 		type: 'object',
 		required: [ 'type', 'data' ],
@@ -87,4 +87,48 @@ AND
 ((cards.data->'mirrors' IS NULL)
 OR
 (cards.data->'mirrors' @> '42')))`)
+})
+
+ava('when querying for array that contains string const we use the @> operator', (test) => {
+	const query = jsonschema2sql('cards', {
+		type: 'object',
+		anyOf: [ {
+			type: 'object'
+		} ],
+		required: [ 'data', 'tags' ],
+		properties: {
+			data: {
+				type: 'object',
+				required: [ 'number' ],
+				properties: {
+					number: {
+						type: 'number', const: 1
+					}
+				}
+			},
+			tags: {
+				type: 'array',
+				contains: {
+					type: 'string',
+					const: 'foo'
+				}
+			}
+		},
+		additionalProperties: false
+	})
+
+	test.deepEqual(query, `SELECT
+cards."data",
+cards."tags"
+FROM cards
+WHERE
+((cards.data->'number' IS NOT NULL)
+AND
+((cards.data->'number' IS NULL)
+OR
+((jsonb_typeof(cards.data->'number') = 'number')
+AND
+(cards.data->'number' @> '1'))))
+AND
+(cards.tags @> ARRAY['foo'])`)
 })


### PR DESCRIPTION
Introducing jsonschema2sql 'shortcuts', a first impl of schema lookahead.
In this impl, the operator @> is used to filter arrays that contain a given value

Connects-to: #2780
Change-type: patch
Signed-off-by: Federico Fissore <federico@fissore.org>
