### PR TITLE
Use headers rather than query string params to send auth info to discourse

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -36,9 +36,11 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 		options
 	})
 
-	const qs = Object.assign({}, options.query || {}, {
-		api_key: integrationOptions.token.api,
-		api_username: username
+	const qs = options.query || {}
+
+	const headers = Object.assign({}, options.headers || {}, {
+		'Api-Key': integrationOptions.token.api,
+		'Api-Username': username
 	})
 
 	const result = await context.request(options.actor, {
@@ -48,7 +50,8 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 		useQuerystring: true,
 		json: true,
 		uri: url,
-		qs
+		qs,
+		headers
 	})
 
 	const summary = `${result.code} ${method} ${url}`

--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -100,9 +100,9 @@ ava.before(async (test) => {
 				baseUrl: 'https://forums.balena.io',
 				json: true,
 				uri: `/t/${id}.json`,
-				qs: {
-					api_key: TOKEN.api,
-					api_username: TOKEN.username
+				headers: {
+					'Api-Key': TOKEN.api,
+					'Api-Username': TOKEN.username
 				}
 			}, (error, response, body) => {
 				if (error) {
@@ -132,9 +132,9 @@ ava.before(async (test) => {
 				baseUrl: 'https://forums.balena.io',
 				json: true,
 				uri: `/t/${id}.json`,
-				qs: {
-					api_key: TOKEN.api,
-					api_username: TOKEN.username
+				headers: {
+					'Api-Key': TOKEN.api,
+					'Api-Username': TOKEN.username
 				}
 			}, (error, response, body) => {
 				if (error) {
@@ -173,9 +173,9 @@ ava.before(async (test) => {
 					raw: description,
 					category: _.parseInt(test.context.category)
 				},
-				qs: {
-					api_key: TOKEN.api,
-					api_username: username
+				headers: {
+					'Api-Key': TOKEN.api,
+					'Api-Username': username
 				}
 			}, (error, response, body) => {
 				if (error) {

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -5,11 +5,9 @@
  */
 
 const ava = require('ava')
-const querystring = require('querystring')
 const _ = require('lodash')
 const nock = require('nock')
 const uuid = require('uuid/v4')
-const url = require('url')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.discourse
@@ -34,18 +32,12 @@ avaTest('should not change the same user email', async (test) => {
 
 	nock('https://forums.balena.io')
 		.get('/admin/users/4.json')
-		.query({
-			api_key: TOKEN.api,
-			api_username: TOKEN.username
-		})
 		.reply(200,
 			require('./webhooks/discourse/inbound-tag-tag/stubs/1/admin-users-4-json.json'))
 
 	nock('https://forums.balena.io')
 		.get('/t/6061.json')
 		.query({
-			api_key: TOKEN.api,
-			api_username: TOKEN.username,
 			print: true
 		})
 		.reply(200,
@@ -53,10 +45,6 @@ avaTest('should not change the same user email', async (test) => {
 
 	nock('https://forums.balena.io')
 		.get('/categories.json')
-		.query({
-			api_key: TOKEN.api,
-			api_username: TOKEN.username
-		})
 		.reply(200,
 			require('./webhooks/discourse/inbound-tag-tag/stubs/1/categories-json.json'))
 
@@ -121,18 +109,12 @@ avaTest('should add a new e-mail to a user', async (test) => {
 
 	nock('https://forums.balena.io')
 		.get('/admin/users/4.json')
-		.query({
-			api_key: TOKEN.api,
-			api_username: TOKEN.username
-		})
 		.reply(200,
 			require('./webhooks/discourse/inbound-tag-tag/stubs/1/admin-users-4-json.json'))
 
 	nock('https://forums.balena.io')
 		.get('/t/6061.json')
 		.query({
-			api_key: TOKEN.api,
-			api_username: TOKEN.username,
 			print: true
 		})
 		.reply(200,
@@ -140,10 +122,6 @@ avaTest('should add a new e-mail to a user', async (test) => {
 
 	nock('https://forums.balena.io')
 		.get('/categories.json')
-		.query({
-			api_key: TOKEN.api,
-			api_username: TOKEN.username
-		})
 		.reply(200,
 			require('./webhooks/discourse/inbound-tag-tag/stubs/1/categories-json.json'))
 
@@ -203,8 +181,7 @@ scenario.run(avaTest, {
 		token: TOKEN
 	},
 	isAuthorized: (self, request) => {
-		const params = querystring.parse(url.parse(request.path).query)
-		return params.api_key === self.options.token.api &&
-			params.api_username === self.options.token.username
+		return request.headers['api-key'] === self.options.token.api &&
+			request.headers['api-username'] === self.options.token.username
 	}
 })


### PR DESCRIPTION
Use headers rather than query string params to send auth info to discourse, as query string params have been deprecated
See https://meta.discourse.org/t/discourse-api-documentation/22706

Connects-to: #2865
Change-type: minor
Signed-off-by: Federico Fissore <federico@balena.io>
