### PR TITLE
Be quick at querying cards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ aliases:
       # transparently merge code coverage reports.
       working_directory: /usr/src/jellyfish
 
-      environment:
+      environment: &job_defaults_environment
         DATABASE: postgres
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
@@ -145,6 +145,13 @@ jobs:
           paths:
             - .nyc_output/*.json
 
+  unit_and_sync_tests_feature_flag:
+    <<: *unit_and_sync_tests
+
+    environment:
+      FEATURE_FLAG_EXPERIMENTAL: 1
+      <<: *job_defaults_environment
+
   integration_tests: &integration_tests
     <<: *job_defaults
 
@@ -169,6 +176,13 @@ jobs:
           root: .
           paths:
             - .nyc_output/*.json
+
+  integration_tests_feature_flag:
+    <<: *integration_tests
+
+    environment:
+      FEATURE_FLAG_EXPERIMENTAL: 1
+      <<: *job_defaults_environment
 
   sync_tests_github_mirror:
     <<: *job_defaults
@@ -890,9 +904,19 @@ workflows:
                     - build
                 <<: *workflow_filter
 
+            - unit_and_sync_tests_feature_flag:
+                requires:
+                  - build
+                <<: *workflow_filter
+
             - integration_tests:
                 requires:
                     - build
+                <<: *workflow_filter
+
+            - integration_tests_feature_flag:
+                requires:
+                  - build
                 <<: *workflow_filter
 
             - e2e_tests_server:
@@ -968,7 +992,9 @@ workflows:
             - results:
                 requires:
                   - unit_and_sync_tests
+                  - unit_and_sync_tests_feature_flag
                   - integration_tests
+                  - integration_tests_feature_flag
                   - e2e_tests_server
                   - e2e_tests_sdk
                   - e2e_tests_ui

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -18,6 +18,7 @@ const streams = require('./streams')
 const queue = require('./queue')
 const utils = require('./utils')
 const markers = require('./markers')
+const environment = require('../../../environment')
 
 /*
  * See https://github.com/balena-io/jellyfish/issues/2401
@@ -34,6 +35,21 @@ const defaultAdditionalPropertiesFalse = (schema) => {
 	}
 
 	return schema
+}
+
+const queryv2 = {}
+
+queryv2.elementMatchesLinkSchemas = (linkTypes, schema, element) => {
+	for (const linkType of linkTypes) {
+		const linkSchema = schema.$$links[linkType]
+		const numberOfLinkedElements = element.links[linkType] ? element.links[linkType].length : 0
+
+		if ((_.isNil(linkSchema) && numberOfLinkedElements > 0) || (!_.isNil(linkSchema) && numberOfLinkedElements === 0)) {
+			return false
+		}
+	}
+
+	return true
 }
 
 const queryTable = async (context, backend, table, schema, options) => {
@@ -68,44 +84,111 @@ const queryTable = async (context, backend, table, schema, options) => {
 	})
 	const queryEndDate = new Date()
 
-	const elements = results
-		.map(utils.convertDatesToISOString)
-		.map((element) => {
-			for (const linkType of Object.keys(schema.$$links || {})) {
-				if (!schema.$$links[linkType]) {
-					continue
+	let elements = null
+	if (options.experimental || environment.featureFlags.experimental) {
+		if (_.isNil(schema.$$links)) {
+			elements = results
+				.map(utils.convertDatesToISOString)
+		} else {
+			elements = []
+			const mainElementsById = {}
+
+			const linkTypes = Object.keys(schema.$$links)
+
+			results
+				.map(utils.convertDatesToISOString)
+				.forEach((element) => {
+					if (element['$link direction$'] === null) {
+						const mainElement = element
+						mainElementsById[mainElement['$main id$']] = mainElement
+						elements.push(mainElement)
+
+						mainElement.links = {}
+						utils.removeLinkMetadataFields(mainElement)
+
+						return
+					}
+
+					const linkedElement = element
+					const mainElement = mainElementsById[linkedElement['$main id$']]
+					const linkType = linkedElement['$link type$']
+					const linkSchema = schema.$$links[linkType]
+
+					// TODO
+					// It would be nicer to always have an array, even if empty
+					// for link types with no matches, but it won't be backwards
+					// compatible, so we lazily create the empty array instead
+					if (!mainElement.links[linkType]) {
+						mainElement.links[linkType] = []
+					}
+					mainElement.links[linkType].push(linkedElement)
+					utils.filter(linkSchema, linkedElement)
+					utils.removeLinkMetadataFields(linkedElement)
+				})
+
+			elements = elements
+				.filter((element) => {
+					return queryv2.elementMatchesLinkSchemas(linkTypes, schema, element)
+				})
+				.map((element) => {
+					// For some reason I don't understand, the previous inner join based version
+					// of the "linked cards" query was returning linked cards sorted by creation
+					// date, even if no `order by` was specified
+					// The current query returns linked cards in unknown order, so we must order
+					// them manually
+					linkTypes
+						.filter((linkType) => {
+							return element.links[linkType]
+						})
+						.forEach((linkType) => {
+							element.links[linkType].sort((l1, l2) => {
+								return l1.created_at.localeCompare(l2.created_at)
+							})
+						})
+
+					return element
+				})
+		}
+	} else {
+		elements = results
+			.map(utils.convertDatesToISOString)
+			.map((element) => {
+				for (const linkType of Object.keys(schema.$$links || {})) {
+					if (!schema.$$links[linkType]) {
+						continue
+					}
+
+					const linkSlug = links.getLinkTypeSlug(linkType)
+					const linkSchema = schema.$$links[linkType]
+
+					if (!element.links) {
+						element.links = {}
+					}
+
+					element.links[linkType] = utils
+						.filter(linkSchema, element[`links.${linkSlug}`])
+						.map(utils.convertDatesToISOString)
+
+					Reflect.deleteProperty(element, `links.${linkSlug}`)
 				}
 
-				const linkSlug = links.getLinkTypeSlug(linkType)
-				const linkSchema = schema.$$links[linkType]
+				return element
+			})
+	}
 
-				if (!element.links) {
-					element.links = {}
-				}
-
-				element.links[linkType] = utils
-					.filter(linkSchema, element[`links.${linkSlug}`])
-					.map(utils.convertDatesToISOString)
-
-				Reflect.deleteProperty(element, `links.${linkSlug}`)
-			}
-
-			return element
-		})
-
-	const result = utils.filter(schema, elements)
+	utils.filter(schema, elements)
 	const postProcessingEndDate = new Date()
 
 	logger.debug(context, 'Query database response', {
 		table,
 		database: backend.database,
-		count: result.length,
+		count: elements.length,
 		queryTime: queryEndDate.getTime() - queryStartDate.getTime(),
 		preProcessingTime: queryStartDate.getTime() - preProcessingStartDate.getTime(),
 		postProcessingTime: postProcessingEndDate.getTime() - queryEndDate.getTime()
 	})
 
-	return result
+	return elements
 }
 
 const upsertObject = async (context, backend, object, options) => {

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -8,6 +8,7 @@ const _ = require('lodash')
 const builder = require('./builder')
 const keywords = require('./keywords')
 const assert = require('../../../../assert')
+const environment = require('../../../../environment')
 
 /*
  * See https://www.postgresql.org/docs/9.6/functions-json.html for reference.
@@ -60,24 +61,157 @@ const walk = (schema, path, context, keys = new Set(), requiredPaths = new Set()
 	}
 }
 
-const getLink = (schema) => {
+const queryv2 = {}
+
+queryv2.generateMainQuery = (table, schema, options, hasLinks) => {
+	let query = []
+
+	query.push(`FROM ${table}`)
+
+	if (_.isBoolean(schema)) {
+		if (!schema) {
+			query.push('WHERE false')
+		}
+
+		return query.join('\n')
+	}
+
+	assert.INTERNAL(null, _.isPlainObject(schema), Error,
+		`The schema should be an object, received: ${schema}`)
+
+	const expression = walk(schema, [ table ])
+	const filter = [ expression.filter ]
+
+	if (!Array.isArray(filter) || filter.length > 0) {
+		filter.unshift('WHERE')
+		query = query.concat(filter)
+	}
+
+	if (schema.additionalProperties === true || hasLinks) {
+		query.unshift(`${table}.*`)
+	} else {
+		const topLevelKeys = []
+		for (const key of expression.keys.entries()) {
+			const parts = key[0].split('/')
+
+			// We don't support nested filtering here yet
+			if (parts.length > 1) {
+				continue
+			}
+
+			const property = [ table, `"${parts[0]}"` ]
+			topLevelKeys.push(property.join('.'))
+		}
+
+		if (topLevelKeys.length !== 0) {
+			query.unshift(topLevelKeys.join(',\n'))
+		} else if (schema.required && schema.required.length > 0) {
+			query.unshift(schema.required
+				.map((key) => {
+					return `${table}."${key}"`
+				})
+				.join(',\n'))
+		}
+
+		if (!query[1].startsWith('FROM') && query[1] !== 'WHERE') {
+			query[0] = `${query[0]}, `
+		}
+	}
+
+	query.unshift('SELECT')
+
+	if (options.sortBy) {
+		const order = _.castArray(options.sortBy)
+
+		const orderBy = [
+			'ORDER BY',
+			builder.getProperty([ table ].concat(order)),
+			options.sortDir === 'desc' ? 'DESC' : 'ASC'
+		].join(' ')
+
+		query.push(orderBy)
+	}
+
+	if (options.skip) {
+		assert.INTERNAL(null, _.isNumber(options.skip), Error,
+			`options.skip should be a number, received: ${options.skip}`)
+		query.push(`OFFSET ${options.skip}`)
+	}
+
+	if (options.limit) {
+		assert.INTERNAL(null, _.isNumber(options.limit), Error,
+			`options.limit should be a number, received: ${options.limit}`)
+		query.push(`LIMIT ${options.limit}`)
+	}
+
+	return query.join('\n')
+}
+
+queryv2.generateLinkedCardsQuery = (table, link) => {
+	const linkedCardFilterClause = link.schema ? `AND ${walk(link.schema, [ table ]).filter}` : ''
+
+	const query = `UNION ALL
+SELECT 'outgoing', ${builder.valueToPostgres(link.type)}, links.fromid, ${table}.*
+FROM ${table}
+INNER JOIN links ON (links.toid = ${table}.id AND links.name = ${builder.valueToPostgres(link.type)})
+WHERE links.fromid IN (SELECT id FROM main)
+${linkedCardFilterClause}
+UNION ALL
+SELECT 'incoming', ${builder.valueToPostgres(link.type)}, links.toid, ${table}.*
+FROM ${table}
+INNER JOIN links ON (links.fromid = ${table}.id AND links.inverseName = ${builder.valueToPostgres(link.type)})
+WHERE links.toid IN (SELECT id FROM main)
+${linkedCardFilterClause}`
+
+	return query
+}
+
+queryv2.generateGraphFriendlyQuery = (table, schema, options) => {
+	const links = getLinks(schema)
+
+	const mainQuery = queryv2.generateMainQuery(table, schema, options, !_.isEmpty(links))
+
+	if (_.isEmpty(links)) {
+		return mainQuery
+	}
+
+	const queryWithLinkedCards = [
+		'WITH main AS (',
+		mainQuery,
+		')',
+		'SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main'
+	]
+
+	links.forEach((link) => {
+		queryWithLinkedCards.push(queryv2.generateLinkedCardsQuery(table, link))
+	})
+
+	return queryWithLinkedCards.join('\n')
+}
+
+const getLinks = (schema) => {
 	if (!schema.$$links) {
 		return null
 	}
 
 	const keys = Object.keys(schema.$$links)
-	assert.INTERNAL(null, keys.length === 1, Error,
-		'The translator only supports traversing one link type for now')
+		.map((key) => {
+			return {
+				type: key,
+				slug: key.toLowerCase().replace(/[^a-z]/g, '_'),
+				schema: schema.$$links[key]
+			}
+		})
 
-	return {
-		type: keys[0],
-		slug: keys[0].toLowerCase().replace(/[^a-z]/g, '_'),
-		schema: schema.$$links[keys[0]]
-	}
+	return keys
 }
 
-module.exports = (table, schema, options = {}) => {
-	const link = getLink(schema)
+const generateQuery = (table, schema, options) => {
+	const links = getLinks(schema)
+	assert.INTERNAL(null, !links || links.length <= 1, Error,
+		'The translator only supports traversing one link type for now')
+
+	const link = links ? links[0] : null
 
 	let query = []
 
@@ -161,7 +295,7 @@ module.exports = (table, schema, options = {}) => {
 				`${table}.linked_at`
 			])
 		} else {
-			query.unshift('*')
+			query.unshift(`${table}.*`)
 		}
 	} else {
 		const topLevelKeys = []
@@ -219,4 +353,12 @@ module.exports = (table, schema, options = {}) => {
 	}
 
 	return query.join('\n')
+}
+
+module.exports = (table, schema, options = {}) => {
+	if (options.experimental || environment.featureFlags.experimental) {
+		return queryv2.generateGraphFriendlyQuery(table, schema, options)
+	}
+
+	return generateQuery(table, schema, options)
 }

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -9,6 +9,9 @@ const skhema = require('skhema')
 const queue = require('./queue')
 
 exports.filter = (schema, element) => {
+	if (_.isNil(schema)) {
+		return element
+	}
 	const result = skhema.filter(schema, element)
 
 	// If additionalProperties is false, remove properties that haven't been
@@ -73,4 +76,10 @@ exports.convertDatesToISOString = (row) => {
 	Reflect.deleteProperty(row, 'new_updated_at')
 
 	return row
+}
+
+exports.removeLinkMetadataFields = (row) => {
+	Reflect.deleteProperty(row, '$link direction$')
+	Reflect.deleteProperty(row, '$link type$')
+	Reflect.deleteProperty(row, '$main id$')
 }

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -166,3 +166,7 @@ exports.test = {
 exports.oauth = {
 	redirectBaseUrl: process.env.OAUTH_REDIRECT_BASE_URL
 }
+
+exports.featureFlags = {
+	experimental: process.env.FEATURE_FLAG_EXPERIMENTAL
+}

--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -3591,7 +3591,7 @@ ava('.query() should be able to query using links and an inverse name', async (t
 		linked_at: {},
 		active: true,
 		data: {
-			payload: 'foo'
+			payload: 'bar'
 		}
 	})
 
@@ -3722,7 +3722,7 @@ ava('.query() should be able to query using links and an inverse name', async (t
 						links: results[0].links['has attached element'][1].links,
 						type: 'message@1.0.0',
 						data: {
-							payload: 'foo'
+							payload: 'bar'
 						}
 					}
 				]

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -36,7 +36,7 @@ ava('when querying for jsonb array field that contains string const we use the @
 	})
 
 	const expected = `SELECT
-*
+cards.*
 FROM cards
 WHERE
 (cards.type = 'support-thread')
@@ -75,12 +75,13 @@ ava('when querying for jsonb array field that contains number const we use the @
 	})
 
 	const expected = `SELECT
-*
+cards.*
 FROM cards
 WHERE
 (cards.type = 'support-thread')
 AND
 (cards.data->'mirrors' @> '42')`
+
 	test.deepEqual(expected, query)
 })
 
@@ -120,6 +121,7 @@ WHERE
 (cards.data->'number' @> '1')
 AND
 (cards.tags @> ARRAY['foo'])`
+
 	test.deepEqual(expected, query)
 })
 
@@ -140,6 +142,7 @@ cards."tags"
 FROM cards
 WHERE
 true`
+
 	test.deepEqual(expected, query)
 })
 
@@ -154,9 +157,122 @@ ava('when querying without filters and additionalProperties=true, query should s
 	})
 
 	const expected = `SELECT
-*
+cards.*
 FROM cards
 WHERE
 true`
+
+	test.deepEqual(expected, query)
+})
+
+ava('when querying for linked cards, we wrap the main query in a WITH block', (test) => {
+	const payload = {
+		query: {
+			type: 'object',
+			additionalProperties: true,
+			$$links: {
+				'has attached element': {
+					type: 'object',
+					properties: {
+						type: {
+							enum: [ 'message', 'create', 'whisper' ]
+						}
+					},
+					additionalProperties: true
+				},
+				'is this and that': {
+					type: 'object',
+					additionalProperties: true
+				}
+			},
+			required: [ 'active', 'type' ],
+			name: 'user-generated-filter',
+			title: 'is',
+			description: 'Status is open',
+			properties: {
+				data: {
+					type: 'object',
+					properties: {
+						product: {
+							const: 'balenaCloud'
+						},
+						category: {
+							const: 'general'
+						},
+						status: {
+							const: 'open'
+						}
+					}
+				},
+				type: {
+					type: 'string',
+					const: 'support-thread'
+				},
+				active: {
+					type: 'boolean',
+					const: true
+				}
+			}
+		},
+		options: {
+			experimental: true,
+			limit: 100,
+			skip: 0,
+			sortBy: [ 'created_at' ],
+			sortDir: 'desc'
+		}
+	}
+
+	const expected = `WITH main AS (
+SELECT
+cards.*
+FROM cards
+WHERE
+(((cards.data->'product' IS NULL)
+OR
+(cards.data->'product' @> '"balenaCloud"'))
+AND
+((cards.data->'category' IS NULL)
+OR
+(cards.data->'category' @> '"general"'))
+AND
+((cards.data->'status' IS NULL)
+OR
+(cards.data->'status' @> '"open"')))
+AND
+(cards.type = 'support-thread')
+AND
+(cards.active = 'true')
+ORDER BY cards.created_at DESC
+LIMIT 100
+)
+SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main
+UNION ALL
+SELECT 'outgoing', 'has attached element', links.fromid, cards.*
+FROM cards
+INNER JOIN links ON (links.toid = cards.id AND links.name = 'has attached element')
+WHERE links.fromid IN (SELECT id FROM main)
+AND cards.type IN ('message', 'create', 'whisper')
+UNION ALL
+SELECT 'incoming', 'has attached element', links.toid, cards.*
+FROM cards
+INNER JOIN links ON (links.fromid = cards.id AND links.inverseName = 'has attached element')
+WHERE links.toid IN (SELECT id FROM main)
+AND cards.type IN ('message', 'create', 'whisper')
+UNION ALL
+SELECT 'outgoing', 'is this and that', links.fromid, cards.*
+FROM cards
+INNER JOIN links ON (links.toid = cards.id AND links.name = 'is this and that')
+WHERE links.fromid IN (SELECT id FROM main)
+AND true
+UNION ALL
+SELECT 'incoming', 'is this and that', links.toid, cards.*
+FROM cards
+INNER JOIN links ON (links.fromid = cards.id AND links.inverseName = 'is this and that')
+WHERE links.toid IN (SELECT id FROM main)
+AND true`
+
+	const query = jsonschema2sql('cards', payload.query, payload.options)
+
 	test.deepEqual(expected, query)
 })


### PR DESCRIPTION
The previous approach was `join` based and queries were taking a long time to run.
This new approach split that query in 3 parts: 1 main cards, 2 cards that link to the main cards, 3 cards the main cards link to.
In essence, some of the work previously done by the db is now done by the server, including some filtering and some sorting.
On the plus side, we can now express queries with multiple links, eg: give me cards of type X, that have links of type Y and no links of type Z.
Unfortunately, this approach is not 100% backwards compatible, due to the way we traverse our graph: we need to rewrite some queries in order to make them "graph friendly".
This needs time and experimentation, so the query is hidden behind a feature flag that UI can trigger via `options.experimental` set to any truthy value.
Tests can be run from the command line with the env var FEATURE_FLAG_EXPERIMENTAL set to 1: this will make all queries use the new approach