### PR TITLE
WIP core: Ensure that we can update the markers materialized view

### DIFF
--- a/lib/core/backend/postgres/markers.js
+++ b/lib/core/backend/postgres/markers.js
@@ -18,35 +18,30 @@ exports.setup = async (context, connection, options = {}) => {
 	const table = exports.getTable(options.source)
 
 	/*
-	 * List all materialized views
+	 * Safely create or override the materialized view definition.
 	 */
-	const views = _.map(await connection.any(`
-		SELECT oid::regclass::text FROM pg_class
-		WHERE relkind = 'm'`), 'oid')
-
-	if (!views.includes(table)) {
-		await connection.any(`
-			CREATE MATERIALIZED VIEW ${table} AS
-			SELECT
-				member.slug,
-				array_agg(${options.source}.slug) AS "markers"
-			FROM ${options.source}
-			INNER JOIN ${options.links} AS link ON (
-				(link.fromId = ${options.source}.id AND link.name = '${LINK_TYPE}') OR
-				(link.toId = ${options.source}.id AND link.inverseName = '${LINK_TYPE}')
-			)
-			INNER JOIN ${options.source} AS member
-			ON (
-				link.toId = member.id OR link.fromId = member.id
-			)
-			WHERE
-			(${options.source}.type = 'org@1.0.0' OR ${options.source}.type = 'org')
-			AND
-			(member.type = 'user@1.0.0' OR member.type = 'user')
-			GROUP BY
-			member.slug
-			WITH DATA`)
-	}
+	await connection.any(`
+		DROP MATERIALIZED VIEW IF EXISTS ${table};
+		CREATE MATERIALIZED VIEW IF NOT EXISTS ${table} AS
+		SELECT
+			member.slug,
+			array_agg(${options.source}.slug) AS "markers"
+		FROM ${options.source}
+		INNER JOIN ${options.links} AS link ON (
+			(link.fromId = ${options.source}.id AND link.name = '${LINK_TYPE}') OR
+			(link.toId = ${options.source}.id AND link.inverseName = '${LINK_TYPE}')
+		)
+		INNER JOIN ${options.source} AS member
+		ON (
+			link.toId = member.id OR link.fromId = member.id
+		)
+		WHERE
+		(${options.source}.type = 'org@1.0.0' OR ${options.source}.type = 'org')
+		AND
+		(member.type = 'user@1.0.0' OR member.type = 'user')
+		GROUP BY
+		member.slug
+		WITH DATA`)
 
 	/*
 	 * This query will give us a list of all the indexes


### PR DESCRIPTION
As it is now, we only create the `cards_markers` materialized view if it
doesn't exist, which means that any change to the definition of this
file doesn't make it to a database that had already been initialized by
Jellyfish.

I couldn't find a better way to update an existing materialized view (if
needed) that didn't involve dropping the view and re-creating it from
scratch.

The `EXISTS` parameters should ensure that this is safe given multiple
containers trying to do the same thing.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!