### PR TITLE
Split webpack bundle in vendor and local

### DIFF
--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -11,6 +11,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
 const DefinePlugin = require('webpack/lib/DefinePlugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const HashedModuleIdsPlugin = require('webpack/lib/HashedModuleIdsPlugin')
 const mergeConfig = require('webpack-merge')
 const baseConfig = require('../../webpack.config.base.js')
 
@@ -34,7 +35,7 @@ const config = mergeConfig(baseConfig, {
 	entry: path.join(uiRoot, 'index.jsx'),
 
 	output: {
-		filename: 'bundle.[hash].js',
+		filename: 'bundle.[contenthash].js',
 		path: outDir,
 		publicPath: '/'
 	},
@@ -42,6 +43,12 @@ const config = mergeConfig(baseConfig, {
 	devServer: {
 		contentBase: outDir,
 		port: 9000
+	},
+
+	optimization: {
+		splitChunks: {
+			chunks: 'all'
+		}
 	},
 
 	plugins: [
@@ -76,6 +83,12 @@ const config = mergeConfig(baseConfig, {
 				VERSION: JSON.stringify(`v${packageJSON.version}`)
 			}
 			/* eslint-enable no-process-env */
+		}),
+
+		new HashedModuleIdsPlugin({
+			hashFunction: 'sha256',
+			hashDigest: 'hex',
+			hashDigestLength: 20
 		})
 	]
 })


### PR DESCRIPTION
Split webpack bundle in `vendor` and `local`, use HashedModuleIdsPlugin so that the hash reflects each file contents. Vendor bundle is made of our dependencies, so it's unlikely to change: this way browsers can cache it more easily
