### PR TITLE
WIP: Ping Flowdock on new support threads

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -82,6 +82,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/triggered-action-user-contact.json'),
 		await loadCard('contrib/triggered-action-integration-import-event.json'),
 		await loadCard('contrib/triggered-action-integration-github-mirror-event.json'),
+		await loadCard('contrib/triggered-action-integration-flowdock-mirror-event.json'),
 		await loadCard('contrib/triggered-action-integration-front-mirror-event.json'),
 		await loadCard('contrib/triggered-action-integration-discourse-mirror-event.json'),
 		await loadCard('contrib/triggered-action-integration-outreach-mirror-event.json'),

--- a/apps/server/default-cards/contrib/triggered-action-integration-flowdock-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-flowdock-mirror-event.json
@@ -1,0 +1,28 @@
+{
+  "slug": "triggered-action-integration-flowdock-mirror-event",
+  "type": "triggered-action@1.0.0",
+  "version": "1.0.0",
+  "tags": [],
+  "markers": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "filter": {
+      "type": "object",
+      "required": [ "type" ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [ "support-thread", "support-thread@1.0.0" ]
+        }
+      }
+    },
+    "action": "action-integration-flowdock-mirror-event@1.0.0",
+    "target": {
+      "$eval": "source.id"
+    },
+    "arguments": {}
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/lib/action-library/actions/action-integration-flowdock-mirror-event.js
+++ b/lib/action-library/actions/action-integration-flowdock-mirror-event.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'action-integration-flowdock-mirror-event',
+	type: 'action@1.0.0',
+	version: '1.0.0',
+	tags: [],
+	markers: [],
+	links: {},
+	active: true,
+	data: {
+		filter: {
+			type: 'object',
+			required: [
+				'type'
+			],
+			properties: {
+				type: {
+					type: 'string',
+					enum: [ 'support-thread', 'support-thread@1.0.0' ]
+				}
+			}
+		},
+		arguments: {}
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -113,6 +113,13 @@ module.exports = {
 			return mirror('github', session, context, card, request)
 		}
 	},
+	'action-integration-flowdock-mirror-event': {
+		card: require('./actions/action-integration-flowdock-mirror-event'),
+		pre: _.noop,
+		handler: async (session, context, card, request) => {
+			return mirror('flowdock', session, context, card, request)
+		}
+	},
 	'action-integration-front-mirror-event': {
 		card: require('./actions/action-integration-front-mirror-event'),
 		pre: _.noop,

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -134,6 +134,7 @@ exports.integration = {
 		signature: process.env.INTEGRATION_OUTREACH_SIGNATURE_KEY
 	},
 	flowdock: {
+		flowToken: process.env.INTEGRATION_FLOWDOCK_FLOW_TOKEN,
 		api: process.env.INTEGRATION_FLOWDOCK_TOKEN,
 		signature: process.env.INTEGRATION_FLOWDOCK_SIGNATURE_KEY
 	}

--- a/lib/sync/integrations/flowdock.js
+++ b/lib/sync/integrations/flowdock.js
@@ -17,8 +17,13 @@ module.exports = class FlowdockIntegration {
 		this.context = this.options.context
 	}
 
-	// eslint-disable-next-line class-methods-use-this
 	async initialize () {
+		if (!this.options.token.api) {
+			this.context.log.warn('No API token set for flowdock integration')
+		}
+		if (!this.options.token.flowToken) {
+			this.context.log.warn('No flow token set for flowdock integration')
+		}
 		return Bluebird.resolve()
 	}
 
@@ -29,6 +34,41 @@ module.exports = class FlowdockIntegration {
 
 	// eslint-disable-next-line class-methods-use-this
 	async mirror (card, options) {
+		if (!this.options.token ||
+			!this.options.token.flowToken ||
+			!this.options.token.api) {
+			return []
+		}
+
+		// If we create a new support thread card, we want to ping the flowdock channel with:
+		// 1. A new 'activity' message
+		// 2. A comment on the new activity thread, @ mentioning the
+		//    support agent at the top of the list.
+		if (card.type.split('@')[0] === 'support-thread') {
+			// TODO: Retrieve the author ID from the associated create card
+			const author = {
+				name: 'Some user',
+				email: 'test@balena.io'
+			}
+
+			const activityMessage = generateActivityMessage(card, author)
+			activityMessage.flow_token = this.options.token.flowToken
+			const adminActorId = await this.context.getActorId({
+				handle: this.options.defaultUser
+			})
+			const headers = {
+				'X-flowdock-wait-for-message': true
+			}
+
+			const response = await this.context.request(adminActorId, {
+				method: 'POST',
+				json: true,
+				uri: 'https://api.flowdock.com/messages',
+				headers
+			})
+
+			// TODO: Verify the response
+		}
 		return []
 	}
 
@@ -221,6 +261,32 @@ module.exports = class FlowdockIntegration {
 		}
 
 		return sequence
+	}
+}
+
+const generateActivityMessage = (card, author) => {
+	return {
+		event: 'activity',
+		app: 'influx',
+		author,
+		title: 'submitted a support request',
+		external_thread_id: card.id,
+		thread: {
+			title: card.name || `Conversation with ${author.name}`,
+			actions: [
+				{
+					'@type': 'ViewAction',
+					url: `https://jel.ly.fish/${card.id}`,
+					name: 'View thread...',
+					description: 'View support thread in Jellyfish'
+				}
+			],
+			external_url: `https://jel.ly.fish/${card.id}`,
+			status: {
+				color: 'red',
+				value: 'Unassigned'
+			}
+		}
 	}
 }
 

--- a/test/e2e/sync/flowdock-mirror.spec.js
+++ b/test/e2e/sync/flowdock-mirror.spec.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const uuid = require('uuid/v4')
+const helpers = require('./helpers')
+const environment = require('../../../lib/environment')
+const TOKEN = environment.integration.flowdock
+
+ava.before(async (test) => {
+	await helpers.mirror.before(test)
+
+	test.context.createSupportThread = async () => {
+		const result = await test.context.sdk.card.create({
+			type: 'support-thread',
+			data: {
+				inbox: 'S/Paid_Support',
+				status: 'open'
+			}
+		})
+		return test.context.sdk.getById(result.id, {
+			type: 'support-thread'
+		})
+	}
+})
+
+ava.after(helpers.mirror.after)
+ava.beforeEach(async (test) => {
+	await helpers.mirror.beforeEach(test, uuid())
+})
+
+ava.afterEach(helpers.mirror.afterEach)
+
+// Skip all tests if any Flowdock environment variable is missing
+const avaTest = !TOKEN.api || !TOKEN.flowToken ? ava.skip : ava.serial
+
+avaTest('should send an activity message based on the support thread card', async (test) => {
+	const supportThread = test.context.createSupportThread()
+
+	// TODO: Verify the flowdock message was created
+	test.pass()
+})


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Ref: #3115 

This PR adds the **mirror** functionality of the Flowdock integration. The objective here is to ping in a particular Flowdock flow whenever a new support thread is created. 

_Note: In due course we will also @ mention the Balena support agent who is at the top of the support draft list, and then keep pinging until the issue is assigned - at which point we could update the thread in Flowdock with the status 'Assigned'._

WIP - I'll need help with this PR as I have a lot to learn about how integrations work! Please take a look at the code so far - which is pretty bare-bones - and give me some pointers :-)
