### PR TITLE
server: Log problematic queries

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -573,6 +573,7 @@ module.exports = (application, jellyfish, worker, queue) => {
 				data
 			})
 		}).catch((error) => {
+			logger.warn(request.context, 'JSON Schema query error', request.body)
 			return sendHTTPError(request, response, error)
 		})
 	})


### PR DESCRIPTION
For debugging purposes. Sometimes we get Rapid7 alerts about problems on
`/api/v2/query`, but no information whatsoever about what query was ran,
which makes it difficult to make any progress.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!