### PR TITLE
Run 1 replica of jellyfish-ui, instead of 3

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-livechat
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-ui
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
Run 1 replica of jellyfish-ui, instead of 3. Jellyfish-ui is an nginx container serving static files, so running multiple replicas provides no advantage

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
