### PR TITLE
Change repo owner to product-os in scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -833,20 +833,20 @@ workflows:
                     - compose-build
                 <<: *workflow_filter
 
-            - e2e_tests_server_previous_dump:
-                requires:
-                    - compose-build
-                <<: *workflow_filter
-
-            - e2e_tests_ui_previous_dump:
-                requires:
-                    - compose-build
-                <<: *workflow_filter
-
-            - e2e_tests_livechat_previous_dump:
-                requires:
-                    - compose-build
-                <<: *workflow_filter
+#            - e2e_tests_server_previous_dump:
+#                requires:
+#                    - compose-build
+#                <<: *workflow_filter
+#
+#            - e2e_tests_ui_previous_dump:
+#                requires:
+#                    - compose-build
+#                <<: *workflow_filter
+#
+#            - e2e_tests_livechat_previous_dump:
+#                requires:
+#                    - compose-build
+#                <<: *workflow_filter
 
             - sync_tests_front_translate:
                 requires:
@@ -885,9 +885,9 @@ workflows:
                   - e2e_tests_server
                   - e2e_tests_ui
                   - e2e_tests_livechat
-                  - e2e_tests_server_previous_dump
-                  - e2e_tests_ui_previous_dump
-                  - e2e_tests_livechat_previous_dump
+                  #- e2e_tests_server_previous_dump
+                  #- e2e_tests_ui_previous_dump
+                  #- e2e_tests_livechat_previous_dump
                   - sync_tests_front_translate
                   - sync_tests_discourse_translate
                   - sync_tests_front_mirror

--- a/scripts/ci/github-pr-summary.js
+++ b/scripts/ci/github-pr-summary.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 const Octokit = require('@octokit/rest')
 const packageJSON = require('../../package.json')
 
-const OWNER = 'balena-io'
+const OWNER = 'product-os'
 const REPO = 'jellyfish'
 const TOKEN = process.env.GITHUB_TOKEN
 const PR = process.argv[2] && parseInt(_.last(process.argv[2].split('/')), 10)

--- a/scripts/ci/postgres-get-previous-dump.sh
+++ b/scripts/ci/postgres-get-previous-dump.sh
@@ -32,7 +32,7 @@ COMMITS="$(git log --merges --pretty="%P %s" |
 	cut -d ' ' -f 2 |
 	head -n 10)"
 
-OWNER="balena-io"
+OWNER="product-os"
 REPO="jellyfish"
 
 function get_statuses() {


### PR DESCRIPTION
Scripts don't find previous db dump. Probably due to github API not dealing with the new org for this repo (from balena-io to product-os)

Also temporary disable "previous dump" jobs, since we changed org and jobs cannot find previous dumps. We'll re-enable them by reverting 772dc52f5718c73dfde3e8c99388a453bb6502d5 in next PR ([flowdock](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/eUO-mNfQGs6tuNyzi2nNkrkuoJ_))