### PR TITLE
Make it easy to run servers only (postgres, redis) using docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ You can then run these commands in different terminal emulators, which will run
 all services in non-daemon mode:
 
 ```sh
-make start-postgres
-make start-redis
+make compose-servers
 make start-server
 make start-tick
 make start-worker # Run more than once for more workers

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -96,11 +96,15 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - {{POSTGRES_PORT}}:{{POSTGRES_PORT}}
   redis:
     image: balena/balena-redis:0.0.3
     restart: always
     networks:
       - internal
+    ports:
+      - {{REDIS_PORT}}:{{REDIS_PORT}}
   sidecar:
     build:
       context: .
@@ -403,8 +407,6 @@ services:
       - balena-mdns-publisher
     ports:
       - '80:80'
-      - '{{POSTGRES_PORT}}:{{POSTGRES_PORT}}'
-      - '{{REDIS_PORT}}:{{REDIS_PORT}}'
     networks:
       internal:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,11 +96,15 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - 5432:5432
   redis:
     image: balena/balena-redis:0.0.3
     restart: always
     networks:
       - internal
+    ports:
+      - 6379:6379
   sidecar:
     build:
       context: .
@@ -403,8 +407,6 @@ services:
       - balena-mdns-publisher
     ports:
       - '80:80'
-      - '5432:5432'
-      - '6379:6379'
     networks:
       internal:
         aliases:


### PR DESCRIPTION
Instead of using custom and local docker commands, or use a locally installed redis or postgres, we should use the exact same thing we use in docker-compose

We can now use `make compose-servers`