### PR TITLE
outreach: Gracefully handle pointless contact updates

### DIFF
--- a/lib/sync/integrations/outreach.js
+++ b/lib/sync/integrations/outreach.js
@@ -227,6 +227,16 @@ const upsertProspect = async (context, actor, errors, baseUrl, card) => {
 			return []
 		}
 
+		// This means that the update didn't bring any new
+		// information to the prospect. The remote resource
+		// was up to date with what we were trying to update.
+		if (result.code === 422 &&
+				result.body.errors[0] &&
+				result.body.errors[0].id === 'validationDuplicateValueError' &&
+				result.body.errors[0].detail === 'A Contact with this email_hash already exists.') {
+			return []
+		}
+
 		const summary = [
 			`Got ${result.code} ${JSON.stringify(result.body, null, 2)}`,
 			`when sending ${JSON.stringify(body, null, 2)} to ${outreachUrl}`

--- a/test/integration/server/outreach-mock.js
+++ b/test/integration/server/outreach-mock.js
@@ -435,8 +435,27 @@ exports.patchProspect = (body) => {
 		}
 	}
 
-	DATA[index].attributes = Object.assign({},
-		DATA[index].attributes, body.data.attributes)
+	const currentAttributes = _.cloneDeep(DATA[index].attributes)
+	const newAttributes = _.cloneDeep(
+		Object.assign({}, DATA[index].attributes, body.data.attributes))
+
+	// When nothing really changes
+	if (_.isEqual(currentAttributes, newAttributes)) {
+		return {
+			code: 422,
+			response: {
+				errors: [
+					{
+						id: 'validationDuplicateValueError',
+						title: 'Validation Duplicate Value Error',
+						detail: 'A Contact with this email_hash already exists.'
+					}
+				]
+			}
+		}
+	}
+
+	DATA[index].attributes = newAttributes
 
 	return {
 		code: 200,


### PR DESCRIPTION
Apparently the Outreach API returns 422 if we try to patch a contact
with already up to date information.

Change-type: patch
Fixes: https://sentry.io/share/issue/c3df9ba3e4c2493f80a6af19db9d743d/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!