### PR TITLE
View templates

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -95,6 +95,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/view-my-inbox.json'),
 		await loadCard('contrib/view-my-orgs.json'),
 		await loadCard('contrib/view-my-todo-items.json'),
+		await loadCard('contrib/view-all-by-type.json'),
 
 		// Balena org cards
 		await loadCard('balena/org-balena.json'),

--- a/apps/server/default-cards/contrib/view-all-by-type.json
+++ b/apps/server/default-cards/contrib/view-all-by-type.json
@@ -1,0 +1,52 @@
+{
+  "slug": "view-all-by-type",
+  "name": "All cards by type",
+  "version": "1.0.0",
+  "type": "view@1.0.0",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "allOf": [
+      {
+        "name": "Card type view",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": {
+                "$eval": "types"
+              }
+            },
+            "active": {
+              "type": "boolean",
+              "const": true
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type"
+          ]
+        }
+      }
+    ],
+    "arguments": {
+      "type": "object",
+      "required": [
+        "types"
+      ],
+      "properties": {
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/apps/server/http/facades/index.js
+++ b/apps/server/http/facades/index.js
@@ -7,5 +7,6 @@
 module.exports = {
 	QueryFacade: require('./query'),
 	AuthFacade: require('./auth'),
-	ActionFacade: require('./action')
+	ActionFacade: require('./action'),
+	ViewFacade: require('./view')
 }

--- a/apps/server/http/facades/view.js
+++ b/apps/server/http/facades/view.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const jsone = require('json-e')
+const skhema = require('skhema')
+const assert = require('../../../../lib/assert')
+
+module.exports = class ViewFacade {
+	constructor (jellyfish, queryFacade) {
+		this.jellyfish = jellyfish
+		this.queryFacade = queryFacade
+	}
+
+	async queryByView (context, sessionToken, viewSlug, params, options, ipAddress) {
+		if (!_.includes(viewSlug, '@')) {
+			throw new Error('View slug must include a version')
+		}
+
+		return this.jellyfish.getCardBySlug(context, sessionToken, viewSlug)
+			.then((view) => {
+				if (!view) {
+					return null
+				}
+
+				let query = null
+				if (_.has(view, [ 'data', 'arguments' ])) {
+					assert.INTERNAL(context, skhema.isValid(view.data.arguments, params),
+						Error, 'Params don\'t match schema of view params')
+
+					query = jsone(view, params)
+				} else {
+					query = view
+				}
+
+				return this.queryFacade.queryAPI(context, sessionToken, query, options, ipAddress)
+			})
+	}
+}

--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -66,6 +66,7 @@ module.exports = (application, jellyfish, worker, queue, options) => {
 	const queryFacade = new facades.QueryFacade(jellyfish)
 	const authFacade = new facades.AuthFacade(jellyfish)
 	const actionFacade = new facades.ActionFacade(worker, queue, fileStore)
+	const viewFacade = new facades.ViewFacade(jellyfish, queryFacade)
 
 	application.get('/api/v2/config', (request, response) => {
 		response.send({
@@ -574,6 +575,28 @@ module.exports = (application, jellyfish, worker, queue, options) => {
 			})
 		}).catch((error) => {
 			logger.warn(request.context, 'JSON Schema query error', request.body)
+			return sendHTTPError(request, response, error)
+		})
+	})
+
+	application.post('/api/v2/view/:slug', (request, response) => {
+		viewFacade.queryByView(
+			request.context,
+			request.sessionToken,
+			request.params.slug,
+			request.body.params,
+			request.body.options,
+			request.ip
+		).then((data) => {
+			if (!data) {
+				return response.status(404).end()
+			}
+
+			return response.status(200).json({
+				error: false,
+				data
+			})
+		}).catch((error) => {
 			return sendHTTPError(request, response, error)
 		})
 	})

--- a/lib/sdk/index.js
+++ b/lib/sdk/index.js
@@ -459,6 +459,48 @@ class JellyfishSDK {
 	}
 
 	/**
+	 * @summary Send a view request to the API
+	 * @name view
+	 * @public
+	 * @function
+	 * @memberof JellyfishSDK
+	 *
+	 * @description Query the API for card data, referencing a view template by
+	 * slug@version and providing its params and options. Internally, it uses
+	 * `query`, so any constraint specific to it is also applied
+	 *
+	 * @param {String} viewSlug - the slug@version of the view to use
+	 * @param {Object} params - the optional params used by the view template
+	 * @param {Object} [options] - Additional options
+	 * @param {Number} [options.limit] - Limit the number of results
+	 * @param {Number} [options.skip] - Skip a set amount of results
+	 *
+	 * @fulfil {Object[]} - An array of cards that match the schema specified by the view
+	 * @returns {Promise}
+	 *
+	 * @example
+	 * const params = {
+	 *   types: [ 'view', 'view@1.0.0' ]
+	 * }
+	 *
+	 * sdk.view('view-all-by-type@1.0.0', params)
+	 * 	.then((cards) => {
+	 * 		console.log(cards);
+	 * 	});
+	 */
+	view (viewSlug, params = {}, options = {}) {
+		const payload = {
+			params,
+			options
+		}
+
+		return this.post(`view/${viewSlug}`, payload)
+			.then((response) => {
+				return response ? response.data.data : []
+			})
+	}
+
+	/**
      * @summary Get all cards by type
      * @name getByType
      * @public

--- a/lib/sdk/index.spec.js
+++ b/lib/sdk/index.spec.js
@@ -408,3 +408,51 @@ ava.serial('.event.create() should create a new event', async (test) => {
 		version: '1.0.0'
 	})
 })
+
+ava.serial('.view() should query using a view template', async (test) => {
+	const {
+		sdk
+	} = test.context
+
+	const server = nock(API_URL)
+
+	const mockData = {
+		example: 'card'
+	}
+
+	server.post(/view\/view-all-by-type@1.0.0/)
+		.reply((uri, requestBody) => {
+			const expected = {
+				params: {
+					types: [ 'view', 'view@1.0.0' ]
+				},
+				options: {
+					limit: 1,
+					skip: 0,
+					sortBy: 'created_at'
+				}
+			}
+
+			if (!_.isEqual(JSON.parse(requestBody), expected)) {
+				return [ 500, 'test error' ]
+			}
+
+			return [
+				200,
+				{
+					error: false,
+					data: [ mockData ]
+				}
+			]
+		})
+
+	const results = await sdk.view('view-all-by-type@1.0.0', {
+		types: [ 'view', 'view@1.0.0' ]
+	}, {
+		limit: 1,
+		skip: 0,
+		sortBy: 'created_at'
+	})
+
+	test.deepEqual(results[0], mockData)
+})

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -788,3 +788,23 @@ ava.serial('/query endpoint should allow you to query using a view\'s id', async
 		return _.first(card.type.split('@'))
 	})), [ 'view' ])
 })
+
+ava.serial('/view/:slug endpoing should return the list of all views', async (test) => {
+	const result = await test.context.http(
+		'POST',
+		'/api/v2/view/view-all-by-type@1.0.0',
+		{
+			params: {
+				types: [ 'view', 'view@1.0.0' ]
+			}
+		},
+		{
+			Authorization: `Bearer ${test.context.token}`
+		}
+	)
+
+	test.is(result.code, 200)
+	test.deepEqual(_.uniq(_.map(result.response.data, (card) => {
+		return _.first(card.type.split('@'))
+	})), [ 'view' ])
+})

--- a/test/unit/apps/server/http/facades/view.spec.js
+++ b/test/unit/apps/server/http/facades/view.spec.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const ava = require('ava')
+const ViewFacade = require('../../../../../../apps/server/http/facades/view')
+
+ava('viewFacade should discard view slugs without version', async (test) => {
+	const viewFacade = new ViewFacade()
+
+	try {
+		await viewFacade.queryByView(null, null, 'slug', null, null, null)
+		test.fail('This code should not run')
+	} catch (err) {
+		test.pass()
+	}
+})
+
+ava('viewFacade should return null if view is not found', async (test) => {
+	const viewFacade = new ViewFacade({
+		getCardBySlug: _.constant(Promise.resolve(null))
+	})
+
+	const result = await viewFacade.queryByView(null, null, 'slug@1.0.0', null, null, null)
+
+	test.falsy(result)
+})
+
+ava('viewFacade should reject params not matching params schema', async (test) => {
+	const viewFacade = new ViewFacade({
+		getCardBySlug: _.constant(Promise.resolve({
+			data: {
+				arguments: {
+					type: 'object',
+					required: [ 'types' ],
+					properties: {
+						types: {
+							type: 'array',
+							items: {
+								type: 'string'
+							}
+						}
+					}
+				}
+			}
+		}))
+	})
+
+	const error = await test.throwsAsync(async () => {
+		await viewFacade.queryByView(null, null, 'slug@1.0.0', 'wrong param type', null, null)
+	})
+
+	test.truthy(error.message)
+})
+
+ava('viewFacade should query using a plain (non template) view', async (test) => {
+	const viewFacade = new ViewFacade({
+		getCardBySlug: _.constant(Promise.resolve({
+			example: 'view'
+		}))
+	}, {
+		async queryAPI (_context, _sessionToken, query, _options, _ipAddress) {
+			test.deepEqual(query, {
+				example: 'view'
+			})
+		}
+	})
+
+	await viewFacade.queryByView(null, null, 'slug@1.0.0', null, null, null)
+})
+
+ava('viewFacade should query using a rendered template view', async (test) => {
+	const viewFacade = new ViewFacade({
+		getCardBySlug: _.constant(Promise.resolve({
+			data: {
+				allOf: [ {
+					name: 'Card type view',
+					schema: {
+						type: 'object',
+						properties: {
+							type: {
+								type: 'string',
+								enum: {
+									$eval: 'types'
+								}
+							},
+							active: {
+								type: 'boolean',
+								const: true
+							}
+						},
+						additionalProperties: true,
+						required: [
+							'type'
+						]
+					}
+				} ],
+				arguments: {
+					type: 'object',
+					required: [ 'types' ],
+					properties: {
+						types: {
+							type: 'array',
+							items: {
+								type: 'string'
+							}
+						}
+					}
+				}
+			}
+		}))
+	}, {
+		async queryAPI (_context, _sessionToken, query, _options, _ipAddress) {
+			test.deepEqual(query, {
+				data: {
+					allOf: [ {
+						name: 'Card type view',
+						schema: {
+							type: 'object',
+							properties: {
+								type: {
+									type: 'string',
+									enum: [ 'view', 'view@1.0.0' ]
+								},
+								active: {
+									type: 'boolean',
+									const: true
+								}
+							},
+							additionalProperties: true,
+							required: [
+								'type'
+							]
+						}
+					} ],
+					arguments: {
+						type: 'object',
+						required: [ 'types' ],
+						properties: {
+							types: {
+								type: 'array',
+								items: {
+									type: 'string'
+								}
+							}
+						}
+					}
+				}
+			})
+		}
+	})
+
+	await viewFacade.queryByView(null, null, 'slug@1.0.0', {
+		types: [ 'view', 'view@1.0.0' ]
+	}, null, null)
+})


### PR DESCRIPTION
Introduce view templates, a way to query by views which are json-e templates, saving callers from building complex query objects every time and instead use a view template referenced by slug and provide its params

Available via `sdk.view`, for example 
```js
sdk.view('view-all-by-type@1.0.0', {
  types: [ 'view', 'view@1.0.0' ]
})
```

Connects-to: #3097
Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
