### PR TITLE
Lazy logging error messages

### DIFF
--- a/lib/assert/index.js
+++ b/lib/assert/index.js
@@ -4,7 +4,11 @@
  * Proprietary and confidential.
  */
 
-const createError = (context, error, message, options = {}) => {
+const _ = require('lodash')
+
+const createError = (context, error, messageOrFunction, options = {}) => {
+	const message = _.isFunction(messageOrFunction) ? messageOrFunction() : messageOrFunction
+
 	// eslint-disable-next-line new-cap
 	const instance = new error(message)
 	instance.context = context
@@ -16,22 +20,22 @@ const createError = (context, error, message, options = {}) => {
 	return instance
 }
 
-exports.USER = (context, expression, error, message) => {
+exports.USER = (context, expression, error, messageOrFunction) => {
 	if (expression) {
 		return
 	}
 
-	throw createError(context, error, message, {
+	throw createError(context, error, messageOrFunction, {
 		expected: true
 	})
 }
 
-exports.INTERNAL = (context, expression, error, message) => {
+exports.INTERNAL = (context, expression, error, messageOrFunction) => {
 	if (expression) {
 		return
 	}
 
-	throw createError(context, error, message, {
+	throw createError(context, error, messageOrFunction, {
 		expected: false
 	})
 }

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -91,7 +91,9 @@ const queryTable = async (context, backend, table, schema, options) => {
 	const results = await backend.connection.any(query).catch((error) => {
 		assert.USER(context, !error.message.startsWith('invalid regular expression:'),
 			backend.errors.JellyfishInvalidRegularExpression,
-			`Invalid pattern in schema: ${JSON.stringify(schema)}`)
+			() => {
+				return `Invalid pattern in schema: ${JSON.stringify(schema)}`
+			})
 		throw error
 	})
 	const queryEndDate = new Date()

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -99,10 +99,12 @@ class Logger {
 	}
 
 	exception (context, message, error) {
-		assert.INTERNAL(context, _.isError(error), Error, [
-			'Last argument to .exception() should be an error:',
-			JSON.stringify(error, null, 2)
-		].join(' '))
+		assert.INTERNAL(context, _.isError(error), Error, () => {
+			return [
+				'Last argument to .exception() should be an error:',
+				JSON.stringify(error, null, 2)
+			].join(' ')
+		})
 
 		const errorObject = errio.toObject(error, {
 			stack: true
@@ -125,7 +127,9 @@ const newTransport = () => {
 			winston.format.colorize(),
 			winston.format.printf((info) => {
 				assert.INTERNAL(null, info.context && info.context.id,
-					LoggerNoContext, `Missing context: ${JSON.stringify(info)}`)
+					LoggerNoContext, () => {
+						return `Missing context: ${JSON.stringify(info)}`
+					})
 
 				const id = info.context.id
 				const prefix = `(${info.version}) ${info.timestamp} [${info.namespace}] [${info.level}] [${id}]:`

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -47,9 +47,6 @@ class Logger {
 	}
 
 	debug (context, message, data) {
-		// TODO: Investigate the LogEntries transport,
-		// as it seems like its not obeying the Winston
-		// instance level.
 		if (this.level !== 'debug') {
 			return
 		}
@@ -63,6 +60,10 @@ class Logger {
 	}
 
 	error (context, message, data) {
+		if (this.level !== 'crit') {
+			return
+		}
+
 		this.logger.log('crit', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
@@ -72,6 +73,10 @@ class Logger {
 	}
 
 	warn (context, message, data) {
+		if (this.level !== 'warning') {
+			return
+		}
+
 		this.logger.log('warning', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
@@ -81,6 +86,10 @@ class Logger {
 	}
 
 	info (context, message, data) {
+		if (this.level !== 'info') {
+			return
+		}
+
 		this.logger.log('info', message, {
 			namespace: this.namespace,
 			version: packageJSON.version,
@@ -104,28 +113,34 @@ class Logger {
 	}
 }
 
-module.exports.getLogger = _.memoize((filename) => {
-	const transport = environment.isProduction() && environment.logentries.token
-		? new winston.transports.Logentries({
+const newTransport = () => {
+	if (environment.isProduction() && environment.logentries.token) {
+		return new winston.transports.Logentries({
 			token: environment.logentries.token
 		})
-		: new winston.transports.Console({
-			format: winston.format.combine(
-				winston.format.colorize(),
-				winston.format.printf((info) => {
-					assert.INTERNAL(null, info.context && info.context.id,
-						LoggerNoContext, `Missing context: ${JSON.stringify(info)}`)
+	}
 
-					const id = info.context.id
-					const prefix = `(${info.version}) ${info.timestamp} [${info.namespace}] [${info.level}] [${id}]:`
-					if (info.data) {
-						return `${prefix} ${info.message} ${JSON.stringify(info.data)}`
-					}
+	return new winston.transports.Console({
+		format: winston.format.combine(
+			winston.format.colorize(),
+			winston.format.printf((info) => {
+				assert.INTERNAL(null, info.context && info.context.id,
+					LoggerNoContext, `Missing context: ${JSON.stringify(info)}`)
 
-					return `${prefix} ${info.message}`
-				}))
-		})
+				const id = info.context.id
+				const prefix = `(${info.version}) ${info.timestamp} [${info.namespace}] [${info.level}] [${id}]:`
+				if (info.data) {
+					return `${prefix} ${info.message} ${JSON.stringify(info.data)}`
+				}
 
-	const logLevel = environment.logger.loglevel || 'debug'
+				return `${prefix} ${info.message}`
+			}))
+	})
+}
+
+const transport = newTransport()
+const logLevel = environment.logger.loglevel || 'debug'
+
+module.exports.getLogger = _.memoize((filename) => {
 	return new Logger(logLevel, filename, transport)
 })

--- a/lib/queue/index.js
+++ b/lib/queue/index.js
@@ -61,7 +61,9 @@ const repostExecuteEvent = async (context, jellyfish, session, executeCard, requ
 const claimRequest = async (context, instance, actor, request) => {
 	assert.INTERNAL(context, request.slug,
 		errors.QueueInvalidRequest,
-		`Request has no slug: ${JSON.stringify(request, null, 2)}`)
+		() => {
+			return `Request has no slug: ${JSON.stringify(request, null, 2)}`
+		})
 
 	logger.debug(context, 'Locking non executed request', {
 		slug: request.slug
@@ -381,10 +383,14 @@ module.exports = class Queue extends EventEmitter {
 
 		assert.INTERNAL(context, request,
 			errors.QueueNoRequest,
-			`Request not found: ${JSON.stringify(actionRequest, null, 2)}`)
+			() => {
+				return `Request not found: ${JSON.stringify(actionRequest, null, 2)}`
+			})
 		assert.INTERNAL(context, request.data.payload,
 			errors.QueueInvalidRequest,
-			`Execute event has no payload: ${JSON.stringify(request, null, 2)}`)
+			() => {
+				return `Execute event has no payload: ${JSON.stringify(request, null, 2)}`
+			})
 
 		return {
 			error: request.data.payload.error,

--- a/lib/sync/integrations/balena-api.js
+++ b/lib/sync/integrations/balena-api.js
@@ -130,7 +130,9 @@ module.exports = class BalenaAPIIntegration {
 			`Not such actor: ${this.options.defaultUser}`)
 		assert.INTERNAL(null, payload.payload.username,
 			this.options.errors.SyncNoActor,
-			`No username: ${JSON.stringify(payload, null, 2)}`)
+			() => {
+				return `No username: ${JSON.stringify(payload, null, 2)}`
+			})
 
 		const sequence = []
 		const slug = `user-${utils.slugify(payload.payload.username)}`

--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -54,13 +54,12 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 		headers
 	})
 
-	const summary = `${result.code} ${method} ${url}`
-	const description = JSON.stringify(result.body, null, 2)
-
 	if (result.code === 429) {
 		assert.INTERNAL(null, retries > 0,
 			integrationOptions.errors.SyncRateLimit,
-			`Rate limit hit ${summary}: ${description}`)
+			() => {
+				return `Rate limit hit ${result.code} ${method} ${url}: ${(JSON.stringify(result.body, null, 2))}`
+			})
 
 		const seconds = result.body.extras.wait_seconds || 5
 		context.log.warn('Discourse rate limit retry', {
@@ -78,7 +77,9 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 	if (result.code >= 500) {
 		assert.USER(null, retries > 0,
 			integrationOptions.errors.SyncExternalRequestError,
-			`Discourse unavailable ${summary}: ${description}`)
+			() => {
+				return `Discourse unavailable ${result.code} ${method} ${url}: ${(JSON.stringify(result.body, null, 2))}`
+			})
 
 		context.log.warn('Discourse unavailable retry', {
 			retries
@@ -95,7 +96,9 @@ const httpDiscourse = async (context, integrationOptions, method, url, options, 
 	if (result.code === 403) {
 		assert.USER(null, retries > 0,
 			integrationOptions.errors.SyncExternalRequestError,
-			`Discourse permission error ${summary}: ${description}`)
+			() => {
+				return `Discourse permission error ${result.code} ${method} ${url}: ${(JSON.stringify(result.body, null, 2))}`
+			})
 
 		context.log.warn('Discourse permission error retry', {
 			retries
@@ -121,7 +124,9 @@ const getCategoryNameById = async (context, options, baseUrl, actor, id) => {
 
 	assert.INTERNAL(null, result.code === 200,
 		options.errors.SyncExternalRequestError,
-		`Couldn't get categories: ${JSON.stringify(result, null, 2)}`)
+		() => {
+			return `Couldn't get categories: ${JSON.stringify(result, null, 2)}`
+		})
 
 	for (const category of result.body.category_list.categories) {
 		CATEGORIES[category.id] = category.name
@@ -143,7 +148,9 @@ const getDiscourseResource = async (context, actor, options, baseUrl, path) => {
 
 	assert.INTERNAL(null, result.code === 200,
 		options.errors.SyncExternalRequestError,
-		`Couldn't get resource ${path}: ${JSON.stringify(result, null, 2)}`)
+		() => {
+			return `Couldn't get resource ${path}: ${JSON.stringify(result, null, 2)}`
+		})
 
 	return result.body
 }
@@ -503,7 +510,9 @@ const getActor = async (context, actor, options, baseUrl, payload) => {
 
 	assert.INTERNAL(null, userId || username,
 		options.errors.SyncNoActor,
-		`No user id in payload: ${JSON.stringify(payload, null, 2)}`)
+		() => {
+			return `No user id in payload: ${JSON.stringify(payload, null, 2)}`
+		})
 
 	const remoteUser = userId
 		? await getDiscourseUserById(
@@ -671,7 +680,9 @@ const getTopicFromPostUrl = async (context, actor, options, url) => {
 		`Could not find topic from ${url}`)
 	assert.INTERNAL(null, topicResponse.code === 200,
 		options.errors.SyncExternalRequestError,
-		`Could not get topic from ${url}: ${JSON.stringify(topicResponse, null, 2)}`)
+		() => {
+			return `Could not get topic from ${url}: ${JSON.stringify(topicResponse, null, 2)}`
+		})
 
 	return topicResponse.body
 }
@@ -770,10 +781,12 @@ module.exports = class DiscourseIntegration {
 				})
 
 			assert.INTERNAL(null, remoteTopic.code === 200,
-				this.options.errors.SyncExternalRequestError, [
-					`Could not fetch Discourse topic: ${discourseUrl},`,
-					JSON.stringify(remoteTopic, null, 2)
-				].join(' '))
+				this.options.errors.SyncExternalRequestError, () => {
+					return [
+						`Could not fetch Discourse topic: ${discourseUrl},`,
+						JSON.stringify(remoteTopic, null, 2)
+					].join(' ')
+				})
 
 			if (remoteTopic.body.title !== card.name ||
 				!_.isEqual(remoteTopic.body.tags, card.data.tags || [])) {
@@ -806,11 +819,13 @@ module.exports = class DiscourseIntegration {
 					})
 
 				assert.INTERNAL(null, result.code === 200,
-					this.options.errors.SyncExternalRequestError, [
-						`Could not update topic ${discourseUrl} as ${username}`,
-						`with ${JSON.stringify(body, null, 2)}:`,
-						JSON.stringify(result, null, 2)
-					].join(' '))
+					this.options.errors.SyncExternalRequestError, () => {
+						return [
+							`Could not update topic ${discourseUrl} as ${username}`,
+							`with ${JSON.stringify(body, null, 2)}:`,
+							JSON.stringify(result, null, 2)
+						].join(' ')
+					})
 			}
 
 			return []
@@ -911,11 +926,13 @@ module.exports = class DiscourseIntegration {
 				}
 
 				assert.INTERNAL(null, editResponse.code === 200,
-					this.options.errors.SyncExternalRequestError, [
-						`Could not update comment ${topicResponse.id}`,
-						`with content: ${card.data.payload.message}:`,
-						JSON.stringify(editResponse, null, 2)
-					].join(' '))
+					this.options.errors.SyncExternalRequestError, () => {
+						return [
+							`Could not update comment ${topicResponse.id}`,
+							`with content: ${card.data.payload.message}:`,
+							JSON.stringify(editResponse, null, 2)
+						].join(' ')
+					})
 
 				return []
 			}
@@ -929,10 +946,12 @@ module.exports = class DiscourseIntegration {
 				})
 
 			assert.INTERNAL(null, topicResponse.code === 200,
-				this.options.errors.SyncExternalRequestError, [
-					`Could not get topic ${threadDiscourseUrl}:`,
-					JSON.stringify(topicResponse, null, 2)
-				].join(' '))
+				this.options.errors.SyncExternalRequestError, () => {
+					return [
+						`Could not get topic ${threadDiscourseUrl}:`,
+						JSON.stringify(topicResponse, null, 2)
+					].join(' ')
+				})
 
 			// We don't mirror posts to deleted topics, but we still let
 			// them get into Jellyfish, so we can post summaries, etc.
@@ -961,11 +980,15 @@ module.exports = class DiscourseIntegration {
 			// A user error
 			assert.USER(null, response.code !== 422,
 				this.options.errors.SyncInvalidRequest,
-				`Couldn't create post: ${JSON.stringify(response, null, 2)}`)
+				() => {
+					return `Couldn't create post: ${JSON.stringify(response, null, 2)}`
+				})
 
 			assert.INTERNAL(null, response.code === 200,
 				this.options.errors.SyncExternalRequestError,
-				`Could not create post: ${JSON.stringify(response, null, 2)}`)
+				() => {
+					return `Could not create post: ${JSON.stringify(response, null, 2)}`
+				})
 
 			card.data.mirrors = card.data.mirrors || []
 			card.data.mirrors.push(getMirrorId(this.baseUrl, response.body))
@@ -1107,10 +1130,12 @@ module.exports = class DiscourseIntegration {
 					this.options.errors.SyncNoExternalResource,
 					`The post ${event.data.payload.post.id} does not exist`)
 				assert.INTERNAL(null, postResponse.code === 200,
-					this.options.errors.SyncExternalRequestError, [
-						`Could not get post ${event.data.payload.post.id}:`,
-						JSON.stringify(postResponse, null, 2)
-					].join(' '))
+					this.options.errors.SyncExternalRequestError, () => {
+						return [
+							`Could not get post ${event.data.payload.post.id}:`,
+							JSON.stringify(postResponse, null, 2)
+						].join(' ')
+					})
 
 				event.data.payload.post.destroyed = Boolean(postResponse.body.deleted_at)
 			}

--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -382,7 +382,9 @@ const getMessage = async (instance, front, intercom, sequence, payload, threadId
 
 	const actor = await getMessageActor(instance.context, front, intercom, payload)
 	assert.INTERNAL(null, actor, instance.options.errors.SyncNoActor,
-		`Not actor id for message ${JSON.stringify(payload)}`)
+		() => {
+			return `Not actor id for message ${JSON.stringify(payload)}`
+		})
 
 	object.data.actor = actor
 
@@ -762,11 +764,13 @@ const getConversationChannel = async (context, errors, front, conversationId, in
 			lastMessageAddresses.includes(result.send_as)
 	})
 
-	assert.INTERNAL(null, channel, errors.SyncNoExternalResource, [
-		`Could not find channel to respond to ${conversationId}`,
-		`using message ${conversationResponse.last_message.id}`,
-		`and addresses ${lastMessageAddresses.join(', ')}`
-	].join(' '))
+	assert.INTERNAL(null, channel, errors.SyncNoExternalResource, () => {
+		return [
+			`Could not find channel to respond to ${conversationId}`,
+			`using message ${conversationResponse.last_message.id}`,
+			`and addresses ${lastMessageAddresses.join(', ')}`
+		].join(' ')
+	})
 
 	context.log.info('Front channel found', {
 		channel: _.omit(channel, [ '_links' ]),
@@ -849,11 +853,15 @@ module.exports = class FrontIntegration {
 
 		const actor = await this.getLocalUser(event)
 		assert.INTERNAL(null, actor, this.options.errors.SyncNoActor,
-			`No actor id for ${JSON.stringify(event)}`)
+			() => {
+				return `No actor id for ${JSON.stringify(event)}`
+			})
 
 		const threadActor = await this.getThreadActor(event)
 		assert.INTERNAL(null, threadActor, this.options.errors.SyncNoActor,
-			`No thread actor id for ${JSON.stringify(event)}`)
+			() => {
+				return `No thread actor id for ${JSON.stringify(event)}`
+			})
 
 		const threadCard = await getThread(
 			this.context, this.front, event, inbox, threadType)

--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -22,10 +22,11 @@ const githubRequest = async (fn, arg, options, retries = 5) => {
 	const result = await fn(arg)
 
 	if (result.status >= 500) {
-		const data = JSON.stringify(result.data, null, 2)
 		assert.USER(null, retries > 0,
 			options.errors.SyncExternalRequestError,
-			`GitHub unavailable ${result.status}: ${data}`)
+			() => {
+				return `GitHub unavailable ${result.status}: ${(JSON.stringify(result.data, null, 2))}`
+			})
 
 		options.context.log.warn('GitHub unavailable retry', {
 			retries
@@ -1040,7 +1041,9 @@ module.exports = class GitHubIntegration {
 		const action = event.data.payload.action
 		const actor = await this.getLocalUser(event)
 		assert.INTERNAL(null, actor, this.options.errors.SyncNoActor,
-			`No actor id for ${JSON.stringify(event)}`)
+			() => {
+				return `No actor id for ${JSON.stringify(event)}`
+			})
 
 		switch (type) {
 			case 'pull_request':

--- a/lib/sync/integrations/outreach.js
+++ b/lib/sync/integrations/outreach.js
@@ -216,7 +216,9 @@ const upsertProspect = async (context, actor, errors, baseUrl, card, retries = 5
 
 		assert.INTERNAL(null, retries > 0,
 			errors.SyncExternalRequestError,
-			`Prospect validation error: ${JSON.stringify(body, null, 2)}`)
+			() => {
+				return `Prospect validation error: ${JSON.stringify(body, null, 2)}`
+			})
 
 		return upsertProspect(context, actor, errors, baseUrl, card, retries - 1)
 	}
@@ -241,13 +243,14 @@ const upsertProspect = async (context, actor, errors, baseUrl, card, retries = 5
 			return []
 		}
 
-		const summary = [
-			`Got ${result.code} ${JSON.stringify(result.body, null, 2)}`,
-			`when sending ${JSON.stringify(body, null, 2)} to ${outreachUrl}`
-		].join('\n')
 		assert.INTERNAL(null, result.code === 200,
 			errors.SyncExternalRequestError,
-			`Could not update prospect: ${summary}`)
+			() => {
+				return [
+					`Could not update prospect: Got ${result.code} ${JSON.stringify(result.body, null, 2)}`,
+					`when sending ${JSON.stringify(body, null, 2)} to ${outreachUrl}`
+				].join('\n')
+			})
 
 		context.log.info('Updated prospect', {
 			contacts: card,
@@ -283,13 +286,14 @@ const upsertProspect = async (context, actor, errors, baseUrl, card, retries = 5
 		return []
 	}
 
-	const summary = [
-		`Got ${result.code} ${JSON.stringify(result.body, null, 2)}`,
-		`when sending ${JSON.stringify(body, null, 2)} to ${outreachUrl}`
-	].join('\n')
 	assert.INTERNAL(null, result.code === 201,
 		errors.SyncExternalRequestError,
-		`Could not create prospect: ${summary}`)
+		() => {
+			return [
+				`Could not create prospect: Got ${result.code} ${JSON.stringify(result.body, null, 2)}`,
+				`when sending ${JSON.stringify(body, null, 2)} to ${outreachUrl}`
+			].join('\n')
+		})
 
 	card.data.mirrors = card.data.mirrors || []
 	card.data.mirrors.push(result.body.data.links.self)
@@ -414,7 +418,9 @@ module.exports = class OutreachIntegration {
 
 			assert.INTERNAL(null, remoteSequence.code === 200,
 				this.options.errors.SyncExternalRequestError,
-				`Could not get sequence from ${url}: ${JSON.stringify(remoteSequence, null, 2)}`)
+				() => {
+					return `Could not get sequence from ${url}: ${JSON.stringify(remoteSequence, null, 2)}`
+				})
 
 			data.attributes.name = data.attributes.name ||
 				remoteSequence.body.data.attributes.name

--- a/lib/sync/oauth.js
+++ b/lib/sync/oauth.js
@@ -111,15 +111,18 @@ const oauthPost = async (baseUrl, path, data) => {
 		form: data
 	})
 
-	const description = JSON.stringify(body, null, 2)
 	assert.INTERNAL(null, code < 500, exports.OAuthRequestError,
-		`POST ${path} responded with ${code}: ${description}`)
+		() => {
+			return `POST ${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
+		})
 
 	assert.USER(null, code < 400, exports.OAuthUnsuccessfulResponse,
 		`POST ${path} responded with ${body.error_description}`)
 
 	assert.INTERNAL(null, code === 200, exports.OAuthRequestError,
-		`POST ${path} responded with ${code}: ${description}`)
+		() => {
+			return `POST ${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
+		})
 
 	return body
 }

--- a/lib/sync/pipeline.js
+++ b/lib/sync/pipeline.js
@@ -135,7 +135,9 @@ exports.importCards = async (context, sequence, options = {}) => {
 
 			const object = evaluateObject(_.omit(segment.card, [ 'links' ]), references)
 			assert.INTERNAL(context, object, errors.SyncInvalidTemplate,
-				`Could not evaluate template in: ${JSON.stringify(segment.card, null, 2)}`)
+				() => {
+					return `Could not evaluate template in: ${JSON.stringify(segment.card, null, 2)}`
+				})
 
 			const finalObject = Object.assign({
 				active: true,
@@ -153,7 +155,9 @@ exports.importCards = async (context, sequence, options = {}) => {
 			}
 
 			assert.INTERNAL(context, segment.actor, errors.SyncNoActor,
-				`No actor in segment: ${JSON.stringify(segment)}`)
+				() => {
+					return `No actor in segment: ${JSON.stringify(segment)}`
+				})
 
 			const result = await context.upsertElement(object.type, finalObject, {
 				timestamp: segment.time,

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -456,12 +456,12 @@ exports.run = async (jellyfish, session, context, library, request) => {
 
 	const argumentsSchema = utils.getActionArgumentsSchema(request.action)
 
-	const args = JSON.stringify(request.arguments, null, 2)
-
 	assert.USER(request.context,
 		skhema.isValid(argumentsSchema, request.arguments),
 		errors.WorkerSchemaMismatch,
-		`Arguments do not match for action ${actionName}: ${args}`)
+		() => {
+			return `Arguments do not match for action ${actionName}: ${(JSON.stringify(request.arguments, null, 2))}`
+		})
 
 	const actionFunction = library[actionName] && library[actionName].handler
 	assert.INTERNAL(request.context,


### PR DESCRIPTION
On your machine, save the following snippet in JF repo root as `test.js`, then run `node test.js`
```js
const assert = require('./lib/assert')

const obj = {
	simple: 'object'
}
const name = 'test'

const assertObj = (obj) => {
	assert.INTERNAL(null, true, Error, `Missing context: ${JSON.stringify(obj)}`)
}
const assertString = (str) => {
	assert.INTERNAL(null, true, Error, `Missing context: ${str}`)
}

const TEN_MILLION = 10000000

let now = new Date()
for (let i = 0; i < TEN_MILLION; i++) {
	assertObj(obj)
}
console.log('object', new Date() - now)
now = new Date()
for (let i = 0; i < TEN_MILLION; i++) {
	assertString(name)
}
console.log('string', new Date() - now)
```

With the current version of `assert`, it will print something like this
```
object 2369
string 40
```
That's 2.3 seconds for **not** throwing errors that involve stringifying objects. The more complex `obj` is, the longer it will take. That's all wasted CPU, used to execute `JSON.stringify(obj)`

Now change `test.js` like so

```diff
@@ -6,10 +6,14 @@ const obj = {
 const name = 'test'
 
 const assertObj = (obj) => {
-       assert.INTERNAL(null, true, Error, `Missing context: ${JSON.stringify(obj)}`)
+       assert.INTERNAL(null, true, Error, () => {
+               return `Missing context: ${JSON.stringify(obj)}`
+       })
 }
 const assertString = (str) => {
-       assert.INTERNAL(null, true, Error, `Missing context: ${str}`)
+       assert.INTERNAL(null, true, Error, () => {
+               return `Missing context: ${str}`
+       })
 }
 
 const TEN_MILLION = 10000000
```

and run it once more: it will print something like this
```
object 13
string 14
```
Much faster, ~180 times, when the error message contains `JSON.stringify(obj)`, because it's not executed. Faster but not so much when it contains a simple string.

Thus, I changed all calls to `assert.USER` and `assert.INTERNAL` to use lazy functions when the error message is not a simple string template.

Additionally, some improvements to `logger` module:
* sharing `transport` instances between `Logger`s
* exit immediately if log level doesn't match