### PR TITLE
Add indexes to `links` table on fromid+inversename and toid+name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,6 @@ jobs:
           paths:
             - .nyc_output/*.json
 
-  unit_and_sync_tests_feature_flag:
-    <<: *unit_and_sync_tests
-
-    environment:
-      FEATURE_FLAG_EXPERIMENTAL: 1
-      <<: *job_defaults_environment
-
   integration_tests: &integration_tests
     <<: *job_defaults
 
@@ -176,13 +169,6 @@ jobs:
           root: .
           paths:
             - .nyc_output/*.json
-
-  integration_tests_feature_flag:
-    <<: *integration_tests
-
-    environment:
-      FEATURE_FLAG_EXPERIMENTAL: 1
-      <<: *job_defaults_environment
 
   sync_tests_github_mirror:
     <<: *job_defaults
@@ -307,7 +293,7 @@ jobs:
           root: .
           paths:
             - .nyc_output/*.json
-            
+
   sync_tests_flowdock_translate:
     <<: *job_defaults
 
@@ -932,19 +918,9 @@ workflows:
                     - build
                 <<: *workflow_filter
 
-            - unit_and_sync_tests_feature_flag:
-                requires:
-                  - build
-                <<: *workflow_filter
-
             - integration_tests:
                 requires:
                     - build
-                <<: *workflow_filter
-
-            - integration_tests_feature_flag:
-                requires:
-                  - build
                 <<: *workflow_filter
 
             - e2e_tests_server:
@@ -1025,9 +1001,7 @@ workflows:
             - results:
                 requires:
                   - unit_and_sync_tests
-                  - unit_and_sync_tests_feature_flag
                   - integration_tests
-                  - integration_tests_feature_flag
                   - e2e_tests_server
                   - e2e_tests_sdk
                   - e2e_tests_ui

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -35,7 +35,9 @@ exports.setup = async (context, connection, database, options) => {
 
 	for (const [ name, column ] of [
 		[ 'idx_link_from', 'fromId' ],
-		[ 'idx_link_to', 'toId' ]
+		[ 'idx_link_to', 'toId' ],
+		[ 'idx_links_fromid_name', 'fromid, name' ],
+		[ 'idx_links_toid_inversename', 'toid, inversename' ]
 	]) {
 		if (indexes.includes(name)) {
 			return


### PR DESCRIPTION
Add indexes to `links` table on fromid+inversename and toid+name: they make graph-like queries faster
Also run e2e_tests_{ui,livechat} with feature flag on, so we have more coverage for the new query mechanism
