### PR TITLE
Speed up image building by reusing previously populated ~/.npm folder

### DIFF
--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -48,8 +48,10 @@ WORKDIR /usr/src/jellyfish
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
+COPY --from=base /root/.npm /root/.npm
 COPY package.json package-lock.json /usr/src/jellyfish/
 RUN NODE_ENV=production npm ci
+RUN rm -rf /root/.npm
 
 COPY --from=base /usr/src/jellyfish/lib ./lib
 COPY --from=base /usr/src/jellyfish/apps ./apps

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -48,8 +48,10 @@ WORKDIR /usr/src/jellyfish
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
+COPY --from=base /root/.npm /root/.npm
 COPY package.json package-lock.json /usr/src/jellyfish/
 RUN NODE_ENV=production npm ci
+RUN rm -rf /root/.npm
 
 COPY --from=base /usr/src/jellyfish/lib ./lib
 COPY --from=base /usr/src/jellyfish/apps ./apps

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -47,8 +47,10 @@ WORKDIR /usr/src/jellyfish
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
+COPY --from=base /root/.npm /root/.npm
 COPY package.json package-lock.json /usr/src/jellyfish/
 RUN NODE_ENV=production npm ci
+RUN rm -rf /root/.npm
 
 COPY --from=base /usr/src/jellyfish/lib ./lib
 COPY --from=base /usr/src/jellyfish/apps ./apps


### PR DESCRIPTION
Speed up image building by reusing previously populated ~/.npm folder, and deleting it to save space once `npm ci` is over

First build on circleci shows 1 min less. Not much, but little drops of water make a mighty ocean