### PR TITLE
deploy-templates: Fix port name warning

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -43,6 +43,5 @@ spec:
           value: {{{NODE_ENV}}}
         ports:
         - containerPort: 80
-          name: jellyfish-livechat
       imagePullSecrets:
         - name: com.docker.hub.travisciresin

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
@@ -10,4 +10,3 @@ spec:
     app: jellyfish-livechat
   ports:
   - port: 80
-    name: jellyfish-livechat


### PR DESCRIPTION
The warning is: `name` must be at most 15 chars.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!