### PR TITLE
WIP: CRM: Fixup ui-component unit tests

### DIFF
--- a/apps/livechat/index.jsx
+++ b/apps/livechat/index.jsx
@@ -12,7 +12,7 @@ import qs from 'query-string'
 import {
 	App,
 	createSdk
-} from '@jellyfish/chat-widget'
+} from '../../lib/chat-widget'
 
 const init = async ({
 	product,

--- a/apps/ui/components/HOC/CardActions.jsx
+++ b/apps/ui/components/HOC/CardActions.jsx
@@ -16,7 +16,7 @@ import {
 	sdk,
 	selectors
 }	from '../../core'
-import CardActions from '@jellyfish/ui-components/CardActions'
+import CardActions from '../../../../lib/ui-components/CardActions'
 
 const mapStateToProps = (state) => {
 	return {

--- a/apps/ui/components/HOC/HomeChannel.jsx
+++ b/apps/ui/components/HOC/HomeChannel.jsx
@@ -14,7 +14,7 @@ import {
 	selectors
 } from '../../core'
 
-import HomeChannel from '@jellyfish/ui-components/HomeChannel'
+import HomeChannel from '../../../../lib/ui-components/HomeChannel'
 
 const mapStateToProps = (state, ownProps) => {
 	const target = _.get(ownProps, [ 'channel', 'data', 'head', 'id' ])

--- a/apps/ui/components/HOC/Login.jsx
+++ b/apps/ui/components/HOC/Login.jsx
@@ -14,7 +14,7 @@ import {
 import {
 	actionCreators
 } from '../../core'
-import Login from '@jellyfish/ui-components/Login'
+import Login from '../../../../lib/ui-components/Login'
 
 const mapDispatchToProps = (dispatch) => {
 	return {

--- a/apps/ui/components/HOC/Notifications.jsx
+++ b/apps/ui/components/HOC/Notifications.jsx
@@ -14,7 +14,7 @@ import {
 	actionCreators,
 	selectors
 } from '../../core'
-import Notifications from '@jellyfish/ui-components/Notifications'
+import Notifications from '../../../../lib/ui-components/Notifications'
 
 const mapStateToProps = (state) => {
 	return {

--- a/apps/ui/components/HOC/Oauth.jsx
+++ b/apps/ui/components/HOC/Oauth.jsx
@@ -15,7 +15,7 @@ import {
 	actionCreators,
 	selectors
 } from '../../core'
-import Oauth from '@jellyfish/ui-components/Oauth'
+import Oauth from '../../../../lib/ui-components/Oauth'
 
 const mapStateToProps = (state) => {
 	return {

--- a/apps/ui/components/HOC/RouteHandler.jsx
+++ b/apps/ui/components/HOC/RouteHandler.jsx
@@ -18,7 +18,7 @@ import {
 import {
 	getLens
 } from '../../lens'
-import RouteHandler from '@jellyfish/ui-components/RouteHandler'
+import RouteHandler from '../../../../lib/ui-components/RouteHandler'
 
 const mapStateToProps = (state) => {
 	return {

--- a/apps/ui/components/Inbox/InboxTab.jsx
+++ b/apps/ui/components/Inbox/InboxTab.jsx
@@ -25,8 +25,8 @@ import {
 } from 'use-debounce'
 import {
 	useSetup
-} from '@jellyfish/ui-components/SetupProvider'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../../../../lib/ui-components/SetupProvider'
+import Icon from '../../../../lib/ui-components/shame/Icon'
 import {
 	selectors
 } from '../../core'

--- a/apps/ui/components/Inbox/MessageList.jsx
+++ b/apps/ui/components/Inbox/MessageList.jsx
@@ -25,9 +25,9 @@ import {
 } from '../../core'
 import {
 	ActionLink
-} from '@jellyfish/ui-components/shame/ActionLink'
-import Column from '@jellyfish/ui-components/shame/Column'
-import Event from '@jellyfish/ui-components/Event'
+} from '../../../../lib/ui-components/shame/ActionLink'
+import Column from '../../../../lib/ui-components/shame/Column'
+import Event from '../../../../lib/ui-components/Event'
 
 class MessageList extends React.Component {
 	constructor (props) {

--- a/apps/ui/components/Inbox/index.jsx
+++ b/apps/ui/components/Inbox/index.jsx
@@ -17,7 +17,7 @@ import {
 	Tabs,
 	Tab
 } from 'rendition'
-import Column from '@jellyfish/ui-components/shame/Column'
+import Column from '../../../../lib/ui-components/shame/Column'
 import InboxTab from './InboxTab'
 
 // Generates a basic query that matches messages against a user slug

--- a/apps/ui/core/index.js
+++ b/apps/ui/core/index.js
@@ -6,7 +6,7 @@
 
 import localForage from 'localforage'
 import * as _ from 'lodash'
-import Analytics from '@jellyfish/ui-components/services/analytics'
+import Analytics from '../../../lib/ui-components/services/analytics'
 import * as environment from '../environment'
 import {
 	sdk as SDK

--- a/apps/ui/core/index.js
+++ b/apps/ui/core/index.js
@@ -83,4 +83,6 @@ localForage.getItem(STORAGE_KEY)
 		console.error(error)
 	})
 
-window.sdk = sdk
+if (typeof window !== 'undefined') {
+	window.sdk = sdk
+}

--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -13,7 +13,7 @@ import * as _ from 'lodash'
 import * as skhema from 'skhema'
 import uuid from 'uuid/v4'
 import actions from './actions'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 import {
 	createNotification
 } from '../../services/notifications'

--- a/apps/ui/core/store/index.js
+++ b/apps/ui/core/store/index.js
@@ -46,8 +46,12 @@ export const setupStore = ({
 		return newState
 	}
 
-	// eslint-disable-next-line no-underscore-dangle
-	const composeEnhancers = (typeof window !== 'undefined' && !isProduction() && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || redux.compose
+	const composeEnhancers = (
+		typeof window !== 'undefined' &&
+		!isProduction() &&
+		// eslint-disable-next-line no-underscore-dangle
+		window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+	) || redux.compose
 
 	return {
 		store: redux.createStore(reducerWrapper, composeEnhancers(redux.applyMiddleware(reduxThunk))),

--- a/apps/ui/core/store/index.js
+++ b/apps/ui/core/store/index.js
@@ -47,7 +47,7 @@ export const setupStore = ({
 	}
 
 	// eslint-disable-next-line no-underscore-dangle
-	const composeEnhancers = (!isProduction() && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || redux.compose
+	const composeEnhancers = (typeof window !== 'undefined' && !isProduction() && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || redux.compose
 
 	return {
 		store: redux.createStore(reducerWrapper, composeEnhancers(redux.applyMiddleware(reduxThunk))),

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -25,7 +25,7 @@ import {
 	store
 } from './core'
 import JellyfishUI from './JellyfishUI'
-import ErrorBoundary from '@jellyfish/ui-components/shame/ErrorBoundary'
+import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
 import * as environment from './environment'
 import {
 	BrowserRouter as Router

--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -17,8 +17,8 @@ import {
 } from 'rendition'
 import {
 	CloseButton
-} from '@jellyfish/ui-components/shame/CloseButton'
-import Column from '@jellyfish/ui-components/shame/Column'
+} from '../../../../lib/ui-components/shame/CloseButton'
+import Column from '../../../../lib/ui-components/shame/Column'
 import CardActions from '../../components/HOC/CardActions'
 import {
 	selectors

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -22,8 +22,8 @@ import {
 	Select,
 	Txt
 } from 'rendition'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
+import Icon from '../../../../lib/ui-components/shame/Icon'
 import CardLayout from '../../layouts/CardLayout'
 import {
 	Form

--- a/apps/ui/lens/actions/CreateView/CreateView.jsx
+++ b/apps/ui/lens/actions/CreateView/CreateView.jsx
@@ -17,9 +17,9 @@ import {
 	Txt
 } from 'rendition'
 import styled from 'styled-components'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
-import Avatar from '@jellyfish/ui-components/shame/Avatar'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import * as helpers from '../../../../../lib/ui-components/services/helpers'
+import Avatar from '../../../../../lib/ui-components/shame/Avatar'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 import CardLayout from '../../../layouts/CardLayout'
 import {
 	analytics,

--- a/apps/ui/lens/actions/CreateView/tests/CreateView.spec.jsx
+++ b/apps/ui/lens/actions/CreateView/tests/CreateView.spec.jsx
@@ -6,10 +6,16 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
 import React from 'react'
 import CreateView from '../CreateView'
+
+configure({
+	adapter: new Adapter()
+})
 
 ava('It should render', (test) => {
 	test.notThrows(() => {

--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -25,7 +25,7 @@ import {
 	Form
 } from 'rendition/dist/unstable'
 import CardLayout from '../../layouts/CardLayout'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 import * as skhema from 'skhema'
 import {
 	actionCreators,

--- a/apps/ui/lens/actions/LinksGraphLens.jsx
+++ b/apps/ui/lens/actions/LinksGraphLens.jsx
@@ -11,11 +11,11 @@ import {
 	connect
 } from 'react-redux'
 import * as redux from 'redux'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 import {
 	CloseButton
-} from '@jellyfish/ui-components/shame/CloseButton'
-import Column from '@jellyfish/ui-components/shame/Column'
+} from '../../../../lib/ui-components/shame/CloseButton'
+import Column from '../../../../lib/ui-components/shame/Column'
 import {
 	actionCreators,
 	sdk

--- a/apps/ui/lens/common/BaseLens.jsx
+++ b/apps/ui/lens/common/BaseLens.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 
 export default class BaseLens extends React.Component {
 	constructor (props) {

--- a/apps/ui/lens/full/MyUser/MyUser.jsx
+++ b/apps/ui/lens/full/MyUser/MyUser.jsx
@@ -23,10 +23,10 @@ import {
 	Form
 } from 'rendition/dist/unstable'
 import * as skhema from 'skhema'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../../lib/ui-components/services/helpers'
 import CardLayout from '../../../layouts/CardLayout'
-import Avatar from '@jellyfish/ui-components/shame/Avatar'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Avatar from '../../../../../lib/ui-components/shame/Avatar'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 
 const SLUG = 'lens-my-user'
 

--- a/apps/ui/lens/full/MyUser/tests/MyUser.spec.jsx
+++ b/apps/ui/lens/full/MyUser/tests/MyUser.spec.jsx
@@ -6,14 +6,20 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
 import React from 'react'
 import MyUser from '../MyUser'
 import {
 	user,
 	userType
 } from './fixtures'
+
+configure({
+	adapter: new Adapter()
+})
 
 ava('It should render', (test) => {
 	test.notThrows(() => {

--- a/apps/ui/lens/full/SingleCard/Segment.jsx
+++ b/apps/ui/lens/full/SingleCard/Segment.jsx
@@ -21,9 +21,9 @@ import {
 } from '../../../lens'
 import {
 	evalSchema
-} from '@jellyfish/ui-components/services/helpers'
-import LinkModal from '@jellyfish/ui-components/LinkModal'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../../../../../lib/ui-components/services/helpers'
+import LinkModal from '../../../../../lib/ui-components/LinkModal'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 
 export default class Segment extends React.Component {
 	constructor (props) {

--- a/apps/ui/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lens/full/SingleCard/SingleCard.jsx
@@ -22,7 +22,7 @@ import CardLayout from '../../../layouts/CardLayout'
 import Timeline from '../../list/Timeline'
 import {
 	colorHash
-} from '@jellyfish/ui-components/services/helpers'
+} from '../../../../../lib/ui-components/services/helpers'
 
 const SingleCardTabs = styled(Tabs) `
 	flex: 1

--- a/apps/ui/lens/full/SupportThread/AuditPanel.jsx
+++ b/apps/ui/lens/full/SupportThread/AuditPanel.jsx
@@ -21,7 +21,7 @@ import {
 import {
 	sdk
 } from '../../../core'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 import Feedback from './Feedback'
 
 export default function AuditPanel (props) {

--- a/apps/ui/lens/full/SupportThread/Feedback.jsx
+++ b/apps/ui/lens/full/SupportThread/Feedback.jsx
@@ -14,7 +14,7 @@ import {
 	Modal,
 	Textarea
 } from 'rendition'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 
 // TODO: Render this form using the rendition Form component and the
 // feedback-item type schema

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -28,17 +28,17 @@ import {
 	selectors,
 	sdk
 } from '../../../core'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../../lib/ui-components/services/helpers'
 import Timeline from '../../list/Timeline'
 import CardLayout from '../../../layouts/CardLayout'
-import CardFields from '@jellyfish/ui-components/CardFields'
-import Event from '@jellyfish/ui-components/Event'
-import RouterLink from '@jellyfish/ui-components/Link'
+import CardFields from '../../../../../lib/ui-components/CardFields'
+import Event from '../../../../../lib/ui-components/Event'
+import RouterLink from '../../../../../lib/ui-components/Link'
 import {
 	Tag
-} from '@jellyfish/ui-components/Tag'
-import ColorHashPill from '@jellyfish/ui-components/shame/ColorHashPill'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../../../../../lib/ui-components/Tag'
+import ColorHashPill from '../../../../../lib/ui-components/shame/ColorHashPill'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 
 const JellyIcon = styled.img.attrs({
 	src: '/icons/jellyfish.svg'

--- a/apps/ui/lens/full/Thread.jsx
+++ b/apps/ui/lens/full/Thread.jsx
@@ -23,7 +23,7 @@ import {
 import {
 	selectors
 } from '../../core'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 import Timeline from '../list/Timeline'
 import CardLayout from '../../layouts/CardLayout'
 

--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -32,14 +32,14 @@ import {
 	selectors,
 	sdk
 } from '../../core'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 import {
 	getLensBySlug
 } from '../'
 import {
 	CloseButton
-} from '@jellyfish/ui-components/shame/CloseButton'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../../../../lib/ui-components/shame/CloseButton'
+import Icon from '../../../../lib/ui-components/shame/Icon'
 
 const USER_FILTER_NAME = 'user-generated-filter'
 

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -31,8 +31,8 @@ import {
 	sdk,
 	selectors
 } from '../../core'
-import Column from '@jellyfish/ui-components/shame/Column'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Column from '../../../../lib/ui-components/shame/Column'
+import Icon from '../../../../lib/ui-components/shame/Icon'
 import BaseLens from '../common/BaseLens'
 
 const NONE_MESSAGE_TIMELINE_TYPES = [

--- a/apps/ui/lens/list/List.jsx
+++ b/apps/ui/lens/list/List.jsx
@@ -37,7 +37,7 @@ import BaseLens from '../common/BaseLens'
 import {
 	getLens
 } from '../'
-import Column from '@jellyfish/ui-components/shame/Column'
+import Column from '../../../../lib/ui-components/shame/Column'
 
 class CardList extends BaseLens {
 	constructor (props) {

--- a/apps/ui/lens/list/SupportThreads.jsx
+++ b/apps/ui/lens/list/SupportThreads.jsx
@@ -25,9 +25,9 @@ import {
 	actionCreators,
 	selectors
 } from '../../core'
-import Column from '@jellyfish/ui-components/shame/Column'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Column from '../../../../lib/ui-components/shame/Column'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
+import Icon from '../../../../lib/ui-components/shame/Icon'
 import CardChatSummary from '../../../../lib/ui-components/CardChatSummary'
 import {
 	InfiniteList

--- a/apps/ui/lens/list/SupportThreadsToAudit/SupportThreadsToAudit.jsx
+++ b/apps/ui/lens/list/SupportThreadsToAudit/SupportThreadsToAudit.jsx
@@ -12,10 +12,10 @@ import * as React from 'react'
 import {
 	Box
 } from 'rendition'
-import Column from '@jellyfish/ui-components/shame/Column'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Column from '../../../../../lib/ui-components/shame/Column'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 import CardChatSummary from '../../../../../lib/ui-components/CardChatSummary'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../../lib/ui-components/services/helpers'
 
 export const SLUG = 'lens-support-threads-to-audit'
 

--- a/apps/ui/lens/list/SupportThreadsToAudit/tests/SupportThreadsToAudit.spec.jsx
+++ b/apps/ui/lens/list/SupportThreadsToAudit/tests/SupportThreadsToAudit.spec.jsx
@@ -6,10 +6,16 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
 import React from 'react'
 import SupportThreadsToAudit from '../SupportThreadsToAudit'
+
+configure({
+	adapter: new Adapter()
+})
 
 ava('It should render', (test) => {
 	test.notThrows(() => {

--- a/apps/ui/lens/list/Timeline.jsx
+++ b/apps/ui/lens/list/Timeline.jsx
@@ -17,7 +17,7 @@ import {
 	selectors
 } from '../../core'
 import * as environment from '../../environment'
-import Timeline from '@jellyfish/ui-components/Timeline'
+import Timeline from '../../../../lib/ui-components/Timeline'
 
 const mapStateToProps = (state, ownProps) => {
 	const card = ownProps.card

--- a/apps/ui/lens/misc/Kanban.jsx
+++ b/apps/ui/lens/misc/Kanban.jsx
@@ -28,7 +28,7 @@ import {
 	selectors,
 	sdk
 } from '../../core'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../../lib/ui-components/services/helpers'
 import BaseLens from '../common/BaseLens'
 
 const UNSORTED_GROUP_ID = 'JELLYFISH_UNSORTED_GROUP'

--- a/apps/ui/lens/misc/SupportAuditChart/SupportAuditChart.jsx
+++ b/apps/ui/lens/misc/SupportAuditChart/SupportAuditChart.jsx
@@ -13,10 +13,10 @@ import {
 import {
 	Box
 } from 'rendition'
-import Column from '@jellyfish/ui-components/shame/Column'
+import Column from '../../../../../lib/ui-components/shame/Column'
 import {
 	colorHash
-} from '@jellyfish/ui-components/services/helpers'
+} from '../../../../../lib/ui-components/services/helpers'
 
 const processDataSets = (items = []) => {
 	// Create a range of dates over the last 30 days, starting from 30 days ago

--- a/apps/ui/lens/misc/Table.jsx
+++ b/apps/ui/lens/misc/Table.jsx
@@ -25,7 +25,7 @@ import {
 	actionCreators,
 	selectors
 } from '../../core'
-import Column from '@jellyfish/ui-components/shame/Column'
+import Column from '../../../../lib/ui-components/shame/Column'
 
 const COLUMNS = [
 	{

--- a/apps/ui/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lens/snippet/SingleCard/SingleCard.jsx
@@ -19,7 +19,7 @@ import Link from '../../../../../lib/ui-components/Link'
 import {
 	Tag
 } from '../../../../../lib/ui-components/Tag'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
 
 export default class SingleCard extends React.Component {
 	shouldComponentUpdate (nextProps) {

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -19,13 +19,16 @@ const sound = new Howl({
 	src: '/audio/dustyroom_cartoon_bubble_pop.mp3'
 })
 
-let canUseNotifications = window.Notification && Notification.permission === 'granted'
+let canUseNotifications = false
+if (typeof window !== 'undefined') {
+	canUseNotifications = window.Notification && Notification.permission === 'granted'
 
-if (window.Notification && Notification.permission !== 'denied') {
-	Notification.requestPermission((status) => {
-		// Status is "granted", if accepted by user
-		canUseNotifications = status === 'granted'
-	})
+	if (window.Notification && Notification.permission !== 'denied') {
+		Notification.requestPermission((status) => {
+			// Status is "granted", if accepted by user
+			canUseNotifications = status === 'granted'
+		})
+	}
 }
 
 export const createNotification = ({

--- a/lib/chat-widget/components/CreateThread.jsx
+++ b/lib/chat-widget/components/CreateThread.jsx
@@ -14,7 +14,7 @@ import {
 	Input
 } from 'rendition'
 import styled from 'styled-components'
-import MessageInput from '@jellyfish/ui-components/Timeline/MessageInput'
+import MessageInput from '../../../lib/ui-components/Timeline/MessageInput'
 import {
 	TaskButton
 } from '../components/TaskButton'

--- a/lib/chat-widget/components/Loader.jsx
+++ b/lib/chat-widget/components/Loader.jsx
@@ -8,7 +8,7 @@ import React from 'react'
 import {
 	Flex
 } from 'rendition'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../../ui-components/shame/Icon'
 
 export const Loader = (props) => {
 	return (

--- a/lib/chat-widget/hooks/use-analytics.js
+++ b/lib/chat-widget/hooks/use-analytics.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react'
-import Analytics from '@jellyfish/ui-components/services/analytics'
+import Analytics from '../../ui-components/services/analytics'
 import * as environment from '../environment'
 
 export const useAnalytics = () => {

--- a/lib/chat-widget/routes/ChatRoute.jsx
+++ b/lib/chat-widget/routes/ChatRoute.jsx
@@ -12,7 +12,7 @@ import {
 import {
 	Box
 } from 'rendition'
-import Timeline from '@jellyfish/ui-components/Timeline'
+import Timeline from '../../ui-components/Timeline'
 import {
 	Task
 } from '../components/Task'

--- a/lib/chat-widget/store/action-creators.js
+++ b/lib/chat-widget/store/action-creators.js
@@ -6,7 +6,7 @@
 
 import _ from 'lodash'
 import * as uuid from 'uuid'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../ui-components/services/helpers'
 import {
 	SET_CARDS,
 	SET_CURRENT_USER

--- a/lib/ui-components/AuthenticatedImage/tests/AuthenticatedImage.spec.jsx
+++ b/lib/ui-components/AuthenticatedImage/tests/AuthenticatedImage.spec.jsx
@@ -6,10 +6,16 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
 import React from 'react'
-import AuthenticatedImage from '../AuthenticatedImage'
+import AuthenticatedImage from '../index'
+
+configure({
+	adapter: new Adapter()
+})
 
 // Borrowed from https://gist.github.com/nolanlawson/0eac306e4dac2114c752
 const getFile = async () => {

--- a/lib/ui-components/CardActions/CardActions.jsx
+++ b/lib/ui-components/CardActions/CardActions.jsx
@@ -13,11 +13,11 @@ import {
 } from 'rendition'
 import CardLinker from '../CardLinker'
 import ContextMenu from '../ContextMenu'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../../lib/ui-components/services/helpers'
 import {
 	ActionLink
-} from '@jellyfish/ui-components/shame/ActionLink'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../shame/ActionLink'
+import Icon from '../shame/Icon'
 
 export default class CardActions extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/CardChatSummary/index.jsx
+++ b/lib/ui-components/CardChatSummary/index.jsx
@@ -21,8 +21,8 @@ import styled, {
 	withTheme
 } from 'styled-components'
 import Link from '../Link'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
-import ColorHashPill from '@jellyfish/ui-components/shame/ColorHashPill'
+import * as helpers from '../services/helpers'
+import ColorHashPill from '../shame/ColorHashPill'
 import Icon from '../shame/Icon'
 import {
 	Tag
@@ -69,7 +69,7 @@ const LatestMessage = styled(Markdown) `
 	}
 `
 
-class CardChatSummary extends React.Component {
+export class CardChatSummary extends React.Component {
 	constructor (props) {
 		super(props)
 

--- a/lib/ui-components/CardChatSummary/tests/fixtures/theme.json
+++ b/lib/ui-components/CardChatSummary/tests/fixtures/theme.json
@@ -1,0 +1,982 @@
+{
+  "global": {
+      "colors": {
+          "icon": {
+              "0": "#",
+              "1": "6",
+              "2": "6",
+              "3": "6",
+              "4": "6",
+              "5": "6",
+              "6": "6",
+              "dark": "#f8f8f8",
+              "light": "#666666"
+          },
+          "active": "rgba(221,221,221,0.5)",
+          "black": "#000000",
+          "border": {
+              "dark": "rgba(255,255,255,0.33)",
+              "light": "rgba(0,0,0,0.33)"
+          },
+          "brand": "#7D4CDB",
+          "control": {
+              "dark": "accent-1",
+              "light": "brand"
+          },
+          "focus": "none",
+          "placeholder": "#abb9c5",
+          "selected": "brand",
+          "text": {
+              "dark": "#f8f8f8",
+              "light": "#444444"
+          },
+          "white": "#FFFFFF",
+          "accent-1": "#6FFFB0",
+          "accent-2": "#FD6FFF",
+          "accent-3": "#81FCED",
+          "accent-4": "#FFCA58",
+          "dark-1": "#333333",
+          "dark-2": "#555555",
+          "dark-3": "#777777",
+          "dark-4": "#999999",
+          "dark-5": "#999999",
+          "dark-6": "#999999",
+          "light-1": "#F8F8F8",
+          "light-2": "#F2F2F2",
+          "light-3": "#EDEDED",
+          "light-4": "#DADADA",
+          "light-5": "#DADADA",
+          "light-6": "#DADADA",
+          "neutral-1": "#00873D",
+          "neutral-2": "#3D138D",
+          "neutral-3": "#00739D",
+          "neutral-4": "#A2423D",
+          "status-critical": "#FF4040",
+          "status-error": "#FF4040",
+          "status-warning": "#FFAA15",
+          "status-ok": "#00C781",
+          "status-unknown": "#CCCCCC",
+          "status-disabled": "#CCCCCC"
+      },
+      "active": {
+          "background": {
+              "color": "#DDE1f0",
+              "opacity": 1
+          },
+          "color": {
+              "dark": "inherit",
+              "light": "inherit"
+          }
+      },
+      "animation": {
+          "duration": "1s",
+          "jiggle": {
+              "duration": "0.1s"
+          }
+      },
+      "borderSize": {
+          "xsmall": "1px",
+          "small": "2px",
+          "medium": "4px",
+          "large": "12px",
+          "xlarge": "24px"
+      },
+      "breakpoints": {
+          "small": {
+              "value": 768,
+              "borderSize": {
+                  "xsmall": "1px",
+                  "small": "2px",
+                  "medium": "4px",
+                  "large": "6px",
+                  "xlarge": "12px"
+              },
+              "edgeSize": {
+                  "none": "0px",
+                  "hair": "1px",
+                  "xxsmall": "2px",
+                  "xsmall": "3px",
+                  "small": "6px",
+                  "medium": "12px",
+                  "large": "24px",
+                  "xlarge": "48px"
+              },
+              "size": {
+                  "xxsmall": "24px",
+                  "xsmall": "48px",
+                  "small": "96px",
+                  "medium": "192px",
+                  "large": "384px",
+                  "xlarge": "768px",
+                  "full": "100%"
+              }
+          },
+          "medium": {
+              "value": 1536
+          },
+          "large": {}
+      },
+      "deviceBreakpoints": {
+          "phone": "small",
+          "tablet": "medium",
+          "computer": "large"
+      },
+      "control": {
+          "border": {
+              "width": "1px",
+              "radius": "4px",
+              "color": "#DDE1f0"
+          },
+          "disabled": {
+              "opacity": 0.4
+          }
+      },
+      "debounceDelay": 300,
+      "drop": {
+          "background": "#ffffff",
+          "border": {
+              "radius": "4px"
+          },
+          "shadowSize": "small",
+          "zIndex": 45,
+          "extend": "\n\t\t\t\tcolor: #2A506F; border: 1px solid #DDE1f0;\n\t\t\t\tanimation-duration: 0s;\n\t\t\t"
+      },
+      "edgeSize": {
+          "none": "0px",
+          "hair": "1px",
+          "xxsmall": "3px",
+          "xsmall": "6px",
+          "small": "12px",
+          "medium": "24px",
+          "large": "48px",
+          "xlarge": "96px",
+          "responsiveBreakpoint": "small"
+      },
+      "elevation": {
+          "light": {
+              "none": "none",
+              "xsmall": "0px 1px 2px rgba(0, 0, 0, 0.20)",
+              "small": "0px 2px 4px rgba(0, 0, 0, 0.20)",
+              "medium": "0px 4px 8px rgba(0, 0, 0, 0.20)",
+              "large": "0px 8px 16px rgba(0, 0, 0, 0.20)",
+              "xlarge": "0px 12px 24px rgba(0, 0, 0, 0.20)"
+          },
+          "dark": {
+              "none": "none",
+              "xsmall": "0px 2px 2px rgba(255, 255, 255, 0.40)",
+              "small": "0px 4px 4px rgba(255, 255, 255, 0.40)",
+              "medium": "0px 6px 8px rgba(255, 255, 255, 0.40)",
+              "large": "0px 8px 16px rgba(255, 255, 255, 0.40)",
+              "xlarge": "0px 12px 24px rgba(255, 255, 255, 0.40)"
+          }
+      },
+      "focus": {
+          "border": {
+              "color": "focus"
+          }
+      },
+      "font": {
+          "size": "14px",
+          "height": 1.5,
+          "maxWidth": "432px",
+          "family": "'Nunito', Arial, sans-serif"
+      },
+      "hover": {
+          "background": {
+              "color": "#DDE1f0",
+              "opacity": 1
+          },
+          "color": {
+              "dark": "inherit",
+              "light": "inherit"
+          }
+      },
+      "input": {
+          "padding": "12px",
+          "weight": 400
+      },
+      "opacity": {
+          "strong": 0.8,
+          "medium": 0.4,
+          "weak": 0.1
+      },
+      "selected": {
+          "background": "#00AEEF",
+          "color": "white"
+      },
+      "spacing": "24px",
+      "size": {
+          "xxsmall": "48px",
+          "xsmall": "96px",
+          "small": "192px",
+          "medium": "384px",
+          "large": "768px",
+          "xlarge": "1152px",
+          "xxlarge": "1536px",
+          "full": "100%"
+      }
+  },
+  "icon": {
+      "size": {
+          "small": "12px",
+          "medium": "24px",
+          "large": "48px",
+          "xlarge": "96px"
+      }
+  },
+  "accordion": {
+      "border": {
+          "side": "bottom",
+          "color": "border"
+      },
+      "heading": {
+          "level": "4"
+      },
+      "icons": {}
+  },
+  "anchor": {
+      "textDecoration": "none",
+      "fontWeight": 600,
+      "color": {
+          "dark": "accent-1",
+          "light": "brand"
+      },
+      "hover": {
+          "textDecoration": "underline"
+      }
+  },
+  "box": {
+      "responsiveBreakpoint": "small"
+  },
+  "button": {
+      "border": {
+          "width": "1px",
+          "radius": "20px",
+          "color": "#2A506F"
+      },
+      "primary": {},
+      "padding": {
+          "vertical": "4px",
+          "horizontal": "30px"
+      },
+      "height": "38px",
+      "font": {
+          "weight": 500
+      }
+  },
+  "calendar": {
+      "small": {
+          "fontSize": "14px",
+          "lineHeight": 1.375,
+          "daySize": "27.428571428571427px",
+          "slideDuration": "0.2s"
+      },
+      "medium": {
+          "fontSize": "18px",
+          "lineHeight": 1.45,
+          "daySize": "54.857142857142854px",
+          "slideDuration": "0.5s"
+      },
+      "large": {
+          "fontSize": "30px",
+          "lineHeight": 1.11,
+          "daySize": "109.71428571428571px",
+          "slideDuration": "0.8s"
+      },
+      "icons": {
+          "small": {}
+      },
+      "heading": {
+          "level": "4"
+      }
+  },
+  "carousel": {
+      "icons": {},
+      "animation": {
+          "duration": 1000
+      },
+      "disabled": {
+          "icons": {}
+      }
+  },
+  "chart": {},
+  "checkBox": {
+      "border": {
+          "color": {
+              "dark": "#DDE1f0",
+              "light": "#DDE1f0"
+          },
+          "width": "1px"
+      },
+      "check": {
+          "radius": "4px",
+          "thickness": "2px"
+      },
+      "hover": {
+          "border": {
+              "color": {
+                  "dark": "#DDE1f0",
+                  "light": "#DDE1f0"
+              }
+          }
+      },
+      "icon": {},
+      "icons": {},
+      "size": "20px",
+      "toggle": {
+          "color": {
+              "dark": "#00AEEF",
+              "light": "#DDE1f0"
+          },
+          "knob": {},
+          "radius": "20px",
+          "size": "40px"
+      },
+      "color": "#00AEEF"
+  },
+  "clock": {
+      "analog": {
+          "hour": {
+              "color": {
+                  "dark": "light-2",
+                  "light": "dark-3"
+              },
+              "width": "8px",
+              "size": "24px",
+              "shape": "round"
+          },
+          "minute": {
+              "color": {
+                  "dark": "light-4",
+                  "light": "dark-3"
+              },
+              "width": "4px",
+              "size": "12px",
+              "shape": "round"
+          },
+          "second": {
+              "color": {
+                  "dark": "accent-1",
+                  "light": "accent-1"
+              },
+              "width": "3px",
+              "size": "9px",
+              "shape": "round"
+          },
+          "size": {
+              "small": "72px",
+              "medium": "96px",
+              "large": "144px",
+              "xlarge": "216px",
+              "huge": "288px"
+          }
+      },
+      "digital": {
+          "text": {
+              "xsmall": {
+                  "size": "10px",
+                  "height": 1.5
+              },
+              "small": {
+                  "size": "14px",
+                  "height": 1.43
+              },
+              "medium": {
+                  "size": "18px",
+                  "height": 1.375
+              },
+              "large": {
+                  "size": "22px",
+                  "height": 1.167
+              },
+              "xlarge": {
+                  "size": "26px",
+                  "height": 1.1875
+              },
+              "xxlarge": {
+                  "size": "34px",
+                  "height": 1.125
+              }
+          }
+      }
+  },
+  "collapsible": {
+      "minSpeed": 200,
+      "baseline": 500
+  },
+  "dataTable": {
+      "groupHeader": {
+          "background": {
+              "dark": "dark-2",
+              "light": "light-2"
+          },
+          "border": {
+              "side": "bottom",
+              "size": "xsmall"
+          },
+          "pad": {
+              "horizontal": "small",
+              "vertical": "xsmall"
+          }
+      },
+      "groupEnd": {
+          "border": {
+              "side": "bottom",
+              "size": "xsmall"
+          }
+      },
+      "header": {},
+      "icons": {},
+      "primary": {
+          "weight": "bold"
+      },
+      "resize": {
+          "border": {
+              "color": "border",
+              "side": "right"
+          }
+      }
+  },
+  "diagram": {
+      "line": {
+          "color": "accent-1"
+      }
+  },
+  "formField": {
+      "border": {
+          "color": "border",
+          "error": {
+              "color": {
+                  "dark": "white",
+                  "light": "status-critical"
+              }
+          },
+          "position": "inner",
+          "side": "bottom"
+      },
+      "content": {
+          "pad": {
+              "horizontal": "small",
+              "bottom": "small"
+          }
+      },
+      "error": {
+          "color": {
+              "dark": "status-critical",
+              "light": "status-critical"
+          },
+          "margin": {
+              "vertical": "xsmall",
+              "horizontal": "small"
+          }
+      },
+      "help": {
+          "color": {
+              "dark": "dark-3",
+              "light": "dark-3"
+          },
+          "margin": {
+              "left": "small"
+          }
+      },
+      "label": {
+          "margin": {
+              "vertical": "xsmall",
+              "horizontal": "small"
+          }
+      },
+      "margin": {
+          "bottom": "small"
+      }
+  },
+  "grommet": {},
+  "heading": {
+      "font": {},
+      "level": {
+          "1": {
+              "font": {},
+              "small": {
+                  "size": "34px",
+                  "height": "40px",
+                  "maxWidth": "816px"
+              },
+              "medium": {
+                  "size": "50px",
+                  "height": "56px",
+                  "maxWidth": "1200px"
+              },
+              "large": {
+                  "size": "82px",
+                  "height": "88px",
+                  "maxWidth": "1968px"
+              },
+              "xlarge": {
+                  "size": "114px",
+                  "height": "120px",
+                  "maxWidth": "2736px"
+              }
+          },
+          "2": {
+              "font": {},
+              "small": {
+                  "size": "26px",
+                  "height": "32px",
+                  "maxWidth": "624px"
+              },
+              "medium": {
+                  "size": "34px",
+                  "height": "40px",
+                  "maxWidth": "816px"
+              },
+              "large": {
+                  "size": "50px",
+                  "height": "56px",
+                  "maxWidth": "1200px"
+              },
+              "xlarge": {
+                  "size": "66px",
+                  "height": "72px",
+                  "maxWidth": "1584px"
+              }
+          },
+          "3": {
+              "font": {},
+              "small": {
+                  "size": "22px",
+                  "height": "28px",
+                  "maxWidth": "528px"
+              },
+              "medium": {
+                  "size": "26px",
+                  "height": "32px",
+                  "maxWidth": "624px"
+              },
+              "large": {
+                  "size": "34px",
+                  "height": "40px",
+                  "maxWidth": "816px"
+              },
+              "xlarge": {
+                  "size": "42px",
+                  "height": "48px",
+                  "maxWidth": "1008px"
+              }
+          },
+          "4": {
+              "font": {},
+              "small": {
+                  "size": "18px",
+                  "height": "24px",
+                  "maxWidth": "432px"
+              },
+              "medium": {
+                  "size": "18px",
+                  "height": "24px",
+                  "maxWidth": "432px"
+              },
+              "large": {
+                  "size": "18px",
+                  "height": "24px",
+                  "maxWidth": "432px"
+              },
+              "xlarge": {
+                  "size": "18px",
+                  "height": "24px",
+                  "maxWidth": "432px"
+              }
+          },
+          "5": {
+              "font": {},
+              "small": {
+                  "size": "16px",
+                  "height": "22px",
+                  "maxWidth": "384px"
+              },
+              "medium": {
+                  "size": "16px",
+                  "height": "22px",
+                  "maxWidth": "384px"
+              },
+              "large": {
+                  "size": "16px",
+                  "height": "22px",
+                  "maxWidth": "384px"
+              },
+              "xlarge": {
+                  "size": "16px",
+                  "height": "22px",
+                  "maxWidth": "384px"
+              }
+          },
+          "6": {
+              "font": {},
+              "small": {
+                  "size": "14px",
+                  "height": "20px",
+                  "maxWidth": "336px"
+              },
+              "medium": {
+                  "size": "14px",
+                  "height": "20px",
+                  "maxWidth": "336px"
+              },
+              "large": {
+                  "size": "14px",
+                  "height": "20px",
+                  "maxWidth": "336px"
+              },
+              "xlarge": {
+                  "size": "14px",
+                  "height": "20px",
+                  "maxWidth": "336px"
+              }
+          }
+      },
+      "responsiveBreakpoint": "small",
+      "weight": 600
+  },
+  "layer": {
+      "background": "white",
+      "border": {
+          "radius": "4px"
+      },
+      "container": {
+          "zIndex": 40
+      },
+      "overlay": {
+          "background": "rgba(0, 0, 0, 0.5)"
+      },
+      "responsiveBreakpoint": "small",
+      "zIndex": 30
+  },
+  "maskedInput": {},
+  "menu": {
+      "icons": {}
+  },
+  "meter": {
+      "color": "accent-1"
+  },
+  "paragraph": {
+      "small": {
+          "size": "14px",
+          "height": "20px",
+          "maxWidth": "336px"
+      },
+      "medium": {
+          "size": "18px",
+          "height": "24px",
+          "maxWidth": "432px"
+      },
+      "large": {
+          "size": "22px",
+          "height": "28px",
+          "maxWidth": "528px"
+      },
+      "xlarge": {
+          "size": "26px",
+          "height": "32px",
+          "maxWidth": "624px"
+      },
+      "xxlarge": {
+          "size": "34px",
+          "height": "40px",
+          "maxWidth": "816px"
+      }
+  },
+  "radioButton": {
+      "border": {
+          "color": {
+              "dark": "#DDE1f0",
+              "light": "#DDE1f0"
+          },
+          "width": "1px"
+      },
+      "check": {
+          "radius": "100%",
+          "color": {
+              "dark": "white",
+              "light": "white"
+          }
+      },
+      "hover": {
+          "border": {
+              "color": {
+                  "dark": "#527699",
+                  "light": "#527699"
+              }
+          }
+      },
+      "icon": {
+          "size": "12px"
+      },
+      "icons": {},
+      "gap": "10px",
+      "size": "20px"
+  },
+  "rangeInput": {
+      "track": {
+          "height": "4px",
+          "color": [
+              null,
+              ";"
+          ]
+      },
+      "thumb": {}
+  },
+  "rangeSelector": {
+      "background": {
+          "invert": {
+              "color": "light-4"
+          }
+      }
+  },
+  "select": {
+      "container": {},
+      "control": {
+          "extend": "color: #2A506F"
+      },
+      "icons": {
+          "margin": {
+              "horizontal": "small"
+          },
+          "color": "#2A506F"
+      },
+      "options": {
+          "container": {
+              "align": "start",
+              "pad": "small"
+          },
+          "text": {
+              "margin": "none"
+          }
+      },
+      "step": 20
+  },
+  "tab": {
+      "active": {
+          "color": "#00AEEF"
+      },
+      "border": {
+          "side": "bottom",
+          "size": "xsmall",
+          "color": "#DDE1f0",
+          "active": {
+              "color": "#00AEEF"
+          },
+          "hover": {
+              "color": "#DDE1f0"
+          }
+      },
+      "color": "#2A506F",
+      "hover": {
+          "color": "#009dd7"
+      },
+      "margin": "none",
+      "pad": {
+          "bottom": "xsmall"
+      },
+      "extend": "padding: 4px 16px"
+  },
+  "tabs": {
+      "header": {},
+      "panel": {}
+  },
+  "table": {
+      "header": {
+          "align": "start",
+          "pad": {
+              "horizontal": "small",
+              "vertical": "xsmall"
+          },
+          "border": "bottom",
+          "verticalAlign": "bottom"
+      },
+      "body": {
+          "align": "start",
+          "pad": {
+              "horizontal": "small",
+              "vertical": "xsmall"
+          }
+      },
+      "footer": {
+          "align": "start",
+          "pad": {
+              "horizontal": "small",
+              "vertical": "xsmall"
+          },
+          "border": "top",
+          "verticalAlign": "top"
+      }
+  },
+  "text": {
+      "xsmall": {
+          "size": "12px",
+          "height": "18px",
+          "maxWidth": "288px"
+      },
+      "small": {
+          "size": "14px",
+          "height": "20px",
+          "maxWidth": "336px"
+      },
+      "medium": {
+          "size": "14px",
+          "height": 1.5,
+          "maxWidth": "432px"
+      },
+      "large": {
+          "size": "22px",
+          "height": "28px",
+          "maxWidth": "528px"
+      },
+      "xlarge": {
+          "size": "26px",
+          "height": "32px",
+          "maxWidth": "624px"
+      },
+      "xxlarge": {
+          "size": "34px",
+          "height": "40px",
+          "maxWidth": "816px"
+      }
+  },
+  "textArea": {},
+  "textInput": {},
+  "video": {
+      "captions": {
+          "background": "rgba(0, 0, 0, 0.7)"
+      },
+      "icons": {},
+      "scrubber": {
+          "color": "light-4"
+      }
+  },
+  "worldMap": {
+      "color": "light-3",
+      "continent": {
+          "active": "8px",
+          "base": "6px"
+      },
+      "hover": {
+          "color": "light-4"
+      },
+      "place": {
+          "active": "20px",
+          "base": "8px"
+      }
+  },
+  "breakpoints": [
+      576,
+      768,
+      992,
+      1200
+  ],
+  "space": [
+      0,
+      4,
+      8,
+      16,
+      38,
+      48,
+      128
+  ],
+  "fontSizes": [
+      12,
+      14,
+      16,
+      20,
+      24,
+      32,
+      48,
+      64,
+      72,
+      96
+  ],
+  "weights": [
+      400,
+      700
+  ],
+  "font": "'Nunito', Arial, sans-serif",
+  "titleFont": "CircularStd, Arial, sans-serif",
+  "monospace": "'Ubuntu Mono', 'Courier New', monospace",
+  "lineHeight": 1.5,
+  "colors": {
+      "primary": {
+          "main": "#00AEEF",
+          "semilight": "#aedff9",
+          "light": "#08bcff",
+          "dark": "#009dd7"
+      },
+      "secondary": {
+          "main": "#2A506F",
+          "semilight": "#abb9c5",
+          "light": "#2e587a",
+          "dark": "#23445e"
+      },
+      "tertiary": {
+          "main": "#527699",
+          "light": "#5b82a7",
+          "semilight": "#bbc8d6",
+          "dark": "#456482"
+      },
+      "quartenary": {
+          "main": "#DDE1f0",
+          "light": "#f8f9fd",
+          "dark": "#b7bed3"
+      },
+      "danger": {
+          "main": "#FF423D",
+          "semilight": "#ffa1a1",
+          "light": "#ffebeb",
+          "dark": "#dc2823"
+      },
+      "warning": {
+          "main": "#FCA321",
+          "semilight": "#fdd190",
+          "light": "#fff5e6",
+          "dark": "#ee8d00"
+      },
+      "success": {
+          "main": "#1AC135",
+          "semilight": "#8ce09a",
+          "light": "#f0fdf2",
+          "dark": "#16a52d"
+      },
+      "info": {
+          "main": "#1496E1",
+          "semilight": "#90cbee",
+          "light": "#e9f4fb",
+          "dark": "#1078b4"
+      },
+      "text": {
+          "main": "#2A506F",
+          "light": "#2e587a",
+          "dark": "#23445e"
+      },
+      "statusIdle": {
+          "main": "#89c683"
+      },
+      "statusConfiguring": {
+          "main": "#ffb25e"
+      },
+      "statusUpdating": {
+          "main": "#75C5F5"
+      },
+      "statusPostProvisioning": {
+          "main": "#aa96d5"
+      },
+      "statusOffline": {
+          "main": "#fd7c7c"
+      },
+      "statusInactive": {
+          "main": "#d3d6db"
+      },
+      "gray": {
+          "main": "#c6c8c9",
+          "light": "#f4f4f4",
+          "dark": "#9f9f9f"
+      }
+  },
+  "radius": 3,
+  "dark": false
+}

--- a/lib/ui-components/CardField.jsx
+++ b/lib/ui-components/CardField.jsx
@@ -17,7 +17,7 @@ import {
 	Mermaid
 } from 'rendition/dist/extra/Mermaid'
 import Label from './Label'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../../lib/ui-components/services/helpers'
 
 const transformMirror = (mirror) => {
 	if (mirror.includes('frontapp.com')) {

--- a/lib/ui-components/CardFields/index.jsx
+++ b/lib/ui-components/CardFields/index.jsx
@@ -8,7 +8,7 @@ import _ from 'lodash'
 import React from 'react'
 import {
 	getLocalSchema
-} from '@jellyfish/ui-components/services/helpers'
+} from '../services/helpers'
 import CardField from '../CardField'
 
 export default function CardFields (props) {

--- a/lib/ui-components/CardLinker/CardLinker.jsx
+++ b/lib/ui-components/CardLinker/CardLinker.jsx
@@ -14,10 +14,10 @@ import {
 } from 'rendition'
 import {
 	constraints as LINKS
-} from '@jellyfish/sdk/link-constraints'
+} from '../../sdk/link-constraints'
 import ContextMenu from '../ContextMenu'
 import LinkModal from '../LinkModal'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../shame/Icon'
 
 class CardLinker extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/CardLinker/tests/CardLinker.spec.jsx
+++ b/lib/ui-components/CardLinker/tests/CardLinker.spec.jsx
@@ -6,10 +6,17 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
 import React from 'react'
 import CardLinker from '../CardLinker'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({
+	adapter: new Adapter()
+})
 
 ava('It should render', (test) => {
 	test.notThrows(() => {

--- a/lib/ui-components/ChannelRenderer.jsx
+++ b/lib/ui-components/ChannelRenderer.jsx
@@ -16,8 +16,8 @@ import {
 import styled from 'styled-components'
 
 // TODO: These ui-components -> ui imports should not happen
-import ErrorBoundary from '@jellyfish/ui-components/shame/ErrorBoundary'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
+import Icon from '../../lib/ui-components/shame/Icon'
 import LinkModal from './LinkModal'
 
 const ErrorNotFound = styled.h1 `

--- a/lib/ui-components/ChatWidgetSidebar.jsx
+++ b/lib/ui-components/ChatWidgetSidebar.jsx
@@ -8,7 +8,7 @@ import React from 'react'
 import styled from 'styled-components'
 import {
 	App
-} from '@jellyfish/chat-widget'
+} from '../../lib/chat-widget'
 import {
 	useSetup
 } from './SetupProvider'

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -32,12 +32,12 @@ import {
 	tagStyle
 } from '../Tag'
 import Link from '../Link'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../services/helpers'
 import {
 	ActionLink
-} from '@jellyfish/ui-components/shame/ActionLink'
-import Avatar from '@jellyfish/ui-components/shame/Avatar'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../shame/ActionLink'
+import Avatar from '../shame/Avatar'
+import Icon from '../shame/Icon'
 
 const ActorPlaceholder = styled.span `
 	width: 80px;

--- a/lib/ui-components/Event/tests/Event.spec.jsx
+++ b/lib/ui-components/Event/tests/Event.spec.jsx
@@ -6,7 +6,8 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
 import React from 'react'
 import Event, {
@@ -15,6 +16,12 @@ import Event, {
 import {
 	card
 } from './fixtures'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({
+	adapter: new Adapter()
+})
 
 const actions = {
 	getActor: async () => {
@@ -33,6 +40,7 @@ ava('It should render', (test) => {
 			<Event
 				actions={actions}
 				card={card}
+				getActor={actions.getActor}
 			/>
 		)
 	})

--- a/lib/ui-components/Filters/tests/Filters.spec.jsx
+++ b/lib/ui-components/Filters/tests/Filters.spec.jsx
@@ -6,10 +6,17 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
 import React from 'react'
 import Filters from '../'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({
+	adapter: new Adapter()
+})
 
 const schema = {
 	type: 'object',

--- a/lib/ui-components/FreeFieldForm.jsx
+++ b/lib/ui-components/FreeFieldForm.jsx
@@ -20,7 +20,7 @@ import {
 } from 'rendition/dist/unstable'
 
 // TODO: This ui-components -> ui import should not happen
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from './shame/Icon'
 
 export default class FreeFieldForm extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/GroupUpdate.jsx
+++ b/lib/ui-components/GroupUpdate.jsx
@@ -19,7 +19,7 @@ import {
 } from 'rendition/dist/unstable'
 import {
 	patchPath
-} from '@jellyfish/ui-components/services/helpers'
+} from './services/helpers'
 import {
 	withSetup
 } from './SetupProvider'

--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -23,9 +23,9 @@ import MentionsCount from '../MentionsCount'
 import TreeMenu from './TreeMenu'
 import RouterLink from '../Link'
 import ViewLink from '../ViewLink'
-import Avatar from '@jellyfish/ui-components/shame/Avatar'
-import Icon from '@jellyfish/ui-components/shame/Icon'
-import MenuPanel from '@jellyfish/ui-components/shame/MenuPanel'
+import Avatar from '../shame/Avatar'
+import Icon from '../shame/Icon'
+import MenuPanel from '../shame/MenuPanel'
 
 // View slugs that should be displayed first
 const DEFAULT_VIEWS = [

--- a/lib/ui-components/HomeChannel/TreeMenu.jsx
+++ b/lib/ui-components/HomeChannel/TreeMenu.jsx
@@ -12,7 +12,7 @@ import {
 	Flex
 } from 'rendition'
 import ViewLink from '../ViewLink'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../shame/Icon'
 
 const TreeMenu = (props) => {
 	const {

--- a/lib/ui-components/LinkModal/LinkModal.jsx
+++ b/lib/ui-components/LinkModal/LinkModal.jsx
@@ -16,8 +16,8 @@ import {
 } from 'rendition'
 import {
 	constraints as LINKS
-} from '@jellyfish/sdk/link-constraints'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+} from '../../sdk/link-constraints'
+import * as helpers from '../services/helpers'
 
 export default class LinkModal extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/Login/Login.jsx
+++ b/lib/ui-components/Login/Login.jsx
@@ -16,7 +16,7 @@ import {
 	Input,
 	Txt
 } from 'rendition'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../shame/Icon'
 
 export default class Login extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/Login/tests/Login.spec.jsx
+++ b/lib/ui-components/Login/tests/Login.spec.jsx
@@ -6,10 +6,17 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
 import React from 'react'
 import Login from '../Login'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({
+	adapter: new Adapter()
+})
 
 ava('It should render', (test) => {
 	test.notThrows(() => {

--- a/lib/ui-components/Oauth.jsx
+++ b/lib/ui-components/Oauth.jsx
@@ -12,7 +12,7 @@ import {
 import {
 	Markdown
 } from 'rendition/dist/extra/Markdown'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from './shame/Icon'
 
 export default class Oauth extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/Tag/tests/Tag.spec.jsx
+++ b/lib/ui-components/Tag/tests/Tag.spec.jsx
@@ -6,12 +6,19 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
 import React from 'react'
 import {
 	Tag
 } from '../'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({
+	adapter: new Adapter()
+})
 
 ava('It should render', (test) => {
 	test.notThrows(() => {

--- a/lib/ui-components/Timeline/MessageInput.jsx
+++ b/lib/ui-components/Timeline/MessageInput.jsx
@@ -13,12 +13,12 @@ import {
 	useTheme
 } from 'rendition'
 import styled from 'styled-components'
-import AutocompleteTextarea from '@jellyfish/ui-components/shame/AutocompleteTextarea'
+import AutocompleteTextarea from '../shame/AutocompleteTextarea'
 import FileIcon from 'react-icons/lib/fa/paperclip'
 import UseSecretIcon from 'react-icons/lib/fa/user-secret'
 import {
 	FileUploadButton
-} from '@jellyfish/ui-components/FileUploader'
+} from '../FileUploader'
 
 const PlainAutocompleteTextarea = styled(AutocompleteTextarea) `
 	border: 0 !important;

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -21,9 +21,9 @@ import styled from 'styled-components'
 import uuid from 'uuid/v4'
 import Event from '../Event'
 import Update from '../Update'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
-import Column from '@jellyfish/ui-components/shame/Column'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import * as helpers from '../services/helpers'
+import Column from '../shame/Column'
+import Icon from '../shame/Icon'
 import MessageInput from './MessageInput'
 import {
 	withSetup

--- a/lib/ui-components/Update/index.jsx
+++ b/lib/ui-components/Update/index.jsx
@@ -21,11 +21,11 @@ import {
 }	from 'rendition'
 import styled from 'styled-components'
 import ContextMenu from '../ContextMenu'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../services/helpers'
 import {
 	ActionLink
-} from '@jellyfish/ui-components/shame/ActionLink'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+} from '../shame/ActionLink'
+import Icon from '../shame/Icon'
 
 const generateJSONPatchDescription = (payload) => {
 	const items = []

--- a/lib/ui-components/ViewLink/ViewLink.jsx
+++ b/lib/ui-components/ViewLink/ViewLink.jsx
@@ -16,9 +16,9 @@ import {
 } from 'rendition'
 import Link from '../Link'
 import MentionsCount from '../MentionsCount'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import * as helpers from '../services/helpers'
 import ContextMenu from '../ContextMenu'
-import Icon from '@jellyfish/ui-components/shame/Icon'
+import Icon from '../shame/Icon'
 
 export default class ViewLink extends React.Component {
 	constructor (props) {

--- a/lib/ui-components/ViewLink/tests/ViewLink.spec.jsx
+++ b/lib/ui-components/ViewLink/tests/ViewLink.spec.jsx
@@ -6,10 +6,17 @@
 
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	configure
 } from 'enzyme'
 import React from 'react'
 import ViewLink from '../ViewLink'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({
+	adapter: new Adapter()
+})
 
 const view = {
 	id: 'ffc200db-0f81-4ce3-a280-01515f94869f',

--- a/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
@@ -14,8 +14,8 @@ import {
 	Txt
 } from 'rendition'
 import styled from 'styled-components'
-import Link from '@jellyfish/ui-components/Link'
-import * as helpers from '@jellyfish/ui-components/services/helpers'
+import Link from '../../Link'
+import * as helpers from '../../services/helpers'
 import Icon from '../Icon'
 import Container from './Container'
 import {

--- a/lib/ui-components/shame/CloseButton.jsx
+++ b/lib/ui-components/shame/CloseButton.jsx
@@ -10,7 +10,7 @@ import {
 } from 'react-router-dom'
 import {
 	pathWithoutChannel
-} from '@jellyfish/ui-components/services/helpers'
+} from '../services/helpers'
 import {
 	Button
 } from 'rendition'

--- a/lib/ui-components/shame/ColorHashPill.jsx
+++ b/lib/ui-components/shame/ColorHashPill.jsx
@@ -11,7 +11,7 @@ import {
 } from 'rendition'
 import {
 	colorHash
-} from '@jellyfish/ui-components/services/helpers'
+} from '../services/helpers'
 
 export default (props) => {
 	const value = props.value

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -4,24 +4,14 @@
  * Proprietary and confidential.
  */
 
-const path = require('path')
 const IgnorePlugin = require('webpack/lib/IgnorePlugin')
-
-// eslint-disable-next-line no-process-env
-const WITH_COVERAGE = process.env.COVERAGE === '1'
 
 const config = {
 	mode: 'development',
 	target: 'web',
 
 	resolve: {
-		extensions: [ '.js', '.jsx', '.json' ],
-		alias: {
-			// We need to change the resolution location if instrumenting code for
-			// coverage (via nyc). Otherwise module requires will load the
-			// un-instrumented version.
-			'@jellyfish': path.resolve(__dirname, WITH_COVERAGE ? '.nyc-root/lib/' : 'lib/')
-		}
+		extensions: [ '.js', '.jsx', '.json' ]
 	},
 
 	module: {


### PR DESCRIPTION
This PR fixes the ui component unit tests. They seem to have not been ran in a while so after updating Sinon and AVA they all needed small fixes.

This PR also removes the `@jellyfish` alias from our Webpack config. Because the ui-components aren't  compiled by Webpack when running the unit tests the alias doesn't work.

Part in breaking down PR #3037 
Depends on: #3160