### PR TITLE
Fix bold mistake introduced in #3140

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -19,6 +19,7 @@ const BASE_PATH = path.join(__dirname, '..', '..')
 require('le_node')
 
 const LoggerNoContext = typedErrors.makeTypedError('LoggerNoContext')
+const LEVELS = winston.config.syslog.levels
 
 class Logger {
 	constructor (level, filename, transport) {
@@ -47,7 +48,7 @@ class Logger {
 	}
 
 	debug (context, message, data) {
-		if (this.level !== 'debug') {
+		if (LEVELS[this.level] < LEVELS.debug) {
 			return
 		}
 
@@ -60,7 +61,7 @@ class Logger {
 	}
 
 	error (context, message, data) {
-		if (this.level !== 'crit') {
+		if (LEVELS[this.level] < LEVELS.crit) {
 			return
 		}
 
@@ -73,7 +74,7 @@ class Logger {
 	}
 
 	warn (context, message, data) {
-		if (this.level !== 'warning') {
+		if (LEVELS[this.level] < LEVELS.warning) {
 			return
 		}
 
@@ -86,7 +87,7 @@ class Logger {
 	}
 
 	info (context, message, data) {
-		if (this.level !== 'info') {
+		if (LEVELS[this.level] < LEVELS.info) {
 			return
 		}
 


### PR DESCRIPTION
We are not currently logging unless levels match, but that's NOT how
log levels work: if log level is 'debug' and we log an exception, it
must be logged