### PR TITLE
(DND pt1) core: Add status to user card

### DIFF
--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -128,6 +128,10 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "status": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
                 "email": {
                   "type": [ "string", "array" ]
                 },
@@ -200,6 +204,10 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "status": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
                 "email": {
                   "type": [ "string", "array" ]
                 },

--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -31,6 +31,62 @@ module.exports = {
 				data: {
 					type: 'object',
 					properties: {
+						status: {
+							oneOf: [
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'Do Not Disturb'
+										},
+										value: {
+											type: 'string',
+											const: 'DoNotDisturb'
+										}
+									}
+								},
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'On Annual Leave'
+										},
+										value: {
+											type: 'string',
+											const: 'AnnualLeave'
+										}
+									}
+								},
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'In a Meeting'
+										},
+										value: {
+											type: 'string',
+											const: 'Meeting'
+										}
+									}
+								},
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'Available'
+										},
+										value: {
+											type: 'string',
+											const: 'Available'
+										}
+									}
+								}
+							]
+						},
 						email: {
 							type: [ 'string', 'array' ],
 							format: 'email',


### PR DESCRIPTION
Currently unused - but will be used to set the user's status and display it to other users

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

'Do Not Disturb' functionality - Step 1 of [5 steps](https://github.com/product-os/jellyfish/issues/3117#issuecomment-591780248):

1. **(THIS PR) Add status to user object (and explicitly enable in community role)**
2. #3179 Add new withActor HOC and refactor Event component (to allow actor updates in the Redux state to be reflected in the timeline events)
3. #3180 Update existing cached actors in the Redux store from relevant stream updates to user cards
4. #3181 Add new UserStatusIcon component and add it to the Avatar component (at this stage it will be hidden as there is no way to set the user status)
5. #3182 Add a 'Do Not Disturb' menu item to the User's popup menu and e2e tests (depends on 1, 4)

ref: #3117 

The user's status can be set to one of four options:
1. Available
1. Do Not Disturb
1. On Annual Leave
1. In a Meeting

If no status object is set on a user card, 'Available' is assumed.