### PR TITLE
Update open-balena-haproxy used in docker-compose to latest 2.11.3

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -380,7 +380,7 @@ services:
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   haproxy:
-    image: 'balena/open-balena-haproxy:master'
+    image: 'balena/open-balena-haproxy:2.11.3'
     cap_add:
       - SYS_RESOURCE
       - SYS_ADMIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -380,7 +380,7 @@ services:
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   haproxy:
-    image: 'balena/open-balena-haproxy:master'
+    image: 'balena/open-balena-haproxy:2.11.3'
     cap_add:
       - SYS_RESOURCE
       - SYS_ADMIN


### PR DESCRIPTION
Previous version relied on a possibly buggy haproxy version which caused haproxy process to get stuck at 100% CPU
New version seems unaffected

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
