### PR TITLE
Don't delete the trigger

### DIFF
--- a/lib/core/backend/postgres/pg-live-select/index.js
+++ b/lib/core/backend/postgres/pg-live-select/index.js
@@ -103,13 +103,5 @@ module.exports = class LivePg extends EventEmitter {
 
 	async stop () {
 		clearInterval(this.interval)
-
-		await this.client.query([
-			'BEGIN',
-			`SELECT pg_advisory_xact_lock(${TRANSACTION_ADVISORY_LOCK_KEY})`,
-			`DROP TRIGGER IF EXISTS "${this.triggerName}" ON ${this.table}`,
-			`DROP FUNCTION IF EXISTS "${this.triggerProcedure}"() CASCADE`,
-			'COMMIT'
-		].join('; '))
 	}
 }


### PR DESCRIPTION
Since ba1a76b203d9e121ed3b5ffc7dad542841ca175f and 2be48207d81fb8921aaef9639c7826684b85ba72 we are properly shutting down a worker, which means we call LivePg.close, which is deleting the trigger
Trigger creation code already is `CREATE OR REPLACE...` so there's no point in deleting it

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
