### PR TITLE
Fix #2894: Move absolute positioning of MentionsCount to specific use-case

### DIFF
--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -273,7 +273,11 @@ export default class HomeChannel extends React.Component {
 						<Icon name="caret-down"/>
 
 						{mentions && mentions.length > 0 && (
-							<MentionsCount>{(mentions.length >= 100) ? '99+' : mentions.length}</MentionsCount>
+							<MentionsCount style={{
+								position: 'absolute',
+								left: '30px',
+								bottom: '10px'
+							}}>{(mentions.length >= 100) ? '99+' : mentions.length}</MentionsCount>
 						)}
 					</Button>
 				</Flex>

--- a/lib/ui-components/MentionsCount.jsx
+++ b/lib/ui-components/MentionsCount.jsx
@@ -33,9 +33,7 @@ const MentionsCount = styled(Box) `
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;
-	position: absolute;
-	left: 30px;
-	bottom: 10px;
+	font-weight: bold;
 	font-size: ${(props) => {
 		return getFontSize(props.children)
 	}}px;


### PR DESCRIPTION
Connects-to: #2894
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
