### PR TITLE
core/worker: Fix versioned slug references regexes

### DIFF
--- a/lib/core/cards/card.js
+++ b/lib/core/cards/card.js
@@ -34,7 +34,7 @@ module.exports = {
 				},
 				type: {
 					type: 'string',
-					pattern: '^[a-z0-9]+(@\\d\\.\\d\\.\\d)?$'
+					pattern: '^[a-z0-9-]+(@\\d+\\.\\d+\\.\\d+)?$'
 				},
 				tags: {
 					type: 'array',

--- a/lib/core/cards/link.js
+++ b/lib/core/cards/link.js
@@ -48,7 +48,7 @@ module.exports = {
 								},
 								type: {
 									type: 'string',
-									pattern: '^[a-z0-9-]+(@\\d\\.\\d\\.\\d)?$'
+									pattern: '^[a-z0-9-]+(@\\d+\\.\\d+\\.\\d+)?$'
 								}
 							}
 						},
@@ -62,7 +62,7 @@ module.exports = {
 								},
 								type: {
 									type: 'string',
-									pattern: '^[a-z0-9-]+(@\\d\\.\\d\\.\\d)?$'
+									pattern: '^[a-z0-9-]+(@\\d+\\.\\d+\\.\\d+)?$'
 								}
 							}
 						}

--- a/lib/worker/cards/triggered-action.js
+++ b/lib/worker/cards/triggered-action.js
@@ -30,7 +30,7 @@ module.exports = {
 						},
 						type: {
 							type: 'string',
-							pattern: '^[a-z0-9-]+(@\\d\\.\\d\\.\\d)?$'
+							pattern: '^[a-z0-9-]+(@\\d+\\.\\d+\\.\\d+)?$'
 						},
 						startDate: {
 							type: 'string',


### PR DESCRIPTION
We want to support multiple digits in the version fragments.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!