### PR TITLE
action-library: Return card versions in most actions

### DIFF
--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -68,6 +68,7 @@ const mirror = async (type, session, context, card, request) => {
 		return {
 			id: element.id,
 			type: element.type,
+			version: element.version,
 			slug: element.slug
 		}
 	})
@@ -98,6 +99,7 @@ module.exports = {
 				return {
 					id: element.id,
 					type: element.type,
+					version: element.version,
 					slug: element.slug
 				}
 			})
@@ -285,6 +287,7 @@ module.exports = {
 				return {
 					id: contact.id,
 					slug: contact.slug,
+					version: contact.version,
 					type: contact.type
 				}
 			}
@@ -354,6 +357,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -492,6 +496,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -524,6 +529,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -559,6 +565,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -708,6 +715,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -746,6 +754,7 @@ module.exports = {
 				return {
 					id: result.id,
 					type: result.type,
+					version: result.version,
 					slug: result.slug
 				}
 			} catch (error) {
@@ -841,6 +850,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -866,6 +876,7 @@ module.exports = {
 				return {
 					id: card.id,
 					type: card.type,
+					version: card.version,
 					slug: card.slug
 				}
 			}
@@ -897,6 +908,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -909,6 +921,7 @@ module.exports = {
 				return {
 					id: card.id,
 					type: card.type,
+					version: card.version,
 					slug: card.slug
 				}
 			}
@@ -939,6 +952,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -968,6 +982,7 @@ module.exports = {
 			return {
 				id: result.id,
 				type: result.type,
+				version: result.version,
 				slug: result.slug
 			}
 		}
@@ -1066,6 +1081,7 @@ module.exports = {
 				return {
 					id: card.id,
 					slug: card.slug,
+					version: card.version,
 					type: card.type
 				}
 			}
@@ -1119,6 +1135,7 @@ module.exports = {
 			return {
 				id: card.id,
 				slug: card.slug,
+				version: card.version,
 				type: card.type
 			}
 		}

--- a/test/e2e/sdk/index.spec.js
+++ b/test/e2e/sdk/index.spec.js
@@ -100,6 +100,7 @@ ava.serial('.action() should resolve with the slug, id and type of the card', as
 	test.deepEqual(card, {
 		id: card.id,
 		slug,
+		version: card.version,
 		type: 'card'
 	})
 })
@@ -926,6 +927,7 @@ ava.serial('.card.create() should resolve with the slug, id and type of the crea
 	test.deepEqual(card, {
 		id: card.id,
 		slug,
+		version: card.version,
 		type: 'card'
 	})
 })
@@ -1371,11 +1373,11 @@ ava.serial('should link two cards together', async (test) => {
 
 	test.deepEqual(thread, _.pick(_.find(expandedIssue.links['issue has attached support thread'], {
 		id: thread.id
-	}), [ 'id', 'type', 'slug' ]))
+	}), [ 'id', 'type', 'slug', 'version' ]))
 
 	test.deepEqual(issue, _.pick(_.find(expandedThread.links['support thread is attached to issue'], {
 		id: issue.id
-	}), [ 'id', 'type', 'slug' ]))
+	}), [ 'id', 'type', 'slug', 'version' ]))
 })
 
 ava.serial('linking two cards should be idempotent', async (test) => {
@@ -1471,9 +1473,9 @@ ava.serial('linking two cards should be idempotent', async (test) => {
 
 	test.deepEqual(thread, _.pick(_.find(expandedIssue.links['issue has attached support thread'], {
 		id: thread.id
-	}), [ 'id', 'type', 'slug' ]))
+	}), [ 'id', 'type', 'slug', 'version' ]))
 
 	test.deepEqual(issue, _.pick(_.find(expandedThread.links['support thread is attached to issue'], {
 		id: issue.id
-	}), [ 'id', 'type', 'slug' ]))
+	}), [ 'id', 'type', 'slug', 'version' ]))
 })

--- a/test/e2e/server/markers.spec.js
+++ b/test/e2e/server/markers.spec.js
@@ -65,6 +65,7 @@ ava.serial('Users should be able to view an element with no markers', async (tes
 	test.deepEqual(thread, {
 		id: userReadThread.id,
 		type: userReadThread.type,
+		version: userReadThread.version,
 		slug: userReadThread.slug
 	})
 })
@@ -149,6 +150,7 @@ ava.serial('Users should be able to view an element if all of their markers matc
 	test.deepEqual(thread, {
 		id: userReadThread.id,
 		type: userReadThread.type,
+		version: userReadThread.version,
 		slug: userReadThread.slug
 	})
 })
@@ -199,6 +201,7 @@ ava.serial('Users should be able to view an element using compound markers', asy
 	test.deepEqual(thread, {
 		id: userReadThread.id,
 		type: userReadThread.type,
+		version: userReadThread.version,
 		slug: userReadThread.slug
 	})
 })
@@ -273,6 +276,7 @@ ava.serial(
 		test.deepEqual(thread, {
 			id: userReadThread.id,
 			type: userReadThread.type,
+			version: userReadThread.version,
 			slug: userReadThread.slug
 		})
 	})
@@ -299,6 +303,7 @@ ava.serial('Users should be able to view an element using compound markers with 
 	test.deepEqual(thread, {
 		id: userReadThread.id,
 		type: userReadThread.type,
+		version: userReadThread.version,
 		slug: userReadThread.slug
 	})
 })
@@ -341,6 +346,7 @@ ava.serial(
 		test.deepEqual(thread, {
 			id: userReadThread.id,
 			type: userReadThread.type,
+			version: userReadThread.version,
 			slug: userReadThread.slug
 		})
 	})

--- a/test/integration/sync/balena-api-translate.spec.js
+++ b/test/integration/sync/balena-api-translate.spec.js
@@ -1374,6 +1374,7 @@ avaTest('should add a company and email to an existing user', async (test) => {
 		{
 			id: userCard.id,
 			slug: userCard.slug,
+			version: userCard.version,
 			type: 'user'
 		}
 	])
@@ -1458,6 +1459,7 @@ avaTest('should add a first name to an existing user', async (test) => {
 		{
 			id: userCard.id,
 			slug: userCard.slug,
+			version: userCard.version,
 			type: 'user'
 		}
 	])
@@ -1544,6 +1546,7 @@ avaTest('should add a last name to an existing user', async (test) => {
 		{
 			id: userCard.id,
 			slug: userCard.slug,
+			version: userCard.version,
 			type: 'user'
 		}
 	])
@@ -1629,6 +1632,7 @@ avaTest('should link an existing user by adding no data', async (test) => {
 		{
 			id: userCard.id,
 			slug: userCard.slug,
+			version: userCard.version,
 			type: 'user'
 		}
 	])

--- a/test/integration/worker/executor.spec.js
+++ b/test/integration/worker/executor.spec.js
@@ -1590,6 +1590,7 @@ ava('.run() should create a card', async (test) => {
 	test.deepEqual(result, {
 		id: result.id,
 		type: 'card',
+		version: '1.0.0',
 		slug: 'foo-bar-baz'
 	})
 })


### PR DESCRIPTION
Its handy to have them once all cards are versioned, otherwise we need
to request the full card again in most cases.

Change-type: minor


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!