### PR TITLE
Makefile: Add support for running Jellyfish on nsolid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,16 @@ ifeq ($(NODE_ENV),profile)
 # See https://github.com/davidmarkclements/0x
 NODE = 0x --open -- node
 else
+
+# Assumes nsolid-console is running on the background
+ifeq ($(NODE_ENV),nsolid)
+NODE = "nsolid"
+NSOLID_COMMAND ?= localhost:9001
+export NSOLID_COMMAND
+
+else
 NODE = "node"
+endif
 endif
 
 # User parameters
@@ -371,28 +380,28 @@ node:
 start-server: LOGLEVEL = info
 ifeq ($(COVERAGE),1)
 start-server: .nyc-root
-	exec $(NODE) $(NODE_ARGS) $^/apps/server/index.js
+	NSOLID_APP=server exec $(NODE) $(NODE_ARGS) $^/apps/server/index.js
 else
 start-server:
-	exec $(NODE) $(NODE_ARGS) apps/server/index.js
+	NSOLID_APP=server exec $(NODE) $(NODE_ARGS) apps/server/index.js
 endif
 
 start-worker: LOGLEVEL = info
 ifeq ($(COVERAGE),1)
 start-worker: .nyc-root
-	exec $(NODE) $(NODE_ARGS) $^/apps/action-server/worker.js
+	NSOLID_APP=worker exec $(NODE) $(NODE_ARGS) $^/apps/action-server/worker.js
 else
 start-worker:
-	exec $(NODE) $(NODE_ARGS) apps/action-server/worker.js
+	NSOLID_APP=worker exec $(NODE) $(NODE_ARGS) apps/action-server/worker.js
 endif
 
 start-tick: LOGLEVEL = info
 ifeq ($(COVERAGE),1)
 start-tick: .nyc-root
-	exec $(NODE) $(NODE_ARGS) $^/apps/action-server/tick.js
+	NSOLID_APP=tick exec $(NODE) $(NODE_ARGS) $^/apps/action-server/tick.js
 else
 start-tick:
-	exec $(NODE) $(NODE_ARGS) apps/action-server/tick.js
+	NSOLID_APP=tick exec $(NODE) $(NODE_ARGS) apps/action-server/tick.js
 endif
 
 start-redis:


### PR DESCRIPTION
Nsolid (https://nodesource.com/products/nsolid) is a free Node.js
runtime with instrumentation support that can be handy for debugging and
profiling purposes.

If you want to run this yourself:

- Start the nsolid console: `nsolid-console`
- Start the services you want with `NODE_ENV=nsolid`
- Go to http://localhost:6753

<img width="1275" alt="Screenshot 2020-02-05 at 14 36 46" src="https://user-images.githubusercontent.com/2192773/73851517-84f72280-4825-11ea-9af7-139c0ee9b743.png">
<img width="1275" alt="Screenshot 2020-02-05 at 14 40 35" src="https://user-images.githubusercontent.com/2192773/73851529-8aed0380-4825-11ea-9670-cfa20c655d69.png">

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!