### PR TITLE
(DND pt4) ui: Add user status icon

### DIFF
--- a/apps/ui/lens/actions/CreateView/CreateView.jsx
+++ b/apps/ui/lens/actions/CreateView/CreateView.jsx
@@ -322,6 +322,7 @@ export default class CreateLens extends React.Component {
 										<Avatar
 											name={user.name || user.slug.replace('user-', '')}
 											url={_.get(user, [ 'data', 'avatar' ])}
+											userStatus={_.get(user, [ 'data', 'status' ])}
 										/>
 
 										<Box ml={2}>

--- a/apps/ui/lens/full/MyUser/MyUser.jsx
+++ b/apps/ui/lens/full/MyUser/MyUser.jsx
@@ -177,6 +177,7 @@ export default class MyUser extends React.Component {
 								<Avatar
 									name={user.name || user.slug.replace('user-', '')}
 									url={_.get(user, [ 'data', 'avatar' ])}
+									userStatus={_.get(user, [ 'data', 'status' ])}
 								/>
 
 								<Box ml={2}>

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -428,6 +428,7 @@ export default class Event extends React.Component {
 							small
 							name={actor ? actor.name : null}
 							url={actor ? actor.avatarUrl : null}
+							userStatus={_.get(actor, [ 'card', 'data', 'status' ])}
 						/>
 
 						{this.props.openChannel &&

--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -268,6 +268,7 @@ export default class HomeChannel extends React.Component {
 						<Avatar
 							name={username}
 							url={_.get(user, [ 'data', 'avatar' ])}
+							userStatus={_.get(user, [ 'data', 'status' ])}
 						/>
 						{Boolean(username) && <Txt mx={2} style={{
 							textOverflow: 'ellipsis',

--- a/lib/ui-components/UserStatusIcon.jsx
+++ b/lib/ui-components/UserStatusIcon.jsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import styled from 'styled-components'
+import _ from 'lodash'
+import {
+	Flex
+} from 'rendition'
+import Icon from './shame/Icon'
+
+const statusSize = (props) => {
+	const size = props.small ? 12 : 18
+	const fontSize = props.small ? 6 : 9
+	return `
+		width: ${size}px;
+		height: ${size}px;
+		font-size: ${fontSize}px;
+	`
+}
+
+// Note: We use class-names here instead of child System Components so
+// that the transition animation works correctly
+const StatusWrapper = styled(Flex) `
+	${statusSize}
+	transition: all ease-in-out 500ms;
+	padding: 2px;
+	border-radius: 50%;
+	background: transparent;
+	&.user-status-icon--available {
+		transform: scale(0);
+	}
+	&.user-status-icon--donotdisturb {
+		background: ${(props) => { return props.theme.colors.tertiary.dark }};
+		color: #fff;
+	}
+	&.user-status-icon--annualleave {
+		background: ${(props) => { return props.theme.colors.success.dark }};
+		color: #FFF;
+	}
+	&.user-status-icon--inameeting {
+		background: ${(props) => { return props.theme.colors.info.main }};
+		color: #FFF;
+	}
+`
+
+const StatusIconNames = {
+	Available: null,
+	DoNotDisturb: 'bell-slash',
+	AnnualLeave: 'umbrella-beach',
+	Meeting: 'calendar-times'
+}
+
+export default function UserStatusIcon ({
+	userStatus, className, ...props
+}) {
+	if (!userStatus || _.isEmpty(userStatus)) {
+		return null
+	}
+	const statusIconName = StatusIconNames[userStatus.value]
+	if (!StatusWrapper) {
+		return null
+	}
+	return (
+		<StatusWrapper
+			className={`${className} user-status-icon--${userStatus.value.toLowerCase()}`}
+			{...props}
+			alignItems="center"
+			justifyContent="center"
+			tooltip={{
+				text: userStatus.title, placement: 'right'
+			}}
+		>
+			{ statusIconName && <Icon name={statusIconName} /> }
+		</StatusWrapper>
+	)
+}

--- a/lib/ui-components/shame/Avatar.jsx
+++ b/lib/ui-components/shame/Avatar.jsx
@@ -12,16 +12,26 @@ import {
 	Img
 } from 'rendition'
 import UserIcon from 'react-icons/lib/fa/user'
+import UserStatusIcon from '../UserStatusIcon'
 
 const dimensions = (props) => {
 	const size = props.small ? 24 : 36
+	const top = props.small ? -2 : -4
 	return `
 		width: ${size}px;
 		height: ${size}px;
+		.user-status-icon {
+			top: ${top}px;
+			right: -2px;
+		}
 	`
 }
 
 const OuterWrapper = styled(Box) `
+	position: relative;
+	.user-status-icon {
+		position: absolute;
+	}
 	box-sizing: content-box;
 	${dimensions}
 `
@@ -48,10 +58,12 @@ const IconWrapper = styled(Flex) `
 
 export default function Avatar ({
 	url,
+	userStatus,
+	small,
 	...rest
 }) {
 	return (
-		<OuterWrapper {...rest}>
+		<OuterWrapper small={small} {...rest}>
 			<InnerWrapper>
 				{url ? (
 					<Img src={url} />
@@ -61,6 +73,7 @@ export default function Avatar ({
 					</IconWrapper>
 				)}
 			</InnerWrapper>
+			<UserStatusIcon className="user-status-icon" small={small} userStatus={userStatus} />
 		</OuterWrapper>
 	)
 }


### PR DESCRIPTION
The icon (when user status can be updated) will appear top-right of the user's avatar.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

'Do Not Disturb' functionality - Step 4 of [5 steps](https://github.com/product-os/jellyfish/issues/3117#issuecomment-591780248):

1. #3178 Add status to user object (and explicitly enable in community role)
2. #3179 Add new withActor HOC and refactor Event component (to allow actor updates in the Redux state to be reflected in the timeline events)
3. #3180 Update existing cached actors in the Redux store from relevant stream updates to user cards
4. **(THIS PR) Add new UserStatusIcon component and add it to the Avatar component (at this stage it will be hidden as there is no way to set the user status)**
5. #3182 Add a 'Do Not Disturb' menu item to the User's popup menu and e2e tests (depends on 1, 4)

ref: #3117 

![image](https://user-images.githubusercontent.com/2925657/75426261-e3bc4180-5976-11ea-8f01-d5c5de67d810.png)

(This icon overlay is designed to be the same size and in a symmetrical position to the 'unread messages' icon overlay)