### PR TITLE
(DND pt2) ui-components: Refactored caching and retrieval of actors

### DIFF
--- a/apps/ui/core/store/helpers.js
+++ b/apps/ui/core/store/helpers.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+
+export const generateActorFromUserCard = (card) => {
+	let name = 'unknown user'
+
+	// IF proxy is true, it indicates that the actor has been created as a proxy
+	// for a real user in JF, usually as a result of syncing from an external
+	// service
+	let proxy = false
+	const email = _.get(card, [ 'data', 'email' ], '')
+
+	const isBalenaTeam = _.find(
+		_.get(card, [ 'links', 'is member of' ], []),
+		{
+			slug: 'org-balena'
+		}
+	)
+
+	// Check if the user is part of the balena org
+	if (isBalenaTeam) {
+		name = card.name || card.slug.replace('user-', '')
+	} else {
+		proxy = true
+		let handle = card.name || _.get(card, [ 'data', 'handle' ])
+		if (!handle) {
+			handle = email || card.slug.replace(/^(account|user)-/, '')
+		}
+		name = `[${handle}]`
+	}
+
+	return {
+		name,
+		email,
+		avatarUrl: _.get(card, [ 'data', 'avatar' ]),
+		proxy,
+		card
+	}
+}

--- a/apps/ui/core/store/helpers.spec.js
+++ b/apps/ui/core/store/helpers.spec.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+const ava = require('ava')
+const {
+	generateActorFromUserCard
+} = require('./helpers')
+
+ava('generateActorFromUserCard can generate name from slug', (test) => {
+	const card = {
+		slug: 'user-foobar',
+		links: {
+			'is member of': [
+				{
+					slug: 'org-balena'
+				}
+			]
+		}
+	}
+	const actor = generateActorFromUserCard(card)
+	test.is(actor.name, 'foobar')
+	test.is(actor.proxy, false)
+})
+
+ava('generateActorFromUserCard can generate name from handle', (test) => {
+	const card = {
+		slug: 'user-foobar',
+		data: {
+			handle: 'a-handle'
+		}
+	}
+	const actor = generateActorFromUserCard(card)
+	test.is(actor.name, '[a-handle]')
+})
+
+ava('generateActorFromUserCard can generate name from email', (test) => {
+	const card = {
+		slug: 'user-foobar',
+		data: {
+			email: 'user@test.com'
+		}
+	}
+	const actor = generateActorFromUserCard(card)
+	test.is(actor.name, '[user@test.com]')
+})
+
+ava('generateActorFromUserCard generates proxy, email and avatarUrl from card', (test) => {
+	const card = {
+		slug: 'user-foobar',
+		data: {
+			email: 'user@test.com',
+			avatar: 'https://www.example.com'
+		}
+	}
+	const actor = generateActorFromUserCard(card)
+	test.is(actor.avatarUrl, 'https://www.example.com')
+	test.is(actor.email, 'user@test.com')
+	test.is(actor.proxy, true)
+})

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -278,7 +278,6 @@ export default class Event extends React.Component {
 		}
 
 		this.state = {
-			actor: null,
 			showMenu: false,
 			expanded: false,
 			messageHeight: null
@@ -294,16 +293,6 @@ export default class Event extends React.Component {
 
 	async componentDidMount () {
 		this.processText()
-
-		const createCard = _.find(_.get(this.props.card, [ 'links', 'has attached element' ]), (linkedCard) => {
-			return [ 'create', 'create@1.0.0' ].includes(linkedCard.type)
-		})
-
-		const actorId = _.get(this.props.card, [ 'data', 'actor' ]) || _.get(createCard, [ 'data', 'actor' ])
-		const actor = await this.props.getActor(actorId)
-		this.setState({
-			actor
-		})
 	}
 
 	downloadAttachment (event) {
@@ -398,7 +387,7 @@ export default class Event extends React.Component {
 
 		return (
 			<Txt color={Theme.colors.text.light}>
-				<em>{text}</em> <strong>{this.state.actor ? this.state.actor.name : ''}</strong>
+				<em>{text}</em> <strong>{this.props.actor ? this.props.actor.name : ''}</strong>
 			</Txt>
 		)
 	}
@@ -406,11 +395,9 @@ export default class Event extends React.Component {
 	render () {
 		const {
 			card,
+			actor,
 			addNotification
 		} = this.props
-		const {
-			actor
-		} = this.state
 		const props = _.omit(this.props, [
 			'card',
 			'menuOptions',

--- a/lib/ui-components/Event/index.js
+++ b/lib/ui-components/Event/index.js
@@ -6,7 +6,16 @@
 
 import Event from './Event'
 import {
+	compose
+} from 'redux'
+import {
 	withSetup
 } from '../SetupProvider'
+import {
+	withActor
+} from '../HOC'
 
-export default withSetup(Event)
+export default compose(
+	withSetup,
+	withActor
+)(Event)

--- a/lib/ui-components/HOC/index.js
+++ b/lib/ui-components/HOC/index.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export * from './with-actor'

--- a/lib/ui-components/HOC/with-actor.jsx
+++ b/lib/ui-components/HOC/with-actor.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	useSelector
+} from 'react-redux'
+import _ from 'lodash'
+
+const getActorIdFromCard = _.memoize((card) => {
+	const createCard = _.find(_.get(card, [ 'links', 'has attached element' ]), (linkedCard) => {
+		return [ 'create', 'create@1.0.0' ].includes(linkedCard.type)
+	})
+	return _.get(card, [ 'data', 'actor' ]) || _.get(createCard, [ 'data', 'actor' ])
+}, (card) => { return card.id })
+
+const getActorFromState = (actorId) => {
+	return (state) => {
+		return _.get(state, [ 'core', 'actors', actorId ], null)
+	}
+}
+
+export const withActor = (BaseComponent) => {
+	return ({
+		card, ...props
+	}) => {
+		const actorId = getActorIdFromCard(card)
+		const actor = useSelector(getActorFromState(actorId))
+
+		React.useEffect(() => {
+			if (!actor) {
+				props.getActor(actorId)
+			}
+		}, [ card.id ])
+
+		return (
+			<BaseComponent
+				{...props}
+				card={card}
+				actor={actor}
+			/>
+		)
+	}
+}


### PR DESCRIPTION
Main change is that we now cache the whole actor in the Redux store, not just the actor's card.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

'Do Not Disturb' functionality - Step 2 of [5 steps](https://github.com/product-os/jellyfish/issues/3117#issuecomment-591780248):

1. #3178  Add status to user object (and explicitly enable in community role)
2. **(THIS PR) Add new withActor HOC and refactor Event component (to allow actor updates in the Redux state to be reflected in the timeline events)**
3. #3180 Update existing cached actors in the Redux store from relevant stream updates to user cards
4. #3181 Add new UserStatusIcon component and add it to the Avatar component (at this stage it will be hidden as there is no way to set the user status)
5. #3182 Add a 'Do Not Disturb' menu item to the User's popup menu and e2e tests (depends on 1, 4)

ref: #3117 

This PR abstracts the code that was all mixed up inside the `Event` component into a separate higher-order-component that, given a `card` prop, is solely responsible for providing an `actor` prop to its base component. 

A necessary refactor to facilitate this is to cache the whole actor object in the Redux store (previously we just cached the actor's user card and rebuilt the meta info each time the actor was requested).