### PR TITLE
server: Fix incorrect logger level call

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -27,7 +27,7 @@ const sendHTTPError = (request, response, error) => {
 	// Add more debugging information in case we pass an invalid object
 	// to `errio` (which doesn't handle other data very well).
 	if (!_.isError(error)) {
-		logger.crit(request.context, 'Invalid error object', {
+		logger.error(request.context, 'Invalid error object', {
 			ip: request.ip,
 			error
 		})


### PR DESCRIPTION
The method is `error`, not `crit`.

Change-type: patch
Fixes: https://sentry.io/share/issue/836594f187be4814935f8078f8903551/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!