### PR TITLE
open-balena-base update, docker-compose update

### DIFF
--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as base
+FROM balena/open-balena-base:v9.1.0 as base
 
 WORKDIR /usr/src/jellyfish
 
@@ -48,7 +48,7 @@ RUN NODE_ENV=production npm ci
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as runtime
+FROM balena/open-balena-base:v9.1.0 as runtime
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as base
+FROM balena/open-balena-base:v9.1.0 as base
 
 WORKDIR /usr/src/jellyfish
 
@@ -48,7 +48,7 @@ RUN NODE_ENV=production npm ci
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as runtime
+FROM balena/open-balena-base:v9.1.0 as runtime
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as base
+FROM balena/open-balena-base:v9.1.0 as base
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as base
+FROM balena/open-balena-base:v9.1.0 as base
 
 WORKDIR /usr/src/jellyfish
 
@@ -47,7 +47,7 @@ RUN NODE_ENV=production npm ci
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as runtime
+FROM balena/open-balena-base:v9.1.0 as runtime
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4
+FROM balena/open-balena-base:v9.1.0
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.0.4 as base
+FROM balena/open-balena-base:v9.1.0 as base
 
 WORKDIR /usr/src/jellyfish
 


### PR DESCRIPTION
- Update open-balena-base to latest 9.1.0
- ~Update docker-compose version to latest 3.7: does not provide any immediate advantage but unlocks options~
Dropped: we [cannot use](https://www.balena.io/docs/learn/develop/multicontainer/#docker-composeyml-file) docker-compose file versions newer than 2.1