### PR TITLE
Rabbitmq: updated deploy templates

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
@@ -1,4 +1,4 @@
-kind: namespace
+kind: Namespace
 apiVersion: v1
 metadata:
   name: {{{KATAPULT_KUBE_NAMESPACE}}}

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -10,5 +10,4 @@ spec:
     app: jellyfish
   ports:
   - port: 8000
-    name: jellyfish-api
   sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-deployment.tpl.yml
@@ -118,6 +118,5 @@ spec:
           value: '8000'
         ports:
         - containerPort: 8000
-          name: jellyfish-api
       imagePullSecrets:
         - name: com.docker.hub.travisciresin

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -43,6 +43,5 @@ spec:
           value: {{{NODE_ENV}}}
         ports:
         - containerPort: 80
-          name: jellyfish-ui
       imagePullSecrets:
         - name: com.docker.hub.travisciresin

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
@@ -10,4 +10,3 @@ spec:
     app: jellyfish-ui
   ports:
   - port: 80
-    name: jellyfish-ui

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-deployment.tpl.yml
@@ -14,15 +14,25 @@ spec:
         app: rabbitmq
     spec:
       containers:
-        - image: <<%&children.sw.containerized-application.rabbitmq.data.assets.image.url%>>
+        - image: <<%&children.sw.containerized-application.jellyfish-rabbitmq.data.assets.image.url%>>
           name: rabbitmq
           env:
             - name: RABBITMQ_DEFAULT_USER
               value: {{{RABBITMQ_USERNAME}}}
             - name: RABBITMQ_DEFAULT_PASS
               value: {{{RABBITMQ_PASSWORD}}}
+            - name: RABBITMQ_ERLANG_COOKIE
+              value: 'cookie used when setting up a rabbitmq cluster'
+            - name: RABBITMQ_USE_LONGNAME
+              value: "true"
           ports:
             - containerPort: 5672
-              name: data-port
+          volumeMounts:
+            - mountPath: /var/lib/rabbitmq
+              name: var-lib-rabbitmq
+      volumes:
+        - name: var-lib-rabbitmq
+          persistentVolumeClaim:
+            claimName: rabbitmq-storage
       imagePullSecrets:
         - name: com.docker.hub.travisciresin

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-persistentvolumeclaim.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-persistentvolumeclaim.tpl.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rabbitmq-storage
+  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/rabbitmq-service.tpl.yml
@@ -10,4 +10,3 @@ spec:
     app: rabbitmq
   ports:
     - port: 5672
-      name: data-port

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
@@ -13,13 +13,12 @@ spec:
         app: redis
     spec:
       containers:
-      - image: <<%&children.sw.containerized-application.balena-redis.data.assets.image.url%>>
-        name: redis
-        env:
-        - name: REDIS_PASSWORD
-          value: {{{REDIS_PASSWORD}}}
-        ports:
-        - containerPort: 6379
-          name: data-port
+        - image: <<%&children.sw.containerized-application.jellyfish-redis.data.assets.image.url%>>
+          name: redis
+          env:
+            - name: REDIS_PASSWORD
+              value: {{{REDIS_PASSWORD}}}
+          ports:
+            - containerPort: 6379
       imagePullSecrets:
         - name: com.docker.hub.travisciresin

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-service.tpl.yml
@@ -10,4 +10,3 @@ spec:
     app: redis
   ports:
     - port: 6379
-      name: data-port

--- a/deploy-templates/keyframe.tpl.yml
+++ b/deploy-templates/keyframe.tpl.yml
@@ -69,8 +69,9 @@ children:
         slug: jellyfish-rabbitmq
         version: 3.8-alpine
         type: sw.containerized-application
-        assets:
-          image:
-            url: rabbitmq:3.8-alpine
-          repo:
-            url: 'https://github.com/rabbitmq/rabbitmq-server.git'
+        data:
+          assets:
+            image:
+              url: rabbitmq:3.8-alpine
+            repo:
+              url: 'https://github.com/rabbitmq/rabbitmq-server.git'

--- a/scripts/production/rabbitmq-info.js
+++ b/scripts/production/rabbitmq-info.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const environment = require('../../lib/environment')
+const request = require('request-promise')
+
+const run = async () => {
+	const queues = await request(`http://${environment.rabbitmq.username}:${environment.rabbitmq.password}@${environment.rabbitmq.host}:${environment.rabbitmq.managementPort}/api/queues/`)
+		.then((body) => {
+			return JSON.parse(body)
+		})
+
+	console.log('Queues')
+	queues.forEach((queue) => {
+		console.log(queue.name)
+	})
+	console.log()
+
+	const consumers = await request(`http://${environment.rabbitmq.username}:${environment.rabbitmq.password}@${environment.rabbitmq.host}:${environment.rabbitmq.managementPort}/api/consumers/`)
+		.then((body) => {
+			return JSON.parse(body)
+		})
+
+	console.log('Consumers')
+	consumers.forEach((consumer) => {
+		console.log(`Queue: ${consumer.queue.name}, prefetch count: ${consumer.prefetch_count}`)
+	})
+}
+
+run().catch(console.error)


### PR DESCRIPTION
- Move k8s namespace creation/declaration at the top of the bundle generated by katapult, as it seems to be wrong doing otherwise
- Don't give ports a name: we don't use them and it's error prone
- Fix keyframe structure for rabbitmq
- Add script to query the status of rabbitmq

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
