### PR TITLE
Add specific index on data->'mirrors' 

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -98,6 +98,11 @@ exports.setup = async (context, connection, database, options = {}) => {
 		indexType: 'GIN',
 		options: 'jsonb_path_ops'
 	}, {
+		name: 'data_mirrors',
+		column: '(data->\'mirrors\')',
+		indexType: 'GIN',
+		options: 'jsonb_path_ops'
+	}, {
 		column: 'created_at',
 		options: 'DESC'
 	}, {
@@ -111,7 +116,7 @@ exports.setup = async (context, connection, database, options = {}) => {
 		 * not be able to cleanup older indexes with the older
 		 * name convention.
 		 */
-		const fullyQualifiedIndexName = `${secondaryIndex.column}_${table}_idx`
+		const fullyQualifiedIndexName = `${secondaryIndex.name || secondaryIndex.column}_${table}_idx`
 
 		/*
 		 * Lets not create the index if it already exists.


### PR DESCRIPTION
Add specific index on `data->'mirrors'` because sysdig reports it's a frequent query and it takes (tens of) seconds