### PR TITLE
Update references to GitHub test repo to new location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ export INTEGRATION_OUTREACH_SIGNATURE_KEY
 # Test Runtime Configuration
 # -----------------------------------------------
 
-TEST_INTEGRATION_GITHUB_REPO ?= balena-io/jellyfish-test-github
+TEST_INTEGRATION_GITHUB_REPO ?= product-os/jellyfish-test-github
 export TEST_INTEGRATION_GITHUB_REPO
 TEST_INTEGRATION_FRONT_INBOX_1 ?= inb_qf8q # Jellyfish Testfront
 export TEST_INTEGRATION_FRONT_INBOX_1

--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -380,7 +380,7 @@ avaTest('should re-open a closed support thread if an attached issue is closed',
 		type: 'issue',
 		version: '1.0.0',
 		data: {
-			repository: 'balena-io/jellyfish-test-github',
+			repository: 'product-os/jellyfish-test-github',
 			description: 'Foo bar',
 			status: 'open',
 			mentionsUser: [],

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -297,7 +297,7 @@ avaTest('should re-open a closed support thread if an attached issue is closed',
 		type: 'issue',
 		version: '1.0.0',
 		data: {
-			repository: 'balena-io/jellyfish-test-github',
+			repository: 'product-os/jellyfish-test-github',
 			description: 'Foo bar',
 			status: 'open',
 			mentionsUser: [],

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -831,7 +831,7 @@ avaTest('jsonb_pattern - inside items in a jsonb column', async (test) => {
 			name: 'active',
 			data: {
 				mirrors: [
-					'https://github.com/balena-io/jellyfish-test-github/issues/5998'
+					'https://github.com/product-os/jellyfish-test-github/issues/5998'
 				]
 			}
 		}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Update references to Jellyfish test GitHub repo to new location.
Old: `balena-io/jellyfish-test-github`
New: `product-os/jellyfish-test-github`

(Just created a new repo with the same name under the new `product-os` org)
