### PR TITLE
Small improvements

### DIFF
--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -33,7 +33,8 @@ const filter = (schema, element) => {
 		}
 	}
 
-	const result = skhema.filter(schema, element)
+	const elementCopy = _.cloneDeep(element)
+	const result = skhema.filter(schema, elementCopy)
 
 	// If additionalProperties is false, remove properties that haven't been
 	// explicitly selected. This is done because the Skhema module will merge
@@ -42,7 +43,7 @@ const filter = (schema, element) => {
 	// properties may be added to the result that the initial query did not
 	// specify, depending on which permission views are merged in.
 	if (schema.additionalProperties === false) {
-		for (const item of _.castArray(element)) {
+		for (const item of _.castArray(elementCopy)) {
 			for (const key in item) {
 				if (!schema.properties[key]) {
 					Reflect.deleteProperty(item, key)
@@ -146,8 +147,8 @@ exports.attach = async (context, instance, schema, options) => {
 			return
 		}
 
-		let newMatch = filter(schema, _.cloneDeep(after))
-		let oldMatch = filter(schema, _.cloneDeep(before))
+		let newMatch = filter(schema, after)
+		let oldMatch = filter(schema, before)
 
 		if (_.isEmpty(newMatch)) {
 			newMatch = null

--- a/test/integration/queue/events.spec.js
+++ b/test/integration/queue/events.spec.js
@@ -115,7 +115,12 @@ ava.cb('.wait() should return when a certain execute event is inserted', (test) 
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef'
-	}).then(() => {
+	}).then(async () => {
+		// Wait a bit for `postgres.upsertObject` to terminate
+		// Otherwise, we close the underlying connections while the rest
+		// of the code of upsertObject is still running, causing errors
+		// unrelated to the test
+		await Bluebird.delay(500)
 		test.end()
 	}).catch(test.end)
 
@@ -167,8 +172,14 @@ ava.cb('.wait() should be able to access the event payload of a huge event', (te
 			action: BIG_EXECUTE_CARD.data.action,
 			card: BIG_EXECUTE_CARD.data.target,
 			actor: BIG_EXECUTE_CARD.data.actor
-		}).then((card) => {
+		}).then(async (card) => {
 		test.deepEqual(card.data.payload, BIG_EXECUTE_CARD.data.payload)
+
+		// Wait a bit for `postgres.upsertObject` to terminate
+		// Otherwise, we close the underlying connections while the rest
+		// of the code of upsertObject is still running, causing errors
+		// unrelated to the test
+		await Bluebird.delay(500)
 		test.end()
 	}).catch(test.end)
 
@@ -219,8 +230,14 @@ ava.cb('.wait() should ignore cards that do not match the id', (test) => {
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef'
-	}).then((request) => {
+	}).then(async (request) => {
 		test.is(request.data.payload.timestamp, '2020-06-30T19:34:42.829Z')
+
+		// Wait a bit for `postgres.upsertObject` to terminate
+		// Otherwise, we close the underlying connections while the rest
+		// of the code of upsertObject is still running, causing errors
+		// unrelated to the test
+		await Bluebird.delay(500)
 		test.end()
 	}).catch(test.end)
 


### PR DESCRIPTION
A couple of small improvements, not related to any specific on going activity, worth pushing to master

* Postpone `cloneDeep` in streams schema validation until we actually need it
* Wait a bit before tearing down queue tests, as kernel is still doing stuff in background. This fix might put an end to those SIGILL failures we have seen any now and then