### PR TITLE
UI: Add click area on message body

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -440,6 +440,27 @@ export default class Event extends React.Component {
 							name={actor ? actor.name : null}
 							url={actor ? actor.avatarUrl : null}
 						/>
+
+						{this.props.openChannel &&
+							<Box
+								tooltip={{
+									placement: 'bottom',
+									text: `Open ${card.type.split('@')[0]}`
+								}}
+							>
+								<Icon
+									style={{
+										marginLeft: 6,
+										marginTop: 16,
+										fontSize: '18px',
+										transform: 'scale(1, -1)',
+										color: '#2e587a'
+									}}
+									name="share"
+								/>
+							</Box>
+						}
+
 					</EventButton>
 					<Box
 						pt={2}


### PR DESCRIPTION
Fixes: #2902 
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

This PR increases the clickable area to include the message body for easier navigation.