### PR TITLE
test: Simplify and re-organize lifecycle helpers in integration/core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,8 +333,7 @@ test-integration:
 	FILES="'./test/integration/**/*.spec.js'" make test
 
 test-e2e:
-	FILES="'./test/e2e/**/*.spec.{js,jsx}'" \
-		AVA_OPTS="--serial" make test
+	FILES="'./test/e2e/**/*.spec.{js,jsx}'" make test
 
 test-unit-%:
 	FILES="'./test/unit/$(subst test-unit-,,$@)/**/*.spec.{js,jsx}'" SCRUB=0 make test
@@ -357,8 +356,7 @@ test-integration-%:
 	FILES="'./test/integration/$(subst test-integration-,,$@)/**/*.spec.js'" make test
 
 test-e2e-%:
-	FILES="'./test/e2e/$(subst test-e2e-,,$@)/**/*.spec.{js,jsx}'" \
-		AVA_OPTS="--serial" make test
+	FILES="'./test/e2e/$(subst test-e2e-,,$@)/**/*.spec.{js,jsx}'" make test
 
 ngrok-%:
 	ngrok start -config ./ngrok.yml $(subst ngrok-,,$@)

--- a/test/e2e/server/helpers.js
+++ b/test/e2e/server/helpers.js
@@ -4,10 +4,10 @@
  * Proprietary and confidential.
  */
 
+const uuid = require('uuid/v4')
 const Bluebird = require('bluebird')
 const _ = require('lodash')
 const request = require('request')
-const helpers = require('../../integration/core/helpers')
 const environment = require('../../../lib/environment')
 
 const waitForServer = async (test, retries = 50) => {
@@ -28,7 +28,14 @@ const waitForServer = async (test, retries = 50) => {
 
 module.exports = {
 	before: async (test) => {
-		test.context.generateRandomSlug = helpers.generateRandomSlug
+		test.context.generateRandomSlug = (options) => {
+			const suffix = uuid()
+			if (options.prefix) {
+				return `${options.prefix}-${suffix}`
+			}
+
+			return suffix
+		}
 
 		test.context.http = (method, uri, payload, headers, options = {}) => {
 			return new Bluebird((resolve, reject) => {

--- a/test/integration/core/backend/helpers.js
+++ b/test/integration/core/backend/helpers.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const uuid = require('uuid/v4')
+const Backend = require('../../../../lib/core/backend')
+const environment = require('../../../../lib/environment')
+const Cache = require('../../../../lib/core/cache')
+const errors = require('../../../../lib/core/errors')
+
+exports.beforeEach = async (test, options = {}) => {
+	const suffix = options.suffix || uuid()
+	const dbName = `test_${suffix.replace(/-/g, '_')}`
+
+	test.context.cache = new Cache(
+		Object.assign({}, environment.redis, {
+			namespace: dbName
+		}))
+
+	test.context.context = {
+		id: `CORE-TEST-${uuid()}`
+	}
+
+	if (test.context.cache) {
+		await test.context.cache.connect(test.context.context)
+	}
+
+	test.context.backend = new Backend(
+		test.context.cache,
+		errors,
+		Object.assign({}, environment.database.options, {
+			database: dbName
+		}))
+
+	if (options.skipConnect) {
+		return
+	}
+
+	await test.context.backend.connect(test.context.context)
+}
+
+exports.afterEach = async (test) => {
+	/*
+	 * We can just disconnect and not destroy the whole
+	 * database as test databases are destroyed before
+	 * the next test run anyways.
+	 */
+	await test.context.backend.disconnect(test.context.context)
+
+	if (test.context.cache) {
+		await test.context.cache.disconnect()
+	}
+}

--- a/test/integration/core/backend/index.spec.js
+++ b/test/integration/core/backend/index.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const uuid = require('uuid/v4')
 const _ = require('lodash')
 const Bluebird = require('bluebird')
-const errors = require('../../../lib/core/errors')
+const errors = require('../../../../lib/core/errors')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.backend.beforeEach)
-ava.afterEach(helpers.backend.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('should only expose the required methods', (test) => {
 	const methods = Object.getOwnPropertyNames(

--- a/test/integration/core/backend/postgres/utils.spec.js
+++ b/test/integration/core/backend/postgres/utils.spec.js
@@ -8,10 +8,10 @@ const ava = require('ava')
 const _ = require('lodash')
 const Bluebird = require('bluebird')
 const utils = require('../../../../../lib/core/backend/postgres/utils')
-const helpers = require('../../helpers')
+const helpers = require('../helpers')
 
-ava.beforeEach(helpers.backend.beforeEach)
-ava.afterEach(helpers.backend.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('.getPendingRequests() should return nothing by default', async (test) => {
 	const result = await utils.getPendingRequests(

--- a/test/integration/core/cache/helpers.js
+++ b/test/integration/core/cache/helpers.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const uuid = require('uuid/v4')
+const environment = require('../../../../lib/environment')
+const Cache = require('../../../../lib/core/cache')
+
+exports.beforeEach = async (test) => {
+	test.context.cache = new Cache(
+		Object.assign({}, environment.redis, {
+			namespace: `test_${uuid()}`
+		}))
+
+	await test.context.cache.connect()
+}
+
+exports.afterEach = async (test) => {
+	await test.context.cache.disconnect()
+}

--- a/test/integration/core/cache/index.spec.js
+++ b/test/integration/core/cache/index.spec.js
@@ -5,10 +5,10 @@
  */
 
 const ava = require('ava')
-const helpers = require('./helpers')
+const helpers = require('../helpers')
 
-ava.afterEach(helpers.cache.afterEach)
-ava.beforeEach(helpers.cache.beforeEach)
+ava.afterEach(helpers.afterEach)
+ava.beforeEach(helpers.beforeEach)
 
 ava('.set() should be able to retrieve item by id', async (test) => {
 	const element1 = {

--- a/test/integration/core/helpers.js
+++ b/test/integration/core/helpers.js
@@ -5,13 +5,10 @@
  */
 
 const uuid = require('uuid/v4')
-const Backend = require('../../../lib/core/backend')
-const environment = require('../../../lib/environment')
-const Cache = require('../../../lib/core/cache')
+const helpers = require('./backend/helpers')
 const Kernel = require('../../../lib/core/kernel')
-const errors = require('../../../lib/core/errors')
 
-exports.generateRandomSlug = (options) => {
+const generateRandomSlug = (options) => {
 	const suffix = uuid()
 	if (options.prefix) {
 		return `${options.prefix}-${suffix}`
@@ -20,94 +17,23 @@ exports.generateRandomSlug = (options) => {
 	return suffix
 }
 
-exports.backend = {
-	beforeEach: async (test, options = {}) => {
-		const suffix = options.suffix || uuid()
-		const dbName = `test_${suffix.replace(/-/g, '_')}`
+exports.beforeEach = async (test, options = {}) => {
+	await helpers.beforeEach(test, {
+		skipConnect: true,
+		suffix: options.suffix
+	})
 
-		test.context.cache = new Cache(
-			Object.assign({}, environment.redis, {
-				namespace: dbName
-			}))
-
-		test.context.context = {
-			id: `CORE-TEST-${uuid()}`
-		}
-
-		if (test.context.cache) {
-			await test.context.cache.connect(test.context.context)
-		}
-
-		test.context.backend = new Backend(
-			test.context.cache,
-			errors,
-			Object.assign({}, environment.database.options, {
-				database: dbName
-			}))
-
-		test.context.generateRandomSlug = exports.generateRandomSlug
-
-		if (options.skipConnect) {
-			return
-		}
-
+	if (options.suffix) {
 		await test.context.backend.connect(test.context.context)
-	},
-	afterEach: async (test) => {
-		/*
-		 * We can just disconnect and not destroy the whole
-		 * database as test databases are destroyed before
-		 * the next test run anyways.
-		 */
-		await test.context.backend.disconnect(test.context.context)
-
-		if (test.context.cache) {
-			await test.context.cache.disconnect()
-		}
+		await test.context.backend.reset(test.context.context)
 	}
+
+	test.context.kernel = new Kernel(test.context.backend)
+	await test.context.kernel.initialize(test.context.context)
+	test.context.generateRandomSlug = generateRandomSlug
 }
 
-exports.kernel = {
-	beforeEach: async (test, options = {}) => {
-		await exports.backend.beforeEach(test, {
-			skipConnect: true,
-			suffix: options.suffix
-		})
-
-		if (options.suffix) {
-			await test.context.backend.connect(test.context.context)
-			await test.context.backend.reset(test.context.context)
-		}
-
-		test.context.kernel = new Kernel(test.context.backend)
-		await test.context.kernel.initialize(test.context.context)
-	},
-	afterEach: async (test) => {
-		await test.context.kernel.disconnect(test.context.context)
-		await exports.backend.afterEach(test)
-	}
-}
-
-exports.jellyfish = {
-	beforeEach: async (test, options) => {
-		await exports.kernel.beforeEach(test, options)
-		test.context.jellyfish = test.context.kernel
-	},
-	afterEach: async (test) => {
-		await exports.kernel.afterEach(test)
-	}
-}
-
-exports.cache = {
-	beforeEach: async (test) => {
-		test.context.cache = new Cache(
-			Object.assign({}, environment.redis, {
-				namespace: `test_${uuid()}`
-			}))
-
-		await test.context.cache.connect()
-	},
-	afterEach: async (test) => {
-		await test.context.cache.disconnect()
-	}
+exports.afterEach = async (test) => {
+	await test.context.kernel.disconnect(test.context.context)
+	await helpers.afterEach(test)
 }

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -12,8 +12,8 @@ const errors = require('../../../lib/core/errors')
 const CARDS = require('../../../lib/core/cards')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.kernel.beforeEach)
-ava.afterEach(helpers.kernel.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('should only expose the required methods', (test) => {
 	const methods = Object.getOwnPropertyNames(

--- a/test/integration/core/permission-filter.spec.js
+++ b/test/integration/core/permission-filter.spec.js
@@ -9,8 +9,8 @@ const permissionFilter = require('../../../lib/core/permission-filter')
 const errors = require('../../../lib/core/errors')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.kernel.beforeEach)
-ava.afterEach(helpers.kernel.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('.getSessionUser() should throw if the session is invalid', async (test) => {
 	await test.throwsAsync(permissionFilter.getSessionUser(

--- a/test/integration/core/views.spec.js
+++ b/test/integration/core/views.spec.js
@@ -9,8 +9,8 @@ const views = require('../../../lib/core/views')
 const CARDS = require('../../../lib/core/cards')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.kernel.beforeEach)
-ava.afterEach(helpers.kernel.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('.getSchema() should return null if the card is not a view', (test) => {
 	const schema = views.getSchema(CARDS['user-admin'])

--- a/test/integration/queue/events.spec.js
+++ b/test/integration/queue/events.spec.js
@@ -10,11 +10,8 @@ const Bluebird = require('bluebird')
 const helpers = require('./helpers')
 const events = require('../../../lib/queue/events')
 
-ava.beforeEach(async (test) => {
-	await helpers.queue.beforeEach(test)
-})
-
-ava.afterEach(helpers.queue.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('.post() should insert an active execute card', async (test) => {
 	const event = await events.post(test.context.context, test.context.jellyfish, test.context.session, {

--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -10,81 +10,71 @@ const helpers = require('../core/helpers')
 const Queue = require('../../../lib/queue')
 const actionLibrary = require('../../../lib/action-library')
 
-exports.jellyfish = {
-	beforeEach: async (test, options) => {
-		await helpers.beforeEach(test, options)
-		test.context.jellyfish = test.context.kernel
-		test.context.session = test.context.jellyfish.sessions.admin
+exports.beforeEach = async (test, options = {}) => {
+	await helpers.beforeEach(test, {
+		suffix: options.suffix
+	})
 
-		const session = await test.context.jellyfish.getCardById(
-			test.context.context, test.context.session, test.context.session)
-		test.context.actor = await test.context.jellyfish.getCardById(
-			test.context.context, test.context.session, session.data.actor)
+	test.context.jellyfish = test.context.kernel
+	test.context.session = test.context.jellyfish.sessions.admin
 
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			require('../../../apps/server/default-cards/contrib/message.json'))
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			require('../../../apps/server/default-cards/contrib/role-user-community.json'))
+	const session = await test.context.jellyfish.getCardById(
+		test.context.context, test.context.session, test.context.session)
+	test.context.actor = await test.context.jellyfish.getCardById(
+		test.context.context, test.context.session, session.data.actor)
 
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-create-card'].card)
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-create-event'].card)
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-set-add'].card)
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-create-user'].card)
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-create-session'].card)
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-update-card'].card)
-		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
-			actionLibrary['action-delete-card'].card)
-	},
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		require('../../../apps/server/default-cards/contrib/message.json'))
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		require('../../../apps/server/default-cards/contrib/role-user-community.json'))
 
-	afterEach: async (test) => {
-		await helpers.afterEach(test)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-create-card'].card)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-create-event'].card)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-set-add'].card)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-create-user'].card)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-create-session'].card)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-update-card'].card)
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		actionLibrary['action-delete-card'].card)
+
+	test.context.queue = new Queue(
+		test.context.context,
+		test.context.jellyfish,
+		test.context.session,
+		options)
+
+	test.context.queue.once('error', (error) => {
+		throw error
+	})
+
+	await test.context.queue.initialize(test.context.context)
+
+	test.context.queueActor = uuid()
+
+	test.context.dequeue = async (context, actor, times = 50) => {
+		const request = await test.context.queue.dequeue(
+			test.context.context, test.context.queueActor)
+
+		if (!request) {
+			if (times <= 0) {
+				return null
+			}
+
+			await Bluebird.delay(1)
+			return test.context.dequeue(context, actor, times - 1)
+		}
+
+		return request
 	}
 }
 
-exports.queue = {
-	beforeEach: async (test, options = {}) => {
-		await exports.jellyfish.beforeEach(test, {
-			suffix: options.suffix
-		})
-
-		test.context.queue = new Queue(
-			test.context.context,
-			test.context.jellyfish,
-			test.context.session,
-			options)
-
-		test.context.queue.once('error', (error) => {
-			throw error
-		})
-
-		await test.context.queue.initialize(test.context.context)
-
-		test.context.queueActor = uuid()
-
-		test.context.dequeue = async (context, actor, times = 50) => {
-			const request = await test.context.queue.dequeue(
-				test.context.context, test.context.queueActor)
-
-			if (!request) {
-				if (times <= 0) {
-					return null
-				}
-
-				await Bluebird.delay(1)
-				return test.context.dequeue(context, actor, times - 1)
-			}
-
-			return request
-		}
-	},
-	afterEach: async (test) => {
-		await test.context.queue.destroy()
-		await exports.jellyfish.afterEach(test)
-	}
+exports.afterEach = async (test) => {
+	await test.context.queue.destroy()
+	await helpers.afterEach(test)
 }

--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -12,7 +12,8 @@ const actionLibrary = require('../../../lib/action-library')
 
 exports.jellyfish = {
 	beforeEach: async (test, options) => {
-		await helpers.jellyfish.beforeEach(test, options)
+		await helpers.beforeEach(test, options)
+		test.context.jellyfish = test.context.kernel
 		test.context.session = test.context.jellyfish.sessions.admin
 
 		const session = await test.context.jellyfish.getCardById(
@@ -42,7 +43,7 @@ exports.jellyfish = {
 	},
 
 	afterEach: async (test) => {
-		await helpers.jellyfish.afterEach(test)
+		await helpers.afterEach(test)
 	}
 }
 

--- a/test/integration/queue/index.prioritybuffer.spec.js
+++ b/test/integration/queue/index.prioritybuffer.spec.js
@@ -10,12 +10,12 @@ const Bluebird = require('bluebird')
 const helpers = require('./helpers')
 
 ava.beforeEach(async (test) => {
-	await helpers.queue.beforeEach(test, {
+	await helpers.beforeEach(test, {
 		enablePriorityBuffer: true
 	})
 })
 
-ava.afterEach(helpers.queue.afterEach)
+ava.afterEach(helpers.afterEach)
 
 const insertRequest = async (test) => {
 	return test.context.kernel.insertCard(

--- a/test/integration/queue/index.spec.js
+++ b/test/integration/queue/index.spec.js
@@ -9,11 +9,8 @@ const ava = require('ava')
 const errors = require('../../../lib/queue/errors')
 const helpers = require('./helpers')
 
-ava.beforeEach(async (test) => {
-	await helpers.queue.beforeEach(test)
-})
-
-ava.afterEach(helpers.queue.afterEach)
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
 
 ava('.dequeue() should return nothing if no requests', async (test) => {
 	const request = await test.context.dequeue(

--- a/test/integration/server/helpers.js
+++ b/test/integration/server/helpers.js
@@ -14,7 +14,6 @@ const {
 const environment = require('../../../lib/environment')
 const bootstrap = require('../../../apps/server/bootstrap')
 const actionServer = require('../../../apps/action-server/bootstrap')
-const helpers = require('../core/helpers')
 
 const workerOptions = {
 	onError: (context, error) => {
@@ -81,7 +80,15 @@ module.exports = {
 		await test.context.server.close()
 	},
 	beforeEach: (test) => {
-		test.context.generateRandomSlug = helpers.generateRandomSlug
+		test.context.generateRandomSlug = (options) => {
+			const suffix = uuid()
+			if (options.prefix) {
+				return `${options.prefix}-${suffix}`
+			}
+
+			return suffix
+		}
+
 		test.context.http = (method, uri, payload, headers, options = {}) => {
 			return new Bluebird((resolve, reject) => {
 				const requestOptions = {

--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -11,7 +11,7 @@ const errio = require('errio')
 
 exports.jellyfish = {
 	beforeEach: async (test) => {
-		await helpers.queue.beforeEach(test)
+		await helpers.beforeEach(test)
 
 		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
 			require('../../../lib/worker/cards/update'))
@@ -22,13 +22,13 @@ exports.jellyfish = {
 	},
 
 	afterEach: async (test) => {
-		await helpers.queue.afterEach(test)
+		await helpers.afterEach(test)
 	}
 }
 
 exports.worker = {
 	beforeEach: async (test, actionLibrary, options = {}) => {
-		await helpers.queue.beforeEach(test, {
+		await helpers.beforeEach(test, {
 			enablePriorityBuffer: true,
 			suffix: options.suffix
 		})
@@ -86,5 +86,5 @@ exports.worker = {
 			await test.context.flush(session, expect - 1)
 		}
 	},
-	afterEach: helpers.queue.afterEach
+	afterEach: helpers.afterEach
 }


### PR DESCRIPTION
The idea is that each test helper file only exposes `before`,
`beforeEach`, `after`, and `afterEach`, without using namespaces such as
`helpers.jellyfish`, `helpers.cache`, etc that make everything more
confusing than it should be.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!