### PR TITLE
Use new jellyfish-sidecar image

### DIFF
--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0
+FROM resinci/jellyfish-sidecar
 
 WORKDIR /usr/src/jellyfish
 
@@ -15,12 +15,6 @@ COPY package.json package-lock.json /usr/src/jellyfish/
 # COPY scripts/template/package*.json \
 # 	/usr/src/jellyfish/scripts/template/
 RUN npm ci
-
-RUN apt-get update && apt-get install -y \
-	libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 \
-	libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
-	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 \
-	postgresql-client-11
 
 COPY ./lib/core ./lib/core
 COPY ./lib/coverage ./lib/coverage


### PR DESCRIPTION
Use new jellyfish-sidecar image, to shove some time* when building compose images
(* mins locally, less on circleci)

New image `resinci/jellyfish-sidecar` is built from [this dockerfile](https://github.com/product-os/jellyfish-base-images/blob/master/Dockerfile.sidecar) and contains all the packages removed in this PR
Using an already built docker image is faster, especially locally

Connects-to: #3103
Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
