### PR TITLE
Improve the way webpack packs bundles

### DIFF
--- a/apps/livechat/webpack.config.js
+++ b/apps/livechat/webpack.config.js
@@ -7,9 +7,9 @@
 /* eslint-env node */
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const path = require('path')
 const DefinePlugin = require('webpack/lib/DefinePlugin')
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const mergeConfig = require('webpack-merge')
 const baseConfig = require('../../webpack.config.base.js')
 
@@ -29,9 +29,28 @@ const config = mergeConfig(baseConfig, {
 	entry: path.join(uiRoot, 'index.jsx'),
 
 	output: {
-		filename: 'bundle.[hash].js',
+		filename: '[name].[contenthash].js',
 		path: outDir,
 		publicPath: '/'
+	},
+
+	devServer: {
+		// eslint-disable-next-line no-process-env
+		port: process.env.LIVECHAT_PORT
+	},
+
+	optimization: {
+		moduleIds: 'hashed',
+		runtimeChunk: 'single',
+		splitChunks: {
+			cacheGroups: {
+				vendor: {
+					test: /[\\/]node_modules[\\/]/,
+					name: 'vendors',
+					chunks: 'all'
+				}
+			}
+		}
 	},
 
 	plugins: [
@@ -47,12 +66,7 @@ const config = mergeConfig(baseConfig, {
 			}
 			/* eslint-enable no-process-env */
 		})
-	],
-
-	devServer: {
-		// eslint-disable-next-line no-process-env
-		port: process.env.LIVECHAT_PORT
-	}
+	]
 })
 
 // eslint-disable-next-line no-process-env

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -13,7 +13,6 @@ const path = require('path')
 const webpack = require('webpack')
 const DefinePlugin = require('webpack/lib/DefinePlugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-const HashedModuleIdsPlugin = require('webpack/lib/HashedModuleIdsPlugin')
 const mergeConfig = require('webpack-merge')
 const baseConfig = require('../../webpack.config.base.js')
 
@@ -37,7 +36,7 @@ const config = mergeConfig(baseConfig, {
 	entry: path.join(uiRoot, 'index.jsx'),
 
 	output: {
-		filename: 'bundle.[contenthash].js',
+		filename: '[name].[contenthash].js',
 		path: outDir,
 		publicPath: '/'
 	},
@@ -48,8 +47,16 @@ const config = mergeConfig(baseConfig, {
 	},
 
 	optimization: {
+		moduleIds: 'hashed',
+		runtimeChunk: 'single',
 		splitChunks: {
-			chunks: 'all'
+			cacheGroups: {
+				vendor: {
+					test: /[\\/]node_modules[\\/]/,
+					name: 'vendors',
+					chunks: 'all'
+				}
+			}
 		}
 	},
 
@@ -85,12 +92,6 @@ const config = mergeConfig(baseConfig, {
 				VERSION: JSON.stringify(`v${packageJSON.version}`)
 			}
 			/* eslint-enable no-process-env */
-		}),
-
-		new HashedModuleIdsPlugin({
-			hashFunction: 'sha256',
-			hashDigest: 'hex',
-			hashDigestLength: 20
 		}),
 
 		new webpack.ContextReplacementPlugin(


### PR DESCRIPTION
Improve the way webpack packs bundles, in order to make them more cache friendly

With #2829 we splitted bundles in main and vendor. ~However according to [this article](https://developers.google.com/web/fundamentals/performance/webpack/use-long-term-caching) it was missing a critical piece called `runtimeChunk`~
~Article found via [hackers news tweet](https://www.debugbear.com/blog/performant-front-end-architecture)~

After some additional research, I've found [this webpack doc](https://webpack.js.org/guides/caching/) about caching: while google is the usual know-it-all, it made more sense to follow webpack instructions instead

This PR relates to #3054 