### PR TITLE
test: Only setup browser environment on necessary tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
       "apps/**/*.spec.{js,jsx}"
     ],
     "require": [
-      "./test/register",
-      "./test/e2e/ui/browser-setup.js"
+      "./test/register"
     ]
   },
   "author": "Balena.io. <hello@balena.io>",

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+require('./browser-setup')
+
 const ava = require('ava')
 const _ = require('lodash')
 const Bluebird = require('bluebird')

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+require('./browser-setup')
+
 const ava = require('ava')
 const bluebird = require('bluebird')
 const _ = require('lodash')

--- a/test/e2e/ui/oauth.spec.js
+++ b/test/e2e/ui/oauth.spec.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+require('./browser-setup')
+
 const ava = require('ava')
 const _ = require('lodash')
 const nock = require('nock')

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+require('./browser-setup')
+
 const ava = require('ava')
 const bluebird = require('bluebird')
 const uuid = require('uuid/v4')

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+require('./browser-setup')
+
 const ava = require('ava')
 const Bluebird = require('bluebird')
 const uuid = require('uuid/v4')


### PR DESCRIPTION
Looks like we were accidentally setting up a browser environment for all
our tests, which meant that on server e2e tests, the SDK would use, on
Node.js, `jsdom` instead of `http` to make HTTP calls, which could
potentially be the root cause of some of the mysterious "Network Error"
test flakiness on the e2e suites.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!