### PR TITLE
Avoid cloning objects in streams `changeHandler`: it's not needed

### DIFF
--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -128,8 +128,8 @@ exports.attach = async (context, instance, schema, options) => {
 			return
 		}
 
-		let newMatch = filter(schema, _.cloneDeep(after))
-		let oldMatch = filter(schema, _.cloneDeep(before))
+		let newMatch = filter(schema, after)
+		let oldMatch = filter(schema, before)
 
 		if (_.isEmpty(newMatch)) {
 			newMatch = null


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
