### PR TITLE
Reduce source interdependencies in dockerfiles

### DIFF
--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -17,7 +17,21 @@ RUN mkdir -p scripts/template
 COPY scripts/template/package*.json \
 	/usr/src/jellyfish/scripts/template/
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-COPY . /usr/src/jellyfish
+
+COPY ./lib/action-library ./lib/action-library
+COPY ./lib/assert ./lib/assert
+COPY ./lib/core ./lib/core
+COPY ./lib/coverage ./lib/coverage
+COPY ./lib/environment ./lib/environment
+COPY ./lib/logger ./lib/logger
+COPY ./lib/jellyscript ./lib/jellyscript
+COPY ./lib/sync ./lib/sync
+COPY ./lib/queue ./lib/queue
+COPY ./lib/uuid ./lib/uuid
+COPY ./lib/worker ./lib/worker
+
+COPY ./apps/action-server ./apps/action-server
+COPY Makefile .
 
 RUN make .nyc-root && \
 	echo "#!/bin/sh" > run.sh && \
@@ -36,7 +50,9 @@ ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
 COPY package.json package-lock.json /usr/src/jellyfish/
 RUN NODE_ENV=production npm ci
-COPY . /usr/src/jellyfish
+
+COPY --from=base /usr/src/jellyfish/lib ./lib
+COPY --from=base /usr/src/jellyfish/apps ./apps
 
 COPY --from=base /usr/src/jellyfish/.nyc-root /usr/src/jellyfish/.nyc-root
 COPY --from=base /usr/src/jellyfish/run.sh /usr/src/jellyfish/

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -17,7 +17,21 @@ RUN mkdir -p scripts/template
 COPY scripts/template/package*.json \
 	/usr/src/jellyfish/scripts/template/
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-COPY . /usr/src/jellyfish
+
+COPY ./lib/action-library ./lib/action-library
+COPY ./lib/assert ./lib/assert
+COPY ./lib/core ./lib/core
+COPY ./lib/coverage ./lib/coverage
+COPY ./lib/environment ./lib/environment
+COPY ./lib/logger ./lib/logger
+COPY ./lib/jellyscript ./lib/jellyscript
+COPY ./lib/sync ./lib/sync
+COPY ./lib/queue ./lib/queue
+COPY ./lib/uuid ./lib/uuid
+COPY ./lib/worker ./lib/worker
+
+COPY ./apps/action-server ./apps/action-server
+COPY Makefile .
 
 RUN make .nyc-root && \
 	echo "#!/bin/sh" > run.sh && \
@@ -36,7 +50,9 @@ ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
 COPY package.json package-lock.json /usr/src/jellyfish/
 RUN NODE_ENV=production npm ci
-COPY . /usr/src/jellyfish
+
+COPY --from=base /usr/src/jellyfish/lib ./lib
+COPY --from=base /usr/src/jellyfish/apps ./apps
 
 COPY --from=base /usr/src/jellyfish/.nyc-root /usr/src/jellyfish/.nyc-root
 COPY --from=base /usr/src/jellyfish/run.sh /usr/src/jellyfish/

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -14,7 +14,18 @@ RUN mkdir -p scripts/template
 COPY scripts/template/package*.json \
 	/usr/src/jellyfish/scripts/template/
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-COPY . /usr/src/jellyfish
+
+COPY webpack.config.base.js .
+# TODO: When
+# https://github.com/balena-io/jellyfish/issues/3004
+# is solved, remove the below
+COPY apps/ui ./apps/ui
+COPY apps/livechat ./apps/livechat
+COPY lib/sdk ./lib/sdk
+COPY lib/ui-components ./lib/ui-components
+COPY lib/chat-widget ./lib/chat-widget
+COPY lib/uuid ./lib/uuid
+COPY Makefile .
 
 ARG ENABLE_COVERAGE=0
 ARG SERVER_HOST=https://api.ly.fish

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -17,7 +17,20 @@ RUN mkdir -p scripts/template
 COPY scripts/template/package*.json \
 	/usr/src/jellyfish/scripts/template/
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-COPY . /usr/src/jellyfish
+
+COPY ./lib/action-library ./lib/action-library
+COPY ./lib/assert ./lib/assert
+COPY ./lib/core ./lib/core
+COPY ./lib/coverage ./lib/coverage
+COPY ./lib/environment ./lib/environment
+COPY ./lib/logger ./lib/logger
+COPY ./lib/jellyscript ./lib/jellyscript
+COPY ./lib/queue ./lib/queue
+COPY ./lib/sync ./lib/sync
+COPY ./lib/uuid ./lib/uuid
+COPY ./lib/worker ./lib/worker
+COPY ./apps/server ./apps/server
+COPY Makefile .
 
 RUN make .nyc-root && \
 	echo "#!/bin/sh" > run.sh && \
@@ -36,7 +49,9 @@ ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
 COPY package.json package-lock.json /usr/src/jellyfish/
 RUN NODE_ENV=production npm ci
-COPY . /usr/src/jellyfish
+
+COPY --from=base /usr/src/jellyfish/lib ./lib
+COPY --from=base /usr/src/jellyfish/apps ./apps
 
 COPY --from=base /usr/src/jellyfish/.nyc-root /usr/src/jellyfish/.nyc-root
 COPY --from=base /usr/src/jellyfish/run.sh /usr/src/jellyfish/

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -6,13 +6,14 @@ FROM balena/open-balena-base:v9.0.3
 
 WORKDIR /usr/src/jellyfish
 
+COPY ./scripts ./scripts
 COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts/eslint-plugin-jellyfish
-COPY scripts/eslint-plugin-jellyfish/package.json \
-	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
-RUN mkdir -p scripts/template
-COPY scripts/template/package*.json \
-	/usr/src/jellyfish/scripts/template/
+# RUN mkdir -p scripts/eslint-plugin-jellyfish
+# COPY scripts/eslint-plugin-jellyfish/package.json \
+# 	/usr/src/jellyfish/scripts/eslint-plugin-jellyfish
+# RUN mkdir -p scripts/template
+# COPY scripts/template/package*.json \
+# 	/usr/src/jellyfish/scripts/template/
 RUN npm ci
 
 RUN apt-get update && apt-get install -y \
@@ -21,7 +22,16 @@ RUN apt-get update && apt-get install -y \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 \
 	postgresql-client-11
 
-COPY . /usr/src/jellyfish
+COPY ./lib/core ./lib/core
+COPY ./lib/coverage ./lib/coverage
+COPY ./lib/chat-widget ./lib/chat-widget
+COPY ./lib/environment ./lib/environment
+COPY ./lib/sdk ./lib/sdk
+COPY ./lib/sync ./lib/sync
+COPY ./lib/uuid ./lib/uuid
+
+COPY ./test ./test
+COPY ./Makefile ./Makefile
 
 # Sleep forever
 # See: https://stackoverflow.com/a/35770783


### PR DESCRIPTION
Before this change, every container depended on every file in the
repository. We instead include only the files that we need in the
container, which should help both circle and livepush caching, decrease
the container size and make the project easier to reason about in
general.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
