### PR TITLE
sync: Always execute translate's `afterEach`

### DIFF
--- a/test/integration/sync/balena-api-translate.spec.js
+++ b/test/integration/sync/balena-api-translate.spec.js
@@ -17,7 +17,7 @@ const environment = require('../../../lib/environment')
 const TOKEN = environment.integration['balena-api']
 
 ava.beforeEach(scenario.beforeEach)
-ava.afterEach(scenario.afterEach)
+ava.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava.serial
 

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -15,7 +15,7 @@ const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.discourse
 
 ava.beforeEach(scenario.beforeEach)
-ava.afterEach(scenario.afterEach)
+ava.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/flowdock-translate.spec.js
+++ b/test/integration/sync/flowdock-translate.spec.js
@@ -11,7 +11,7 @@ const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.flowdock
 
 ava.beforeEach(scenario.beforeEach)
-ava.afterEach(scenario.afterEach)
+ava.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/front-translate.spec.js
+++ b/test/integration/sync/front-translate.spec.js
@@ -11,7 +11,7 @@ const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.front
 
 ava.beforeEach(scenario.beforeEach)
-ava.afterEach(scenario.afterEach)
+ava.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/github-translate.spec.js
+++ b/test/integration/sync/github-translate.spec.js
@@ -11,7 +11,7 @@ const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.github
 
 ava.beforeEach(scenario.beforeEach)
-ava.afterEach(scenario.afterEach)
+ava.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/outreach-translate.spec.js
+++ b/test/integration/sync/outreach-translate.spec.js
@@ -11,7 +11,7 @@ const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.outreach
 
 ava.beforeEach(scenario.beforeEach)
-ava.afterEach(scenario.afterEach)
+ava.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 


### PR DESCRIPTION
Consider running the thousands of test cases we generate on translate
without using Ava's `--fail-fast` mode. If a test case fails, then its
`afterEach()` won't be executed, which means that we would have a
full-blown `lib/core` instance that is never uninitialised.

Given the large amount of tests we generate, we may end up consuming all
the available connections and make all the remaining tests fail:
https://circleci.com/gh/balena-io/jellyfish/64449.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!