### PR TITLE
dev: Add support for Redux Dev Tools

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,8 @@ extends:
   - 'plugin:react/recommended'
   - standard
 settings:
+  react:
+    version: "detect"
   jsdoc:
     additionalTagNames:
       customTags:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text eol=lf
+*.jpg binary
+*.png binary

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ http://localhost:9000 and login as:
 Testing
 -------
 
+>Note: the `make lint` script has a dependency on [shellcheck](https://github.com/koalaman/shellcheck) which must
+>be installed first.
+
 You can run the linter like this:
 
 ```sh

--- a/apps/ui/core/store/index.js
+++ b/apps/ui/core/store/index.js
@@ -8,6 +8,9 @@ import localForage from 'localforage'
 import * as redux from 'redux'
 import reduxThunk from 'redux-thunk'
 import {
+	isProduction
+} from '../../environment'
+import {
 	reducer
 } from './reducer'
 import actions from './actions'
@@ -43,8 +46,11 @@ export const setupStore = ({
 		return newState
 	}
 
+	// eslint-disable-next-line no-underscore-dangle
+	const composeEnhancers = (!isProduction() && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || redux.compose
+
 	return {
-		store: redux.createStore(reducerWrapper, redux.applyMiddleware(reduxThunk)),
+		store: redux.createStore(reducerWrapper, composeEnhancers(redux.applyMiddleware(reduxThunk))),
 		actions,
 		actionCreators: new ActionCreator({
 			sdk,


### PR DESCRIPTION
In non-production builds, enables the integration with [Redux Dev Tools Chrome Extension](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/README.md). 

Also 
- Fix an ESLint warning about React version not being specified
- Add a note in the README about the dependency on `shellcheck`
- Specify LF line endings in git attributes file. This is helpful for keeping things consistent when using Windows and WSL.