### PR TITLE
CI: Add tentative Buildkite pipeline with Terraform deployment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,12 @@
+steps:
+  - command: "npm ci --unsafe-perm && make build-ui COVERAGE=1 NODE_ENV=test && COVERAGE=1 NODE_ENV=test make build-livechat"
+    plugins:
+      - docker#v3.3.0:
+          image: "resinci/jellyfish-test:latest"
+          always-pull: true
+          workdir: "/jellyfish"
+          environment:
+            - "NPM_CONFIG_CACHE=/node-cache"
+          volumes:
+            - "node-cache:/node-cache"
+            - "$BUILDKITE_BUILD_CHECKOUT_PATH:/jellyfish"

--- a/.buildkite/terraform/Makefile
+++ b/.buildkite/terraform/Makefile
@@ -1,0 +1,35 @@
+.PHONY: lint
+lint:
+	make init
+	terraform validate
+
+.PHONY: init
+init:
+	echo $(S3_BUCKET)
+	make clean
+	terraform init
+
+.PHONY: clean
+clean:
+	rm -fr .terraform
+	rm -f *.tfplan
+	rm -f terraform.tfstate*
+
+.PHONY: deploy
+deploy:
+	terraform plan -out=terraform.tfplan
+	terraform apply terraform.tfplan
+
+.PHONY: destroy
+destroy:
+	terraform destroy -auto-approve
+
+.PHONY: show
+show:
+	terraform show
+
+.PHONY: inspec
+inspec:
+	terraform output -json > inspec/files/output.json
+	inspec exec inspec -t aws://
+	rm -f inspec/files/output.json

--- a/.buildkite/terraform/inspec/controls/main.rb
+++ b/.buildkite/terraform/inspec/controls/main.rb
@@ -1,0 +1,70 @@
+require 'json'
+
+# Read Terraform output JSON.
+file = inspec.profile.file('output.json')
+output = JSON.parse(file)
+
+# Set project-wide variables.
+deploy_id = output['deploy_id']['value']
+
+# Network Resources
+vpc = output['network']['value']['vpc']
+subnet = output['network']['value']['subnet']
+security_group = output['network']['value']['security_group']
+route_table = output['network']['value']['route_table']
+control 'network' do
+  title 'validate network resources'
+  desc 'check that all required network resources exist as expected'
+  tag 'network','vpc','subnet','security_group'
+  describe aws_vpc(vpc_id: vpc['id']) do
+    it {
+      should exist
+      should be_available
+    }
+    its('state') { should eq 'available' }
+    its('cidr_block') { should cmp vpc['cidr_block'] }
+    its('instance_tenancy') { should cmp vpc['instance_tenancy'] }
+    its('dhcp_options_id') { should cmp vpc['dhcp_options_id'] }
+    its('tags') { should include('deploy_id' => deploy_id) }
+  end
+  describe aws_subnet(subnet_id: subnet['id']) do
+    it {
+      should exist
+      should be_available
+    }
+    its('tags') { should include('deploy_id' => deploy_id) }
+  end
+  describe aws_security_group(group_id: security_group['id']) do
+    it { should exist }
+    its('tags') { should include('deploy_id' => deploy_id) }
+  end
+  describe aws_route_table(route_table_id: route_table['id']) do
+    it { should exist }
+    its('vpc_id') { should cmp vpc['id'] }
+    its('vpc_id') { should cmp route_table['vpc_id'] }
+    its('tags') { should include('deploy_id' => deploy_id) }
+    its('associations.count') { should eq 1 }
+  end
+end
+
+# Instances
+instances = output['instances']['value']['instance']
+control 'instances' do
+  title 'validate ec2 instances'
+  desc 'checks that all required ec2 instances exist as expected'
+  tag 'instance'
+  instances.each do |instance|
+    describe aws_ec2_instance(instance['id']) do
+      it {
+        should exist
+        should be_running
+      }
+      its('image_id') { should cmp instance['ami'] }
+      its('instance_type') { should cmp instance['instance_type'] }
+      its('availability_zone') { should cmp instance['availability_zone'] }
+      its('key_name') { should cmp instance['key_name'] }
+      its('subnet_id') { should cmp instance['subnet_id'] }
+      its('tags') { should include(key: 'deploy_id', value: deploy_id) }
+    end     
+  end
+end

--- a/.buildkite/terraform/inspec/inspec.yml
+++ b/.buildkite/terraform/inspec/inspec.yml
@@ -1,0 +1,14 @@
+name: jellyfish-buildkite
+title: InSpec Profile for Jellyfish Buildkite
+maintainer: Josh Bowling
+copyright: (C) Balena.io - All Rights Reserved
+copyright_email: hello@balena.io
+license: null
+summary: Verify the Jellyfish Buildkite Terraform deployment
+version: 1.0.0
+inspec_version: '>= 4.18.51'
+depends:
+  - name: inspec-aws
+    url: https://github.com/inspec/inspec-aws/archive/v1.5.1.tar.gz
+supports:
+  - platform: aws

--- a/.buildkite/terraform/main.tf
+++ b/.buildkite/terraform/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {}
+
+terraform {
+  backend "s3" {
+    bucket = "buildkite-terraform"
+    key    = "jellyfish"
+    region = "us-west-2"
+  }
+}
+
+module "network" {
+  source                    = "./modules/network"
+  deploy_id                 = local.deploy_id
+  vpc_cidr_block            = var.vpc_cidr_block
+  subnet_availability_zone  = var.subnet_availability_zone
+  security_group_cidr_block = var.security_group_cidr_block
+}
+
+module "instances" {
+  source                = "./modules/instance"
+  deploy_id             = local.deploy_id
+  instance_type         = var.instance_type
+  ami_id                = var.ami_id
+  key_name              = var.key_name
+  security_group_id     = module.network.security_group.id
+  subnet_id             = module.network.subnet.id
+  instance_count        = var.instance_count
+  buildkite_agent_token = var.buildkite_agent_token
+  buildkite_agent_key   = var.buildkite_agent_key
+}

--- a/.buildkite/terraform/modules/instance/main.tf
+++ b/.buildkite/terraform/modules/instance/main.tf
@@ -1,0 +1,46 @@
+resource "aws_instance" "instance" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  vpc_security_group_ids = [var.security_group_id]
+  subnet_id              = var.subnet_id
+  count                  = var.instance_count
+  user_data              = <<-EOF
+    #!/bin/bash
+    sudo apt update && sudo apt-upgrade -y
+    # Install Buildkite Agent
+    echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+    sudo apt-get update && sudo apt-get install -y buildkite-agent
+    sudo sed -i "s/xxx/${var.buildkite_agent_token}/g" /etc/buildkite-agent/buildkite-agent.cfg
+    sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent
+    # Install Docker
+    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo apt-key fingerprint 0EBFCD88
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+    sudo systemctl enable docker && sudo systemctl start docker
+    sudo usermod -aG docker buildkite-agent
+    # Install Docker Compose
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    # Copy private SSH key
+    mkdir -p /var/lib/buildkite-agent/.ssh
+    echo "${var.buildkite_agent_key}" > /var/lib/buildkite-agent/.ssh/id_rsa
+    chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh
+    chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh/id_rsa
+    chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa
+    # Reboot system
+    sudo reboot
+    EOF
+  tags = {
+    deploy_id = var.deploy_id
+  }
+}
+
+resource "aws_eip" "ip" {
+  instance = aws_instance.instance.*.id[count.index]
+  vpc      = true
+  count    = var.instance_count
+}

--- a/.buildkite/terraform/modules/instance/outputs.tf
+++ b/.buildkite/terraform/modules/instance/outputs.tf
@@ -1,0 +1,3 @@
+output "instance" {
+  value = aws_instance.instance
+}

--- a/.buildkite/terraform/modules/instance/variables.tf
+++ b/.buildkite/terraform/modules/instance/variables.tf
@@ -1,0 +1,44 @@
+variable "deploy_id" {
+  description = "Deployment ID"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "ID of AMI to use for instances"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 Instance Type"
+  type        = string
+}
+
+variable "instance_count" {
+  description = "Number of instances to deploy"
+  type        = number
+}
+
+variable "key_name" {
+  description = "SSH Key pair name"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "ID of subnet to place instances in"
+  type        = string
+}
+
+variable "security_group_id" {
+  description = "ID of security group to associate instances with"
+  type        = string
+}
+
+variable "buildkite_agent_token" {
+  description = "Buildkite agent token"
+  type        = string
+}
+
+variable "buildkite_agent_key" {
+  description = "Private SSH key for Buildkite agents"
+  type        = string
+}

--- a/.buildkite/terraform/modules/network/main.tf
+++ b/.buildkite/terraform/modules/network/main.tf
@@ -1,0 +1,60 @@
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    deploy_id = var.deploy_id
+  }
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(aws_vpc.vpc.cidr_block, 3, 1)
+  availability_zone = var.subnet_availability_zone
+  tags = {
+    deploy_id = var.deploy_id
+  }
+}
+
+resource "aws_security_group" "security_group" {
+  name   = "main"
+  vpc_id = aws_vpc.vpc.id
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.security_group_cidr_block]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.security_group_cidr_block]
+  }
+  tags = {
+    deploy_id = var.deploy_id
+  }
+}
+
+resource "aws_internet_gateway" "gateway" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    deploy_id = var.deploy_id
+  }
+}
+
+resource "aws_route_table" "table" {
+  vpc_id = aws_vpc.vpc.id
+  route {
+    cidr_block = var.security_group_cidr_block
+    gateway_id = aws_internet_gateway.gateway.id
+  }
+  tags = {
+    deploy_id = var.deploy_id
+  }
+}
+
+resource "aws_route_table_association" "association" {
+  subnet_id      = aws_subnet.subnet.id
+  route_table_id = aws_route_table.table.id
+}

--- a/.buildkite/terraform/modules/network/outputs.tf
+++ b/.buildkite/terraform/modules/network/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc" {
+  value = aws_vpc.vpc
+}
+
+output "subnet" {
+  value = aws_subnet.subnet
+}
+
+output "security_group" {
+  value = aws_security_group.security_group
+}
+
+output "route_table" {
+  value = aws_route_table.table
+}

--- a/.buildkite/terraform/modules/network/variables.tf
+++ b/.buildkite/terraform/modules/network/variables.tf
@@ -1,0 +1,19 @@
+variable "deploy_id" {
+  description = "Deployment ID"
+  type        = string
+}
+
+variable "vpc_cidr_block" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "subnet_availability_zone" {
+  description = "Subnet availability zone"
+  type        = string
+}
+
+variable "security_group_cidr_block" {
+  description = "CIDR block used for security group ingress/egress rules"
+  type        = string
+}

--- a/.buildkite/terraform/outputs.tf
+++ b/.buildkite/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "deploy_id" {
+  value = local.deploy_id
+}
+
+output "network" {
+  value = module.network
+}
+
+output "instances" {
+  value = module.instances
+}

--- a/.buildkite/terraform/terraform.tfvars
+++ b/.buildkite/terraform/terraform.tfvars
@@ -1,0 +1,3 @@
+# Instance
+instance_type  = "t2.micro"
+instance_count = 4

--- a/.buildkite/terraform/variables.tf
+++ b/.buildkite/terraform/variables.tf
@@ -1,0 +1,54 @@
+locals {
+  deploy_id = substr(uuid(), 0, 4)
+}
+
+variable "key_name" {
+  description = "SSH key pair name for logging into instances"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ami_id" {
+  description = "ID of AMI to use for instances"
+  type        = string
+  default     = "ami-06d51e91cea0dac8d"
+}
+
+variable "instance_count" {
+  description = "Number of instances to deploy"
+  type        = number
+  default     = 1
+}
+
+variable "vpc_cidr_block" {
+  description = "VPC CIDR block"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_availability_zone" {
+  description = "Subnet availability zone"
+  type        = string
+  default     = "us-west-2a"
+}
+
+variable "security_group_cidr_block" {
+  description = "CIDR block used for security group ingress/egress rules"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "buildkite_agent_token" {
+  description = "Buildkite agent token"
+  type        = string
+}
+
+variable "buildkite_agent_key" {
+  description = "Private SSH key for Buildkite agents"
+  type        = string
+}


### PR DESCRIPTION
Although we haven't decided on which CI solution to use instead of CircleCI just yet, I wanted to try and make some headway on checking out Buildkite as Codefresh is apparently quite expensive.
Have no idea as to how resource deployment to AWS is done inside of Balena, but assuming Terraform is an option I've put together the following in this branch. The pipeline is still in the very early stages, but the Terraform is in a working and usable state (was able to deploy and scale up the number of Buildkite agents to my test project through Terraform with just a couple of `make` commands).

**Apparently we can also use Elastic CI Stack for AWS to manage agent machines, which might be a better solution than Terraform: [Elastic CI Stack + Buildkite Screencast](https://buildkite.com/screencasts/elastic-ci-stack-for-aws)**  

Whats here:
- Beginnings of a Buildkite pipeline that runs steps in Docker on custom agents (tested to work)
- Some Terraform for Buildkite agent machine deployment that:
  - Deploys a network: VPC, subnet, security group, internet gateway, and route table
  - Deploys a variable amount of EC2 instances that join a Buildkite project automatically on creation
  - Can be tested with the included [Chef Inspec](https://github.com/inspec/inspec) tests
  - Can be deployed/tested/etc. with a few simple `make` commands
  - Stores its state in an S3 bucket
  - Requires the following environment variables:
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `AWS_DEFAULT_REGION`
    - `TF_VAR_key_name`(AWS key pair name, SSH key used to SSH to machines)
    - `TF_VAR_buildkite_agent_token`
    - `TF_VAR_buildkite_agent_key` (Private SSH key used to `git clone`)

After setting up the S3 bucket to store the Terraform state data and exporting the above required variables, Buildkite agent machines can be deployed, confirmed, and tested with `make`.

## Deploy
```
$ source ~/set-buildkite-vars.sh
$ make init && make deploy
echo 

make clean
make[1]: Entering directory '/home/josh/aws-buildkite'
rm -fr .terraform
rm -f *.tfplan
rm -f terraform.tfstate*
make[1]: Leaving directory '/home/josh/aws-buildkite'
terraform init
Initializing modules...
- instances in modules/instance
- network in modules/network

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "aws" (hashicorp/aws) 2.43.0...
...
```

## Show
```
$ make show
terraform show
# module.network.aws_internet_gateway.gateway:
resource "aws_internet_gateway" "gateway" {
    id       = "igw-07586e5708bfd7005"
    owner_id = "701735229187"
    tags     = {
        "deploy_id" = "1e57"
    }
    vpc_id   = "vpc-0064f937b386d10a2"
}

# module.network.aws_route_table.table:
resource "aws_route_table" "table" {
    id               = "rtb-08f481e7a59e14abd"
...
```

## Test
```
$ make inspec
18:14:34 josh@work aws-buildkite make inspec
terraform output -json > inspec/files/output.json
inspec exec inspec -t aws://

Profile: InSpec Profile for Jellyfish Buildkite (jellyfish-buildkite)
Version: 1.0.0
Target:  aws://

  ✔  network: validate network resources
     ✔  VPC vpc-0376b495b01018cbf is expected to be available
     ✔  VPC vpc-0376b495b01018cbf state is expected to eq "available"
     ✔  VPC vpc-0376b495b01018cbf cidr_block is expected to cmp == "10.0.0.0/16"
     ✔  VPC vpc-0376b495b01018cbf instance_tenancy is expected to cmp == "default"
     ✔  VPC vpc-0376b495b01018cbf dhcp_options_id is expected to cmp == "dopt-5444b42c"
     ✔  VPC vpc-0376b495b01018cbf tags is expected to include {"deploy_id" => "1ef6"}
...
```

## End Result
Which after a few moments should result in the machines showing up in your Buildkite agent list
![buildkite](https://user-images.githubusercontent.com/45343541/71441954-15324a00-2747-11ea-927d-8fb3b9b3845e.png)

## Thoughts on Pipeline
- Run every step in Docker for consistent and predictable environments?
- Pass around npm cache as a docker volume to each step that can use it?
- Pass host docker socket as volume so we can run docker/compose commands inside containers?
- Auto-scale agents? ([Document](https://buildkite.com/docs/tutorials/parallel-builds#auto-scaling-your-build-agents))

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
