### PR TITLE
Run flowdock translate tests together with the other translate tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,13 @@ jobs:
           name: Sync Tests Github Translate Without Tokens
           command: make test FILES=./test/integration/sync/github-translate.spec.js COVERAGE=1 INTEGRATION_GITHUB_TOKEN=
 
+      - run:
+          name: Sync Tests Flowdock Translate
+          command: make test FILES=./test/integration/sync/flowdock-translate.spec.js COVERAGE=1 INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY INTEGRATION_FLOWDOCK_TOKEN=$FLOWDOCK_TOKEN
+      - run:
+          name: Sync Tests Flowdock Translate Without Tokens
+          command: make test FILES=./test/integration/sync/flowdock-translate.spec.js COVERAGE=1 INTEGRATION_FLOWDOCK_SIGNATURE_KEY= INTEGRATION_FLOWDOCK_TOKEN=
+
       - persist_to_workspace:
           root: .
           paths:
@@ -288,34 +295,6 @@ jobs:
       - run:
           name: Copy Code Coverage Reports
           command: make compose-up-worker_1 DETACH=1 && docker cp jellyfish_worker_1_1:/usr/src/jellyfish/.nyc_output .nyc_output && make compose-stop
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .nyc_output/*.json
-
-  sync_tests_flowdock_translate:
-    <<: *job_defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: .
-
-      - run:
-          name: Start PostgreSQL
-          command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
-
-      - run:
-          name: Sync Tests
-          command: make test FILES=./test/integration/sync/flowdock-translate.spec.js COVERAGE=1 INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY INTEGRATION_FLOWDOCK_TOKEN=$FLOWDOCK_TOKEN
-      - run:
-          name: Sync End To End Tests Without Tokens
-          command: make test FILES=./test/integration/sync/flowdock-translate.spec.js COVERAGE=1 INTEGRATION_FLOWDOCK_SIGNATURE_KEY= INTEGRATION_FLOWDOCK_TOKEN=
 
       - persist_to_workspace:
           root: .
@@ -973,11 +952,6 @@ workflows:
                     - build
                 <<: *workflow_filter
 
-            - sync_tests_flowdock_translate:
-                requires:
-                    - build
-                <<: *workflow_filter
-
             - sync_tests_front_mirror:
                 requires:
                     - compose-build
@@ -1012,7 +986,6 @@ workflows:
                   - e2e_tests_livechat_previous_dump
                   - sync_tests_front_translate
                   - sync_tests_discourse_translate
-                  - sync_tests_flowdock_translate
                   - sync_tests_front_mirror
                   - sync_tests_discourse_mirror
                   - sync_tests_github_mirror


### PR DESCRIPTION
Run flowdock translate tests together with the other translate tests: they are fast and it takes longer to spin up a new worker than to run the tests

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
