### PR TITLE
UI: Show card type and color code by type on single card layout

### DIFF
--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -4,30 +4,43 @@
  * Proprietary and confidential.
  */
 
+import * as _ from 'lodash'
 import React from 'react'
+import {
+	connect
+} from 'react-redux'
 import {
 	Box,
 	Flex,
-	Heading
+	Heading,
+	Txt
 } from 'rendition'
-import CardActions from '../../../../lib/ui-components/CardActions'
 import {
 	CloseButton
 } from '@jellyfish/ui-components/shame/CloseButton'
 import Column from '@jellyfish/ui-components/shame/Column'
+import CardActions from '../../../../lib/ui-components/CardActions'
+import {
+	selectors
+} from '../../core'
 
-export default function CardLayout (props) {
+const CardLayout = (props) => {
 	const {
 		actionItems,
 		card,
 		channel,
 		children,
 		noActions,
+		overflowY,
 		title,
-		overflowY
+		types
 	} = props
 
 	const typeBase = card.type && card.type.split('@')[0]
+
+	const typeName = _.get(_.find(types, {
+		slug: typeBase
+	}), [ 'name' ], null)
 
 	return (
 		<Column
@@ -40,9 +53,15 @@ export default function CardLayout (props) {
 					{title}
 
 					{!title && (
-						<Heading.h4>
-							{card.name || card.slug || card.type}
-						</Heading.h4>
+						<div>
+							<Heading.h4>
+								{card.name || card.slug || card.type}
+							</Heading.h4>
+
+							{Boolean(typeName) && (
+								<Txt color="text.light" fontSize="0">{typeName}</Txt>
+							)}
+						</div>
 					)}
 
 					<Flex align="baseline">
@@ -65,3 +84,11 @@ export default function CardLayout (props) {
 		</Column>
 	)
 }
+
+const mapStateToProps = (state) => {
+	return {
+		types: selectors.getTypes(state)
+	}
+}
+
+export default connect(mapStateToProps)(CardLayout)

--- a/apps/ui/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lens/full/SingleCard/SingleCard.jsx
@@ -20,6 +20,9 @@ import Segment from './Segment'
 import CardFields from '../../../../../lib/ui-components/CardFields'
 import CardLayout from '../../../layouts/CardLayout'
 import Timeline from '../../list/Timeline'
+import {
+	colorHash
+} from '../../../services/helpers'
 
 const SingleCardTabs = styled(Tabs) `
 	flex: 1
@@ -83,7 +86,7 @@ export default class SingleCardFull extends React.Component {
 				card={card}
 				channel={channel}
 			>
-				<Divider width="100%" color="#eee" />
+				<Divider width="100%" color={colorHash(card.type)} />
 
 				<SingleCardTabs
 					activeIndex={this.state.activeIndex}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>
![Annotation 2020-01-17 113458](https://user-images.githubusercontent.com/15064535/72609802-c0d15300-391d-11ea-86ef-9d38b5630e72.jpg)


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
