### PR TITLE
SQL query speed improvement

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -222,10 +222,9 @@ const generateQuery = (table, schema, options) => {
 	// We cannot enforce link existence without using a join, and we don't want to use it
 	// So we wrap the query with a WITH and filter on the length of the resulting linked cards array
 	if (link) {
-		query.unshift('WITH main AS (')
+		query.unshift('SELECT * FROM (')
 		query.push(...[
-			')',
-			'SELECT * FROM main'
+			') AS main'
 		])
 		if (link.schema) {
 			query.push(`WHERE array_length("links.${link.slug}", 1) > 0`)

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -461,7 +461,7 @@ ava('when querying cards with linked cards, we fetch links with a subquery, and 
 		}
 	}
 
-	const expected = `WITH main AS (
+	const expected = `SELECT * FROM (
 SELECT
 cards.id,
 cards.slug,
@@ -517,8 +517,7 @@ SELECT 1 FROM links
 WHERE links.inversename = 'has attached element' AND toId = cards.id
 )
 ORDER BY cards.created_at DESC
-)
-SELECT * FROM main
+) AS main
 WHERE array_length("links.has_attached_element", 1) > 0
 LIMIT 100`
 
@@ -573,7 +572,7 @@ ava('when querying cards without linked cards, we fetch links with a subquery, a
 		}
 	}
 
-	const expected = `WITH main AS (
+	const expected = `SELECT * FROM (
 SELECT
 cards.id,
 cards.slug,
@@ -629,8 +628,7 @@ SELECT 1 FROM links
 WHERE links.inversename = 'has attached element' AND toId = cards.id
 )
 ORDER BY cards.created_at DESC
-)
-SELECT * FROM main
+) AS main
 WHERE array_length("links.has_attached_element", 1) IS NULL
 LIMIT 100`
 


### PR DESCRIPTION
In [this flow](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/0PpWbssr3JiXvHrBRnEYeIlpqil) @Page- suggested an improvement for our main query generator

Before merging this, numbers must be proven against the production db