### PR TITLE
discourse: Retry HTTP requests on 403

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -86,6 +86,23 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 			context, integrationOptions, method, url, options, retries - 1)
 	}
 
+	// We saw some cases where the Discourse API reports
+	// 403 "Request forbidden by administrative rules"
+	// but it works fine again after a little while
+	if (result.code === 403) {
+		assert.USER(null, retries > 0,
+			integrationOptions.errors.SyncExternalRequestError,
+			`Discourse permission error ${summary}: ${description}`)
+
+		context.log.warn('Discourse permission error retry', {
+			retries
+		})
+
+		await Bluebird.delay(5000)
+		return httpDiscourse(
+			context, integrationOptions, method, url, options, retries - 1)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
Change-type: patch
Fixes: https://sentry.io/share/issue/d7fb153005d34fa78c93edbe71ef691b/
Fixes: https://sentry.io/share/issue/21327cdb91df4c07903772637b975618/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!