### PR TITLE
github: Don't pass versioned types to revertEventChanges

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -668,7 +668,7 @@ module.exports = class GitHubIntegration {
 			return [ makeCard(issueCard, actor, root.updated_at) ]
 		}
 
-		const issueCard = await this.getCardFromEvent(revertEventChanges(event, 'issue@1.0.0'), {
+		const issueCard = await this.getCardFromEvent(revertEventChanges(event, 'issue'), {
 			status: 'open'
 		})
 
@@ -679,7 +679,7 @@ module.exports = class GitHubIntegration {
 				? root.closed_at
 				: new Date(root.updated_at) - 1
 
-			const closedCard = await this.getCardFromEvent(revertEventChanges(event, 'issue@1.0.0'), {
+			const closedCard = await this.getCardFromEvent(revertEventChanges(event, 'issue'), {
 				status: 'closed',
 				id: {
 					$eval: 'cards[0].id'


### PR DESCRIPTION
This function expects properties from the GitHub webhook payload, not
Jellyfish types.

Fixes: https://sentry.io/share/issue/9b548c1f976e42848bd31d88344d003e/
Fixes: #2983 


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!