### PR TITLE
Improve sidecar Dockerfile, based on hadolint warnings

### DIFF
--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -15,13 +15,16 @@ COPY scripts/template/package*.json \
 	/usr/src/jellyfish/scripts/template/
 RUN npm ci
 
-RUN apt-get update && apt-get install -y \
-	libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 \
-	libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
-	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	libx11-xcb1=2:1.6.7-1 libxcomposite1=1:0.4.4-2 libxcursor1=1:1.1.15-2 \
+	libxdamage1=1:1.1.4-3+b3 libxi6=2:1.7.9-1 libxtst6=2:1.2.3-1 libnss3=2:3.42.1-1+deb10u1 \
+	libcups2=2.2.10-6+deb10u1 libxss1=1:1.2.3-1 libxrandr2=2:1.5.1-1 \
+	gconf-gsettings-backend=3.2.6-5 libasound2=1.1.8-1 libatk1.0-0=2.30.0-2 libgtk-3-0=3.24.5-1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY . /usr/src/jellyfish
 
 # Sleep forever
 # See: https://stackoverflow.com/a/35770783
-CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
+CMD ["/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"]


### PR DESCRIPTION
## `hadolint` Warnings
```
$ hadolint apps/sidecar/Dockerfile 
apps/sidecar/Dockerfile:18 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
apps/sidecar/Dockerfile:18 DL3009 Delete the apt-get lists after installing something
apps/sidecar/Dockerfile:18 DL3015 Avoid additional packages by specifying `--no-install-recommends`
apps/sidecar/Dockerfile:27 DL3025 Use arguments JSON notation for CMD and ENTRYPOINT arguments
```

### 1. DL3008
- Warning: **Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`**
- hadolint Wiki: [Link](https://github.com/hadolint/hadolint/wiki/DL3008)

#### Rationale
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get  
  
> Version pinning forces the build to retrieve a particular version regardless of what’s in the cache. This technique can also reduce failures due to unanticipated changes in required packages.

### 2. DL3009
- Warning: **Delete the apt-get lists after installing something**
- hadolint Wiki: [Link](https://github.com/hadolint/hadolint/wiki/DL3009)

#### Rationale
https://docs.docker.com/engine/articles/dockerfile_best-practices/  
  
> In addition, cleaning up the apt cache and removing /var/lib/apt/lists helps keep the image size down. Since the RUN statement starts with apt-get update, the package cache will always be refreshed prior to apt-get install.

### 3. DL3015
- Warning: **Avoid additional packages by specifying `--no-install-recommends`**
- hadolint Wiki: [Link](https://github.com/hadolint/hadolint/wiki/DL3015)

#### Rationale
Avoid installing additional packages that you did not explicitly want.

### 4. DL3025
- Warning: **Use arguments JSON notation for CMD and ENTRYPOINT arguments**
- hadolint Wiki: [Link](https://github.com/hadolint/hadolint/wiki/DL3025)

#### Rationale
When using the plain text version of passing arguments, signals from the OS are not correctly passed to the executables, which is in the majority of the cases what you would expect.
  
https://docs.docker.com/engine/articles/dockerfile_best-practices/
  
> CMD should almost always be used in the form of CMD [“executable”, “param1”, “param2”…]
  
> The shell form prevents any CMD or run command line arguments from being used, but has the disadvantage that your ENTRYPOINT will be started as a subcommand of /bin/sh -c, which does not pass signals. This means that the executable will not be the container’s PID 1 - and will not receive Unix signals - so your executable will not receive a SIGTERM from docker stop .

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
