### PR TITLE
Use postgres host env var in more places

### DIFF
--- a/scripts/postgres-delete-test-databases.js
+++ b/scripts/postgres-delete-test-databases.js
@@ -18,6 +18,7 @@ const scrub = async () => {
 		user: environment.postgres.user,
 		password: environment.postgres.password,
 		database: 'postgres',
+		host: environment.postgres.host,
 		port: environment.postgres.port
 	})
 

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -148,6 +148,7 @@ ava.before(async (test) => {
 		user: environment.postgres.user,
 		password: environment.postgres.password,
 		database: 'postgres',
+		host: environment.postgres.host,
 		port: environment.postgres.port
 	}).any(`
 		CREATE DATABASE ${test.context.database} OWNER = ${environment.postgres.user};
@@ -162,6 +163,7 @@ ava.before(async (test) => {
 		user: environment.postgres.user,
 		database: test.context.database,
 		password: environment.postgres.password,
+		host: environment.postgres.host,
 		port: environment.postgres.port
 	})
 })

--- a/test/integration/core/backend/postgres/streams/index.spec.js
+++ b/test/integration/core/backend/postgres/streams/index.spec.js
@@ -26,6 +26,7 @@ ava.beforeEach(async (test) => {
 		user: environment.postgres.user,
 		password: environment.postgres.password,
 		database: 'postgres',
+		host: environment.postgres.host,
 		port: environment.postgres.port
 	})
 
@@ -41,6 +42,7 @@ ava.beforeEach(async (test) => {
 			user: environment.postgres.user,
 			database: test.context.database,
 			password: environment.postgres.password,
+			host: environment.postgres.host,
 			port: environment.postgres.port
 		})
 	}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Found a few places in the code that doesn't respect the Postgres host environment variable and had to change them to get tests to run and pass.