### PR TITLE
front: Don't consider private inboxes

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -475,7 +475,13 @@ const getEventMessage = async (instance, front, intercom, sequence, event, targe
 const getEventInbox = async (context, front, event) => {
 	// eslint-disable-next-line no-underscore-dangle
 	if (event.data.payload.source._meta.type === 'inboxes') {
-		return event.data.payload.source.data[0].name
+		// We don't care about private inboxes, such as a personal inbox
+		// which happened to be managed by Front
+		const publicInboxes = _.filter(event.data.payload.source.data, {
+			is_private: false
+		})
+
+		return _.first(publicInboxes).name
 	}
 
 	const response = await handleRateLimit(context, () => {

--- a/test/integration/sync/webhooks/front/index.js
+++ b/test/integration/sync/webhooks/front/index.js
@@ -5,6 +5,13 @@
  */
 
 module.exports = {
+	'outbound-private-inbox': {
+		expected: require('./outbound-private-inbox/expected.json'),
+		steps: [
+			require('./outbound-private-inbox/01.json'),
+			require('./outbound-private-inbox/02.json')
+		]
+	},
 	'inbound-comment-edit-blank': {
 		expected: require('./inbound-comment-edit-blank/expected.json'),
 		steps: [

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/01.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/01.json
@@ -1,0 +1,107 @@
+{
+  "headers": {
+    "accept": "application/json",
+    "user-agent": "Needle/1.3.0 (Node.js v9.11.1; linux x64)",
+    "x-front-signature": "W5XFATNCB+uEiulxDpUT6iSNYW0=",
+    "content-length": "2038",
+    "content-type": "application/json; charset=utf-8",
+    "host": "d940a2e4.ngrok.io",
+    "connection": "close",
+    "x-forwarded-proto": "https",
+    "x-forwarded-for": "52.53.178.0"
+  },
+  "payload": {
+    "_links": {
+      "self": "https://api2.frontapp.com/events/evt_4ima6xn"
+    },
+    "id": "evt_4ima6xn",
+    "type": "assign",
+    "emitted_at": 1539209349.262,
+    "conversation": {
+      "_links": {
+        "self": "https://api2.frontapp.com/conversations/cnv_11sfzr7",
+        "related": {
+          "events": "https://api2.frontapp.com/conversations/cnv_11sfzr7/events",
+          "followers": "https://api2.frontapp.com/conversations/cnv_11sfzr7/followers",
+          "messages": "https://api2.frontapp.com/conversations/cnv_11sfzr7/messages",
+          "comments": "https://api2.frontapp.com/conversations/cnv_11sfzr7/comments",
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sfzr7/inboxes"
+        }
+      },
+      "id": "cnv_11sfzr7",
+      "subject": "",
+      "status": "invisible",
+      "assignee": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_grc",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+          }
+        },
+        "id": "tea_grc",
+        "email": "juan@resin.io",
+        "username": "jviotti",
+        "first_name": "Juan Cruz",
+        "last_name": "Viotti",
+        "is_admin": true,
+        "is_available": true
+      },
+      "recipient": {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      },
+      "tags": [],
+      "last_message": {},
+      "created_at": 1539209337.175,
+      "is_private": false
+    },
+    "source": {
+      "_meta": {
+        "type": "teammate"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_grc",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+          }
+        },
+        "id": "tea_grc",
+        "email": "juan@resin.io",
+        "username": "jviotti",
+        "first_name": "Juan Cruz",
+        "last_name": "Viotti",
+        "is_admin": true,
+        "is_available": true
+      }
+    },
+    "target": {
+      "_meta": {
+        "type": "teammate"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_grc",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+          }
+        },
+        "id": "tea_grc",
+        "email": "juan@resin.io",
+        "username": "jviotti",
+        "first_name": "Juan Cruz",
+        "last_name": "Viotti",
+        "is_admin": true,
+        "is_available": true
+      }
+    }
+  }
+}

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/02.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/02.json
@@ -1,0 +1,220 @@
+{
+  "headers": {
+    "accept": "application/json",
+    "user-agent": "Needle/1.3.0 (Node.js v9.11.1; linux x64)",
+    "x-front-signature": "LEHJGXbCovfxi/nRL4ctfwzPYh4=",
+    "content-length": "4059",
+    "content-type": "application/json; charset=utf-8",
+    "host": "d940a2e4.ngrok.io",
+    "connection": "close",
+    "x-forwarded-proto": "https",
+    "x-forwarded-for": "13.57.178.107"
+  },
+  "payload": {
+    "_links": {
+      "self": "https://api2.frontapp.com/events/evt_4imaazv"
+    },
+    "id": "evt_4imaazv",
+    "type": "outbound",
+    "emitted_at": 1539209361.921,
+    "conversation": {
+      "_links": {
+        "self": "https://api2.frontapp.com/conversations/cnv_11sfzr7",
+        "related": {
+          "events": "https://api2.frontapp.com/conversations/cnv_11sfzr7/events",
+          "followers": "https://api2.frontapp.com/conversations/cnv_11sfzr7/followers",
+          "messages": "https://api2.frontapp.com/conversations/cnv_11sfzr7/messages",
+          "comments": "https://api2.frontapp.com/conversations/cnv_11sfzr7/comments",
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sfzr7/inboxes"
+        }
+      },
+      "id": "cnv_11sfzr7",
+      "subject": "Outbound test",
+      "status": "assigned",
+      "assignee": {
+        "_links": {
+          "self": "https://api2.frontapp.com/teammates/tea_grc",
+          "related": {
+            "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+            "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+          }
+        },
+        "id": "tea_grc",
+        "email": "juan@resin.io",
+        "username": "jviotti",
+        "first_name": "Juan Cruz",
+        "last_name": "Viotti",
+        "is_admin": true,
+        "is_available": true
+      },
+      "recipient": {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      },
+      "tags": [],
+      "last_message": {
+        "_links": {
+          "self": "https://api2.frontapp.com/messages/msg_1y9kf8r",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_11sfzr7"
+          }
+        },
+        "id": "msg_1y9kf8r",
+        "type": "email",
+        "is_inbound": false,
+        "created_at": 1539209361.921,
+        "blurb": "Hello ",
+        "body": "<div>Hello</div><br><div class=\"front-signature fa-uid_3261ad35206a43895d965cefeb9a22c2\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div>",
+        "text": "Hello\n",
+        "is_draft": false,
+        "error_type": null,
+        "metadata": {},
+        "author": {
+          "_links": {
+            "self": "https://api2.frontapp.com/teammates/tea_grc",
+            "related": {
+              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+            }
+          },
+          "id": "tea_grc",
+          "email": "juan@resin.io",
+          "username": "jviotti",
+          "first_name": "Juan Cruz",
+          "last_name": "Viotti",
+          "is_admin": true,
+          "is_available": true
+        },
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": null
+              }
+            },
+            "handle": "test@resin.io",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+              }
+            },
+            "handle": "juan@resin.io",
+            "role": "to"
+          }
+        ],
+        "attachments": []
+      },
+      "created_at": 1539209337.175,
+      "is_private": false
+    },
+    "source": {
+      "_meta": {
+        "type": "inboxes"
+      },
+      "data": [
+        {
+          "_links": {
+            "self": "https://api2.frontapp.com/inboxes/inb_xxxx",
+            "related": {
+              "channels": "https://api2.frontapp.com/inboxes/inb_xxxx/channels",
+              "conversations": "https://api2.frontapp.com/inboxes/inb_xxxx/conversations",
+              "teammates": "https://api2.frontapp.com/inboxes/inb_xxxx/teammates",
+              "owner": "https://api2.frontapp.com/teams/tim_qh"
+            }
+          },
+          "id": "inb_xxxx",
+          "name": "Foo Bar",
+          "is_private": true,
+          "address": "johndoe@gmail.com",
+          "send_as": "johndoe@gmail.com",
+          "type": "smtp"
+        },
+        {
+          "_links": {
+            "self": "https://api2.frontapp.com/inboxes/inb_fczf",
+            "related": {
+              "channels": "https://api2.frontapp.com/inboxes/inb_fczf/channels",
+              "conversations": "https://api2.frontapp.com/inboxes/inb_fczf/conversations",
+              "teammates": "https://api2.frontapp.com/inboxes/inb_fczf/teammates",
+              "owner": "https://api2.frontapp.com/teams/tim_qh"
+            }
+          },
+          "id": "inb_fczf",
+          "name": "Test_Contracts",
+          "is_private": false,
+          "address": "ei8z-resin_io@in.frontapp.com",
+          "send_as": "test@resin.io",
+          "type": "smtp"
+        }
+      ]
+    },
+    "target": {
+      "_meta": {
+        "type": "message"
+      },
+      "data": {
+        "_links": {
+          "self": "https://api2.frontapp.com/messages/msg_1y9kf8r",
+          "related": {
+            "conversation": "https://api2.frontapp.com/conversations/cnv_11sfzr7"
+          }
+        },
+        "id": "msg_1y9kf8r",
+        "type": "email",
+        "is_inbound": false,
+        "created_at": 1539209361.921,
+        "blurb": "Hello ",
+        "body": "<div>Hello</div><br><div class=\"front-signature fa-uid_3261ad35206a43895d965cefeb9a22c2\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div>",
+        "text": "Hello\n",
+        "is_draft": false,
+        "error_type": null,
+        "metadata": {},
+        "author": {
+          "_links": {
+            "self": "https://api2.frontapp.com/teammates/tea_grc",
+            "related": {
+              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+            }
+          },
+          "id": "tea_grc",
+          "email": "juan@resin.io",
+          "username": "jviotti",
+          "first_name": "Juan Cruz",
+          "last_name": "Viotti",
+          "is_admin": true,
+          "is_available": true
+        },
+        "recipients": [
+          {
+            "_links": {
+              "related": {
+                "contact": null
+              }
+            },
+            "handle": "test@resin.io",
+            "role": "from"
+          },
+          {
+            "_links": {
+              "related": {
+                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+              }
+            },
+            "handle": "juan@resin.io",
+            "role": "to"
+          }
+        ],
+        "attachments": []
+      }
+    }
+  }
+}

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/expected.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/expected.json
@@ -1,0 +1,82 @@
+{
+  "head": {
+    "name": "Outbound test",
+    "type": "support-thread@1.0.0",
+    "version": "1.0.0",
+    "active": true,
+    "tags": [],
+    "requires": [],
+    "capabilities": [],
+    "data": {
+      "environment": "production",
+      "inbox": "Test_Contracts",
+      "mirrors": [
+        "https://api2.frontapp.com/conversations/cnv_11sfzr7"
+      ],
+      "mentionsUser": [],
+      "alertsUser": [],
+      "description": "",
+      "status": "open"
+    }
+  },
+  "tail": [
+    {
+      "type": "create@1.0.0",
+      "active": true,
+      "version": "1.0.0",
+      "tags": [],
+      "requires": [],
+      "capabilities": [],
+      "data": {
+        "actor": {
+          "active": true,
+          "slug": "user-juan-resin-io"
+        },
+        "timestamp": "2018-10-10T22:08:57.175Z",
+        "payload": {
+          "name": "Outbound test",
+          "type": "support-thread@1.0.0",
+          "active": true,
+          "version": "1.0.0",
+          "tags": [],
+          "requires": [],
+          "capabilities": [],
+          "data": {
+            "environment": "production",
+            "inbox": "Test_Contracts",
+            "mirrors": [
+              "https://api2.frontapp.com/conversations/cnv_11sfzr7"
+            ],
+            "mentionsUser": [],
+            "alertsUser": [],
+            "description": "",
+            "status": "open"
+          }
+        }
+      }
+    },
+    {
+      "type": "message@1.0.0",
+      "active": true,
+      "version": "1.0.0",
+      "tags": [],
+      "requires": [],
+      "capabilities": [],
+      "data": {
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
+        "mirrors": [
+          "https://api2.frontapp.com/messages/msg_1y9kf8r"
+        ],
+        "timestamp": "2018-10-10T22:09:21.921Z",
+        "payload": {
+          "mentionsUser": [],
+          "alertsUser": [],
+          "message": "Hello\n\n—\nJuan Cruz Viotti,\n\nSoftware Engineer, Resin.io (https://resin.io)\n\ntwt: @resin\\_io"
+        }
+      }
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/contacts-crd-5-ef-35.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/contacts-crd-5-ef-35.json
@@ -1,0 +1,25 @@
+{
+  "_links": {
+    "self": "https://api2.frontapp.com/contacts/crd_5ef35",
+    "related": {
+      "notes": "https://api2.frontapp.com/contacts/crd_5ef35/notes",
+      "conversations": "https://api2.frontapp.com/contacts/crd_5ef35/conversations",
+      "owner": "https://api2.frontapp.com/teams/tim_qh"
+    }
+  },
+  "id": "crd_5ef35",
+  "name": "juan@resin.io",
+  "description": "",
+  "avatar_url": null,
+  "links": [],
+  "handles": [
+    {
+      "source": "email",
+      "handle": "juan@resin.io"
+    }
+  ],
+  "groups": [],
+  "updated_at": 1473374839,
+  "custom_fields": {},
+  "is_private": false
+}

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/conversations-cnv-11-sfzr-7-comments.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/conversations-cnv-11-sfzr-7-comments.json
@@ -1,0 +1,10 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_11sfzr7/comments"
+  },
+  "_results": []
+}

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/conversations-cnv-11-sfzr-7-inboxes.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/conversations-cnv-11-sfzr-7-inboxes.json
@@ -1,0 +1,28 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_11sdgij/inboxes"
+  },
+  "_results": [
+    {
+      "_links": {
+        "self": "https://api2.frontapp.com/inboxes/inb_fczf",
+        "related": {
+          "channels": "https://api2.frontapp.com/inboxes/inb_fczf/channels",
+          "conversations": "https://api2.frontapp.com/inboxes/inb_fczf/conversations",
+          "teammates": "https://api2.frontapp.com/inboxes/inb_fczf/teammates",
+          "owner": "https://api2.frontapp.com/teams/tim_qh"
+        }
+      },
+      "id": "inb_fczf",
+      "name": "Test_Contracts",
+      "is_private": false,
+      "address": "ei8z-resin_io@in.frontapp.com",
+      "send_as": "test@resin.io",
+      "type": "smtp"
+    }
+  ]
+}

--- a/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/conversations-cnv-11-sfzr-7-messages-limit-100.json
+++ b/test/integration/sync/webhooks/front/outbound-private-inbox/stubs/1/conversations-cnv-11-sfzr-7-messages-limit-100.json
@@ -1,0 +1,10 @@
+{
+  "_pagination": {
+    "prev": null,
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/conversations/cnv_11sfzr7/messages?limit=100"
+  },
+  "_results": []
+}


### PR DESCRIPTION
If a conversation starts on a private personal inbox and is then moved
to i.e. support, then the conversation will belong to both inboxes at
the same time.

When looking what inbox a thread belongs to, we shouldn't take into
account private ones, as we don't know what to do with them.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!