### PR TITLE
action-server: Don't enable queue priority buffer on tick server

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -76,7 +76,7 @@ const bootstrap = async (context, library, options) => {
 
 	const session = jellyfish.sessions.admin
 	const queue = new Queue(context, jellyfish, session, {
-		enablePriorityBuffer: true
+		enablePriorityBuffer: options.enablePriorityBuffer
 	})
 
 	await queue.initialize(context)
@@ -208,6 +208,7 @@ const bootstrap = async (context, library, options) => {
 
 exports.worker = async (context, options) => {
 	return bootstrap(context, actionLibrary, {
+		enablePriorityBuffer: true,
 		delay: 500,
 		onError: options.onError,
 		onLoop: async (serverContext, jellyfish, worker, queue, session) => {
@@ -227,6 +228,7 @@ exports.worker = async (context, options) => {
 
 exports.tick = async (context, options) => {
 	return bootstrap(context, actionLibrary, {
+		enablePriorityBuffer: false,
 		delay: 2000,
 		onError: options.onError,
 		onLoop: async (serverContext, jellyfish, worker, queue, session) => {


### PR DESCRIPTION
Enabling the priority buffer on a queue instance means that the queue
also opens a stream for action requests and attempts to consume from
there before finding the action request on the requests table, as an
optimisation.

We don't need this optimisation on the tick's queue, as we don't consume
incoming action requests like the other types of action servers.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!