### PR TITLE
WIP: ui: Add support for ownership of support threads

### DIFF
--- a/apps/server/default-cards/contrib/account.json
+++ b/apps/server/default-cards/contrib/account.json
@@ -92,13 +92,8 @@
           "type": "contact"
         },
         {
-          "title": "Primary owner",
-          "link": "has primary owner",
-          "type": "user"
-        },
-        {
-          "title": "Secondary owners",
-          "link": "has secondary owner",
+          "title": "Backup owners",
+          "link": "has backup owner",
           "type": "user"
         }
       ]

--- a/apps/server/default-cards/contrib/contact.json
+++ b/apps/server/default-cards/contrib/contact.json
@@ -96,13 +96,8 @@
           "type": "account"
         },
         {
-          "title": "Primary owner",
-          "link": "has primary owner",
-          "type": "user"
-        },
-        {
-          "title": "Secondary owners",
-          "link": "has secondary owner",
+          "title": "Backup owners",
+          "link": "has backup owner",
           "type": "user"
         },
         {

--- a/apps/server/default-cards/contrib/project.json
+++ b/apps/server/default-cards/contrib/project.json
@@ -36,11 +36,6 @@
 		"meta": {
 			"relationships": [
 				{
-					"title": "Owner",
-					"link": "is owned by",
-					"type": "user"
-				},
-				{
 					"title": "Guide",
 					"link": "is guided by",
 					"type": "user"

--- a/apps/ui/components/HOC/CardActions.jsx
+++ b/apps/ui/components/HOC/CardActions.jsx
@@ -4,39 +4,28 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash'
+import {
+	compose
+} from 'redux'
 import {
 	connect
 } from 'react-redux'
 import {
-	bindActionCreators
-} from 'redux'
-import {
-	actionCreators,
-	sdk,
 	selectors
 }	from '../../core'
 import CardActions from '../../../../lib/ui-components/CardActions'
+import {
+	withSetup
+} from '../../../../lib/ui-components/SetupProvider'
 
 const mapStateToProps = (state) => {
 	return {
-		sdk,
-		types: selectors.getTypes(state)
+		types: selectors.getTypes(state),
+		user: selectors.getCurrentUser(state)
 	}
 }
 
-const mapDispatchToProps = (dispatch) => {
-	return {
-		actions: bindActionCreators(
-			_.pick(actionCreators, [
-				'addNotification',
-				'addChannel',
-				'createLink',
-				'queryAPI'
-			]),
-			dispatch
-		)
-	}
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(CardActions)
+export default compose(
+	withSetup,
+	connect(mapStateToProps)
+)(CardActions)

--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -1004,7 +1004,7 @@ export default class ActionCreator {
 				})
 
 				if (!options.skipSuccessMessage) {
-					dispatch(this.addNotification('success', 'Created new link'))
+					dispatch(this.addNotification('success', options.successNotificationMessage || 'Created new link'))
 				}
 			} catch (error) {
 				dispatch(this.addNotification('danger', error.message))

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -22,7 +22,8 @@ import {
 import {
 	analytics,
 	sdk,
-	store
+	store,
+	actionCreators
 } from './core'
 import JellyfishUI from './JellyfishUI'
 import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
@@ -86,8 +87,8 @@ ReactDOM.render(
 					fontSize: 14
 				}}
 			>
-				<SetupProvider sdk={sdk} analytics={analytics}>
-					<Provider store={store}>
+				<Provider store={store}>
+					<SetupProvider sdk={sdk} analytics={analytics} actionCreators={actionCreators}>
 						<React.Fragment>
 							<GlobalStyle />
 
@@ -95,8 +96,8 @@ ReactDOM.render(
 								<JellyfishUI />
 							</ErrorBoundary>
 						</React.Fragment>
-					</Provider>
-				</SetupProvider>
+					</SetupProvider>
+				</Provider>
 			</RProvider>
 		</Router>
 	),

--- a/apps/ui/lens/full/SingleCard/Segment.jsx
+++ b/apps/ui/lens/full/SingleCard/Segment.jsx
@@ -138,7 +138,6 @@ export default class Segment extends React.Component {
 		} = this.state
 
 		const {
-			actions,
 			card,
 			segment,
 			types
@@ -194,7 +193,6 @@ export default class Segment extends React.Component {
 				)}
 
 				<LinkModal
-					actions={actions}
 					card={card}
 					types={[ type ]}
 					show={showLinkModal}

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -301,6 +301,7 @@ class SupportThreadBase extends React.Component {
 				title={(
 					<Flex flex={1} justifyContent="space-between">
 						<Flex
+							alignItems="center"
 							style={{
 								transform: 'translateY(2px)'
 							}}

--- a/lib/sdk/card.js
+++ b/lib/sdk/card.js
@@ -7,10 +7,65 @@
 const {
 	commaListsOr
 } = require('common-tags')
+
+const uuidv4 = require('uuid/v4')
+const Bluebird = require('bluebird')
 const clone = require('deep-copy')
 const jsonpatch = require('fast-json-patch')
 const _ = require('lodash')
 const uuid = require('../uuid')
+const {
+	MULTIPLICITY
+} = require('./link-constraints')
+
+const getLinkQuery = (verb, fromCard, toCard = null) => {
+	const query = {
+		type: 'object',
+		properties: {
+			name: {
+				type: 'string',
+				const: verb
+			},
+			type: {
+				type: 'string',
+				enum: [ 'link', 'link@1.0.0' ]
+			},
+			active: {
+				type: 'boolean',
+				const: true
+			},
+			data: {
+				type: 'object',
+				properties: {
+					from: {
+						type: 'object',
+						properties: {
+							id: {
+								type: 'string',
+								const: fromCard.id
+							}
+						}
+					}
+				}
+			}
+		},
+		additionalProperties: true
+	}
+
+	if (toCard) {
+		query.properties.data.properties.to = {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'string',
+					const: toCard.id
+				}
+			}
+		}
+	}
+
+	return query
+}
 
 /**
  * @namespace JellyfishSDK.card
@@ -407,7 +462,7 @@ class CardSdk {
 	 *
 	 * @returns {Promise}
 	 */
-	link (fromCard, toCard, verb) {
+	async link (fromCard, toCard, verb) {
 		if (!verb) {
 			throw new Error('No verb provided when creating link')
 		}
@@ -440,6 +495,38 @@ class CardSdk {
 			throw new Error(`No id in "to" card: ${JSON.stringify(toCard)}`)
 		}
 
+		// If there is a link constraint...
+		if (option.data.toMultiplicity === MULTIPLICITY.ZERO_OR_ONE) {
+			// ...check for existing links from
+			const links = await this.sdk.query(
+				getLinkQuery(verb, fromCard),
+				{
+				// There should only be max one existing link in this case
+					limit: 1
+				})
+
+			// ...if there is an existing link...
+			if (links && links.length) {
+				// ...remove it before creating the new link
+				const existingLink = links[0]
+				await this.remove(existingLink.id, existingLink.type)
+			}
+		}
+
+		// Check for existing link with this verb between these two cards
+		const links = await this.sdk.query(
+			getLinkQuery(verb, fromCard, toCard),
+			{
+				// There should only be max one existing link in this case
+				limit: 1
+			})
+
+		// If found, just return that object
+		if (links && links.length) {
+			return links[0]
+		}
+
+		// If not found, create the new link
 		const payload = {
 			card: 'link',
 			type: 'type',
@@ -447,7 +534,7 @@ class CardSdk {
 			arguments: {
 				reason: null,
 				properties: {
-					slug: `link-${fromCard.id}-${verb.replace(/\s/g, '-')}-${toCard.id}`,
+					slug: `link-${fromCard.id}-${verb.replace(/\s/g, '-')}-${toCard.id}-${uuidv4()}`,
 					tags: [],
 					version: '1.0.0',
 					links: {},
@@ -472,26 +559,28 @@ class CardSdk {
 
 		return this.sdk.action(payload)
 			.catch((error) => {
-				if (error.name !== 'JellyfishElementAlreadyExists') {
-					throw error
-				}
-
-				return this.sdk.card.get(payload.arguments.properties.slug)
-					.then((card) => {
-						return this.update(card.id, card.type, [
-							{
-								op: 'replace',
-								path: '/name',
-								value: verb
-							},
-							{
-								op: 'replace',
-								path: '/data',
-								value: payload.arguments.properties.data
-							}
-						])
-					})
+				console.error('Failed to create a link', error)
+				throw error
 			})
+	}
+
+	unlink (fromCard, toCard, verb) {
+		if (!verb) {
+			throw new Error('No verb provided when removing link')
+		}
+
+		// First query for link cards
+		return this.sdk.query(
+			getLinkQuery(verb, fromCard, toCard)).then((linkCards) => {
+			// Then remove the link cards
+			const removeActions = linkCards.map((linkCard) => {
+				return this.remove(linkCard.id, linkCard.type)
+			})
+			return Bluebird.all(removeActions)
+		}).catch((error) => {
+			console.error('Failed to unlink cards', error)
+			throw error
+		})
 	}
 
 	/**

--- a/lib/sdk/link-constraints.js
+++ b/lib/sdk/link-constraints.js
@@ -4,6 +4,18 @@
  * Proprietary and confidential.
  */
 
+/**
+	* Link cardinality constants.
+	*/
+const MULTIPLICITY = {
+	ZERO_OR_ONE: '0..1',
+
+	// ANY is the default. It is assumed if no multiplicity is specified.
+	ANY: '*'
+}
+
+exports.MULTIPLICITY = MULTIPLICITY
+
 // TODO Use 'LINK_CONSTRAINTS' on type cards instead of hardcoding lere
 exports.constraints = [
 	{
@@ -34,6 +46,27 @@ exports.constraints = [
 			from: 'user',
 			to: 'contact',
 			inverse: 'link-constraint-contact-is-attached-to-user'
+		}
+	},
+	{
+		slug: 'link-constraint-support-thread-is-owned-by',
+		name: 'is owned by',
+		data: {
+			title: 'Owner',
+			from: 'support-thread',
+			to: 'user',
+			inverse: 'link-constraint-user-is-owner-of-support-thread',
+			toMultiplicity: MULTIPLICITY.ZERO_OR_ONE
+		}
+	},
+	{
+		slug: 'link-constraint-user-is-owner-of-support-thread',
+		name: 'is owner of support thread',
+		data: {
+			title: 'Support thread',
+			from: 'user',
+			to: 'support-thread',
+			inverse: 'link-constraint-support-thread-is-owned-by'
 		}
 	},
 	{
@@ -127,83 +160,83 @@ exports.constraints = [
 		}
 	},
 	{
-		slug: 'link-constraint-contact-has-primary-owner',
-		name: 'has primary owner',
+		slug: 'link-constraint-contact-is-owned-by-user',
+		name: 'is owned by',
 		data: {
-			title: 'Primary owner',
+			title: 'Owner',
 			from: 'contact',
 			to: 'user',
-			inverse: 'link-constraint-user-is-primary-owner-of-contact'
+			inverse: 'link-constraint-user-owns-contact'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-primary-owner-of-contact',
-		name: 'is primary owner of',
+		slug: 'link-constraint-user-owns-contact',
+		name: 'owns',
 		data: {
-			title: 'Primary owner',
+			title: 'Contact',
 			from: 'user',
 			to: 'contact',
-			inverse: 'link-constraint-contact-has-primary-owner'
+			inverse: 'link-constraint-contact-is-owned-by-user'
 		}
 	},
 	{
-		slug: 'link-constraint-contact-has-secondary-owner',
-		name: 'has secondary owner',
+		slug: 'link-constraint-contact-has-backup-owner',
+		name: 'has backup owner',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'contact',
 			to: 'user',
-			inverse: 'link-constraint-user-is-secondary-owner-of-contact'
+			inverse: 'link-constraint-user-is-backup-owner-of-contact'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-secondary-owner-of-contact',
-		name: 'is secondary owner of',
+		slug: 'link-constraint-user-is-backup-owner-of-contact',
+		name: 'is backup owner of',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'user',
 			to: 'contact',
-			inverse: 'link-constraint-contact-has-secondary-owner'
+			inverse: 'link-constraint-contact-has-backup-owner'
 		}
 	},
 	{
-		slug: 'link-constraint-account-has-primary-owner',
-		name: 'has primary owner',
+		slug: 'link-constraint-account-is-owned-by-user',
+		name: 'is owned by',
 		data: {
-			title: 'Primary owner',
+			title: 'Owner',
 			from: 'account',
 			to: 'user',
-			inverse: 'link-constraint-user-is-primary-owner-of-account'
+			inverse: 'link-constraint-user-owns-account'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-primary-owner-of-account',
-		name: 'is primary owner of',
+		slug: 'link-constraint-user-owns-account',
+		name: 'owns',
 		data: {
-			title: 'Primary owner',
+			title: 'Account',
 			from: 'user',
 			to: 'account',
-			inverse: 'link-constraint-account-has-primary-owner'
+			inverse: 'link-constraint-account-is-owned-by-user'
 		}
 	},
 	{
-		slug: 'link-constraint-account-has-secondary-owner',
-		name: 'has secondary owner',
+		slug: 'link-constraint-account-has-backup-owner',
+		name: 'has backup owner',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'account',
 			to: 'user',
-			inverse: 'link-constraint-user-is-secondary-owner-of-account'
+			inverse: 'link-constraint-user-is-backup-owner-of-account'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-secondary-owner-of-account',
-		name: 'is secondary owner of',
+		slug: 'link-constraint-user-is-backup-owner-of-account',
+		name: 'is backup owner of',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'user',
 			to: 'account',
-			inverse: 'link-constraint-account-has-secondary-owner'
+			inverse: 'link-constraint-account-has-backup-owner'
 		}
 	},
 	{

--- a/lib/ui-components/CardActions/CardActions.jsx
+++ b/lib/ui-components/CardActions/CardActions.jsx
@@ -12,6 +12,7 @@ import {
 	Modal
 } from 'rendition'
 import CardLinker from '../CardLinker'
+import CardOwner from '../CardOwner'
 import ContextMenu from '../ContextMenu'
 import * as helpers from '../../../lib/ui-components/services/helpers'
 import {
@@ -75,9 +76,18 @@ export default class CardActions extends React.Component {
 		}
 	}
 	render () {
+		const supportsOwnership = helpers.supportsLink(this.props.card.type, 'is owned by', this.props.sdk.LINKS)
 		return (
 			<React.Fragment>
 				<Flex alignItems="center" justifyContent="flex-end">
+					{supportsOwnership && (
+						<CardOwner
+							user={this.props.user}
+							types={this.props.types}
+							card={this.props.card}
+							sdk={this.props.sdk}
+							actions={this.props.actions} />
+					)}
 					<Button
 						plain
 						mr={3}

--- a/lib/ui-components/CardLinker/CardLinker.jsx
+++ b/lib/ui-components/CardLinker/CardLinker.jsx
@@ -100,7 +100,6 @@ class CardLinker extends React.Component {
 
 	render () {
 		const {
-			actions,
 			card,
 			connectDragSource,
 			types
@@ -179,7 +178,6 @@ class CardLinker extends React.Component {
 				</span>
 
 				<LinkModal
-					actions={actions}
 					card={card}
 					types={types}
 					show={showLinkModal}

--- a/lib/ui-components/CardOwner/CardOwner.jsx
+++ b/lib/ui-components/CardOwner/CardOwner.jsx
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import path from 'path'
+import {
+	Box,
+	Txt,
+	DropDownButton
+} from 'rendition'
+import _ from 'lodash'
+import {
+	withRouter
+} from 'react-router-dom'
+import {
+	getType,
+	userDisplayName
+} from '../services/helpers'
+import {
+	ActionLink
+} from '../shame/ActionLink'
+import LinkModal from '../LinkModal'
+import Icon from '../shame/Icon'
+
+class CardOwner extends React.Component {
+	constructor (props) {
+		super(props)
+		this.state = {
+			showLinkModal: false
+		}
+		this.assignToMe = this.assignToMe.bind(this)
+		this.unassign = this.unassign.bind(this)
+		this.assign = this.assign.bind(this)
+		this.hideLinkModal = this.hideLinkModal.bind(this)
+		this.openOwnerChannel = this.openOwnerChannel.bind(this)
+	}
+
+	assignToMe () {
+		const {
+			actions,
+			card,
+			user,
+			onRefresh
+		} = this.props
+		const cardTypeName = card.type.split('@')[0]
+		this.setState({
+			busy: true
+		}, async () => {
+			await this.unassign(true)
+
+			actions.createLink(card, user, 'is owned by', {
+				skipSuccessMessage: true
+			})
+				.then(async (data) => {
+					actions.addNotification('success', `${cardTypeName} assigned to me`)
+					await onRefresh()
+				})
+				.catch((err) => {
+					actions.addNotification('danger', `Failed to assign ${cardTypeName}`)
+					console.error('Failed to create link', err)
+				})
+				.finally(() => {
+					this.setState({
+						busy: false
+					})
+				})
+		})
+	}
+
+	async unassign (isInTransaction = false) {
+		const {
+			sdk,
+			actions,
+			card,
+			links,
+			onRefresh
+		} = this.props
+		if (links && links.length) {
+			const ownerName = userDisplayName(links[0])
+			const cardTypeName = card.type.split('@')[0]
+			const owner = links[0]
+			if (!isInTransaction) {
+				this.setState({
+					busy: true
+				})
+			}
+
+			try {
+				await sdk.card.unlink(card, owner, 'is owned by')
+				if (!isInTransaction) {
+					actions.addNotification('success', `${ownerName} was unassigned from this ${cardTypeName}`)
+					await onRefresh()
+				}
+			} catch (err) {
+				actions.addNotification('danger', `Could not unassign ${ownerName} from the ${cardTypeName}`)
+				console.error('Failed to remove link', err)
+			} finally {
+				if (!isInTransaction) {
+					this.setState({
+						busy: false
+					})
+				}
+			}
+		}
+	}
+
+	assign () {
+		this.setState({
+			showLinkModal: true
+		})
+	}
+
+	hideLinkModal () {
+		this.setState({
+			showLinkModal: false
+		})
+		this.props.onRefresh()
+	}
+
+	openOwnerChannel (ev) {
+		const {
+			links, history
+		} = this.props
+		ev.preventDefault()
+		ev.stopPropagation()
+		const owner = links && links.length === 1 ? links[0] : null
+		history.push(path.join(window.location.pathname, owner.slug))
+	}
+
+	render () {
+		const {
+			user,
+			card,
+			types,
+			sdk,
+			links,
+			linkNotSupported
+		} = this.props
+		const {
+			busy,
+			showLinkModal
+		} = this.state
+
+		if (linkNotSupported) {
+			return null
+		}
+
+		const type = getType('user', types)
+		const owner = links && links.length ? links[0] : null
+		const cardTypeName = card.type.split('@')[0]
+		const linkType = _.find(
+			sdk.LINKS,
+			// eslint-disable-next-line lodash/matches-shorthand
+			(link) => { return link.name === 'is owned by' && link.data.from === card.type.split('@')[0] }
+		)
+
+		if (!links) {
+			return (
+				<Box mr={3}>
+					<Icon name="cog" spin />
+				</Box>
+			)
+		}
+		return (
+			<React.Fragment>
+				<DropDownButton
+					data-test="card-owner-dropdown"
+					mr={3}
+					tertiary={owner && (owner.id === user.id)}
+					quartenary={owner && (owner.id !== user.id)}
+					disabled={busy}
+					label={owner ? (
+						<Txt.span data-test="card-owner-dropdown__label--assigned" onClick={this.openOwnerChannel} bold tooltip={{
+							text: `${userDisplayName(owner)} owns this ${cardTypeName}`,
+							placement: 'bottom'
+						}}>{userDisplayName(owner)}</Txt.span>
+					) : (
+						<Txt.span data-test="card-owner-dropdown__label--unassigned" bold italic tooltip={{
+							text: `This ${cardTypeName} is unassigned`,
+							placement: 'bottom'
+						}}>Unassigned</Txt.span>
+					)}
+				>
+					<ActionLink
+						disabled={owner && (owner.id === user.id)}
+						onClick={!owner || (owner.id !== user.id) ? this.assignToMe : _.noop}
+						data-test="card-owner-menu__assign-to-me"
+					>
+					Assign to me
+					</ActionLink>
+
+					<ActionLink
+						disabled={!owner}
+						onClick={owner ? () => { this.unassign(false) } : _.noop}
+						data-test="card-owner-menu__unassign"
+					>
+					Unassign
+					</ActionLink>
+
+					<ActionLink
+						onClick={this.assign}
+						data-test="card-owner-menu__assign"
+					>
+					Assign to someone else
+					</ActionLink>
+				</DropDownButton>
+
+				<LinkModal
+					linkType={linkType}
+					card={card}
+					types={[ type ]}
+					show={showLinkModal}
+					onHide={this.hideLinkModal}
+					linkCreatedNotificationMessage={
+						(from, to) => { return `${from.type.split('@')[0]} assigned to ${userDisplayName(to)}` }
+					}
+				/>
+			</React.Fragment>
+		)
+	}
+}
+
+export default withRouter(CardOwner)

--- a/lib/ui-components/CardOwner/index.jsx
+++ b/lib/ui-components/CardOwner/index.jsx
@@ -4,9 +4,7 @@
  * Proprietary and confidential.
  */
 
-import LinkModal from './LinkModal'
-import {
-	withSetup
-} from '../SetupProvider'
+import withLinks from '../HOC/with-links'
+import CardOwner from './CardOwner'
 
-export default withSetup(LinkModal)
+export default withLinks('is owned by')(CardOwner)

--- a/lib/ui-components/ChannelRenderer.jsx
+++ b/lib/ui-components/ChannelRenderer.jsx
@@ -70,7 +70,6 @@ class ChannelRenderer extends React.Component {
 	render () {
 		const {
 			getLens,
-			actions,
 			channel,
 			connectDropTarget,
 			isOver,
@@ -145,7 +144,6 @@ class ChannelRenderer extends React.Component {
 
 				{showLinkModal && (
 					<LinkModal
-						actions={actions}
 						target={head}
 						card={linkFrom}
 						types={types}

--- a/lib/ui-components/HOC/with-links.jsx
+++ b/lib/ui-components/HOC/with-links.jsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+
+export default function withLinks (linkName) {
+	return (BaseComponent) => {
+		return ({
+			card, actions, ...props
+		}) => {
+			const [ links, setLinks ] = React.useState(null)
+			const [ error, setError ] = React.useState(null)
+
+			const getData = () => {
+				actions.getLinks(card, linkName).then(setLinks).catch(setError)
+			}
+
+			React.useEffect(() => {
+				getData(false)
+			}, [ linkName, card.id ])
+
+			return (
+				<BaseComponent
+					{...props}
+					card={card}
+					linkNotSupported={Boolean(error)}
+					actions={actions}
+					linkName={linkName}
+					links={links}
+					onRefresh={getData}
+				/>
+			)
+		}
+	}
+}

--- a/lib/ui-components/SetupProvider.jsx
+++ b/lib/ui-components/SetupProvider.jsx
@@ -5,19 +5,28 @@
  */
 
 import React from 'react'
+import {
+	bindActionCreators
+} from 'redux'
+import {
+	useDispatch
+} from 'react-redux'
 
 const setupContext = React.createContext(null)
 
 export const SetupProvider = ({
-	analytics, sdk, actions, children
+	analytics, sdk, actionCreators, children
 }) => {
+	const dispatch = useDispatch()
+
+	const actions = bindActionCreators(actionCreators || [], dispatch)
 	const setup = React.useMemo(() => {
 		return {
 			sdk,
 			analytics,
 			actions
 		}
-	}, [ sdk, analytics, actions ])
+	}, [ sdk, analytics, actionCreators ])
 
 	return (
 		<setupContext.Provider value={setup}>{children}</setupContext.Provider>

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -422,3 +422,23 @@ export const patchPath = (card, keyPath, value) => {
 
 	return patch
 }
+
+export const getType = _.memoize((typeSlug, types) => {
+	return _.find(types, {
+		slug: typeSlug.split('@')[0]
+	})
+})
+
+export const supportsLink = _.memoize((cardType, linkName, links) => {
+	return _.find(
+		links,
+		// eslint-disable-next-line lodash/matches-shorthand
+		(link) => { return link.name === linkName && link.data.from === cardType.split('@')[0] }
+	)
+}, (cardType, linkName) => {
+	return `${cardType}-${linkName}`
+})
+
+export const userDisplayName = (user) => {
+	return user.name || user.slug.replace('user-', '')
+}

--- a/test/e2e/sdk/card.spec.js
+++ b/test/e2e/sdk/card.spec.js
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const uuid = require('uuid/v4')
+const helpers = require('./helpers')
+
+// TODO: Possibly move this file to test/integration/sdk if/when
+// we resolve where to place sdk helper methods that are used by
+// both e2e tests and integration tests.
+
+const context = {
+	context: {
+		id: `SDK-CARD-E2E-TEST-${uuid()}`
+	}
+}
+
+const user = {
+	username: `johndoe-${uuid()}`,
+	email: `johndoe-${uuid()}@example.com`,
+	password: 'password'
+}
+
+const createSupportThread = async (sdk) => {
+	return sdk.card.create({
+		type: 'support-thread',
+		data: {
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
+	})
+}
+
+const createSupportIssue = async (sdk) => {
+	return sdk.card.create({
+		type: 'support-issue',
+		name: `test-support-issue-${uuid()}`,
+		data: {
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
+	})
+}
+
+const createUser = async (sdk) => {
+	const {
+		id
+	} = await sdk.action({
+		card: 'user@1.0.0',
+		type: 'type',
+		action: 'action-create-user@1.0.0',
+		arguments: {
+			email: user.email,
+			username: `user-${user.username}`,
+			password: user.password
+		}
+	})
+
+	return sdk.card.get(id)
+}
+
+ava.before(async () => {
+	await helpers.before({
+		context
+	})
+})
+
+ava.after(async () => {
+	await helpers.after({
+		context
+	})
+})
+
+ava.beforeEach(async () => {
+	await helpers.beforeEach({
+		context
+	})
+})
+
+ava.afterEach(async () => {
+	await helpers.afterEach({
+		context
+	})
+})
+
+ava('If you call card.link twice with the same params you will get the same link card back', async (test) => {
+	const {
+		sdk
+	} = context
+
+	// Create a support thread and support issue
+	const supportThread = await createSupportThread(sdk)
+
+	const supportIssue = await createSupportIssue(sdk)
+
+	// Link the support thread to the support issue
+	const link1 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Try to link the same support thread to the same support issue
+	const link2 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Verify the link ID is the same
+	test.is(link1.id, link2.id)
+})
+
+ava('If the link multiplicity is 0..1 an existing link will be replaced by the new link', async (test) => {
+	const {
+		sdk
+	} = context
+
+	const currentUser = await sdk.auth.whoami()
+	const otherUser = await createUser(sdk)
+
+	// Create a support thread
+	const supportThread = await createSupportThread(sdk)
+
+	// Link the support thread to the current user
+	await sdk.card.link(supportThread, currentUser, 'is owned by')
+
+	// Then link the same support thread to the other user
+	await sdk.card.link(supportThread, otherUser, 'is owned by')
+
+	// Now get all 'is owned by' links for this support thread
+	const supportThreadWithOwners = await sdk.card.getWithLinks(supportThread.id, [ 'is owned by' ])
+
+	// And verify the second user is the active link
+	test.is(supportThreadWithOwners.links['is owned by'].length, 1)
+	test.is(supportThreadWithOwners.links['is owned by'][0].id, otherUser.id)
+})
+
+ava('card.link will create a new link if the previous one was deleted', async (test) => {
+	const {
+		sdk
+	} = context
+
+	// Create a support thread and support issue
+	const supportThread = await createSupportThread(sdk)
+
+	const supportIssue = await createSupportIssue(sdk)
+
+	// Link the support thread to the support issue
+	const link1 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Now remove the link
+	await sdk.card.remove(link1.id, link1.type)
+
+	// Try to link the same support thread to the same support issue
+	const link2 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Verify the link ID is not the same
+	test.not(link1.id, link2.id)
+})


### PR DESCRIPTION
You can now easily set the owner of a support thread via a dropdown button on the Card Actions area.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![CardOwnership Progress 2](https://user-images.githubusercontent.com/2925657/75129184-66849880-56fa-11ea-865a-d216d2c4f930.gif)

## Card Ownership changes

This PR replaces the concept of 'Primary owner' and 'Secondary owners' with 'Owner' and 'Backup owners'. This is a breaking change in so far as any existing 'primary' and 'secondary' owners will no longer be shown in the UI. But the understanding is that these links (used on just Projects, Accounts and Contacts) were not being used yet anyway.
* The 'Primary owner' tab has been removed from Account, Project and Contact card lenses. 
* The 'Secondary owners' tab has been renamed to 'Backup owners'
* The following cards support card ownership and therefore have the new 'Card Owner' dropdown control in the 'Card Actions' section:
  * `account`
  * `contact`
  * `project`
  * `support-thread` 

## Link changes
As part of this work, I've had to update the way link card slugs are generated:
* they now contain a uuid to ensure they won't conflict with a previously created _inactive_ link card with the same verb, fromId and toId.
* when linking cards, we first query for existing links with that verb, fromId and toId. If found, we just return the existing card. Otherwise we create a new link card - which will have a unique slug thanks to the uuid part of it.

## SetupProvider
This PR also fixes the `SetupProvider` component. The react-redux `Provider` component is now above the `SetupProvider` component in the component hierarchy and so all the redux actions (generated from the action creators) can be passed down in the React context (along with `sdk` and `analytics`).

This change simplifies various down-stream components as they now have access to all the Redux actions and we don't need to manually pass them through or bind them specifically each time. There's probably various other components where this could be tidied up a lot too!
