### PR TITLE
Allow users to read user card that don't have an email field

### DIFF
--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -219,7 +219,6 @@
             "data": {
               "type": "object",
               "additionalProperties": false,
-              "required": [ "email" ],
               "properties": {
                 "email": {
                   "type": [ "string", "array" ]

--- a/test/e2e/server/users.spec.js
+++ b/test/e2e/server/users.spec.js
@@ -89,3 +89,55 @@ ava.serial.skip('Users should have an avatar value calculated on signup', async 
 
 	nock.cleanAll()
 })
+
+ava.serial('Users should be able to read other users, even if they don\'t have an email address', async (test) => {
+	const {
+		sdk
+	} = test.context
+
+	const user1Details = createUserDetails()
+	const user2Details = createUserDetails()
+
+	// Create user 1 and login as them
+	await sdk.action({
+		card: 'user',
+		type: 'type',
+		action: 'action-create-user',
+		arguments: {
+			username: `user-${user1Details.username}`,
+			email: user1Details.email,
+			password: user1Details.password
+		}
+	})
+
+	await sdk.auth.login(user1Details)
+
+	const user1 = await sdk.auth.whoami()
+
+	// Remove the email field from user 1
+	await sdk.card.update(user1.id, 'user', [
+		{
+			op: 'remove',
+			path: '/data/email'
+		}
+	])
+
+	// Create and login as user 2
+	await sdk.action({
+		card: 'user',
+		type: 'type',
+		action: 'action-create-user',
+		arguments: {
+			username: `user-${user2Details.username}`,
+			email: user2Details.email,
+			password: user2Details.password
+		}
+	})
+
+	await sdk.auth.login(user2Details)
+
+	// Try and read user 1
+	const result = await sdk.card.get(user1.id)
+
+	test.is(result.id, user1.id)
+})


### PR DESCRIPTION
Fixes #2801

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
