### PR TITLE
(DND pt5) WIP: ui: Add ability to toggle 'Do Not Disturb' mode

### DIFF
--- a/apps/ui/components/HOC/HomeChannel.jsx
+++ b/apps/ui/components/HOC/HomeChannel.jsx
@@ -45,6 +45,7 @@ const mapDispatchToProps = (dispatch) => {
 				'setChatWidgetOpen',
 				'setDefault',
 				'setUIState',
+				'setUserStatus',
 				'streamView'
 			]), dispatch)
 	}

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -10,6 +10,7 @@ import {
 import * as _ from 'lodash'
 import {
 	actionCreators,
+	selectors,
 	store
 } from '../core'
 
@@ -37,6 +38,12 @@ export const createNotification = ({
 	target
 }) => {
 	if (!canUseNotifications) {
+		return
+	}
+
+	// Skip notifications if the user's status is set to 'Do Not Disturb'
+	const userStatus = selectors.getCurrentUserStatus(store.getState())
+	if (_.get(userStatus, [ 'value' ]) === 'DoNotDisturb') {
 		return
 	}
 

--- a/lib/ui-components/HomeChannel/DoNotDisturb.jsx
+++ b/lib/ui-components/HomeChannel/DoNotDisturb.jsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Box,
+	Button,
+	Flex,
+	Txt
+} from 'rendition'
+import {
+	useSelector
+} from 'react-redux'
+import styled from 'styled-components'
+import _ from 'lodash'
+import {
+	useSetup
+} from '../SetupProvider'
+import Icon from '../shame/Icon'
+import {
+	getUserStatuses
+} from '../services/helpers'
+
+const DndButton = styled(Button) `
+	display: flex;
+	width: 100%;
+`
+
+export default function DoNotDisturb ({
+	user,
+	...rest
+}) {
+	const {
+		actions
+	} = useSetup()
+	const types = useSelector((state) => {
+		return state.core.types
+	})
+
+	const userType = _.find(types, {
+		slug: 'user'
+	})
+	const userStatusOptions = getUserStatuses(userType)
+
+	const status = _.get(user, [ 'data', 'status' ], userStatusOptions.Available)
+	const isDnd = status.value === userStatusOptions.DoNotDisturb.value
+	const toggleStatus = () => {
+		const newStatus = isDnd
+			? userStatusOptions.Available
+			: userStatusOptions.DoNotDisturb
+		actions.setUserStatus(newStatus)
+	}
+	const buttonProps = {
+		...rest,
+		plain: true,
+		'data-test': 'button-dnd',
+		tooltip: {
+			text: isDnd ? 'Turn off Do Not Disturb' : 'Turn off notifications',
+			placement: 'right'
+		},
+		onClick: toggleStatus
+	}
+	return (
+		<DndButton {...buttonProps}>
+			<Flex flex={1} alignItems="center" justifyContent="space-between">
+				<Txt>{userStatusOptions.DoNotDisturb.title}</Txt>
+				<Box>{ isDnd && <Icon name="check" /> }</Box>
+			</Flex>
+		</DndButton>
+	)
+}

--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -21,6 +21,7 @@ import {
 } from 'rendition'
 import MentionsCount from '../MentionsCount'
 import TreeMenu from './TreeMenu'
+import DoNotDisturb from './DoNotDisturb'
 import RouterLink from '../Link'
 import ViewLink from '../ViewLink'
 import Avatar from '../shame/Avatar'
@@ -289,8 +290,14 @@ export default class HomeChannel extends React.Component {
 				</Flex>
 
 				{this.state.showMenu && (
-					<Fixed top={true} right={true} bottom={true} left={true} z={9999999} onClick={this.hideMenu}>
+					<Fixed top={true} right={true} bottom={true} left={true} z={10} onClick={this.hideMenu}>
 						<MenuPanel className="user-menu" mx={3} p={3}>
+							{user && (
+								<Box mb={2}>
+									<DoNotDisturb user={user} />
+								</Box>
+							)}
+
 							{user && (
 								<div>
 									<RouterLink

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -422,3 +422,33 @@ export const patchPath = (card, keyPath, value) => {
 
 	return patch
 }
+
+/**
+ * Returns a dictionary of user status options, keyed by
+ * the user status value. For example:
+ * {
+ *   DoNotDisturb: {
+ *     title: 'Do Not Disturb',
+ *     value: 'DoNotDisturb'
+ *   },
+ *   {
+ *     ...
+ *   }
+ * }
+ */
+export const getUserStatuses = _.memoize((userType) => {
+	const userStatusOptionsList = _.get(
+		userType,
+		[ 'data', 'schema', 'properties', 'data', 'properties', 'status', 'oneOf' ],
+		[]
+	)
+	return _.reduce(userStatusOptionsList, (opts, opt) => {
+		if (_.has(opt, [ 'properties', 'value', 'const' ])) {
+			opts[opt.properties.value.const] = {
+				title: opt.properties.title.const,
+				value: opt.properties.value.const
+			}
+		}
+		return opts
+	}, {})
+})

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -5,7 +5,9 @@
  */
 
 const ava = require('ava')
+const _ = require('lodash')
 const helpers = require('./helpers')
+const user = require('../../core/cards/user')
 
 ava('.createPrefixRegExp() match underscore characters', (test) => {
 	const matchRE = helpers.createPrefixRegExp('@')
@@ -109,4 +111,16 @@ ava('.findWordsByPrefix() should ignore symbols with no following test', (test) 
 	const source = '!'
 
 	test.deepEqual(helpers.findWordsByPrefix('!', source), [])
+})
+
+ava('.getUserStatuses() returns a dictionary of statuses if status is provided in schema', (test) => {
+	const userStatuses = helpers.getUserStatuses(user)
+	const dnd = userStatuses.DoNotDisturb
+	test.is(dnd.title, 'Do Not Disturb')
+	test.is(dnd.value, 'DoNotDisturb')
+})
+
+ava('.getUserStatuses() returns an empty object if status is missing from schema', (test) => {
+	const userType = _.omit(user, 'data.schema.properties.data.properties.status')
+	test.deepEqual(helpers.getUserStatuses(userType), {})
 })

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -462,6 +462,45 @@ ava.serial('lens: A lens selection should be remembered', async (test) => {
 	test.pass()
 })
 
+// User Status
+// =============================================================================
+ava.serial('user status: You should be able to enable and disable Do Not Disturb', async (test) => {
+	const {
+		page
+	} = context
+
+	await ensureCommunityLogin(page)
+
+	const verifyDndState = async (expectedOn) => {
+		// Open the user menu
+		await macros.waitForThenClickSelector(page, '.user-menu-toggle')
+
+		const doNotDisturbButton = await page.waitForSelector('[data-test="button-dnd"]')
+
+		// A 'check' icon implies 'Do Not Disturb' is ON
+		const checkIcon = await doNotDisturbButton.$('i')
+		test.is(Boolean(checkIcon), expectedOn)
+
+		// The user's avatar should also have a status icon if 'Do Not Disturb' is ON
+		const statusIcon = await page.$('.user-menu-toggle .user-status-icon')
+		test.is(Boolean(statusIcon), expectedOn)
+		return doNotDisturbButton
+	}
+
+	const toggleDnd = async (doNotDisturbButton) => {
+		doNotDisturbButton.click()
+		await macros.waitForThenDismissAlert(page, 'success')
+	}
+
+	let dndButton = await verifyDndState(false)
+	await toggleDnd(dndButton)
+	dndButton = await verifyDndState(true)
+	await toggleDnd(dndButton)
+	dndButton = await verifyDndState(false)
+
+	test.pass()
+})
+
 // User Profile
 // =============================================================================
 

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -177,3 +177,7 @@ exports.waitForSelectorToDisappear = async (page, selector) => {
 		throw new Error(`Element still exists: ${selector}`)
 	})
 }
+
+exports.waitForThenDismissAlert = async (page, alertType) => {
+	await exports.waitForThenClickSelector(page, `[data-test="alert--${alertType}"] button`)
+}


### PR DESCRIPTION
If 'Do Not Disturb' mode is on, the user will not receive desktop notifications

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

'Do Not Disturb' functionality - Step 5 of [5 steps](https://github.com/product-os/jellyfish/issues/3117#issuecomment-591780248):

1. #3178 Add status to user object (and explicitly enable in community role)
2. #3179 Add new withActor HOC and refactor Event component (to allow actor updates in the Redux state to be reflected in the timeline events)
3. #3180 Update existing cached actors in the Redux store from relevant stream updates to user cards
4. #3181 Add new UserStatusIcon component and add it to the Avatar component (at this stage it will be hidden as there is no way to set the user status)
5. **(THIS PR) Add a 'Do Not Disturb' menu item to the User's popup menu and e2e tests (depends on 1, 4)**

ref: #3117 

![image](https://user-images.githubusercontent.com/2925657/75431814-0141d900-5980-11ea-87ba-357eda45f001.png)

A toast notification is displayed when the user's status is updated, and a tick is displayed next to the 'Do Not Disturb' menu item if 'Do Not Disturb' is turned on.

TODO: 

* The access of `actions` from `useSetup()` depends on the fix that is currently part of [this PR](https://github.com/product-os/jellyfish/pull/3152)
