### PR TITLE
Use caching headers for livechat assets

### DIFF
--- a/apps/livechat/conf/nginx.conf
+++ b/apps/livechat/conf/nginx.conf
@@ -13,10 +13,16 @@ server {
 	location = /404.html {
 		root /usr/share/nginx/html;
 		internal;
+
+		add_header Cache-Control "no-store, no-cache, must-revalidate";
 	}
 
 	location ~\.(js|css)$ {
 		root /usr/share/nginx/html;
+
+		 expires 1y;
+		 add_header Cache-Control "public";
+		 access_log off;
 	}
 
 	location / {
@@ -24,6 +30,8 @@ server {
 		# Redirect unknown paths to index.html, to allow for paths handled by the UI
 		# to work on initial page load
 		try_files $uri /index.html;
+
+		add_header Cache-Control "no-store, no-cache, must-revalidate";
 	}
 }
 


### PR DESCRIPTION
Since #3093, livechat assets are split as well, so we can now use caching headers such as 'expires' and 'cache-control'
