### PR TITLE
Update pg-promise to latest 10.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2409,9 +2409,9 @@
       }
     },
     "assert-options": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.1.3.tgz",
-      "integrity": "sha512-DXrZ5WkCv/igD+H8OmeUTl9k0pBhYSTdyA7DRZoSJERCzQ8Z2v85yDjkhYVnHUOeCXGfCNKaogRbLWQsIQbtpg=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.6.0.tgz",
+      "integrity": "sha512-xmBFb5sY0AO8SNihIfavR6uMhOyzq6D7RoFKJxxAditMQc876szBBQ9RQVwLi6Bm3zUoG0nexZK11Gy5TBX69A=="
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -12968,15 +12968,16 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.11.0.tgz",
-      "integrity": "sha512-YO4V7vCmEMGoF390LJaFaohWNKaA2ayoQOEZmiHVcAUF+YsRThpf/TaKCgSvsSE7cDm37Q/Cy3Gz41xiX/XjTw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.1.tgz",
+      "integrity": "sha512-1KtKBKg/zWrjEEv//klBbVOPGucuc7HHeJf6OEMueVcUeyF3yueHf+DvhVwBjIAe9/97RAydO/lWjkcMwssuEw==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "^2.0.4",
-        "pg-types": "~2.0.0",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.10",
+        "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
       },
@@ -13004,31 +13005,36 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.4.1.tgz",
-      "integrity": "sha512-8aZ9xdx7Pe/ppFYVOqvU5KgmM6ttXjaBlsl9Y8yzrUH4xSNVucJKKOwm4Y4H+LCvzZGjZIm4Rkf2Ajt5ixtkBQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.1.tgz",
+      "integrity": "sha512-nqUTo8y9T0VhiJoWC0sK0+2S8hYDiu7CdH0Z9ijPi2iikiQ44mfcAFxEJxfvF8H3h/bDBvXthtOQPIB3pLWIow=="
+    },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
     },
     "pg-pool": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
-      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
     },
     "pg-promise": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-8.7.5.tgz",
-      "integrity": "sha512-r/OmS1b1i0nA0KHqlbcAoMLoNo3EGUdcZxaseyXnHrzepcS8ciK516Lw6/lIb6AeWI85ZOBSNdiPlw22xoFx3A==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.4.0.tgz",
+      "integrity": "sha512-Xfxk56AFruPeA/5uJAb/LEPKIPlEw95xcGOsf1SITslOq/5jlmJxtecEwz4XdYzct/RSLzGEveqBVSHkq6Hnww==",
       "requires": {
-        "assert-options": "0.1.3",
+        "assert-options": "0.6.0",
         "manakin": "0.5.2",
-        "pg": "7.11.0",
-        "pg-minify": "1.4.1",
-        "spex": "2.2.0"
+        "pg": "7.18.1",
+        "pg-minify": "1.5.1",
+        "spex": "3.0.0"
       }
     },
     "pg-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.1.tgz",
-      "integrity": "sha512-b7y6QM1VF5nOeX9ukMQ0h8a9z89mojrBHXfJeSug4mhL0YpxNBm83ot2TROyoAmX/ZOX3UbwVO4EbH7i1ZZNiw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "requires": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -15686,9 +15692,9 @@
       }
     },
     "spex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-2.2.0.tgz",
-      "integrity": "sha512-iwBxqKe4ZKD+P/i/WdzWw5qxmerHvzVb29wQm4zwYaDPuwsTKjS7nbqt8OyBSLAi2q0ZFUN3F2b4erX0UwF0fA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.0.0.tgz",
+      "integrity": "sha512-JoMfgbrJcEPn53JCLkSNH1o7fZ9rzkb24UKEt5LTcsp0YsaN+yxtb5MEmibbMRltj9CdXDNGitPrYi11JY2hog=="
     },
     "split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "node-jose": "^1.1.3",
     "object-hash": "^1.3.0",
     "pg-format": "^1.0.4",
-    "pg-promise": "^8.5.5",
+    "pg-promise": "^10.4.0",
     "query-string": "^6.7.0",
     "randomstring": "^1.1.5",
     "react": "^16.8.5",

--- a/scripts/postgres-delete-test-databases.js
+++ b/scripts/postgres-delete-test-databases.js
@@ -22,7 +22,7 @@ const scrub = async () => {
 	})
 
 	try {
-		await connection.proc('version')
+		await connection.query('select version()')
 	} catch (error) {
 		if (error.code === 'ECONNREFUSED' && error.syscall === 'connect') {
 			console.log('Couldn\'t connect to Postgres')


### PR DESCRIPTION
Unfortunately, this update brings no speed improvements, but if we want to switch to a different driver (see #3021) it makes sense to use the latest version of the current one

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>

