### PR TITLE
Allow window to be undefined for UI unit tests

### DIFF
--- a/apps/ui/core/index.js
+++ b/apps/ui/core/index.js
@@ -83,4 +83,6 @@ localForage.getItem(STORAGE_KEY)
 		console.error(error)
 	})
 
-window.sdk = sdk
+if (typeof window !== 'undefined') {
+	window.sdk = sdk
+}

--- a/apps/ui/core/store/index.js
+++ b/apps/ui/core/store/index.js
@@ -46,8 +46,12 @@ export const setupStore = ({
 		return newState
 	}
 
-	// eslint-disable-next-line no-underscore-dangle
-	const composeEnhancers = (!isProduction() && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || redux.compose
+	const composeEnhancers = (
+		typeof window !== 'undefined' &&
+		!isProduction() &&
+		// eslint-disable-next-line no-underscore-dangle
+		window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+	) || redux.compose
 
 	return {
 		store: redux.createStore(reducerWrapper, composeEnhancers(redux.applyMiddleware(reduxThunk))),

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -19,13 +19,16 @@ const sound = new Howl({
 	src: '/audio/dustyroom_cartoon_bubble_pop.mp3'
 })
 
-let canUseNotifications = window.Notification && Notification.permission === 'granted'
+let canUseNotifications = false
+if (typeof window !== 'undefined') {
+	canUseNotifications = window.Notification && Notification.permission === 'granted'
 
-if (window.Notification && Notification.permission !== 'denied') {
-	Notification.requestPermission((status) => {
-		// Status is "granted", if accepted by user
-		canUseNotifications = status === 'granted'
-	})
+	if (window.Notification && Notification.permission !== 'denied') {
+		Notification.requestPermission((status) => {
+			// Status is "granted", if accepted by user
+			canUseNotifications = status === 'granted'
+		})
+	}
 }
 
 export const createNotification = ({


### PR DESCRIPTION
To support writing UI unit tests we need to allow window to be undefined during these tests.