### PR TITLE
Implement file upload on thread creation

### DIFF
--- a/lib/chat-widget/components/CreateThread.jsx
+++ b/lib/chat-widget/components/CreateThread.jsx
@@ -49,7 +49,7 @@ export const CreateThread = ({
 	const currentUser = useSelector(selectCurrentUser())
 	const [ subject, setSubject ] = React.useState('')
 	const [ text, setText ] = React.useState('')
-	const [ files, setFiles ] = React.useState('')
+	const [ files, setFiles ] = React.useState([])
 	const actions = useActions()
 	const initiateThreadTask = useTask(actions.initiateThread)
 
@@ -103,6 +103,7 @@ export const CreateThread = ({
 					value={text}
 					placeholder="Type your message"
 					onChange={handleTextChange}
+					files={files}
 					onFileChange={handleFileChange}
 					onSubmit={handleSubmit}
 				/>

--- a/lib/chat-widget/store/action-creators.js
+++ b/lib/chat-widget/store/action-creators.js
@@ -8,6 +8,9 @@ import _ from 'lodash'
 import * as uuid from 'uuid'
 import * as helpers from '../../ui-components/services/helpers'
 import {
+	FILE_PROXY_MESSAGE
+} from '../../ui-components/Timeline'
+import {
 	SET_CARDS,
 	SET_CURRENT_USER
 } from './action-types'
@@ -61,6 +64,11 @@ export const initiateThread = (ctx) => {
 				alertsUser: alerts,
 				message: text.replace(messageSymbolRE, '')
 			}
+		}
+
+		if (files.length) {
+			newMessage.payload.file = files[0]
+			newMessage.payload.message += `\n${FILE_PROXY_MESSAGE} ${helpers.createPermaLink(thread)}`
 		}
 
 		const message = await ctx.sdk.event.create(newMessage)

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -38,6 +38,9 @@ import {
 } from '../shame/ActionLink'
 import Avatar from '../shame/Avatar'
 import Icon from '../shame/Icon'
+import {
+	HIDDEN_ANCHOR
+} from '../Timeline'
 
 const ActorPlaceholder = styled.span `
 	width: 80px;
@@ -109,11 +112,10 @@ export const getMessage = (card) => {
 		return `![Attached image](https://app.frontapp.com${message.slice(1, -1)})`
 	}
 
-	if (message.includes('#jellyfish-hidden')) {
-		return ''
-	}
-
 	return message
+		.split('\n')
+		.filter((line) => { return !line.includes(HIDDEN_ANCHOR) })
+		.join('\n')
 }
 
 const downloadFile = async (sdk, cardId, file) => {

--- a/lib/ui-components/FileUploader.jsx
+++ b/lib/ui-components/FileUploader.jsx
@@ -5,8 +5,12 @@
  */
 
 import React from 'react'
+import FileIcon from 'react-icons/lib/fa/paperclip'
 import {
-	Button
+	Box,
+	Button,
+	Flex,
+	Tag
 } from 'rendition'
 import styled from 'styled-components'
 
@@ -52,5 +56,56 @@ export const FileUploadButton = ({
 		<FileUploader onChange={onChange}>
 			{(startUpload) => { return <Button onClick={startUpload} {...rest} /> }}
 		</FileUploader>
+	)
+}
+
+const FileTag = ({
+	file, onRemove, ...rest
+}) => {
+	const handleRemove = React.useCallback(() => {
+		onRemove(file)
+	}, [ file, onRemove ])
+
+	return (
+		<Tag onClose={handleRemove} {...rest} name={file.name} />
+	)
+}
+
+export const FilesInput = ({
+	value = [],
+	onChange,
+	multiple,
+	...rest
+}) => {
+	const handleRemove = React.useCallback((file) => {
+		onChange(value.filter((item) => {
+			return item !== file
+		}))
+	}, [ value ])
+
+	return (
+		<Flex {...rest} alignItems="center">
+			{(multiple || !value.length) && (
+				<Box style={{
+					lineHeight: 1
+				}}>
+					<FileUploadButton
+						p={2}
+						fontSize="18px"
+						plain
+						multiple={multiple}
+						onChange={onChange}
+						icon={<FileIcon />}
+					/>
+				</Box>
+			)}
+			<Box flex="1">
+				{value.map((file) => {
+					return (
+						<FileTag ml={1} key={file.name} file={file} onRemove={handleRemove} />
+					)
+				})}
+			</Box>
+		</Flex>
 	)
 }

--- a/lib/ui-components/Timeline/MessageInput.jsx
+++ b/lib/ui-components/Timeline/MessageInput.jsx
@@ -14,10 +14,9 @@ import {
 } from 'rendition'
 import styled from 'styled-components'
 import AutocompleteTextarea from '../shame/AutocompleteTextarea'
-import FileIcon from 'react-icons/lib/fa/paperclip'
 import UseSecretIcon from 'react-icons/lib/fa/user-secret'
 import {
-	FileUploadButton
+	FilesInput
 } from '../FileUploader'
 
 const PlainAutocompleteTextarea = styled(AutocompleteTextarea) `
@@ -64,6 +63,7 @@ const MessageInput = React.memo(({
 	value,
 	onChange,
 	onSubmit,
+	files,
 	onFileChange,
 	wide = true,
 	style,
@@ -127,12 +127,9 @@ const MessageInput = React.memo(({
 	)
 
 	const fileUploadButton = (
-		<FileUploadButton
-			fontSize="18px"
-			plain
-			p={2}
+		<FilesInput
+			value={files}
 			onChange={onFileChange}
-			icon={<FileIcon />}
 		/>
 	)
 
@@ -164,13 +161,13 @@ const MessageInput = React.memo(({
 				}}>
 					{textInput}
 				</Box>
-				<Box px={2} style={{
+				<Flex px={2} style={{
 					gridColumn: 2,
 					gridRow: 1
 				}}>
 					{toggleWhisperButton}
 					{fileUploadButton}
-				</Box>
+				</Flex>
 				<Box style={{
 					gridColumn: 1,
 					gridRow: 2

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -35,7 +35,8 @@ const messageSymbolRE = /^\s*%\s*/
  * This message text is used when uploading a file so that syncing can be done
  * effectively without have to sync the entire file
  */
-const FILE_PROXY_MESSAGE = '[](#jellyfish-hidden)A file has been uploaded using Jellyfish:'
+export const HIDDEN_ANCHOR = '#jellyfish-hidden'
+export const FILE_PROXY_MESSAGE = `[](${HIDDEN_ANCHOR})A file has been uploaded using Jellyfish:`
 
 const TypingNotice = styled.div `
 	background: white;


### PR DESCRIPTION
Change-type: minor

***

**Currently supports only single file upload**

<img width="380" alt="Screenshot 2020-02-19 at 16 15 18" src="https://user-images.githubusercontent.com/2152815/74833520-0f19ad80-5333-11ea-8810-54397c9ba728.png">

<img width="376" alt="Screenshot 2020-02-29 at 01 48 52" src="https://user-images.githubusercontent.com/2152815/75590042-de094d80-5a95-11ea-931b-4c29516e3071.png">

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
