### PR TITLE
Serve jellyfish js assets via AWS CloudFront

### DIFF
--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -29,8 +29,11 @@ const audioFolderPath = path.join(resourcesRoot, 'audio')
 const faviconPath = path.join(resourcesRoot, 'favicon.ico')
 const outDir = path.join(root, 'dist/ui')
 const packageJSON = require('../../package.json')
+const environment = require('../../lib/environment')
 
 console.log(`Generating bundle from ${uiRoot}`)
+
+const publicPath = environment.isProduction() ? '//dc8ubcsrd55s5.cloudfront.net/' : '/'
 
 const config = mergeConfig(baseConfig, {
 	entry: path.join(uiRoot, 'index.jsx'),
@@ -38,7 +41,7 @@ const config = mergeConfig(baseConfig, {
 	output: {
 		filename: '[name].[contenthash].js',
 		path: outDir,
-		publicPath: '/'
+		publicPath
 	},
 
 	devServer: {

--- a/deploy-templates/cloudformation/jellyfish-cloudfront.yml
+++ b/deploy-templates/cloudformation/jellyfish-cloudfront.yml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  jellyfish:
+    Type: 'AWS::CloudFront::Distribution'
+    Properties:
+      DistributionConfig:
+        Origins:
+          - DomainName: jel.ly.fish
+            Id: jellyfish
+            CustomOriginConfig:
+              HTTPPort: '80'
+              HTTPSPort: '443'
+              OriginProtocolPolicy: match-viewer
+        Enabled: 'true'
+        DefaultCacheBehavior:
+          TargetOriginId: jellyfish
+          SmoothStreaming: 'false'
+          ForwardedValues:
+            QueryString: 'false'
+            Cookies:
+              Forward: none
+          Compress: 'true'
+          ViewerProtocolPolicy: allow-all
+        PriceClass: PriceClass_All
+        ViewerCertificate:
+          CloudFrontDefaultCertificate: 'true'
+        IPV6Enabled: 'false'


### PR DESCRIPTION
This PR is still a draft because:
* it requires eyes from devops to validate the cloudformation template
* once devops will run the template, they'll provide the actual domain name that cloudfront has generated, and we'll update the webpack config file providing it. Or maybe we use an env var: thoughts are welcome

Connects-to: #3054
Change-type: minor
Signed-off-by: Federico Fissore <federico@balena.io>
