### PR TITLE
docker-compose: use mustache for generating workers

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -13,9 +13,9 @@ services:
       - postgres
       - redis
       - tick
-      - worker_1
-      - worker_2
-      - worker_3
+      {{#workers}}
+      - worker_{{idx}}
+      {{/workers}}
       - balena-mdns-publisher
     environment:
       - DATABASE={{DATABASE}}
@@ -206,7 +206,8 @@ services:
       NODE_ENV: {{NODE_ENV}}
     networks:
       - internal
-  worker_1:
+  {{#workers}}
+  worker_{{idx}}:
     build:
       args:
         ENABLE_COVERAGE: ${COVERAGE}
@@ -257,108 +258,7 @@ services:
       - internal
     volumes:
       - nyc_output:/usr/src/jellyfish/.nyc_output:rw
-  worker_2:
-    build:
-      args:
-        ENABLE_COVERAGE: ${COVERAGE}
-      context: .
-      dockerfile: apps/action-server/Dockerfile.worker
-    depends_on:
-      - postgres
-      - redis
-      - balena-mdns-publisher
-    environment:
-      - DATABASE={{DATABASE}}
-      - LOGLEVEL={{LOGLEVEL}}
-      - NODE_ENV={{NODE_ENV}}
-      - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_PORT={{POSTGRES_PORT}}
-      - POSTGRES_USER=docker
-      - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
-      - REDIS_PORT={{REDIS_PORT}}
-      - SENTRY_DSN_SERVER
-      - LOGENTRIES_TOKEN
-      - FS_DRIVER
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_S3_BUCKET_NAME
-      - INTEGRATION_BALENA_API_PRIVATE_KEY
-      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
-      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
-      - INTEGRATION_BALENA_API_APP_ID
-      - INTEGRATION_BALENA_API_APP_SECRET
-      - INTEGRATION_BALENA_API_OAUTH_BASE_URL
-      - INTEGRATION_DEFAULT_USER
-      - INTEGRATION_INTERCOM_TOKEN
-      - INTEGRATION_FRONT_TOKEN
-      - INTEGRATION_GITHUB_TOKEN
-      - INTEGRATION_GITHUB_SIGNATURE_KEY
-      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
-      - INTEGRATION_DISCOURSE_TOKEN
-      - INTEGRATION_DISCOURSE_USERNAME
-      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
-      - INTEGRATION_OUTREACH_APP_ID
-      - INTEGRATION_OUTREACH_APP_SECRET
-      - INTEGRATION_OUTREACH_SIGNATURE_KEY
-    restart: always
-    networks:
-      - internal
-    volumes:
-      - nyc_output:/usr/src/jellyfish/.nyc_output:rw
-  worker_3:
-    build:
-      args:
-        ENABLE_COVERAGE: ${COVERAGE}
-      context: .
-      dockerfile: apps/action-server/Dockerfile.worker
-    depends_on:
-      - postgres
-      - redis
-      - balena-mdns-publisher
-    environment:
-      - DATABASE={{DATABASE}}
-      - LOGLEVEL={{LOGLEVEL}}
-      - NODE_ENV={{NODE_ENV}}
-      - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_PORT={{POSTGRES_PORT}}
-      - POSTGRES_USER=docker
-      - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
-      - REDIS_PORT={{REDIS_PORT}}
-      - SENTRY_DSN_SERVER
-      - LOGENTRIES_TOKEN
-      - FS_DRIVER
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_S3_BUCKET_NAME
-      - INTEGRATION_BALENA_API_PRIVATE_KEY
-      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
-      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
-      - INTEGRATION_BALENA_API_APP_ID
-      - INTEGRATION_BALENA_API_APP_SECRET
-      - INTEGRATION_BALENA_API_OAUTH_BASE_URL
-      - INTEGRATION_DEFAULT_USER
-      - INTEGRATION_INTERCOM_TOKEN
-      - INTEGRATION_FRONT_TOKEN
-      - INTEGRATION_GITHUB_TOKEN
-      - INTEGRATION_GITHUB_SIGNATURE_KEY
-      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
-      - INTEGRATION_DISCOURSE_TOKEN
-      - INTEGRATION_DISCOURSE_USERNAME
-      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
-      - INTEGRATION_OUTREACH_APP_ID
-      - INTEGRATION_OUTREACH_APP_SECRET
-      - INTEGRATION_OUTREACH_SIGNATURE_KEY
-    restart: always
-    networks:
-      - internal
-    volumes:
-      - nyc_output:/usr/src/jellyfish/.nyc_output:rw
+  {{/workers}}
   balena-mdns-publisher:
     image: 'balena/balena-mdns-publisher:master'
     network_mode: host
@@ -390,9 +290,9 @@ services:
       - /run
       - /sys/fs/cgroup
     depends_on:
-      - worker_1
-      - worker_2
-      - worker_3
+      {{#workers}}
+      - worker_{{idx}}
+      {{/workers}}
       - ui
       - tick
       - sidecar

--- a/scripts/template/index.js
+++ b/scripts/template/index.js
@@ -16,5 +16,13 @@ if (!TEMPLATE) {
 console.error(`Opening ${TEMPLATE}`)
 const contents = fs.readFileSync(TEMPLATE, 'utf8')
 
-console.log(mustache.render(contents, process.env))
+console.log(mustache.render(contents, Object.assign({}, process.env, {
+	workers: [ {
+		idx: 1
+	}, {
+		idx: 2
+	}, {
+		idx: 3
+	} ]
+})))
 console.error(`Done rendering ${TEMPLATE}`)


### PR DESCRIPTION
Allow to change the number of running workers in docker-compose by editing `scripts/template/index.js` rather than copy-pasting yaml