### PR TITLE
scripts: Retry "curl" calls on transient issues

### DIFF
--- a/scripts/ci/postgres-get-previous-dump.sh
+++ b/scripts/ci/postgres-get-previous-dump.sh
@@ -36,7 +36,7 @@ OWNER="balena-io"
 REPO="jellyfish"
 
 function get_statuses() {
-	curl --header "Authorization: Bearer $GITHUB_TOKEN" \
+	curl --retry 5 --header "Authorization: Bearer $GITHUB_TOKEN" \
 		"https://api.github.com/repos/$OWNER/$REPO/commits/$1/statuses"
 }
 
@@ -45,7 +45,7 @@ function filter_results_job() {
 }
 
 get_artifact_link() {
-	curl -u "$CIRCLE_TOKEN:" "$1/artifacts" | jq -r ".[] | select(.path==\"$2\") .url"
+	curl --retry 5 -u "$CIRCLE_TOKEN:" "$1/artifacts" | jq -r ".[] | select(.path==\"$2\") .url"
 }
 
 for commit in $COMMITS; do
@@ -62,7 +62,7 @@ for commit in $COMMITS; do
 	DUMP_URL="$(get_artifact_link "$API_URL" "test-results/dump-$TYPE.gz")"
 	echo "    --> Postgres dump URL: $DUMP_URL"
 	set +e
-	curl -v -o dump.gz -L "$DUMP_URL?circle-token=$CIRCLE_TOKEN"
+	curl --retry 5 -v -o dump.gz -L "$DUMP_URL?circle-token=$CIRCLE_TOKEN"
 	EXIT_CODE="$?"
 	set -e
 

--- a/scripts/ci/summary.sh
+++ b/scripts/ci/summary.sh
@@ -15,7 +15,7 @@ ARTIFACT_UI_WEBPACK_REPORT="test-results/ui/webpack-bundle-report.html"
 ARTIFACT_LIVECHAT_WEBPACK_REPORT="test-results/livechat/webpack-bundle-report.html"
 
 get_artifact_link() (
-	curl -u "$CIRCLE_TOKEN:" "$API_URL/artifacts" | jq -r ".[] | select(.path==\"$1\") .url"
+	curl --retry 5 -u "$CIRCLE_TOKEN:" "$API_URL/artifacts" | jq -r ".[] | select(.path==\"$1\") .url"
 )
 
 echo "Ship shape and ready to sail!"


### PR DESCRIPTION
From the man page:

```
 --retry <num>
				If a transient error is returned when curl  tries  to  perform  a
				transfer,  it  will  retry this number of times before giving up.
				Setting the number to 0 makes curl do no retries  (which  is  the
				default).  Transient  error  means  either: a timeout, an FTP 4xx
				response code or an HTTP 408 or 5xx response code.
```

Consider https://circleci.com/gh/balena-io/jellyfish/63262 as an
example. cURL failed with 504 Gateway Timeout when trying to fetch the
Postgres build.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!