### PR TITLE
core: Add 'Owned conversations' tab to user card

### DIFF
--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -310,6 +310,41 @@ module.exports = {
 							additionalProperties: true
 						}
 					]
+				},
+				{
+					title: 'Owned conversations',
+					query: [
+						{
+							$$links: {
+								'is owned by': {
+									type: 'object',
+									properties: {
+										type: {
+											const: 'user@1.0.0'
+										},
+										id: {
+											const: {
+												$eval: 'result.id'
+											}
+										}
+									},
+									required: [
+										'id'
+									]
+								}
+							},
+							type: 'object',
+							properties: {
+								type: {
+									enum: [
+										'support-thread@1.0.0',
+										'sales-thread@1.0.0'
+									]
+								}
+							},
+							additionalProperties: true
+						}
+					]
 				}
 			]
 		}


### PR DESCRIPTION
The meta relationships of a user card now defines a 'Owned conversations' relationship, exposed as a tab on the user card's (default) lens. Currently this only displays owned support-threads and sales-threads.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![image](https://user-images.githubusercontent.com/2925657/75130209-a13cff80-56ff-11ea-9c1c-8ffe9c5de6f8.png)
