### PR TITLE
Rabbitmq on production (just the server)

### DIFF
--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -28,6 +28,14 @@ properties:
     type: string
   REDIS_PASSWORD:
     type: string
+  RABBITMQ_QUEUE_NAME:
+    type: string
+  RABBITMQ_HOSTNAME:
+    type: string
+  RABBITMQ_USERNAME:
+    type: string
+  RABBITMQ_PASSWORD:
+    type: string
   NODE_ENV:
     type: string
   SENTRY_DSN_SERVER:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -42,6 +42,14 @@ spec:
           value: {{REDIS_HOST}}
         - name: REDIS_PASSWORD
           value: {{{REDIS_PASSWORD}}}
+        - name: RABBITMQ_QUEUE_NAME
+          value: {{{RABBITMQ_QUEUE_NAME}}}
+        - name: RABBITMQ_HOSTNAME
+          value: {{{RABBITMQ_HOSTNAME}}}
+        - name: RABBITMQ_USERNAME
+          value: {{{RABBITMQ_USERNAME}}}
+        - name: RABBITMQ_PASSWORD
+          value: {{{RABBITMQ_PASSWORD}}}
         - name: NODE_ENV
           value: {{{NODE_ENV}}}
         - name: SENTRY_DSN_SERVER

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-deployment.tpl.yml
@@ -64,6 +64,14 @@ spec:
           value: {{REDIS_HOST}}
         - name: REDIS_PASSWORD
           value: '{{{REDIS_PASSWORD}}}'
+        - name: RABBITMQ_QUEUE_NAME
+          value: {{{RABBITMQ_QUEUE_NAME}}}
+        - name: RABBITMQ_HOSTNAME
+          value: {{{RABBITMQ_HOSTNAME}}}
+        - name: RABBITMQ_USERNAME
+          value: {{{RABBITMQ_USERNAME}}}
+        - name: RABBITMQ_PASSWORD
+          value: {{{RABBITMQ_PASSWORD}}}
         - name: NODE_ENV
           value: '{{{NODE_ENV}}}'
         - name: SENTRY_DSN_SERVER

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-deployment.tpl.yml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+spec:
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - image: <<%&children.sw.containerized-application.rabbitmq.data.assets.image.url%>>
+          name: rabbitmq
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: {{{RABBITMQ_USERNAME}}}
+            - name: RABBITMQ_DEFAULT_PASS
+              value: {{{RABBITMQ_PASSWORD}}}
+          ports:
+            - containerPort: 5672
+              name: data-port
+      imagePullSecrets:
+        - name: com.docker.hub.travisciresin

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-service.tpl.yml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: redis
-  name: redis
+    name: rabbitmq
+  name: rabbitmq
   namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
 spec:
   selector:
-    app: redis
+    app: rabbitmq
   ports:
-    - port: 6379
+    - port: 5672
       name: data-port

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
@@ -36,6 +36,14 @@ spec:
           value: {{REDIS_HOST}}
         - name: REDIS_PASSWORD
           value: {{{REDIS_PASSWORD}}}
+        - name: RABBITMQ_QUEUE_NAME
+          value: {{{RABBITMQ_QUEUE_NAME}}}
+        - name: RABBITMQ_HOSTNAME
+          value: {{{RABBITMQ_HOSTNAME}}}
+        - name: RABBITMQ_USERNAME
+          value: {{{RABBITMQ_USERNAME}}}
+        - name: RABBITMQ_PASSWORD
+          value: {{{RABBITMQ_PASSWORD}}}
         - name: NODE_ENV
           value: {{{NODE_ENV}}}
         - name: SENTRY_DSN_SERVER

--- a/deploy-templates/keyframe.tpl.yml
+++ b/deploy-templates/keyframe.tpl.yml
@@ -55,3 +55,12 @@ children:
               url: 'balena/balena-redis:latest'
             repo:
               url: 'https://github.com/balena-io/balena-redis.git'
+      jellyfish-rabbitmq:
+        slug: jellyfish-rabbitmq
+        version: 3.8-alpine
+        type: sw.containerized-application
+        assets:
+          image:
+            url: rabbitmq:3.8-alpine
+          repo:
+            url: 'https://github.com/rabbitmq/rabbitmq-server.git'


### PR DESCRIPTION
On production, start a new, unused rabbitmq instance, so we can check its wiring

Connects-to: #2796
Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
