### PR TITLE
core: Throw a better error when a JSON Patch operation lacks a "path"

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -17,6 +17,11 @@ const logger = require('../logger').getLogger(__filename)
 
 const patchCard = (card, patch, options = {}) => {
 	return patch.reduce((accumulator, operation) => {
+		if (!operation.path) {
+			throw new errors.JellyfishInvalidPatch(
+				`Patch operation has no path: ${JSON.stringify(operation, null, 2)}`)
+		}
+
 		// FIXME remove references to new_* columns
 		if (operation.path.startsWith('/id') ||
 			operation.path.startsWith('/links') ||

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -353,6 +353,29 @@ ava('.patchCardBySlug() should not be able to delete a top level property', asyn
 	test.deepEqual(result, card)
 })
 
+ava('.patchCardBySlug() should throw given an operation without a path', async (test) => {
+	const card = await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: 'foobarbaz',
+			tags: [],
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				foo: 'bar'
+			}
+		})
+
+	await test.throwsAsync(test.context.kernel.patchCardBySlug(
+		test.context.context, test.context.kernel.sessions.admin, `${card.slug}@${card.version}`, [
+			{
+				op: 'add',
+				value: 'foo'
+			}
+		], {
+			type: card.type
+		}), errors.JellyfishInvalidPatch)
+})
+
 ava('.patchCardBySlug() should throw if the patch does not match', async (test) => {
 	const card = await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {


### PR DESCRIPTION
Fixes: https://sentry.io/share/issue/028f311e89584f99854e7763e330e4c3/
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!