### PR TITLE
front: Correctly throw error object from request-promise

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -1390,8 +1390,12 @@ module.exports = class FrontIntegration {
 				}
 			}
 
-			if (error.error) {
+			// Get the original request error object
+			// See https://github.com/request/request-promise
+			if (_.isError(error.error)) {
 				throw error.error
+			} else if (_.isError(error.cause)) {
+				throw error.cause
 			}
 
 			throw error


### PR DESCRIPTION
According to the docs at https://github.com/request/request-promise, the
error object that the promise rejects with looks like this:

```
cause: err,
error: err,
options: options,
response: response
```

And apparently the actual error can be either on `cause` or on `error`,
but its unclear why they have such distinction or on what cases
`error.error` is a string.

We should probably refactor this to not use `request-promise`, but then
we're ditching Front anyways, so it might not be worth the effort.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!