### PR TITLE
Add the `password-reset` default card.

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -59,6 +59,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/issue.json'),
 		await loadCard('contrib/message.json'),
 		await loadCard('contrib/opportunity.json'),
+		await loadCard('contrib/password-reset.json'),
 		await loadCard('contrib/ping.json'),
 		await loadCard('contrib/pipeline.json'),
 		await loadCard('contrib/product-improvement.json'),

--- a/apps/server/default-cards/contrib/password-reset.json
+++ b/apps/server/default-cards/contrib/password-reset.json
@@ -1,0 +1,34 @@
+{
+  "slug": "password-reset",
+  "name": "Password Reset",
+  "version": "1.0.0",
+  "type": "type@1.0.0",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "requestedAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "expiresAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "resetToken": {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{64}$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -44,7 +44,9 @@
                   "user",
                   "user@1.0.0",
                   "view",
-                  "view@1.0.0"
+                  "view@1.0.0",
+                  "password-reset",
+                  "password-reset@1.0.0"
                 ]
               }
             }


### PR DESCRIPTION
Implements https://github.com/product-os/jellyfish/projects/10#card-33658506)

There appear to be no unit tests for any card loader code that I can see. If I'm missing something then please let me know and I'll happily add them.