### PR TITLE
[WIP] Be quick at querying cards

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -36,6 +36,19 @@ const defaultAdditionalPropertiesFalse = (schema) => {
 	return schema
 }
 
+const elementMatchesLinkSchemas = (linkTypes, schema, element) => {
+	for (const linkType of linkTypes) {
+		const linkSchema = schema.$$links[linkType]
+		const numberOfLinkedElements = element.links[linkType].length
+
+		if ((_.isNil(linkSchema) && numberOfLinkedElements > 0) || (!_.isNil(linkSchema) && numberOfLinkedElements === 0)) {
+			return false
+		}
+	}
+
+	return true
+}
+
 const queryTable = async (context, backend, table, schema, options) => {
 	logger.debug(context, 'Querying from table', {
 		table,
@@ -57,7 +70,10 @@ const queryTable = async (context, backend, table, schema, options) => {
 		exclude: [ 'additionalProperties' ]
 	})
 
-	const query = jsonschema2sql(table, schema, config)
+	const {
+		query,
+		hasLinks
+	} = jsonschema2sql(table, schema, config)
 
 	const queryStartDate = new Date()
 	const results = await backend.connection.any(query).catch((error) => {
@@ -68,44 +84,76 @@ const queryTable = async (context, backend, table, schema, options) => {
 	})
 	const queryEndDate = new Date()
 
-	const elements = results
-		.map(utils.convertDatesToISOString)
-		.map((element) => {
-			for (const linkType of Object.keys(schema.$$links || {})) {
-				if (!schema.$$links[linkType]) {
-					continue
+	let elements = null
+	if (hasLinks === false) {
+		elements = results
+			.map(utils.convertDatesToISOString)
+	} else {
+		elements = []
+		const mainElementsById = {}
+
+		const linkTypes = Object.keys(schema.$$links)
+
+		results
+			.map(utils.convertDatesToISOString)
+			.forEach((element) => {
+				if (element['$link direction$'] === null) {
+					const mainElement = element
+					mainElementsById[mainElement['$main id$']] = mainElement
+					elements.push(mainElement)
+
+					mainElement.links = {}
+					linkTypes.forEach((linkType) => {
+						mainElement.links[linkType] = []
+					})
+					utils.removeLinkMetadataFields(mainElement)
+
+					return
 				}
 
-				const linkSlug = links.getLinkTypeSlug(linkType)
+				const linkedElement = element
+				const mainElement = mainElementsById[linkedElement['$main id$']]
+				const linkType = linkedElement['$link type$']
 				const linkSchema = schema.$$links[linkType]
 
-				if (!element.links) {
-					element.links = {}
-				}
+				mainElement.links[linkType].push(linkedElement)
+				utils.filter(linkSchema, linkedElement)
+				utils.removeLinkMetadataFields(linkedElement)
+			})
 
-				element.links[linkType] = utils
-					.filter(linkSchema, element[`links.${linkSlug}`])
-					.map(utils.convertDatesToISOString)
+		elements = elements
+			.filter((element) => {
+				return elementMatchesLinkSchemas(linkTypes, schema, element)
+			})
+			.map((element) => {
+				// For some reason I don't understand, the previous inner join based version
+				// of the "linked cards" query was returning linked cards sorted by creation
+				// date, even if no order by was specified
+				// The current query returns cards in unknown order, so we must order them
+				// manually
+				linkTypes.forEach((linkType) => {
+					element.links[linkType].sort((l1, l2) => {
+						return l1.created_at.localeCompare(l2.created_at)
+					})
+				})
 
-				Reflect.deleteProperty(element, `links.${linkSlug}`)
-			}
+				return element
+			})
+	}
 
-			return element
-		})
-
-	const result = utils.filter(schema, elements)
+	utils.filter(schema, elements)
 	const postProcessingEndDate = new Date()
 
 	logger.debug(context, 'Query database response', {
 		table,
 		database: backend.database,
-		count: result.length,
+		count: elements.length,
 		queryTime: queryEndDate.getTime() - queryStartDate.getTime(),
 		preProcessingTime: queryStartDate.getTime() - preProcessingStartDate.getTime(),
 		postProcessingTime: postProcessingEndDate.getTime() - queryEndDate.getTime()
 	})
 
-	return result
+	return elements
 }
 
 const upsertObject = async (context, backend, object, options) => {

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -60,56 +60,10 @@ const walk = (schema, path, context, keys = new Set(), requiredPaths = new Set()
 	}
 }
 
-const getLink = (schema) => {
-	if (!schema.$$links) {
-		return null
-	}
-
-	const keys = Object.keys(schema.$$links)
-	assert.INTERNAL(null, keys.length === 1, Error,
-		'The translator only supports traversing one link type for now')
-
-	return {
-		type: keys[0],
-		slug: keys[0].toLowerCase().replace(/[^a-z]/g, '_'),
-		schema: schema.$$links[keys[0]]
-	}
-}
-
-module.exports = (table, schema, options = {}) => {
-	const link = getLink(schema)
-
+const generateMainQuery = (table, schema, options, hasLinks) => {
 	let query = []
 
-	const linkCard = link ? `link__${link.slug}` : null
-	const linkedCard = link ? `linked_card__${link.slug}` : null
-
-	if (link && link.schema) {
-		const prefix = schema.additionalProperties ? ', ' : ''
-		query.push(`${prefix}array_agg(to_jsonb(${linkedCard})) AS "links.${link.slug}"`)
-	}
-
 	query.push(`FROM ${table}`)
-
-	if (link) {
-		const joinType = link.schema ? 'INNER' : 'LEFT'
-
-		query.push(...[
-			`${joinType} JOIN links AS ${linkCard} ON (`,
-			`  (${linkCard}.fromId = ${table}.id AND ${linkCard}.name = '${link.type}') OR`,
-			`  (${linkCard}.toId = ${table}.id AND ${linkCard}.inverseName = '${link.type}')`,
-			')'
-		])
-
-		if (link.schema) {
-			query.push(...[
-				`INNER JOIN ${table} AS ${linkedCard} ON (`,
-				`  (${linkCard}.fromId != ${table}.id AND ${linkCard}.fromId = ${linkedCard}.id) OR`,
-				`  (${linkCard}.toId != ${table}.id AND ${linkCard}.toId = ${linkedCard}.id)`,
-				')'
-			])
-		}
-	}
 
 	if (_.isBoolean(schema)) {
 		if (!schema) {
@@ -130,39 +84,8 @@ module.exports = (table, schema, options = {}) => {
 		query = query.concat(filter)
 	}
 
-	if (link) {
-		query.push('AND')
-
-		if (link.schema) {
-			query.push(`(${walk(link.schema, [ linkedCard ]).filter})`)
-			query.push(`GROUP BY ${table}.id`)
-		} else {
-			query.push(`${linkCard} IS NULL`)
-		}
-	}
-
-	if (schema.additionalProperties === true) {
-		if (link) {
-			query.unshift(...[
-				`${table}.id,`,
-				`${table}.slug,`,
-				`${table}.type,`,
-				`${table}.active,`,
-				`${table}.version,`,
-				`${table}.name,`,
-				`${table}.tags,`,
-				`${table}.markers,`,
-				`${table}.created_at,`,
-				`${table}.links,`,
-				`${table}.requires,`,
-				`${table}.capabilities,`,
-				`${table}.data,`,
-				`${table}.updated_at,`,
-				`${table}.linked_at`
-			])
-		} else {
-			query.unshift('*')
-		}
+	if (schema.additionalProperties === true || hasLinks) {
+		query.unshift(`${table}.*`)
 	} else {
 		const topLevelKeys = []
 		for (const key of expression.keys.entries()) {
@@ -219,4 +142,69 @@ module.exports = (table, schema, options = {}) => {
 	}
 
 	return query.join('\n')
+}
+
+const getLinks = (schema) => {
+	if (!schema.$$links) {
+		return null
+	}
+
+	const keys = Object.keys(schema.$$links)
+		.map((key) => {
+			return {
+				type: key,
+				slug: key.toLowerCase().replace(/[^a-z]/g, '_'),
+				schema: schema.$$links[key]
+			}
+		})
+
+	return keys
+}
+
+const generateLinkedCardsQuery = (table, link) => {
+	const linkedCardFilterClause = link.schema ? `AND ${walk(link.schema, [ table ]).filter}` : ''
+
+	const query = `UNION ALL
+SELECT 'outgoing', ${builder.valueToPostgres(link.type)}, links.fromid, ${table}.*
+FROM ${table}
+INNER JOIN links ON (links.toid = ${table}.id AND links.name = ${builder.valueToPostgres(link.type)})
+WHERE links.fromid IN (SELECT id FROM main)
+${linkedCardFilterClause}
+UNION ALL
+SELECT 'incoming', ${builder.valueToPostgres(link.type)}, links.toid, ${table}.*
+FROM ${table}
+INNER JOIN links ON (links.fromid = ${table}.id AND links.inverseName = ${builder.valueToPostgres(link.type)})
+WHERE links.toid IN (SELECT id FROM main)
+${linkedCardFilterClause}`
+
+	return query
+}
+
+module.exports = (table, schema, options = {}) => {
+	const links = getLinks(schema)
+
+	const mainQuery = generateMainQuery(table, schema, options, !_.isEmpty(links))
+
+	if (_.isEmpty(links)) {
+		return {
+			query: mainQuery,
+			hasLinks: false
+		}
+	}
+
+	const queryWithLinkedCards = [
+		'WITH main AS (',
+		mainQuery,
+		')',
+		'SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main'
+	]
+
+	links.forEach((link) => {
+		queryWithLinkedCards.push(generateLinkedCardsQuery(table, link))
+	})
+
+	return {
+		query: queryWithLinkedCards.join('\n'),
+		hasLinks: true
+	}
 }

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -9,6 +9,9 @@ const skhema = require('skhema')
 const queue = require('./queue')
 
 exports.filter = (schema, element) => {
+	if (_.isNil(schema)) {
+		return element
+	}
 	const result = skhema.filter(schema, element)
 
 	// If additionalProperties is false, remove properties that haven't been
@@ -73,4 +76,10 @@ exports.convertDatesToISOString = (row) => {
 	Reflect.deleteProperty(row, 'new_updated_at')
 
 	return row
+}
+
+exports.removeLinkMetadataFields = (row) => {
+	Reflect.deleteProperty(row, '$link direction$')
+	Reflect.deleteProperty(row, '$link type$')
+	Reflect.deleteProperty(row, '$main id$')
 }

--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -3591,7 +3591,7 @@ ava('.query() should be able to query using links and an inverse name', async (t
 		linked_at: {},
 		active: true,
 		data: {
-			payload: 'foo'
+			payload: 'bar'
 		}
 	})
 
@@ -3722,7 +3722,7 @@ ava('.query() should be able to query using links and an inverse name', async (t
 						links: results[0].links['has attached element'][1].links,
 						type: 'message@1.0.0',
 						data: {
-							payload: 'foo'
+							payload: 'bar'
 						}
 					}
 				]

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -120,7 +120,9 @@ const runner = async ({
 	/*
 	 * 3. Query the elements back using our translator.
 	 */
-	const query = jsonschema2sql(table, schema, options)
+	const {
+		query
+	} = jsonschema2sql(table, schema, options)
 
 	/*
 	 * 4. Return the results.

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -4325,7 +4325,10 @@ ava('.query() should return an unexecuted action request', async (test) => {
 
 	test.deepEqual(result, [
 		Object.assign({}, request, {
-			updated_at: result[0].updated_at
+			updated_at: result[0].updated_at,
+			links: {
+				'is executed by': []
+			}
 		})
 	])
 })

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -8,7 +8,9 @@ const ava = require('ava')
 const jsonschema2sql = require('../../../../../../lib/core/backend/postgres/jsonschema2sql')
 
 ava('when querying for jsonb array field that contains string const we use the @> operator', (test) => {
-	const query = jsonschema2sql('cards', {
+	const {
+		query
+	} = jsonschema2sql('cards', {
 		type: 'object',
 		required: [ 'type', 'data' ],
 		additionalProperties: true,
@@ -36,7 +38,7 @@ ava('when querying for jsonb array field that contains string const we use the @
 	})
 
 	const expected = `SELECT
-*
+cards.*
 FROM cards
 WHERE
 (cards.type = 'support-thread')
@@ -47,7 +49,9 @@ AND
 })
 
 ava('when querying for jsonb array field that contains number const we use the @> operator', (test) => {
-	const query = jsonschema2sql('cards', {
+	const {
+		query
+	} = jsonschema2sql('cards', {
 		type: 'object',
 		required: [ 'type', 'data' ],
 		additionalProperties: true,
@@ -75,7 +79,7 @@ ava('when querying for jsonb array field that contains number const we use the @
 	})
 
 	const expected = `SELECT
-*
+cards.*
 FROM cards
 WHERE
 (cards.type = 'support-thread')
@@ -85,7 +89,9 @@ AND
 })
 
 ava('when querying for array that contains string const we use the @> operator', (test) => {
-	const query = jsonschema2sql('cards', {
+	const {
+		query
+	} = jsonschema2sql('cards', {
 		type: 'object',
 		anyOf: [ {
 			type: 'object'
@@ -125,7 +131,9 @@ AND
 
 ava('when querying without filters and additionalProperties=false, ' +
 	'query should use required to list columns to select', (test) => {
-	const query = jsonschema2sql('cards', {
+	const {
+		query
+	} = jsonschema2sql('cards', {
 		type: 'object',
 		anyOf: [ {
 			type: 'object'
@@ -144,7 +152,9 @@ true`
 })
 
 ava('when querying without filters and additionalProperties=true, query should select *', (test) => {
-	const query = jsonschema2sql('cards', {
+	const {
+		query
+	} = jsonschema2sql('cards', {
 		type: 'object',
 		anyOf: [ {
 			type: 'object'
@@ -154,9 +164,122 @@ ava('when querying without filters and additionalProperties=true, query should s
 	})
 
 	const expected = `SELECT
-*
+cards.*
 FROM cards
 WHERE
 true`
+	test.deepEqual(expected, query)
+})
+
+ava('when querying for linked cards, we wrap the main query in a WITH block', (test) => {
+	const payload = {
+		query: {
+			type: 'object',
+			additionalProperties: true,
+			$$links: {
+				'has attached element': {
+					type: 'object',
+					properties: {
+						type: {
+							enum: [ 'message', 'create', 'whisper' ]
+						}
+					},
+					additionalProperties: true
+				},
+				'is this and that': {
+					type: 'object',
+					additionalProperties: true
+				}
+			},
+			required: [ 'active', 'type' ],
+			name: 'user-generated-filter',
+			title: 'is',
+			description: 'Status is open',
+			properties: {
+				data: {
+					type: 'object',
+					properties: {
+						product: {
+							const: 'balenaCloud'
+						},
+						category: {
+							const: 'general'
+						},
+						status: {
+							const: 'open'
+						}
+					}
+				},
+				type: {
+					type: 'string',
+					const: 'support-thread'
+				},
+				active: {
+					type: 'boolean',
+					const: true
+				}
+			}
+		},
+		options: {
+			limit: 100,
+			skip: 0,
+			sortBy: [ 'created_at' ],
+			sortDir: 'desc'
+		}
+	}
+
+	const expected = `WITH main AS (
+SELECT
+cards.*
+FROM cards
+WHERE
+(((cards.data->'product' IS NULL)
+OR
+(cards.data->'product' @> '"balenaCloud"'))
+AND
+((cards.data->'category' IS NULL)
+OR
+(cards.data->'category' @> '"general"'))
+AND
+((cards.data->'status' IS NULL)
+OR
+(cards.data->'status' @> '"open"')))
+AND
+(cards.type = 'support-thread')
+AND
+(cards.active = 'true')
+ORDER BY cards.created_at DESC
+LIMIT 100
+)
+SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main
+UNION ALL
+SELECT 'outgoing', 'has attached element', links.fromid, cards.*
+FROM cards
+INNER JOIN links ON (links.toid = cards.id AND links.name = 'has attached element')
+WHERE links.fromid IN (SELECT id FROM main)
+AND cards.type IN ('message', 'create', 'whisper')
+UNION ALL
+SELECT 'incoming', 'has attached element', links.toid, cards.*
+FROM cards
+INNER JOIN links ON (links.fromid = cards.id AND links.inverseName = 'has attached element')
+WHERE links.toid IN (SELECT id FROM main)
+AND cards.type IN ('message', 'create', 'whisper')
+UNION ALL
+SELECT 'outgoing', 'is this and that', links.fromid, cards.*
+FROM cards
+INNER JOIN links ON (links.toid = cards.id AND links.name = 'is this and that')
+WHERE links.fromid IN (SELECT id FROM main)
+AND true
+UNION ALL
+SELECT 'incoming', 'is this and that', links.toid, cards.*
+FROM cards
+INNER JOIN links ON (links.fromid = cards.id AND links.inverseName = 'is this and that')
+WHERE links.toid IN (SELECT id FROM main)
+AND true`
+
+	const {
+		query
+	} = jsonschema2sql('cards', payload.query, payload.options)
+
 	test.deepEqual(expected, query)
 })


### PR DESCRIPTION
The previous approach was `join` based and queries were taking a long time to run.
This new approach split that query in 3 parts: 1 main cards, 2 cards that link to the main cards, 3 cards the main cards link to.
In essence, some of the work previously done by the db is now done by the server, including some filtering and some sorting.
On the plus side, we can now express queries with multiple links, eg: give me cards of type X, that have links of type Y and no links of type Z