### PR TITLE
ui: Fixed 'Add x' button on Kanban view

### DIFF
--- a/apps/ui/lens/misc/Kanban.jsx
+++ b/apps/ui/lens/misc/Kanban.jsx
@@ -227,6 +227,7 @@ const mapDispatchToProps = (dispatch) => {
 	return {
 		actions: bindActionCreators(
 			_.pick(actionCreators, [
+				'addChannel',
 				'addNotification'
 			]),
 			dispatch


### PR DESCRIPTION
Clicking the 'Add x' button in the bottom right of a Kanban lens view now correctly opens the form for creating a new card.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes issue #3081

Turns out the `addChannel` action wasn't being passed to the Kanban lens component so the component was erroring out when you click on the 'Add x' button and it tried to add a new channel!