### PR TITLE
UI: Wrap long notification messages

### DIFF
--- a/lib/ui-components/Notifications.jsx
+++ b/lib/ui-components/Notifications.jsx
@@ -11,11 +11,7 @@ import {
 	Box,
 	Fixed
 } from 'rendition'
-import styled from 'styled-components'
 
-const MessageText = styled.span `
-	white-space: pre;
-`
 class JellyFishAlert extends React.Component {
 	constructor (props) {
 		super(props)
@@ -43,9 +39,9 @@ class JellyFishAlert extends React.Component {
 				onDismiss={this.dismiss}
 				prefix={false}
 			>
-				<MessageText>
+				<span>
 					{_.isString(message) ? message : JSON.stringify(message)}
-				</MessageText>
+				</span>
 			</Alert>
 		)
 	}


### PR DESCRIPTION
Notification messages that are longer than the fixed width of the notification box now wrap onto multiple lines, rather than being cut off.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before:
![Notification cut off](https://user-images.githubusercontent.com/2925657/73757447-d5c23900-479b-11ea-871b-349ed420396e.png)

After:
![Notification fixed](https://user-images.githubusercontent.com/2925657/73757463-d9ee5680-479b-11ea-8114-6d79d5fb484b.png)

