### PR TITLE
fixes #2989: set auth schema to use enum for user type

### DIFF
--- a/apps/server/http/facades/auth.js
+++ b/apps/server/http/facades/auth.js
@@ -29,7 +29,7 @@ module.exports = class AuthFacade extends QueryFacade {
 				},
 				type: {
 					type: 'string',
-					const: 'user@1.0.0'
+					enum: [ 'user', 'user@1.0.0' ]
 				},
 				links: {
 					type: 'object',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>
Fixes #2989

Related flowdock discussion