### PR TITLE
Add view org permission to chat widget user

### DIFF
--- a/apps/server/default-cards/contrib/role-user-external-support.json
+++ b/apps/server/default-cards/contrib/role-user-external-support.json
@@ -198,13 +198,13 @@
               "type": "string",
               "enum": [ "user", "user@1.0.0" ]
             },
+            "name": {
+              "type": "string"
+            },
             "data": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "handle": {
-                  "type": "string"
-                },
                 "email": {
                   "type": [ "string", "array" ]
                 },
@@ -212,6 +212,21 @@
                   "type": [ "string", "null" ]
                 }
               }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "type", "slug" ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [ "org", "org@1.0.0" ]
+            },
+            "slug": {
+              "type": "string",
+              "const": "org-balena"
             }
           }
         }


### PR DESCRIPTION
Change-type: patch
Connects-to: #3129

User name that displays over message is determined by slug if user belongs to balena organisation:

```javascript
const isBalenaTeam = _.find(
	_.get(actor, [ 'links', 'is member of' ], []),
	{
		slug: 'org-balena'
	}
)

// Check if the user is part of the balena org
email = _.get(actor, ['data', 'email'], '')

const isBalenaTeam = _.find(
	_.get(actor, ['links', 'is member of'], []),
	{
		slug: 'org-balena'
	}
)

// Check if the user is part of the balena org
if (isBalenaTeam) {
	name = actor.name || actor.slug.replace('user-', '')
} else {
	proxy = true
	let handle = actor.name || _.get(actor, ['data', 'handle'])
	if (!handle) {
		handle = email || actor.slug.replace(/^(account|user)-/, '')
	}
	name = `[${handle}]`
}
```

So `user-external-support` role should have org permission too.

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
