### PR TITLE
github: Handle edits to deleted messages

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -342,24 +342,36 @@ module.exports = class GitHubIntegration {
 				action: 'getComment'
 			})
 
-			const result = await githubRequest(this.github.issues.getComment, {
-				owner: repoDetails.owner,
-				repo: repoDetails.repository,
-				comment_id: _.parseInt(_.last(githubUrl.split('-')))
-			}, this.options)
-
-			if (result.data.body !== `${prefix} ${card.data.payload.message}`) {
-				this.context.log.debug(GITHUB_API_REQUEST_LOG_TITLE, {
-					category: 'issues',
-					action: 'updateComment'
-				})
-
-				await githubRequest(this.github.issues.updateComment, {
+			try {
+				const result = await githubRequest(this.github.issues.getComment, {
 					owner: repoDetails.owner,
 					repo: repoDetails.repository,
-					comment_id: result.data.id,
-					body: card.data.payload.message
+					comment_id: _.parseInt(_.last(githubUrl.split('-')))
 				}, this.options)
+
+				if (result.data.body !== `${prefix} ${card.data.payload.message}`) {
+					this.context.log.debug(GITHUB_API_REQUEST_LOG_TITLE, {
+						category: 'issues',
+						action: 'updateComment'
+					})
+
+					await githubRequest(this.github.issues.updateComment, {
+						owner: repoDetails.owner,
+						repo: repoDetails.repository,
+						comment_id: result.data.id,
+						body: card.data.payload.message
+					}, this.options)
+				}
+			} catch (error) {
+				if (error.name === 'HttpError' && error.status === 404) {
+					return [
+						makeCard(Object.assign({}, card, {
+							active: false
+						}), options.actor)
+					]
+				}
+
+				throw error
 			}
 
 			return []


### PR DESCRIPTION
If a Jellyfish user attempts to edit a deleted GitHub message, then we
acknowledge the fact that the message has been deleted, we mirror that
in Jellyfish, and discard the external GitHub update request.

Change-type: patch
Fixes: https://sentry.io/share/issue/4303c3aeabc749bba28875ee303168cc/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!