### PR TITLE
Update open-balena-base and disable circleci docker_layer_caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,8 +188,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -264,8 +263,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -340,8 +338,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -388,8 +385,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -433,8 +429,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -476,8 +471,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -519,8 +513,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -564,8 +557,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -609,8 +601,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - restore_cache:
           key: jellyfish-docker-layers-{{ .Branch }}
@@ -653,8 +644,7 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - run:
           name: Log into balenaCloud

--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as base
+FROM balena/open-balena-base:v9.2.0 as base
 
 WORKDIR /usr/src/jellyfish
 
@@ -48,7 +48,7 @@ RUN NODE_ENV=production npm ci
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as runtime
+FROM balena/open-balena-base:v9.2.0 as runtime
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as base
+FROM balena/open-balena-base:v9.2.0 as base
 
 WORKDIR /usr/src/jellyfish
 
@@ -48,7 +48,7 @@ RUN NODE_ENV=production npm ci
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as runtime
+FROM balena/open-balena-base:v9.2.0 as runtime
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as base
+FROM balena/open-balena-base:v9.2.0 as base
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as base
+FROM balena/open-balena-base:v9.2.0 as base
 
 WORKDIR /usr/src/jellyfish
 
@@ -47,7 +47,7 @@ RUN NODE_ENV=production npm ci
 # Runtime
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as runtime
+FROM balena/open-balena-base:v9.2.0 as runtime
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.1.0 as base
+FROM balena/open-balena-base:v9.2.0 as base
 
 WORKDIR /usr/src/jellyfish
 


### PR DESCRIPTION
* Update open-balena-base to latest 9.2.0
* Disable circleci docker_layer_caching when not needed, as it costs 200 credit per job run https://circleci.com/docs/2.0/docker-layer-caching/

For the record, the only job that needs `docker_layer_caching` is `compose-build`. The other ones use the saved docker layers that we restore each time, so no need to spend those 200 credits, as we don't leverage `docker_layer_caching` in those cases