### PR TITLE
Don't use `process.env` as UI env vars container

### DIFF
--- a/apps/livechat/webpack.config.js
+++ b/apps/livechat/webpack.config.js
@@ -60,7 +60,7 @@ const config = mergeConfig(baseConfig, {
 
 		new DefinePlugin({
 			/* eslint-disable no-process-env */
-			'process.env': {
+			env: {
 				API_URL: JSON.stringify(process.env.API_URL),
 				NODE_ENV: JSON.stringify(process.env.NODE_ENV)
 			}

--- a/apps/ui/environment.js
+++ b/apps/ui/environment.js
@@ -4,30 +4,29 @@
  * Proprietary and confidential.
  */
 
-/* global process */
-/* eslint-disable no-process-env */
+/* global env */
 
 export const isTest = () => {
-	return process.env.NODE_ENV === 'test'
+	return env.NODE_ENV === 'test'
 }
 
 export const isProduction = () => {
-	return process.env.NODE_ENV === 'production'
+	return env.NODE_ENV === 'production'
 }
 
 export const sentry = {
-	dsn: process.env.SENTRY_DSN_UI || '0'
+	dsn: env.SENTRY_DSN_UI || '0'
 }
 
 export const api = {
-	prefix: process.env.API_PREFIX || 'api/v2',
-	url: process.env.API_URL || window.location.origin
+	prefix: env.API_PREFIX || 'api/v2',
+	url: env.API_URL || window.location.origin
 }
 
 export const analytics = {
 	mixpanel: {
-		token: process.env.MIXPANEL_TOKEN_UI
+		token: env.MIXPANEL_TOKEN_UI
 	}
 }
 
-export const version = process.env.VERSION
+export const version = env.VERSION

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -81,7 +81,7 @@ const config = mergeConfig(baseConfig, {
 
 		new DefinePlugin({
 			/* eslint-disable no-process-env */
-			'process.env': {
+			env: {
 				API_URL: JSON.stringify(process.env.API_URL),
 				API_PREFIX: JSON.stringify(process.env.API_PREFIX || 'api/v2/'),
 				NODE_ENV: JSON.stringify(process.env.NODE_ENV),

--- a/lib/chat-widget/environment.js
+++ b/lib/chat-widget/environment.js
@@ -4,20 +4,19 @@
  * Proprietary and confidential.
  */
 
-/* global process */
-/* eslint-disable no-process-env */
+/* global env */
 
 export const isTest = () => {
-	return process.env.NODE_ENV === 'test'
+	return env.NODE_ENV === 'test'
 }
 
 export const api = {
-	prefix: process.env.API_PREFIX || 'api/v2',
-	url: process.env.API_URL
+	prefix: env.API_PREFIX || 'api/v2',
+	url: env.API_URL
 }
 
 export const analytics = {
 	mixpanel: {
-		token: process.env.MIXPANEL_TOKEN_CHAT_WIDGET
+		token: env.MIXPANEL_TOKEN_CHAT_WIDGET
 	}
 }


### PR DESCRIPTION
Don't use `process.env` as UI env vars container, because it interferes with some third party modules using it: the result is a different `vendors` bundle for each release of the UI, even if no
changes involved third party libraries.

If you cherry-pick this changeset, and apply it to two different releases, v24.70.2 and v24.70.1, the output of `make build-ui` will be the same `vendors` and `runtime` bundles, and two different `main` bundles (the only difference being jellyfish version).

If instead you run `make build-ui` on the two mentioned versions, without this changeset, the output will be two different `main` **and** `vendors` bundles. See [gist](https://gist.github.com/ffissore/c242669a37254a3eee2cae0e94045648).

The reason is that webpack will replace every occurrence of `process.env` with the object defined with `DefinePlugin`, **even for third party libraries**: list includes debug, bluebird, monaco-editor, react-chartjs-2, react-trello, styled-components.
Take a look at [this line from "debug" module](https://gist.github.com/ffissore/c242669a37254a3eee2cae0e94045648#file-vendors-diff-L8) for example: the [original code](https://github.com/visionmedia/debug/blob/master/src/browser.js#L217) is `process.env.DEBUG`, and webpack replaces it with `Object({...our keys...}).DEBUG`.

Connects-to: #3134
Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
