### PR TITLE
core: Require version suffixes in .getBySlug()

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -252,14 +252,8 @@ module.exports = class Kernel {
 
 		const [ base, version ] = slug.split('@')
 
-		// TODO: Convert this into an INTERNAL JellyfishInvalidVersion
-		// assertion once we make sure that the production system is
-		// completely migrated.
-		if (!version) {
-			logger.warn(context, 'No version reference', {
-				slug
-			})
-		}
+		assert.INTERNAL(context, version,
+			errors.JellyfishInvalidVersion, `No version reference: ${slug}`)
 
 		const queryOptions = {
 			limit: 1


### PR DESCRIPTION
We should make sure we didn't get any "No version reference" warning for
a while, as a confirmation that we migrated all the data correctly.

Change-type: major


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!