### PR TITLE
queue: Don't execute `.getCardBySlug` when not needed

### DIFF
--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -266,6 +266,11 @@ exports.wait = async (context, jellyfish, session, options) => {
 			resolve(result)
 		})
 
+		// Don't perform a "get by slug" if we already have a match.
+		if (result) {
+			return
+		}
+
 		jellyfish.getCardBySlug(
 			context, session, `${slug}@${EXECUTION_EVENT_VERSION}`).then((card) => {
 			if (!card) {


### PR DESCRIPTION
There is a (tiny) chance that the stream resolves a wait match before
(or while) we attempted to run `.getCardBySlug()`.

We've seen this happening on Circle CI, where the race condition showed
itself as:

```
  ✔ events › .wait() should ignore cards that do not match the id (521ms)
Uncaught AbortError: EXEC can't be processed. The connection is already closed.

FROM
  ✖ test/integration/queue/events.spec.js exited due to SIGILL
```

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!