### PR TITLE
core/server: Log query times when querying with "profile" mode

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -69,7 +69,8 @@ const queryTable = async (context, backend, table, schema, options) => {
 		database: backend.database,
 		limit: options.limit,
 		skip: options.skip,
-		sortBy: options.sortBy
+		sortBy: options.sortBy,
+		profile: options.profile
 	})
 
 	if (options.limit <= 0) {
@@ -181,7 +182,8 @@ const queryTable = async (context, backend, table, schema, options) => {
 	utils.filter(schema, elements)
 	const postProcessingEndDate = new Date()
 
-	logger.debug(context, 'Query database response', {
+	const mode = options.profile ? 'debug' : 'info'
+	logger[mode](context, 'Query database response', {
 		table,
 		database: backend.database,
 		count: elements.length,

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -488,7 +488,8 @@ module.exports = class Kernel {
 			limit: options.limit,
 			skip: options.skip,
 			sortBy: options.sortBy,
-			sortDir: options.sortDir
+			sortDir: options.sortDir,
+			profile: options.profile
 		})
 	}
 


### PR DESCRIPTION
For debugging and performance inspection purposes. The idea is that we
can set `profile: true` on a particular query and get more detailed
information, on the logs, about the time it took to resolve.

Change-type: minor


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!