### PR TITLE
github: Handle label events without `payload.label`

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -1000,11 +1000,13 @@ module.exports = class GitHubIntegration {
 
 		sequence.push(makeCard(card, actor, root.created_at))
 
-		return sequence.concat([
-			makeCard(updateCardFromSequence(sequence, 0, {
+		if (event.data.payload.label) {
+			sequence.push(makeCard(updateCardFromSequence(sequence, 0, {
 				tags: card.tags.concat(event.data.payload.label.name)
-			}), actor, new Date(root.updated_at) - 1),
+			}), actor, new Date(root.updated_at) - 1))
+		}
 
+		return sequence.concat([
 			makeCard(updateCardFromSequence(sequence, 0, {
 				tags: originalTags
 			}), actor, root.updated_at)


### PR DESCRIPTION
Change-type: patch
Fixes: https://sentry.io/share/issue/de257e15fecc48b4879db5724b6f3d59/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!