### PR TITLE
UI: Use immutability-helper in Redux reducers

### DIFF
--- a/apps/ui/core/store/reducer.spec.js
+++ b/apps/ui/core/store/reducer.spec.js
@@ -9,6 +9,26 @@ const {
 	reducer
 } = require('./reducer')
 
+// //////////////////////////////////////////////
+// Views Reducer Tests
+
+ava('SET_VIEW_DATA action updates the specified view data', (test) => {
+	const initialState = reducer()
+	const value = {
+		id: 12345,
+		data: {
+			foo: 'bar'
+		}
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.SET_VIEW_DATA,
+		value
+	})
+
+	test.deepEqual(newState.views.viewData[value.id], value.data)
+})
+
 ava('reducer should create a default state if one is not provided', (test) => {
 	const initialState = reducer()
 
@@ -52,6 +72,7 @@ ava('reducer should create a default state if one is not provided', (test) => {
 			}
 		},
 		views: {
+			activeView: null,
 			viewData: {},
 			subscriptions: {}
 		}
@@ -69,4 +90,429 @@ ava('REMOVE_VIEW_DATA_ITEM action should do nothing if there is no view data', (
 	})
 
 	test.deepEqual(initialState, newState)
+})
+
+ava('REMOVE_VIEW_DATA_ITEM action removes the specified view data item', (test) => {
+	const initialState = reducer()
+	const viewId = 12345
+	const dataToRemove = {
+		id: 21
+	}
+	const dataToKeep = {
+		id: 'bar'
+	}
+	initialState.views.viewData[viewId] = [
+		dataToRemove,
+		dataToKeep
+	]
+
+	const newState = reducer(initialState, {
+		type: actions.REMOVE_VIEW_DATA_ITEM,
+		value: {
+			id: viewId,
+			data: dataToRemove
+		}
+	})
+
+	test.deepEqual(newState.views.viewData[viewId], [ dataToKeep ])
+})
+
+ava('UPSERT_VIEW_DATA_ITEM action adds the specified view data item if not already in list', (test) => {
+	const initialState = reducer()
+	const viewId = 12345
+	const initialViewDataItem = {
+		id: 'bar'
+	}
+	const newViewDataItem = {
+		id: 'foo'
+	}
+	initialState.views.viewData[viewId] = [
+		initialViewDataItem
+	]
+	const value = {
+		id: 12345,
+		data: newViewDataItem
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.UPSERT_VIEW_DATA_ITEM,
+		value
+	})
+
+	test.deepEqual(newState.views.viewData[value.id], [ initialViewDataItem, newViewDataItem ])
+})
+
+ava('UPSERT_VIEW_DATA_ITEM action updates the specified view data item if already in list', (test) => {
+	const initialState = reducer()
+	const viewId = 12345
+	const initialViewDataItem = {
+		id: 'bar',
+		foo: 'a'
+	}
+	const newViewDataItem = {
+		id: 'bar',
+		foo: 'b'
+	}
+	initialState.views.viewData[viewId] = [
+		initialViewDataItem
+	]
+	const value = {
+		id: 12345,
+		data: newViewDataItem
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.UPSERT_VIEW_DATA_ITEM,
+		value
+	})
+
+	test.deepEqual(newState.views.viewData[value.id], [ newViewDataItem ])
+})
+
+ava('APPEND_VIEW_DATA_ITEM action appends the specified view data item', (test) => {
+	const initialState = reducer()
+	const viewId = 12345
+	const initialViewDataItem = {
+		id: 'bar'
+	}
+	const newViewDataItem = {
+		id: 'foo'
+	}
+	initialState.views.viewData[viewId] = [
+		initialViewDataItem
+	]
+	const value = {
+		id: 12345,
+		data: newViewDataItem
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.APPEND_VIEW_DATA_ITEM,
+		value
+	})
+
+	test.deepEqual(newState.views.viewData[value.id], [ initialViewDataItem, newViewDataItem ])
+})
+
+ava('APPEND_VIEW_DATA_ITEM action ignores the specified view data item if it already exists', (test) => {
+	const initialState = reducer()
+	const viewId = 12345
+	const initialViewDataItem = {
+		id: 'bar',
+		foo: 'a'
+	}
+	const newViewDataItem = {
+		id: 'bar',
+		foo: 'b'
+	}
+	initialState.views.viewData[viewId] = [
+		initialViewDataItem
+	]
+	const value = {
+		id: 12345,
+		data: newViewDataItem
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.APPEND_VIEW_DATA_ITEM,
+		value
+	})
+
+	test.deepEqual(newState.views.viewData[value.id], [ initialViewDataItem ])
+})
+
+// //////////////////////////////////////////////
+// Core Reducer Tests
+
+ava('UPDATE_CHANNEL action overrides the specified channel if found', (test) => {
+	const initialState = reducer()
+	initialState.core.channels = [
+		{
+			id: 1,
+			foo: 'bar'
+		}
+	]
+	const updatedChannel = {
+		id: 1,
+		v1: 'test'
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.UPDATE_CHANNEL,
+		value: updatedChannel
+	})
+
+	test.deepEqual(newState.core.channels, [ updatedChannel ])
+})
+
+ava('UPDATE_CHANNEL action does nothing if channel not found in state', (test) => {
+	const initialState = reducer()
+	initialState.core.channels = [
+		{
+			id: 1,
+			foo: 'bar'
+		}
+	]
+	const updatedChannel = {
+		id: 2,
+		v1: 'test'
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.UPDATE_CHANNEL,
+		value: updatedChannel
+	})
+
+	test.deepEqual(newState.core.channels, initialState.core.channels)
+})
+
+ava('ADD_CHANNEL action adds channel and trims non-parent channels', (test) => {
+	const initialState = reducer()
+	initialState.core.channels = [
+		{
+			id: 1,
+			name: 'a'
+		},
+		{
+			id: 2,
+			name: 'b'
+		}
+	]
+	const newChannel = {
+		id: 3,
+		name: 'c',
+		data: {
+			parentChannel: 1
+		}
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.ADD_CHANNEL,
+		value: newChannel
+	})
+
+	test.deepEqual(newState.core.channels, [
+		{
+			id: 1,
+			name: 'a'
+		},
+		newChannel
+	])
+})
+
+ava('REMOVE_CHANNEL action removes the specified channel', (test) => {
+	const initialState = reducer()
+	initialState.core.channels = [
+		{
+			id: 1
+		},
+		{
+			id: 2
+		}
+	]
+
+	const newState = reducer(initialState, {
+		type: actions.REMOVE_CHANNEL,
+		value: {
+			id: 1
+		}
+	})
+
+	test.deepEqual(newState.core.channels, [
+		{
+			id: 2
+		}
+	])
+})
+
+ava('SET_ACTOR action overwrites the specified actor', (test) => {
+	const initialState = reducer()
+	initialState.core.actors = {
+		1: {
+			id: 1,
+			name: 'test'
+		},
+		2: {
+			id: 2
+		}
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.SET_ACTOR,
+		value: {
+			id: 1,
+			actor: {
+				id: 1,
+				foo: 'bar'
+			}
+		}
+	})
+
+	test.deepEqual(newState.core.actors, {
+		1: {
+			id: 1,
+			foo: 'bar'
+		},
+		2: {
+			id: 2
+		}
+	})
+})
+
+ava('SET_USER action sets the authToken to null if not already set', (test) => {
+	const initialState = reducer()
+
+	test.is(initialState.core.session, null)
+
+	const newState = reducer(initialState, {
+		type: actions.SET_USER,
+		value: 1
+	})
+
+	test.deepEqual(newState.core.session, {
+		authToken: null,
+		user: 1
+	})
+})
+
+ava('SET_TIMELINE_MESSAGE action sets the message of the specified timeline', (test) => {
+	const initialState = reducer()
+
+	const newState = reducer(initialState, {
+		type: actions.SET_TIMELINE_MESSAGE,
+		value: {
+			target: 2,
+			message: 'test'
+		}
+	})
+
+	test.deepEqual(newState.core.ui.timelines, {
+		2: {
+			message: 'test'
+		}
+	})
+})
+
+ava('ADD_NOTIFICATION action limits notifications to two', (test) => {
+	const initialState = reducer()
+	initialState.core.notifications = [
+		{
+			id: 1
+		},
+		{
+			id: 2
+		}
+	]
+	const newState = reducer(initialState, {
+		type: actions.ADD_NOTIFICATION,
+		value: {
+			id: 3
+		}
+	})
+
+	test.deepEqual(newState.core.notifications, [
+		{
+			id: 2
+		},
+		{
+			id: 3
+		}
+	])
+})
+
+ava('REMOVE_NOTIFICATION action removes the corresponding notification', (test) => {
+	const initialState = reducer()
+	initialState.core.notifications = [
+		{
+			id: 1
+		},
+		{
+			id: 2
+		}
+	]
+	const newState = reducer(initialState, {
+		type: actions.REMOVE_NOTIFICATION,
+		value: 1
+	})
+
+	test.deepEqual(newState.core.notifications, [
+		{
+			id: 2
+		}
+	])
+})
+
+ava('SET_LENS_STATE action merges the specified lens state', (test) => {
+	const initialState = reducer()
+	const lens = 1
+	const cardId = 2
+	initialState.core.ui.lensState = {
+		[lens]: {
+			[cardId]: {
+				var1: 'value1',
+				var2: 'value2'
+			}
+		}
+	}
+	const newState = reducer(initialState, {
+		type: actions.SET_LENS_STATE,
+		value: {
+			lens,
+			cardId,
+			state: {
+				var1: 'value1New',
+				var3: 'value3'
+			}
+		}
+	})
+
+	test.deepEqual(newState.core.ui.lensState, {
+		[lens]: {
+			[cardId]: {
+				var1: 'value1New',
+				var2: 'value2',
+				var3: 'value3'
+			}
+		}
+	})
+})
+
+ava('USER_STARTED_TYPING action adds the user to the usersTyping for that card', (test) => {
+	const initialState = reducer()
+	const newState = reducer(initialState, {
+		type: actions.USER_STARTED_TYPING,
+		value: {
+			card: 2,
+			user: 'test'
+		}
+	})
+
+	test.deepEqual(newState.core.usersTyping, {
+		2: {
+			test: true
+		}
+	})
+})
+
+ava('USER_STOPPED_TYPING action removes the user from the usersTyping for that card', (test) => {
+	const initialState = reducer()
+	initialState.core.usersTyping = {
+		2: {
+			test1: true,
+			test2: true
+		}
+	}
+	const newState = reducer(initialState, {
+		type: actions.USER_STOPPED_TYPING,
+		value: {
+			card: 2,
+			user: 'test1'
+		}
+	})
+
+	test.deepEqual(newState.core.usersTyping, {
+		2: {
+			test2: true
+		}
+	})
 })

--- a/lib/chat-widget/store/reducer.js
+++ b/lib/chat-widget/store/reducer.js
@@ -5,6 +5,7 @@
  */
 
 import _ from 'lodash'
+import update from 'immutability-helper'
 import {
 	SET_CARDS,
 	SET_CURRENT_USER
@@ -21,30 +22,30 @@ export const createReducer = ({
 		currentUser: null
 	}
 
-	const setCard = (stateChain, card) => {
-		return stateChain.set(
-			[ 'cards' ],
-			stateChain.get('cards').unionBy([ card ], 'id').value()
-		)
-	}
-
 	return (state = initialState, action) => {
-		let chain = _.chain(state).cloneDeep()
-
 		switch (action.type) {
 			case SET_CARDS:
-				for (const card of action.payload) {
-					chain = setCard(chain, card)
-				}
-				break
+				return update(state, {
+					cards: {
+						$apply: (cards) => {
+							return _.unionBy(action.payload, cards, 'id')
+						}
+					}
+				})
 			case SET_CURRENT_USER:
-				chain = setCard(chain, action.payload)
-					.set([ 'currentUser' ], action.payload.id)
-				break
+				return update(state, {
+					currentUser: {
+						$set: action.payload.id
+					},
+					cards: {
+						$apply: (cards) => {
+							return _.unionBy([ action.payload ], cards, 'id')
+						}
+					}
+				})
+
 			default:
 				return state
 		}
-
-		return chain.value()
 	}
 }

--- a/lib/chat-widget/store/reducer.spec.js
+++ b/lib/chat-widget/store/reducer.spec.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+const ava = require('ava')
+
+const actionTypes = require('./action-types')
+const {
+	createReducer
+} = require('./reducer')
+
+ava.beforeEach((test) => {
+	test.context.initialState = {
+		product: 'jelly-chat-test',
+		productTitle: 'Jelly Chat Test',
+		cards: [],
+		currentUser: null
+	}
+	test.context.reducer = createReducer(test.context.initialState)
+})
+
+ava('SET_CARDS add the specified cards to an empty list', (test) => {
+	const newState = test.context.reducer(test.context.initialState, {
+		type: actionTypes.SET_CARDS,
+		payload: [
+			{
+				id: 1
+			},
+			{
+				id: 2
+			}
+		]
+	})
+
+	test.deepEqual(newState.cards, [
+		{
+			id: 1
+		},
+		{
+			id: 2
+		}
+	])
+})
+
+ava('SET_CARDS replaces a card that\'s already in the state', (test) => {
+	test.context.initialState.cards = [
+		{
+			id: 1,
+			foo: 'a'
+		},
+		{
+			id: 2
+		}
+	]
+	const newState = test.context.reducer(test.context.initialState, {
+		type: actionTypes.SET_CARDS,
+		payload: [
+			{
+				id: 1,
+				foo: 'b'
+			},
+			{
+				id: 3
+			}
+		]
+	})
+
+	test.deepEqual(newState.cards, [
+		{
+			id: 1,
+			foo: 'b'
+		},
+		{
+			id: 3
+		},
+		{
+			id: 2
+		}
+	])
+})
+
+ava('SET_CURRENT_USER adds the specified card and sets the current user ID', (test) => {
+	const newState = test.context.reducer(test.context.initialState, {
+		type: actionTypes.SET_CURRENT_USER,
+		payload: {
+			id: 1,
+			foo: 'a'
+		}
+	})
+
+	test.deepEqual(newState.cards, [
+		{
+			id: 1,
+			foo: 'a'
+		}
+	])
+	test.is(newState.currentUser, 1)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -9807,11 +9807,11 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immutability-helper": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
-      "integrity": "sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.0.1.tgz",
+      "integrity": "sha512-U92ROQQt7XkIwrdqCByUI118TQM1hXdKnRQpvKeA0HRyGSnJipu9IWHe4UD8zCN00O8UnQjQzPCgZ1CC3yBzHA==",
       "requires": {
-        "invariant": "^2.2.0"
+        "invariant": "^2.2.4"
       }
     },
     "import-fresh": {
@@ -13939,6 +13939,14 @@
           "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
           "requires": {
             "react-is": "^16.7.0"
+          }
+        },
+        "immutability-helper": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
+          "integrity": "sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==",
+          "requires": {
+            "invariant": "^2.2.0"
           }
         },
         "react-redux": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "front-sdk": "^0.7.1",
     "geoip-lite": "^1.3.7",
     "howler": "^2.0.12",
+    "immutability-helper": "^3.0.1",
     "intercom-client": "^2.10.4",
     "json-e": "^2.6.0",
     "json-schema-ref-parser": "^6.0.2",

--- a/test/register.js
+++ b/test/register.js
@@ -31,6 +31,7 @@ require('@babel/register')({
 	],
 	only: [
 		/lib\/ui-components/,
+		/lib\/chat-widget/,
 		/\.jsx$/,
 		/apps\/ui/,
 		/apps\/chat-widget/


### PR DESCRIPTION
Ref: #3029 

This PR refactors the way the UI app state is updated in the Redux reducers. It makes use of  [immutability-helper](https://github.com/kolodny/immutability-helper) to ensure application state is immutable (within the reducers) but is still updated fast. 

Some more unit tests have been added to verify/explain the behavior of some of the more complex reducers. _Note: `lib/chat-widget` is now also included in the paths to run through babel for the unit test pre-processing. Before there were no unit tests in this directory._

Changelog-Entry: Performance improvements under the hood
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

**Please note: this is a significant (but simple) refactor of application-critical code by someone who is new to the code-base (me!). I'm working on the assumption that e2e tests (in addition to the unit tests I've added) are sufficient to verify the absence of regression bugs.**