### PR TITLE
Graph traversal

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -39,13 +39,24 @@ const defaultAdditionalPropertiesFalse = (schema) => {
 
 const queryv2 = {}
 
-queryv2.elementMatchesLinkSchemas = (linkTypes, schema, element) => {
+queryv2.elementMatchesLinkSchemas = (schema, element) => {
+	const linkTypes = Object.keys(schema.$$links)
+
 	for (const linkType of linkTypes) {
 		const linkSchema = schema.$$links[linkType]
 		const numberOfLinkedElements = element.links[linkType] ? element.links[linkType].length : 0
 
 		if ((_.isNil(linkSchema) && numberOfLinkedElements > 0) || (!_.isNil(linkSchema) && numberOfLinkedElements === 0)) {
 			return false
+		}
+
+		if (!_.isNil(linkSchema) && !_.isNil(linkSchema.$$links)) {
+			for (const linkedElement of element.links[linkType]) {
+				const matches = queryv2.elementMatchesLinkSchemas(linkSchema, linkedElement)
+				if (!matches) {
+					return false
+				}
+			}
 		}
 	}
 
@@ -91,44 +102,34 @@ const queryTable = async (context, backend, table, schema, options) => {
 				.map(utils.convertDatesToISOString)
 		} else {
 			elements = []
-			const mainElementsById = {}
-
-			const linkTypes = Object.keys(schema.$$links)
+			const elementsById = {}
 
 			results
 				.map(utils.convertDatesToISOString)
 				.forEach((element) => {
-					if (element['$link direction$'] === null) {
-						const mainElement = element
-						mainElementsById[mainElement['$main id$']] = mainElement
-						elements.push(mainElement)
+					elementsById[element.id] = element
 
-						mainElement.links = {}
-						utils.removeLinkMetadataFields(mainElement)
+					if (element['$parent id$'] === null) {
+						elements.push(element)
+					} else {
+						const parentElement = elementsById[element['$parent id$']]
+						parentElement.links = parentElement.links || {}
+						const linkType = element['$link type$']
+						parentElement.links[linkType] = parentElement.links[linkType] || []
+						parentElement.links[linkType].push(element)
 
-						return
+						const linkSchema = schema.$$links[linkType]
+						utils.filter(linkSchema, element)
 					}
 
-					const linkedElement = element
-					const mainElement = mainElementsById[linkedElement['$main id$']]
-					const linkType = linkedElement['$link type$']
-					const linkSchema = schema.$$links[linkType]
-
-					// TODO
-					// It would be nicer to always have an array, even if empty
-					// for link types with no matches, but it won't be backwards
-					// compatible, so we lazily create the empty array instead
-					if (!mainElement.links[linkType]) {
-						mainElement.links[linkType] = []
-					}
-					mainElement.links[linkType].push(linkedElement)
-					utils.filter(linkSchema, linkedElement)
-					utils.removeLinkMetadataFields(linkedElement)
+					utils.removeLinkMetadataFields(element)
 				})
+
+			const linkTypes = Object.keys(schema.$$links)
 
 			elements = elements
 				.filter((element) => {
-					return queryv2.elementMatchesLinkSchemas(linkTypes, schema, element)
+					return queryv2.elementMatchesLinkSchemas(schema, element)
 				})
 				.map((element) => {
 					// For some reason I don't understand, the previous inner join based version

--- a/lib/core/backend/postgres/jsonschema2sql/graph.js
+++ b/lib/core/backend/postgres/jsonschema2sql/graph.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const builder = require('./builder')
+const assert = require('../../../../assert')
+
+const generateMainQuery = (table, schema, options, hasLinks, walk) => {
+	let query = []
+
+	query.push(`FROM ${table}`)
+
+	if (_.isBoolean(schema)) {
+		if (!schema) {
+			query.push('WHERE false')
+		}
+
+		return query.join('\n')
+	}
+
+	assert.INTERNAL(null, _.isPlainObject(schema), Error,
+		`The schema should be an object, received: ${schema}`)
+
+	const expression = walk(schema, [ table ])
+	const filter = [ expression.filter ]
+
+	if (!Array.isArray(filter) || filter.length > 0) {
+		filter.unshift('WHERE')
+		query = query.concat(filter)
+	}
+
+	if (schema.additionalProperties === true || hasLinks) {
+		query.unshift(`${table}.*`)
+	} else {
+		const topLevelKeys = []
+		for (const key of expression.keys.entries()) {
+			const parts = key[0].split('/')
+
+			// We don't support nested filtering here yet
+			if (parts.length > 1) {
+				continue
+			}
+
+			const property = [ table, `"${parts[0]}"` ]
+			topLevelKeys.push(property.join('.'))
+		}
+
+		if (topLevelKeys.length !== 0) {
+			query.unshift(topLevelKeys.join(',\n'))
+		} else if (schema.required && schema.required.length > 0) {
+			query.unshift(schema.required
+				.map((key) => {
+					return `${table}."${key}"`
+				})
+				.join(',\n'))
+		}
+
+		if (!query[1].startsWith('FROM') && query[1] !== 'WHERE') {
+			query[0] = `${query[0]}, `
+		}
+	}
+
+	query.unshift('SELECT')
+
+	if (options.sortBy) {
+		const order = _.castArray(options.sortBy)
+
+		const orderBy = [
+			'ORDER BY',
+			builder.getProperty([ table ].concat(order)),
+			options.sortDir === 'desc' ? 'DESC' : 'ASC'
+		].join(' ')
+
+		query.push(orderBy)
+	}
+
+	if (options.skip) {
+		assert.INTERNAL(null, _.isNumber(options.skip), Error,
+			`options.skip should be a number, received: ${options.skip}`)
+		query.push(`OFFSET ${options.skip}`)
+	}
+
+	if (options.limit) {
+		assert.INTERNAL(null, _.isNumber(options.limit), Error,
+			`options.limit should be a number, received: ${options.limit}`)
+		query.push(`LIMIT ${options.limit}`)
+	}
+
+	return query.join('\n')
+}
+
+const generateLinkedCardsQuery = (table, link, walk) => {
+	const linkedCardFilterClause = link.schema ? `AND ${walk(link.schema, [ table ]).filter}` : ''
+
+	const query = `UNION ALL
+SELECT 'outgoing', ${builder.valueToPostgres(link.type)}, links.fromid, ${table}.*
+FROM ${table}
+INNER JOIN links ON (links.toid = ${table}.id AND links.name = ${builder.valueToPostgres(link.type)})
+WHERE links.fromid IN (SELECT id FROM main)
+${linkedCardFilterClause}
+UNION ALL
+SELECT 'incoming', ${builder.valueToPostgres(link.type)}, links.toid, ${table}.*
+FROM ${table}
+INNER JOIN links ON (links.fromid = ${table}.id AND links.inverseName = ${builder.valueToPostgres(link.type)})
+WHERE links.toid IN (SELECT id FROM main)
+${linkedCardFilterClause}`
+
+	return query
+}
+
+exports.generateQuery = (table, schema, options, getLinks, walk) => {
+	const links = getLinks(schema)
+
+	const mainQuery = generateMainQuery(table, schema, options, !_.isEmpty(links), walk)
+
+	if (_.isEmpty(links)) {
+		return mainQuery
+	}
+
+	const queryWithLinkedCards = [
+		'WITH main AS (',
+		mainQuery,
+		')',
+		'SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main'
+	]
+
+	links.forEach((link) => {
+		queryWithLinkedCards.push(generateLinkedCardsQuery(table, link, walk))
+	})
+
+	return queryWithLinkedCards.join('\n')
+}

--- a/lib/core/backend/postgres/jsonschema2sql/graph.js
+++ b/lib/core/backend/postgres/jsonschema2sql/graph.js
@@ -92,23 +92,29 @@ const generateMainQuery = (table, schema, options, hasLinks, walk) => {
 	return query.join('\n')
 }
 
-const generateLinkedCardsQuery = (table, link, walk) => {
-	const linkedCardFilterClause = link.schema ? `AND ${walk(link.schema, [ table ]).filter}` : ''
+const generateLinkedCardsQuery = (table, currentLink, currentQueryId, previousQueryId, queries, walk, getLinks) => {
+	const linkedCardFilterClause = currentLink.schema ? `${walk(currentLink.schema, [ table ]).filter}` : 'true'
 
-	const query = `UNION ALL
-SELECT 'outgoing', ${builder.valueToPostgres(link.type)}, links.fromid, ${table}.*
+	const query = `SELECT 'outgoing', links.inversename, links.toid, ${table}.*
 FROM ${table}
-INNER JOIN links ON (links.toid = ${table}.id AND links.name = ${builder.valueToPostgres(link.type)})
-WHERE links.fromid IN (SELECT id FROM main)
-${linkedCardFilterClause}
+INNER JOIN links ON (${table}.id = links.fromid AND links.inversename = ${builder.valueToPostgres(currentLink.type)})
+INNER JOIN ${previousQueryId} on (${previousQueryId}.id = links.toid)
+WHERE ${linkedCardFilterClause}
 UNION ALL
-SELECT 'incoming', ${builder.valueToPostgres(link.type)}, links.toid, ${table}.*
+SELECT 'incoming', links.name, links.fromid, ${table}.*
 FROM ${table}
-INNER JOIN links ON (links.fromid = ${table}.id AND links.inverseName = ${builder.valueToPostgres(link.type)})
-WHERE links.toid IN (SELECT id FROM main)
-${linkedCardFilterClause}`
+INNER JOIN links ON (${table}.id = links.toid AND links.name = ${builder.valueToPostgres(currentLink.type)})
+INNER JOIN ${previousQueryId} on (${previousQueryId}.id = links.fromid)
+WHERE ${linkedCardFilterClause}`
 
-	return query
+	queries.push([ currentQueryId, query ])
+
+	const links = getLinks(currentLink.schema)
+
+	links.forEach((link, idx) => {
+		const queryId = `${currentQueryId}_${idx}`
+		generateLinkedCardsQuery(table, link, queryId, currentQueryId, queries, walk, getLinks)
+	})
 }
 
 exports.generateQuery = (table, schema, options, getLinks, walk) => {
@@ -120,16 +126,30 @@ exports.generateQuery = (table, schema, options, getLinks, walk) => {
 		return mainQuery
 	}
 
-	const queryWithLinkedCards = [
-		'WITH main AS (',
-		mainQuery,
-		')',
-		'SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main'
+	const queries = [
+		[ 'query_0', 'SELECT null AS "$link direction$", null AS "$link type$", null::uuid AS "$parent id$", main.* FROM main' ]
 	]
 
-	links.forEach((link) => {
-		queryWithLinkedCards.push(generateLinkedCardsQuery(table, link, walk))
+	links.forEach((link, idx) => {
+		const queryId = `query_1_${idx}`
+		generateLinkedCardsQuery(table, link, queryId, 'query_0', queries, walk, getLinks)
 	})
 
-	return queryWithLinkedCards.join('\n')
+	let query = `WITH main AS (\n${mainQuery}\n)`
+
+	query += queries
+		.map(([ qId, q ]) => {
+			return `, ${qId} AS (\n${q}\n)`
+		})
+		.join('\n')
+
+	query += '\n'
+
+	query += queries
+		.map(([ qId, _q ]) => {
+			return `SELECT * FROM ${qId}`
+		})
+		.join('\nUNION ALL\n')
+
+	return query
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -63,8 +63,8 @@ const walk = (schema, path, context, keys = new Set(), requiredPaths = new Set()
 }
 
 const getLinks = (schema) => {
-	if (!schema.$$links) {
-		return null
+	if (!schema || !schema.$$links) {
+		return []
 	}
 
 	const keys = Object.keys(schema.$$links)
@@ -81,10 +81,10 @@ const getLinks = (schema) => {
 
 const generateQuery = (table, schema, options) => {
 	const links = getLinks(schema)
-	assert.INTERNAL(null, !links || links.length <= 1, Error,
+	assert.INTERNAL(null, links.length <= 1, Error,
 		'The translator only supports traversing one link type for now')
 
-	const link = links ? links[0] : null
+	const link = links.length > 0 ? links[0] : null
 
 	let query = []
 

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -9,6 +9,7 @@ const builder = require('./builder')
 const keywords = require('./keywords')
 const assert = require('../../../../assert')
 const environment = require('../../../../environment')
+const graph = require('./graph')
 
 /*
  * See https://www.postgresql.org/docs/9.6/functions-json.html for reference.
@@ -59,134 +60,6 @@ const walk = (schema, path, context, keys = new Set(), requiredPaths = new Set()
 		keys,
 		filter: builder.and(...result)
 	}
-}
-
-const queryv2 = {}
-
-queryv2.generateMainQuery = (table, schema, options, hasLinks) => {
-	let query = []
-
-	query.push(`FROM ${table}`)
-
-	if (_.isBoolean(schema)) {
-		if (!schema) {
-			query.push('WHERE false')
-		}
-
-		return query.join('\n')
-	}
-
-	assert.INTERNAL(null, _.isPlainObject(schema), Error,
-		`The schema should be an object, received: ${schema}`)
-
-	const expression = walk(schema, [ table ])
-	const filter = [ expression.filter ]
-
-	if (!Array.isArray(filter) || filter.length > 0) {
-		filter.unshift('WHERE')
-		query = query.concat(filter)
-	}
-
-	if (schema.additionalProperties === true || hasLinks) {
-		query.unshift(`${table}.*`)
-	} else {
-		const topLevelKeys = []
-		for (const key of expression.keys.entries()) {
-			const parts = key[0].split('/')
-
-			// We don't support nested filtering here yet
-			if (parts.length > 1) {
-				continue
-			}
-
-			const property = [ table, `"${parts[0]}"` ]
-			topLevelKeys.push(property.join('.'))
-		}
-
-		if (topLevelKeys.length !== 0) {
-			query.unshift(topLevelKeys.join(',\n'))
-		} else if (schema.required && schema.required.length > 0) {
-			query.unshift(schema.required
-				.map((key) => {
-					return `${table}."${key}"`
-				})
-				.join(',\n'))
-		}
-
-		if (!query[1].startsWith('FROM') && query[1] !== 'WHERE') {
-			query[0] = `${query[0]}, `
-		}
-	}
-
-	query.unshift('SELECT')
-
-	if (options.sortBy) {
-		const order = _.castArray(options.sortBy)
-
-		const orderBy = [
-			'ORDER BY',
-			builder.getProperty([ table ].concat(order)),
-			options.sortDir === 'desc' ? 'DESC' : 'ASC'
-		].join(' ')
-
-		query.push(orderBy)
-	}
-
-	if (options.skip) {
-		assert.INTERNAL(null, _.isNumber(options.skip), Error,
-			`options.skip should be a number, received: ${options.skip}`)
-		query.push(`OFFSET ${options.skip}`)
-	}
-
-	if (options.limit) {
-		assert.INTERNAL(null, _.isNumber(options.limit), Error,
-			`options.limit should be a number, received: ${options.limit}`)
-		query.push(`LIMIT ${options.limit}`)
-	}
-
-	return query.join('\n')
-}
-
-queryv2.generateLinkedCardsQuery = (table, link) => {
-	const linkedCardFilterClause = link.schema ? `AND ${walk(link.schema, [ table ]).filter}` : ''
-
-	const query = `UNION ALL
-SELECT 'outgoing', ${builder.valueToPostgres(link.type)}, links.fromid, ${table}.*
-FROM ${table}
-INNER JOIN links ON (links.toid = ${table}.id AND links.name = ${builder.valueToPostgres(link.type)})
-WHERE links.fromid IN (SELECT id FROM main)
-${linkedCardFilterClause}
-UNION ALL
-SELECT 'incoming', ${builder.valueToPostgres(link.type)}, links.toid, ${table}.*
-FROM ${table}
-INNER JOIN links ON (links.fromid = ${table}.id AND links.inverseName = ${builder.valueToPostgres(link.type)})
-WHERE links.toid IN (SELECT id FROM main)
-${linkedCardFilterClause}`
-
-	return query
-}
-
-queryv2.generateGraphFriendlyQuery = (table, schema, options) => {
-	const links = getLinks(schema)
-
-	const mainQuery = queryv2.generateMainQuery(table, schema, options, !_.isEmpty(links))
-
-	if (_.isEmpty(links)) {
-		return mainQuery
-	}
-
-	const queryWithLinkedCards = [
-		'WITH main AS (',
-		mainQuery,
-		')',
-		'SELECT null AS "$link direction$", null AS "$link type$", main.id AS "$main id$", main.* FROM main'
-	]
-
-	links.forEach((link) => {
-		queryWithLinkedCards.push(queryv2.generateLinkedCardsQuery(table, link))
-	})
-
-	return queryWithLinkedCards.join('\n')
 }
 
 const getLinks = (schema) => {
@@ -357,7 +230,7 @@ const generateQuery = (table, schema, options) => {
 
 module.exports = (table, schema, options = {}) => {
 	if (options.experimental || environment.featureFlags.experimental) {
-		return queryv2.generateGraphFriendlyQuery(table, schema, options)
+		return graph.generateQuery(table, schema, options, getLinks, walk)
 	}
 
 	return generateQuery(table, schema, options)

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -81,5 +81,5 @@ exports.convertDatesToISOString = (row) => {
 exports.removeLinkMetadataFields = (row) => {
 	Reflect.deleteProperty(row, '$link direction$')
 	Reflect.deleteProperty(row, '$link type$')
-	Reflect.deleteProperty(row, '$main id$')
+	Reflect.deleteProperty(row, '$parent id$')
 }

--- a/test/integration/core/backend.spec.js
+++ b/test/integration/core/backend.spec.js
@@ -3929,6 +3929,285 @@ ava('.query() should omit a result if a link does not match', async (test) => {
 	])
 })
 
+ava('.query() should be able to traverse the graph', async (test) => {
+	const thread1 = await test.context.backend.upsertElement(test.context.context, {
+		type: 'thread@1.0.0',
+		slug: 'thread1',
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		linked_at: {},
+		active: true,
+		data: {}
+	})
+
+	const message1 = await test.context.backend.upsertElement(test.context.context, {
+		type: 'message@1.0.0',
+		slug: 'message1',
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		linked_at: {},
+		active: true,
+		data: {}
+	})
+
+	const user1 = await test.context.backend.upsertElement(test.context.context, {
+		type: 'user@1.0.0',
+		slug: 'user1',
+		version: '1.0.0',
+		tags: [],
+		links: {},
+		markers: [],
+		requires: [],
+		capabilities: [],
+		linked_at: {},
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		active: true,
+		data: {
+			username: 'user1'
+		}
+	})
+
+	const link1MessageThread = await test.context.backend.upsertElement(test.context.context, {
+		type: 'link@1.0.0',
+		slug: `link-${message1.slug}-is-part-of-${thread1.slug}`,
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		linked_at: {},
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		active: true,
+		name: 'is part of',
+		data: {
+			inverseName: 'is made of',
+			from: {
+				id: message1.id,
+				type: message1.type
+			},
+			to: {
+				id: thread1.id,
+				type: thread1.type
+			}
+		}
+	})
+
+	const link1UserMessage = await test.context.backend.upsertElement(test.context.context, {
+		type: 'link@1.0.0',
+		slug: `link-${user1.slug}-created-${message1.slug}`,
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		linked_at: {},
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		active: true,
+		name: 'created',
+		data: {
+			inverseName: 'was created',
+			from: {
+				id: user1.id,
+				type: user1.type
+			},
+			to: {
+				id: message1.id,
+				type: message1.type
+			}
+		}
+	})
+
+	const thread2 = await test.context.backend.upsertElement(test.context.context, {
+		type: 'thread@1.0.0',
+		slug: 'thread2',
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		linked_at: {},
+		active: true,
+		data: {}
+	})
+
+	const message2 = await test.context.backend.upsertElement(test.context.context, {
+		type: 'message@1.0.0',
+		slug: 'message2',
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		linked_at: {},
+		active: true,
+		data: {}
+	})
+
+	const user2 = await test.context.backend.upsertElement(test.context.context, {
+		type: 'user@1.0.0',
+		slug: 'user2',
+		version: '1.0.0',
+		tags: [],
+		links: {},
+		markers: [],
+		requires: [],
+		capabilities: [],
+		linked_at: {},
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		active: true,
+		data: {
+			username: 'user2'
+		}
+	})
+
+	await test.context.backend.upsertElement(test.context.context, {
+		type: 'link@1.0.0',
+		slug: `link-${message2.slug}-is-part-of-${thread2.slug}`,
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		linked_at: {},
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		active: true,
+		name: 'is part of',
+		data: {
+			inverseName: 'is made of',
+			from: {
+				id: message2.id,
+				type: message2.type
+			},
+			to: {
+				id: thread2.id,
+				type: thread2.type
+			}
+		}
+	})
+
+	await test.context.backend.upsertElement(test.context.context, {
+		type: 'link@1.0.0',
+		slug: `link-${user2.slug}-created-${message2.slug}`,
+		version: '1.0.0',
+		links: {},
+		tags: [],
+		markers: [],
+		requires: [],
+		capabilities: [],
+		linked_at: {},
+		created_at: new Date().toISOString(),
+		updated_at: null,
+		active: true,
+		name: 'created',
+		data: {
+			inverseName: 'was created',
+			from: {
+				id: user2.id,
+				type: user2.type
+			},
+			to: {
+				id: message2.id,
+				type: message2.type
+			}
+		}
+	})
+
+	// "I want threads that have messages created by user1"
+	const results = await test.context.backend.query(test.context.context, {
+		type: 'object',
+		required: [ 'type' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'thread@1.0.0'
+			}
+		},
+		$$links: {
+			'is made of': {
+				type: 'object',
+				required: [ 'type' ],
+				additionalProperties: true,
+				properties: {
+					type: {
+						type: 'string',
+						const: 'message@1.0.0'
+					}
+				},
+				$$links: {
+					'was created': {
+						type: 'object',
+						required: [ 'id' ],
+						additionalProperties: true,
+						properties: {
+							id: {
+								type: 'string',
+								const: user1.id
+							}
+						}
+					}
+				}
+			}
+		}
+	}, {
+		experimental: true
+	})
+
+	const expected = Object.assign({}, thread1, {
+		linked_at: {
+			'is made of': link1MessageThread.created_at
+		},
+		links: {
+			'is made of': [
+				Object.assign({}, message1, {
+					linked_at: {
+						'is part of': link1MessageThread.created_at,
+						'was created': link1UserMessage.created_at
+					},
+					links: {
+						'was created': [
+							Object.assign({}, user1, {
+								linked_at: {
+									created: link1UserMessage.created_at
+								}
+							})
+						]
+					}
+				})
+			]
+		}
+	})
+
+	test.deepEqual(results.length, 1)
+	test.deepEqual(results, [ expected ])
+})
+
 ava.cb('.stream() should report back new elements that match a certain type', (test) => {
 	test.context.backend.stream(test.context.context, {
 		type: 'object',


### PR DESCRIPTION
Added support to schema queries with nested `$$links`, a.k.a. graph traversal

See for example: https://github.com/balena-io/jellyfish/pull/2860/files#diff-c71d7c962ee2c414ab38f11dd06127d7R4142