### PR TITLE
core: Throw a better error when querying with an invalid regex

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -60,7 +60,12 @@ const queryTable = async (context, backend, table, schema, options) => {
 	const query = jsonschema2sql(table, schema, config)
 
 	const queryStartDate = new Date()
-	const results = await backend.connection.any(query)
+	const results = await backend.connection.any(query).catch((error) => {
+		assert.USER(context, !error.message.startsWith('invalid regular expression:'),
+			backend.errors.JellyfishInvalidRegularExpression,
+			`Invalid pattern in schema: ${JSON.stringify(schema)}`)
+		throw error
+	})
 	const queryEndDate = new Date()
 
 	const elements = results

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -16,6 +16,7 @@ _.each([
 	'JellyfishInvalidVersion',
 	'JellyfishInvalidPatch',
 	'JellyfishInvalidLimit',
+	'JellyfishInvalidRegularExpression',
 	'JellyfishInvalidSession',
 	'JellyfishElementAlreadyExists',
 	'JellyfishNoIdentifier',

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -176,6 +176,23 @@ ava.serial('.query() should fail with a user error if "limit" is beyond the limi
 	test.true(error.expected)
 })
 
+ava.serial('.query() should fail with a user error given an invalid regex', async (test) => {
+	const error = await test.throwsAsync(test.context.sdk.query({
+		type: 'object',
+		additionalProperties: true,
+		required: [ 'slug' ],
+		properties: {
+			slug: {
+				type: 'string',
+				pattern: '-(^[xx'
+			}
+		}
+	}))
+
+	test.true(error.message.startsWith('Invalid pattern in schema'))
+	test.true(error.expected)
+})
+
 ava.serial('.query() should accept a "limit" option', async (test) => {
 	const {
 		sdk

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -1807,6 +1807,21 @@ ava('.getCardById() should return an inactive card by its id', async (test) => {
 	test.deepEqual(card, result)
 })
 
+ava('.query() should throw an error given an invalid regex', async (test) => {
+	await test.throwsAsync(test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: true,
+			required: [ 'slug' ],
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '-(^[xx'
+				}
+			}
+		}), errors.JellyfishInvalidRegularExpression)
+})
+
 ava('.query() should be able to limit the results', async (test) => {
 	const result1 = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 		slug: 'foo',


### PR DESCRIPTION
Change-type: patch
Fixes: https://sentry.io/share/issue/2633173906d54520a342de12e6fc78d7/
Fixes: https://sentry.io/share/issue/eae2bff153b64dfc8ade1e3fe4721c24/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!