### PR TITLE
Use redis PUB/SUB to notify about execute events

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -85,13 +85,13 @@ const bootstrap = async (context, library, options) => {
 
 	const session = jellyfish.sessions.admin
 	const consumer = new Consumer(jellyfish, session)
-	const producer = new Producer(jellyfish, session)
+	const producer = new Producer(jellyfish, session, environment.redis)
 
 	// The main server has a special worker for itself so that
 	// it can bootstrap without needing any external workers
 	// to process the default cards
 	const worker = new Worker(
-		jellyfish, session, library, consumer, producer)
+		jellyfish, session, library, consumer, producer, environment.redis)
 	await worker.initialize(context)
 
 	let run = true
@@ -137,6 +137,7 @@ const bootstrap = async (context, library, options) => {
 	const closeWorker = async () => {
 		run = false
 		await consumer.cancel()
+		await producer.stop()
 		triggerStream.removeAllListeners()
 		await triggerStream.close()
 		await refreshingTriggers

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -300,7 +300,9 @@ module.exports = class PostgresBackend {
 		/*
 		 * Omit the options that are falsy, like empty strings.
 		 */
-		this.options = _.omitBy(options, _.isEmpty)
+		this.options = _.omitBy(options, (value) => {
+			return !_.isNumber(value) && _.isEmpty(value)
+		})
 
 		/*
 		 * The PostgreSQL database name that we will connect to.

--- a/lib/queue/consumer.js
+++ b/lib/queue/consumer.js
@@ -47,6 +47,7 @@ module.exports = class Consumer {
 		this.jellyfish = jellyfish
 		this.session = session
 		this.messagesBeingHandled = 0
+		this.graphileRunner = null
 	}
 
 	async initializeWithEventHandler (context, onMessageEventHandler) {
@@ -89,15 +90,16 @@ module.exports = class Consumer {
 	 *
 	 * @param {String} actor - actor
 	 * @param {Object} context - execution context
+	 * @param {Object} redisClient - redis client
 	 * @param {Object} actionRequest - action request
 	 * @param {Object} results - action results
 	 * @param {Boolean} results.error - whether the result is an error
 	 * @param {Any} results.data - action result
 	 * @returns {Object} event card
 	 */
-	async postResults (actor, context, actionRequest, results) {
+	async postResults (actor, context, redisClient, actionRequest, results) {
 		const eventCard = await events.post(
-			context, this.jellyfish, this.session, {
+			context, redisClient, this.jellyfish, this.session, {
 				action: actionRequest.data.action,
 				actor: actionRequest.data.actor,
 				id: actionRequest.id,

--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -5,7 +5,10 @@
  */
 
 const Bluebird = require('bluebird')
-const logger = require('../logger').getLogger(__filename)
+const EventEmitter = require('events').EventEmitter
+const redis = require('redis')
+Bluebird.promisifyAll(redis.RedisClient.prototype)
+const ExpireMap = require('map-cache-ttl')
 
 /**
  * @summary The execution event card type slug
@@ -17,12 +20,19 @@ const EXECUTION_EVENT_TYPE = 'execute'
 /**
  * @summary The execution event card version
  * @type {String}
- * @privatej
+ * @private
  * @description
  * Events in the system are meant to be immutable, so
  * they would always stay at a fixed version.
  */
 const EXECUTION_EVENT_VERSION = '1.0.0'
+
+/**
+ * @summary The name of the notification we send when an execution event has been inserted
+ * @type {string}
+ * @private
+ */
+const EXECUTE_EVENT_NAME = 'slug-inserted'
 
 /**
  * @summary Get the slug of an execute event card
@@ -33,7 +43,7 @@ const EXECUTION_EVENT_VERSION = '1.0.0'
  * @param {String} options.id - request id
  * @returns {String} slug
  */
-exports.getExecuteEventSlug = (options) => {
+const getExecuteEventSlug = (options) => {
 	return `${EXECUTION_EVENT_TYPE}-${options.id}`
 }
 
@@ -43,6 +53,7 @@ exports.getExecuteEventSlug = (options) => {
  * @public
  *
  * @param {Object} context - execution context
+ * @param {Object} redisClient - redis client
  * @param {Object} jellyfish - jellyfish instance
  * @param {String} session - session id
  * @param {Object} options - options
@@ -73,24 +84,10 @@ exports.getExecuteEventSlug = (options) => {
  *
  * console.log(card.id)
  */
-exports.post = async (context, jellyfish, session, options, results) => {
-	const date = new Date()
-	const data = {
-		timestamp: date.toISOString(),
-		target: options.id,
-		actor: options.actor,
-		payload: {
-			action: options.action,
-			card: options.card,
-			timestamp: options.timestamp,
-			error: results.error,
-			data: results.data
-		}
-	}
-
+exports.post = async (context, redisClient, jellyfish, session, options, results) => {
 	const contents = {
 		type: `${EXECUTION_EVENT_TYPE}@${EXECUTION_EVENT_VERSION}`,
-		slug: exports.getExecuteEventSlug({
+		slug: getExecuteEventSlug({
 			id: options.id
 		}),
 		version: EXECUTION_EVENT_VERSION,
@@ -100,14 +97,31 @@ exports.post = async (context, jellyfish, session, options, results) => {
 		tags: [],
 		requires: [],
 		capabilities: [],
-		data
+		data: {
+			timestamp: new Date().toISOString(),
+			target: options.id,
+			actor: options.actor,
+			payload: {
+				action: options.action,
+				card: options.card,
+				timestamp: options.timestamp,
+				error: results.error,
+				data: results.data
+			}
+		}
 	}
 
 	if (options.originator) {
 		contents.data.originator = options.originator
 	}
 
-	return jellyfish.insertCard(context, session, contents)
+	const executeEvent = await jellyfish.insertCard(context, session, contents)
+	await exports.notifyExecuteEvent(redisClient, executeEvent)
+	return executeEvent
+}
+
+exports.notifyExecuteEvent = async (redisClient, card) => {
+	return redisClient.publish(EXECUTE_EVENT_NAME, JSON.stringify(card))
 }
 
 /**
@@ -170,11 +184,51 @@ exports.getLastExecutionEvent = async (context, jellyfish, session, originator) 
 	return events[0] || null
 }
 
+exports.ExecuteEventsListener = class ExecuteEventsListener {
+	constructor (redisOptions) {
+		this.expireMap = new ExpireMap('30s', '1m')
+		this.eventEmitter = new EventEmitter()
+		this.redisOptions = redisOptions
+		this.redis = null
+	}
+
+	async init () {
+		this.redis = await redis.createClient(this.redisOptions)
+		this.redis.on('message', (channel, message) => {
+			this.add(JSON.parse(message))
+		})
+		this.redis.subscribe(EXECUTE_EVENT_NAME)
+	}
+
+	add (card) {
+		this.expireMap.set(card.slug, card)
+		this.eventEmitter.emit(card.slug, card)
+	}
+
+	once (slug, callback) {
+		const card = this.expireMap.get(slug)
+		if (card) {
+			callback(card)
+			return
+		}
+		this.eventEmitter.once(slug, callback)
+	}
+
+	async stop () {
+		if (!this.redis) {
+			return
+		}
+
+		await this.redis.quit()
+	}
+}
+
 /**
  * @summary Wait for an execution request event
  * @function
  * @public
  *
+ * @param {Object} executeEventsListener - an instance of ExecuteEventsListener
  * @param {Object} context - execution context
  * @param {Object} jellyfish - jellyfish instance
  * @param {String} session - session id
@@ -185,108 +239,17 @@ exports.getLastExecutionEvent = async (context, jellyfish, session, originator) 
  *
  * @example
  * const session = '4a962ad9-20b5-4dd8-a707-bf819593cc84'
- * const card = await events.wait({ ... }, jellyfish, session, {
+ * const card = await events.wait(executeEventsListener, { ... }, jellyfish, session, {
  *   id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
  *   card: '033d9184-70b2-4ec9-bc39-9a249b186422'
  * })
  *
  * console.log(card.id)
  */
-exports.wait = async (context, jellyfish, session, options) => {
+exports.wait = async (executeEventsListener, context, jellyfish, session, options) => {
 	const slug = `${EXECUTION_EVENT_TYPE}-${options.id}`
-	const schema = {
-		type: 'object',
-		additionalProperties: true,
-		required: [ 'slug', 'active', 'type', 'data' ],
-		properties: {
-			slug: {
-				type: 'string',
-				const: slug
-			},
-			active: {
-				type: 'boolean',
-				const: true
-			},
-			type: {
-				type: 'string',
-				enum: [
 
-					// TODO: Remove this OR operator once the whole
-					// system relies on versioned references.
-					EXECUTION_EVENT_TYPE,
-
-					`${EXECUTION_EVENT_TYPE}@${EXECUTION_EVENT_VERSION}`
-				]
-			},
-			data: {
-				type: 'object',
-				additionalProperties: true,
-				required: [ 'payload' ],
-				properties: {
-					payload: {
-						type: 'object',
-						additionalProperties: true
-					}
-				}
-			}
-		}
-	}
-
-	let result = null
-
-	const stream = await jellyfish.stream(context, session, schema)
-	logger.info(context, 'Wait stream opened', {
-		slug
-	})
-
-	stream.once('data', (change) => {
-		result = change.after
-
-		logger.info(context, 'Found results using stream', {
-			slug: result.slug,
-			data: Object.keys(change.after.data)
-		})
-
-		stream.close()
-	})
-
-	return new Bluebird((resolve, reject) => {
-		stream.once('error', (error) => {
-			stream.removeAllListeners()
-			logger.exception(context, 'Wait stream error', error)
-			reject(error)
-		})
-
-		stream.once('closed', () => {
-			stream.removeAllListeners()
-			logger.info(context, 'Closing wait stream', {
-				slug
-			})
-
-			resolve(result)
-		})
-
-		// Don't perform a "get by slug" if we already have a match.
-		if (result) {
-			return
-		}
-
-		jellyfish.getCardBySlug(
-			context, session, `${slug}@${EXECUTION_EVENT_VERSION}`).then((card) => {
-			if (!card) {
-				return
-			}
-
-			logger.info(context, 'Found results on first slug query', {
-				slug: card.slug,
-				data: Object.keys(card.data)
-			})
-
-			result = result || card
-			stream.close()
-		}).catch((error) => {
-			stream.removeAllListeners()
-			reject(error)
-		})
+	return new Promise((resolve) => {
+		executeEventsListener.once(slug, resolve)
 	})
 }

--- a/lib/queue/producer.js
+++ b/lib/queue/producer.js
@@ -13,12 +13,15 @@ const events = require('./events')
 const CARDS = require('./cards')
 
 module.exports = class Producer {
-	constructor (jellyfish, session) {
+	constructor (jellyfish, session, redisOptions) {
 		this.jellyfish = jellyfish
 		this.session = session
+		this.executeEventsListener = new events.ExecuteEventsListener(redisOptions)
 	}
 
 	async initialize (context) {
+		await this.executeEventsListener.init()
+
 		logger.info(context, 'Inserting essential cards')
 		await Bluebird.map(Object.values(CARDS), async (card) => {
 			return this.jellyfish.replaceCard(context, this.session, card)
@@ -149,11 +152,10 @@ module.exports = class Producer {
 			}
 		})
 
-		const request = await events.wait(
-			context, this.jellyfish, this.session, {
-				id: actionRequest.id,
-				actor: actionRequest.data.actor
-			})
+		const request = await events.wait(this.executeEventsListener, context, this.jellyfish, this.session, {
+			id: actionRequest.id,
+			actor: actionRequest.data.actor
+		})
 
 		logger.info(context, 'Got request results', {
 			request: {
@@ -196,5 +198,9 @@ module.exports = class Producer {
 	async getLastExecutionEvent (context, originator) {
 		return events.getLastExecutionEvent(
 			context, this.jellyfish, this.session, originator)
+	}
+
+	async stop () {
+		await this.executeEventsListener.stop()
 	}
 }

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -15,6 +15,8 @@ const CARDS = require('./cards')
 const uuid = require('../uuid')
 const assert = require('../assert')
 const logger = require('../logger').getLogger(__filename)
+const redis = require('redis')
+Bluebird.promisifyAll(redis.RedisClient.prototype)
 
 const runExecutor = async (fn, instance, context, session, typeCard, card, options, patch) => {
 	return fn(context, instance.jellyfish, session, typeCard, {
@@ -47,6 +49,7 @@ module.exports = class Worker {
 	 * @param {Object} actionLibrary - action library
 	 * @param {Object} consumer - action consumer
 	 * @param {Object} producer - action producer
+	 * @param {Object} redisOptions - redis options
 	 *
 	 * @example
 	 * const worker = new Worker({ ... }, '4a962ad9-20b5-4dd8-a707-bf819593cc84', {
@@ -57,7 +60,7 @@ module.exports = class Worker {
 	 * })
 	 */
 	// FIXME worker violates single responsibility principle in that it both handles events and produces tick events
-	constructor (jellyfish, session, actionLibrary, consumer, producer) {
+	constructor (jellyfish, session, actionLibrary, consumer, producer, redisOptions) {
 		this.jellyfish = jellyfish
 		this.triggers = []
 		this.errors = errors
@@ -65,6 +68,8 @@ module.exports = class Worker {
 		this.library = actionLibrary
 		this.consumer = consumer
 		this.producer = producer
+		this.redisOptions = redisOptions
+		this.redis = null
 	}
 
 	/**
@@ -106,6 +111,12 @@ module.exports = class Worker {
 		await Bluebird.map(_.map(_.values(this.library), 'card'), async (card) => {
 			return this.jellyfish.replaceCard(context, this.session, card)
 		})
+
+		this.redis = redis.createClient(this.redisOptions)
+	}
+
+	async stop () {
+		await this.redis.quit()
 	}
 
 	/**
@@ -436,7 +447,7 @@ module.exports = class Worker {
 		})
 
 		const event = await this.consumer.postResults(
-			this.getId(), request.data.context, request, result)
+			this.getId(), request.data.context, this.redis, request, result)
 		assert.INTERNAL(request.context, event,
 			errors.WorkerNoExecuteEvent,
 			`Could not create execute event for request: ${request.id}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11843,6 +11843,22 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
+    "map-cache-ttl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/map-cache-ttl/-/map-cache-ttl-0.1.1.tgz",
+      "integrity": "sha1-G0lufytkGM5T5bhUTnL2geLj3Cw=",
+      "requires": {
+        "ms": "^0.7.1",
+        "object-hash": "^1.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+        }
+      }
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "localforage": "^1.6.0",
     "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",
+    "map-cache-ttl": "^0.1.1",
     "mark.js": "^8.11.1",
     "marked": "^0.7.0",
     "mixpanel-browser": "^2.22.4",

--- a/test/integration/queue/index.spec.js
+++ b/test/integration/queue/index.spec.js
@@ -264,7 +264,7 @@ ava('.dequeue() should cope with link materialization failures', async (test) =>
 		})
 
 	await test.context.queue.consumer.postResults(
-		test.context.queueActor, test.context.context, actionRequest, {
+		test.context.queueActor, test.context.context, test.context.redisClient, actionRequest, {
 			error: false,
 			data: {
 				foo: 'true'

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -82,7 +82,7 @@ ava('should not re-enqueue requests after duplicated execute events', async (tes
 	const enqueuedRequest1 = await test.context.dequeue()
 
 	await test.context.queue.consumer.postResults(
-		await uuid.random(), test.context.context, enqueuedRequest1, {
+		await uuid.random(), test.context.context, test.context.redisClient, enqueuedRequest1, {
 			error: false,
 			data: {
 				id: await uuid.random(),
@@ -136,7 +136,7 @@ ava('should not re-enqueue requests after execute failure', async (test) => {
 		})
 
 	await test.context.queue.consumer.postResults(
-		await uuid.random(), test.context.context, enqueuedRequest1, {
+		await uuid.random(), test.context.context, test.context.redisClient, enqueuedRequest1, {
 			error: false,
 			data: {
 				id: await uuid.random(),


### PR DESCRIPTION
Use redis PUB/SUB feature to notify listeners waiting for action requests `execute` events

This way we don't use `streams` and schema filtering, avoiding CPU load caused by schema validation

#### Benchmark
This time I used a different tool to run the benchmark: [wrk](https://github.com/wg/wrk), run with
```
wrk -c 20 -t 20 -d 1m http://localhost:8000/ping
```
which is 20 connections on 20 threads for 1 minute.

On master, the average load on api server is 90/100 % CPU. With this branch, load drops to 40/50 % CPU. Both master and this branch can deliver ~60 req/s.
These results are puzzling: if this branch uses half the CPU, it should deliver twice the amount of requests. This means we have a bottleneck, probably in redis or in postgres.

Anyway, halving CPU usage is a good thing, so these changes still make sense