### PR TITLE
Speed up `make compose-build`

### DIFF
--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -38,6 +38,12 @@ RUN make .nyc-root && \
 	make --dry-run start-tick >> run.sh && \
 	chmod +x run.sh && cat run.sh
 
+# Optimization: in the runtime image we to run NODE_ENV=production npm ci
+# but that would require all modules to be downloaded again
+# Instead, we run it in the base image, and copy node_modules from base
+# to runtime INSTEAD OF running npm ci: this saves bandwidth and time
+RUN NODE_ENV=production npm ci
+
 ###########################################################
 # Runtime
 ###########################################################
@@ -48,14 +54,14 @@ WORKDIR /usr/src/jellyfish
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN NODE_ENV=production npm ci
+COPY package.json package-lock.json ./
+COPY --from=base /usr/src/jellyfish/node_modules ./node_modules
 
 COPY --from=base /usr/src/jellyfish/lib ./lib
 COPY --from=base /usr/src/jellyfish/apps ./apps
 
-COPY --from=base /usr/src/jellyfish/.nyc-root /usr/src/jellyfish/.nyc-root
-COPY --from=base /usr/src/jellyfish/run.sh /usr/src/jellyfish/
+COPY --from=base /usr/src/jellyfish/.nyc-root ./.nyc-root
+COPY --from=base /usr/src/jellyfish/run.sh ./
 
 # Production debugging scripts
 COPY ./scripts/production ./scripts/production

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -38,6 +38,12 @@ RUN make .nyc-root && \
 	make --dry-run start-worker >> run.sh && \
 	chmod +x run.sh && cat run.sh
 
+# Optimization: in the runtime image we to run NODE_ENV=production npm ci
+# but that would require all modules to be downloaded again
+# Instead, we run it in the base image, and copy node_modules from base
+# to runtime INSTEAD OF running npm ci: this saves bandwidth and time
+RUN NODE_ENV=production npm ci
+
 ###########################################################
 # Runtime
 ###########################################################
@@ -48,14 +54,14 @@ WORKDIR /usr/src/jellyfish
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN NODE_ENV=production npm ci
+COPY package.json package-lock.json ./
+COPY --from=base /usr/src/jellyfish/node_modules ./node_modules
 
 COPY --from=base /usr/src/jellyfish/lib ./lib
 COPY --from=base /usr/src/jellyfish/apps ./apps
 
-COPY --from=base /usr/src/jellyfish/.nyc-root /usr/src/jellyfish/.nyc-root
-COPY --from=base /usr/src/jellyfish/run.sh /usr/src/jellyfish/
+COPY --from=base /usr/src/jellyfish/.nyc-root ./.nyc-root
+COPY --from=base /usr/src/jellyfish/run.sh ./
 
 # Production debugging scripts
 COPY ./scripts/production ./scripts/production

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -37,6 +37,12 @@ RUN make .nyc-root && \
 	make --dry-run start-server >> run.sh && \
 	chmod +x run.sh && cat run.sh
 
+# Optimization: in the runtime image we to run NODE_ENV=production npm ci
+# but that would require all modules to be downloaded again
+# Instead, we run it in the base image, and copy node_modules from base
+# to runtime INSTEAD OF running npm ci: this saves bandwidth and time
+RUN NODE_ENV=production npm ci
+
 ###########################################################
 # Runtime
 ###########################################################
@@ -47,14 +53,14 @@ WORKDIR /usr/src/jellyfish
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN NODE_ENV=production npm ci
+COPY package.json package-lock.json ./
+COPY --from=base /usr/src/jellyfish/node_modules ./node_modules
 
 COPY --from=base /usr/src/jellyfish/lib ./lib
 COPY --from=base /usr/src/jellyfish/apps ./apps
 
-COPY --from=base /usr/src/jellyfish/.nyc-root /usr/src/jellyfish/.nyc-root
-COPY --from=base /usr/src/jellyfish/run.sh /usr/src/jellyfish/
+COPY --from=base /usr/src/jellyfish/.nyc-root ./.nyc-root
+COPY --from=base /usr/src/jellyfish/run.sh ./
 
 # Production debugging scripts
 COPY ./scripts/production ./scripts/production


### PR DESCRIPTION
Speed up `make compose-build` by running `NODE_ENV=production npm ci` in the base image and then copying `node_modules` to the runtime image, instead of running `NODE_ENV=production npm ci` again in the runtime image
Building takes less time, bandwidth, and the final image is 100M smaller
