### PR TITLE
server/sync/ui/worker: Use versioned action input cards slugs

### DIFF
--- a/apps/server/default-cards/contrib/triggered-action-increment-tag.json
+++ b/apps/server/default-cards/contrib/triggered-action-increment-tag.json
@@ -46,7 +46,7 @@
       }
     },
     "action": "action-increment-tag",
-    "target": "tag",
+    "target": "tag@1.0.0",
     "arguments": {
       "reason": null,
       "name": {

--- a/test/e2e/server/actions/action-increment-tag.spec.js
+++ b/test/e2e/server/actions/action-increment-tag.spec.js
@@ -22,7 +22,7 @@ ava.serial('should create a new tag using using action-increment-tag', async (te
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'tag',
+			card: 'tag@1.0.0',
 			type: 'type',
 			action: 'action-increment-tag',
 			arguments: {
@@ -66,7 +66,7 @@ ava.serial('action-increment-tag should not try two concurrent inserts', async (
 
 	for (const time of _.range(10)) {
 		const options = {
-			card: 'tag',
+			card: 'tag@1.0.0',
 			type: 'type',
 			action: 'action-increment-tag',
 			arguments: {
@@ -95,7 +95,7 @@ ava.serial('should increment an existing tag using using action-increment-tag', 
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'tag',
+			card: 'tag@1.0.0',
 			type: 'type',
 			action: 'action-create-card',
 			arguments: {
@@ -116,7 +116,7 @@ ava.serial('should increment an existing tag using using action-increment-tag', 
 
 	await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'tag',
+			card: 'tag@1.0.0',
 			type: 'type',
 			action: 'action-increment-tag',
 			arguments: {

--- a/test/e2e/server/actions/action-increment.spec.js
+++ b/test/e2e/server/actions/action-increment.spec.js
@@ -29,7 +29,7 @@ ava.serial('should increment a card value using action-increment', async (test) 
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'card',
+			card: 'card@1.0.0',
 			type: 'type',
 			action: 'action-create-card',
 			arguments: {

--- a/test/e2e/server/external-support-user-security.spec.js
+++ b/test/e2e/server/external-support-user-security.spec.js
@@ -25,7 +25,7 @@ const createUserDetails = () => {
 const createUser = async (test, org, role, details) => {
 	// Create user
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -28,7 +28,7 @@ const createUserDetails = () => {
 ava.serial('should parse application/vnd.api+json bodies', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -40,7 +40,7 @@ ava.serial('should parse application/vnd.api+json bodies', async (test) => {
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -59,7 +59,7 @@ if (environment.isProduction()) {
 	ava.serial('should not login as the default test user', async (test) => {
 		const result = await test.context.http(
 			'POST', '/api/v2/action', {
-				card: `user-${environment.test.user.username}`,
+				card: `user-${environment.test.user.username}@1.0.0`,
 				type: 'user',
 				action: 'action-create-session',
 				arguments: {
@@ -73,7 +73,7 @@ if (environment.isProduction()) {
 	ava.serial('should login as the default test user', async (test) => {
 		const result = await test.context.http(
 			'POST', '/api/v2/action', {
-				card: `user-${environment.test.user.username}`,
+				card: `user-${environment.test.user.username}@1.0.0`,
 				type: 'user',
 				action: 'action-create-session',
 				arguments: {
@@ -88,7 +88,7 @@ if (environment.isProduction()) {
 ava.serial('should include the request and api ids on responses', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -100,7 +100,7 @@ ava.serial('should include the request and api ids on responses', async (test) =
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -116,7 +116,7 @@ ava.serial('should include the request and api ids on responses', async (test) =
 ava.serial('should create different request ids for every response', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -128,7 +128,7 @@ ava.serial('should create different request ids for every response', async (test
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -138,7 +138,7 @@ ava.serial('should create different request ids for every response', async (test
 
 	const result2 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -148,7 +148,7 @@ ava.serial('should create different request ids for every response', async (test
 
 	const result3 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -185,7 +185,7 @@ ava.serial('AGGREGATE($events): should work when creating cards via the SDK', as
 
 	// Create a new user
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -257,7 +257,7 @@ ava.serial('should add and evaluate a time triggered action', async (test) => {
 	const userDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -342,7 +342,7 @@ ava.serial('should be able to resolve links', async (test) => {
 	const userDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -518,7 +518,7 @@ ava.serial('should get all elements by type', async (test) => {
 ava.serial('should fail with a user error when executing an unknown action', async (test) => {
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user-admin',
+			card: 'user-admin@1.0.0',
 			type: 'user',
 			action: 'action-foo-bar-baz-qux',
 			arguments: {
@@ -542,7 +542,7 @@ ava.serial('should fail with a user error when executing an unknown action', asy
 ava.serial('should fail with a user error given an arguments mismatch', async (test) => {
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user',
+			card: 'user@1.0.0',
 			type: 'type',
 			action: 'action-create-card',
 			arguments: {
@@ -567,7 +567,7 @@ ava.serial('an update that renders a card invalid for its type is a user error',
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'ping',
+			card: 'ping@1.0.0',
 			type: 'type',
 			action: 'action-create-card',
 			arguments: {
@@ -620,7 +620,7 @@ ava.serial('should fail with a user error if no action card type', async (test) 
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'ping',
+			card: 'ping@1.0.0',
 			action: 'action-create-card',
 			arguments: {
 				reason: null,
@@ -713,7 +713,7 @@ ava.serial('should respond with an error given a payload middleware exception', 
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'card',
+			card: 'card@1.0.0',
 			type: 'type',
 			action: 'action-create-card',
 			arguments: {
@@ -734,9 +734,9 @@ ava.serial('should respond with an error given a payload middleware exception', 
 	test.deepEqual(result.response, {
 		error: true,
 		data: {
-			expected: 98061078,
+			expected: 98061084,
 			expose: true,
-			length: 98061078,
+			length: 98061084,
 			limit: 5242880,
 			headers: result.response.data.headers,
 			ip: result.response.data.ip,

--- a/test/e2e/server/markers.spec.js
+++ b/test/e2e/server/markers.spec.js
@@ -21,7 +21,7 @@ ava.before(async (test) => {
 	await helpers.before(test)
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -95,7 +95,7 @@ ava.serial('Users should not be able to view an element that has a marker they d
 
 	const userDetails = createUserDetails()
 	await sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -358,7 +358,7 @@ ava.serial('Updating a user should not remove their org membership', async (test
 
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -410,7 +410,7 @@ ava.serial('Updating a user should not remove their org membership', async (test
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: user.type,
 			action: 'action-update-card',
 			arguments: {
@@ -442,7 +442,7 @@ ava.serial('.query() should be able to see previously restricted cards after an 
 
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {

--- a/test/e2e/server/messages.spec.js
+++ b/test/e2e/server/messages.spec.js
@@ -15,7 +15,7 @@ ava.afterEach(helpers.afterEach)
 
 ava.serial('should sanely handle line breaks before tags in messages/whispers', async (test) => {
 	const thread = await test.context.sdk.card.create({
-		type: 'card',
+		type: 'card@1.0.0',
 		slug: test.context.generateRandomSlug({
 			prefix: 'thread'
 		}),

--- a/test/e2e/server/security.spec.js
+++ b/test/e2e/server/security.spec.js
@@ -26,7 +26,7 @@ const createUserDetails = () => {
 ava.serial('a community user should not be able to reset other user\'s passwords given the right password', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -38,7 +38,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -53,7 +53,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	const newUserDetails = createUserDetails()
 	const result2 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user',
+			card: 'user@1.0.0',
 			type: 'type',
 			action: 'action-create-user',
 			arguments: {
@@ -101,7 +101,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 ava.serial('a community user should not be able to reset other user\'s passwords given an incorrect password', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -113,7 +113,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -128,7 +128,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	const newUserDetails = createUserDetails()
 	const result2 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user',
+			card: 'user@1.0.0',
 			type: 'type',
 			action: 'action-create-user',
 			arguments: {
@@ -175,7 +175,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 ava.serial('a community user should not be able to reset other user\'s passwords given no password', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -187,7 +187,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -202,7 +202,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	const newUserDetails = createUserDetails()
 	const result2 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user',
+			card: 'user@1.0.0',
 			type: 'type',
 			action: 'action-create-user',
 			arguments: {
@@ -249,7 +249,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 ava.serial('a community user should not be able to set a first time password to another user', async (test) => {
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -261,7 +261,7 @@ ava.serial('a community user should not be able to set a first time password to 
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -324,7 +324,7 @@ ava.serial('creating a user with the guest user session should fail', async (tes
 	const username = `user-${userDetails.username.toLowerCase()}`
 
 	const result = await test.context.http('POST', '/api/v2/action', {
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -349,7 +349,7 @@ ava.serial('creating a role with a user community session using action-create-ca
 	const userDetails = createUserDetails()
 
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -361,7 +361,7 @@ ava.serial('creating a role with a user community session using action-create-ca
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -374,7 +374,7 @@ ava.serial('creating a role with a user community session using action-create-ca
 	const token = result1.response.data.id
 
 	const result2 = await test.context.http('POST', '/api/v2/action', {
-		card: 'role',
+		card: 'role@1.0.0',
 		type: 'type',
 		action: 'action-create-card',
 		arguments: {
@@ -399,14 +399,14 @@ ava.serial('creating a role with a user community session using action-create-ca
 		data: {
 			context: result2.response.data.context,
 			name: 'QueueInvalidRequest',
-			message: 'No such input card: role'
+			message: 'No such input card: role@1.0.0'
 		}
 	})
 })
 
 ava.serial('creating a role with the guest user session using action-create-card should fail', async (test) => {
 	const result = await test.context.http('POST', '/api/v2/action', {
-		card: 'role',
+		card: 'role@1.0.0',
 		type: 'type',
 		action: 'action-create-card',
 		arguments: {
@@ -438,7 +438,7 @@ ava.serial('creating a user with the guest user session using action-create-card
 	const username = `user-${createUserDetails().username}`
 
 	const result = await test.context.http('POST', '/api/v2/action', {
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-card',
 		arguments: {
@@ -465,7 +465,7 @@ ava.serial('creating a user with a community user session should succeed', async
 	const userDetails = createUserDetails()
 
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -477,7 +477,7 @@ ava.serial('creating a user with a community user session should succeed', async
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {
@@ -493,7 +493,7 @@ ava.serial('creating a user with a community user session should succeed', async
 
 	const result2 = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user',
+			card: 'user@1.0.0',
 			type: 'type',
 			action: 'action-create-user',
 			arguments: {
@@ -542,7 +542,7 @@ ava.serial('Users should be able to change their own email addresses', async (te
 
 	const userDetails = createUserDetails()
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -556,7 +556,7 @@ ava.serial('Users should be able to change their own email addresses', async (te
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: user.type,
 			action: 'action-update-card',
 			arguments: {
@@ -584,7 +584,7 @@ ava.serial('Users should not be able to view other users passwords', async (test
 
 	const userDetails = createUserDetails()
 	const targetUser = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -597,7 +597,7 @@ ava.serial('Users should not be able to view other users passwords', async (test
 	const activeUserDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -623,7 +623,7 @@ ava.serial('.query() the guest user should only see its own private fields', asy
 	}
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -673,7 +673,7 @@ ava.serial('timeline cards should reference the correct actor', async (test) => 
 	const userDetails = createUserDetails()
 
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -719,7 +719,7 @@ ava.serial('timeline cards should reference the correct actor', async (test) => 
 	await test.context.executeThenWait(async () => {
 		const result = await test.context.http(
 			'POST', '/api/v2/action', {
-				card: thread.slug,
+				card: `${thread.slug}@${thread.version}`,
 				type: thread.type,
 				action: 'action-update-card',
 				arguments: {
@@ -757,7 +757,7 @@ ava.serial('.query() community users should be able to query views', async (test
 	const userDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -792,7 +792,7 @@ ava.serial('the guest user should not be able to add a new role to another user'
 
 	const userDetails = createUserDetails()
 	const targetUser = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -849,7 +849,7 @@ ava.serial('the guest user should not be able to change other users passwords', 
 
 	const userDetails = createUserDetails()
 	const targetUser = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -883,7 +883,7 @@ ava.serial('users with the "user-community" role should not be able to change ot
 
 	const userDetails = createUserDetails()
 	const targetUser = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -895,7 +895,7 @@ ava.serial('users with the "user-community" role should not be able to change ot
 
 	const communityUserDetails = createUserDetails()
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -929,7 +929,7 @@ ava.serial('users with the "user-community" role should not be able to change ot
 
 	const userDetails = createUserDetails()
 	const targetUser = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -941,7 +941,7 @@ ava.serial('users with the "user-community" role should not be able to change ot
 
 	const communityUserDetails = createUserDetails()
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -975,7 +975,7 @@ ava.serial('users with the "user-community" role should not be able to change th
 
 	const communityUserDetails = createUserDetails()
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1010,7 +1010,7 @@ ava.serial('users with the "user-community" role should not be able to change it
 
 	const communityUserDetails = createUserDetails()
 	const targetUser = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1046,7 +1046,7 @@ ava.serial('When updating a user, inaccessible fields should not be removed', as
 
 	// Create a new user
 	const user = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1060,7 +1060,7 @@ ava.serial('When updating a user, inaccessible fields should not be removed', as
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: user.slug,
+			card: `${user.slug}@${user.version}`,
 			type: user.type,
 			action: 'action-update-card',
 			arguments: {
@@ -1105,7 +1105,7 @@ ava.serial('Users should not be able to login as the core admin user', async (te
 	const userData = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1129,7 +1129,7 @@ ava.serial('.query() additionalProperties should not affect listing users as a n
 
 	const details = createUserDetails()
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1141,7 +1141,7 @@ ava.serial('.query() additionalProperties should not affect listing users as a n
 
 	const userDetails = createUserDetails()
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1191,7 +1191,7 @@ ava.serial('should apply permissions on resolved links', async (test) => {
 	const user1Details = createUserDetails()
 	const targetDetails = createUserDetails()
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1201,7 +1201,7 @@ ava.serial('should apply permissions on resolved links', async (test) => {
 		}
 	})
 	const targetUserInfo = await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1315,7 +1315,7 @@ ava.serial('Users should not be able to create sessions as other users', async (
 	const user1Details = createUserDetails()
 	const targetDetails = createUserDetails()
 	await sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1325,7 +1325,7 @@ ava.serial('Users should not be able to create sessions as other users', async (
 		}
 	})
 	const targetUserInfo = await sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -1382,7 +1382,7 @@ ava.serial('Users should not be able to create action requests', async (test) =>
 	const userDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {

--- a/test/e2e/server/sessions.spec.js
+++ b/test/e2e/server/sessions.spec.js
@@ -15,7 +15,7 @@ ava.afterEach(helpers.afterEach)
 
 ava.serial('should fail with a user error given the wrong username during login', async (test) => {
 	const result = await test.context.http('POST', '/api/v2/action', {
-		card: 'user-nonexistentuser12345',
+		card: 'user-nonexistentuser12345@1.0.0',
 		type: 'user',
 		action: 'action-create-session',
 		arguments: {
@@ -154,7 +154,7 @@ ava.serial('should fail with a user error when posting an action with an expired
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {
-			card: 'user-nonexistentuser12345',
+			card: 'user-nonexistentuser12345@1.0.0',
 			type: 'user',
 			action: 'action-create-session',
 			arguments: {

--- a/test/e2e/server/users.spec.js
+++ b/test/e2e/server/users.spec.js
@@ -32,7 +32,7 @@ ava.serial('Users should have an avatar value set to null if it doesn\'t exist',
 	const userDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -69,7 +69,7 @@ ava.serial.skip('Users should have an avatar value calculated on signup', async 
 	const userDetails = createUserDetails()
 
 	await test.context.sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -100,7 +100,7 @@ ava.serial('Users should be able to read other users, even if they don\'t have a
 
 	// Create user 1 and login as them
 	await sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {
@@ -124,7 +124,7 @@ ava.serial('Users should be able to read other users, even if they don\'t have a
 
 	// Create and login as user 2
 	await sdk.action({
-		card: 'user',
+		card: 'user@1.0.0',
 		type: 'type',
 		action: 'action-create-user',
 		arguments: {

--- a/test/e2e/sync/helpers.js
+++ b/test/e2e/sync/helpers.js
@@ -21,7 +21,7 @@ exports.mirror = {
 		// Create the user, only if it doesn't exist yet
 		const userCard = await test.context.sdk.card.get(`user-${test.context.username}`) ||
 			await test.context.sdk.action({
-				card: 'user',
+				card: 'user@1.0.0',
 				type: 'type',
 				action: 'action-create-user',
 				arguments: {

--- a/test/e2e/ui/helpers.js
+++ b/test/e2e/ui/helpers.js
@@ -46,7 +46,7 @@ exports.browser = {
 
 		test.context.createUser = async (user) => {
 			const result = await test.context.sdk.action({
-				card: 'user',
+				card: 'user@1.0.0',
 				type: 'type',
 				action: 'action-create-user',
 				arguments: {

--- a/test/integration/worker/executor.spec.js
+++ b/test/integration/worker/executor.spec.js
@@ -1607,7 +1607,7 @@ ava('.run() should throw if the input card does not exist', async (test) => {
 		action: actionCard,
 		context: test.context.context,
 		timestamp: '2018-07-04T00:22:52.247Z',
-		card: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+		card: 'foobarbaz@9.9.9',
 		type: 'card@1.0.0',
 		arguments: {
 			properties: {


### PR DESCRIPTION
In a backwards compatible way.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!