### PR TITLE
server: Return early if error is not an error object

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -32,6 +32,11 @@ const sendHTTPError = (request, response, error) => {
 			ip: request.ip,
 			error
 		})
+
+		return response.status(500).json({
+			error: true,
+			data: error
+		})
 	}
 
 	const errorObject = errio.toObject(error, {


### PR DESCRIPTION
We log the warning in the conditional, but we let it through anyways,
which causes `errio` to then throw in a more obscure way.

Returning with an error earlier in this case will unclutter Sentry and
the logs.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!