### PR TITLE
Add test data cleanup scripts and CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -781,6 +781,18 @@ jobs:
           name: Test
           command: cd ./scripts/eslint-plugin-jellyfish && npm install && npm test
 
+  clean_old_test_data:
+    <<: *job_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Clean up old test data
+          command: |
+            make clean-github
+            make clean-front
+
 workflows:
     version: 2
     build:
@@ -879,4 +891,9 @@ workflows:
                 <<: *workflow_filter
 
             - eslint_jellyfish:
+                <<: *workflow_filter
+
+            - clean_old_test_data:
+                requires:
+                    - build
                 <<: *workflow_filter

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@
 	test-unit \
 	test-integration \
 	test-e2e \
-	scrub
+	scrub \
+	clean-front \
+	clean-github
 
 # See https://stackoverflow.com/a/18137056
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -371,6 +373,15 @@ test-integration-%:
 
 test-e2e-%:
 	FILES="'./test/e2e/$(subst test-e2e-,,$@)/**/*.spec.{js,jsx}'" make test
+
+clean-front:
+	FRONT_INBOX_1=$(TEST_INTEGRATION_FRONT_INBOX_1) \
+	FRONT_INBOX_2=$(TEST_INTEGRATION_FRONT_INBOX_2) \
+	node ./scripts/ci/front-delete-conversations.js
+
+clean-github:
+	GITHUB_REPO=$(TEST_INTEGRATION_GITHUB_REPO) \
+	node ./scripts/ci/github-close-issues.js
 
 ngrok-%:
 	ngrok start -config ./ngrok.yml $(subst ngrok-,,$@)

--- a/scripts/ci/front-delete-conversations.js
+++ b/scripts/ci/front-delete-conversations.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+/* eslint-disable no-underscore-dangle */
+
+/*
+ * This script looks through Front inboxes and deletes conversations that were created two or more days ago.
+ * Usage: FRONT_TOKEN=<...> FRONT_INBOX_1=<...> FRONT_INBOX_2=<...> node ./scripts/ci/front-delete-conversations.js
+ */
+
+const _ = require('lodash')
+const Bluebird = require('bluebird')
+const Front = require('front-sdk').Front
+const moment = require('moment')
+
+const BEFORE = moment.utc().subtract(1, 'days').hours(0).minutes(0).seconds(0).unix()
+const CONVERSATION_LIMIT = 100
+const DELAY = 500
+
+/**
+ * @summary Find and delete old Front test conversations
+ * @function
+ *
+ * @param {Object} options - required Front options (API token and list of inbox IDs)
+ *
+ * @returns {Promise<Number>} the number of conversations deleted
+ */
+const deleteConversations = async (options) => {
+	let total = 0
+	const oldConversations = []
+	const front = new Front(options.token)
+	const pageTokenRegex = /page_token=([a-z0-9A-Z]+)/
+
+	// Loop through all test inboxes, getting old conversations.
+	await Bluebird.each(options.inboxes, async (inbox) => {
+		console.log(`Looking through ${inbox}...`)
+		let pageToken = null
+		while (true) {
+			const conversations = await front.inbox.listConversations({
+				inbox_id: inbox,
+				limit: CONVERSATION_LIMIT,
+				page_token: pageToken
+			})
+
+			// Set next page token for subsequent search.
+			if (conversations._pagination.next) {
+				const pageTokenMatches = conversations._pagination.next.match(pageTokenRegex)
+				if (pageTokenMatches.length === 2) {
+					pageToken = pageTokenMatches[1]
+				}
+			}
+
+			// Check if conversation is old enough to delete.
+			conversations._results.forEach((conversation) => {
+				if (conversation.created_at <= BEFORE && conversation.status !== 'deleted') {
+					oldConversations.push(`${inbox}:${conversation.id}`)
+				}
+			})
+
+			// Break loop if no more conversations are left to delete.
+			if (!conversations._pagination.next) {
+				break
+			}
+		}
+	})
+
+	// Delete old conversations.
+	console.log(`Found ${oldConversations.length} old conversations to delete`)
+	await Bluebird.each(oldConversations, async (conversation) => {
+		console.log(`Deleting conversation: [${conversation}]...`)
+		const [ inboxId, conversationId ] = conversation.split(':')
+		await front.conversation.update({
+			inbox_id: inboxId,
+			conversation_id: conversationId,
+			status: 'deleted'
+		}).then(() => {
+			total += 1
+		}).catch((err) => {
+			console.error(err)
+		})
+		await Bluebird.delay(DELAY)
+	})
+	return total
+}
+
+/**
+ * @summary Validate set options
+ * @function
+ *
+ * @param {Object} options - Front options
+ */
+const validate = (options) => {
+	// Check that the Front token is set.
+	if (!options.token) {
+		handleError('Must set FRONT_TOKEN')
+	}
+
+	// Check that Front inbox IDs are set.
+	if (options.inboxes.length === 0) {
+		handleError('Must set FRONT_INBOX_1 and/or FRONT_INBOX_2')
+	}
+}
+
+/**
+ * @summary Handle errors
+ * @function
+ *
+ * @param {String} msg - error message
+ */
+const handleError = (msg) => {
+	console.error(msg)
+	process.exit(1)
+}
+
+// Set required options and validate them.
+const options = {
+	token: process.env.FRONT_TOKEN,
+	inboxes: _.compact([ process.env.FRONT_INBOX_1, process.env.FRONT_INBOX_2 ])
+}
+validate(options)
+
+// Delete old conversations using provided options.
+deleteConversations(options)
+	.then((total) => {
+		console.log(`Successfully deleted ${total} conversations`)
+	})
+	.catch((err) => {
+		console.error(err)
+	})

--- a/scripts/ci/github-close-issues.js
+++ b/scripts/ci/github-close-issues.js
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+/* eslint-disable id-length */
+
+/*
+ * This script looks through a GitHub repository and closes issues that were created two or more days ago.
+ * Usage: GITHUB_TOKEN=<...> GITHUB_REPO=<...> node ./scripts/ci/github-close-issues.js
+ */
+
+const _ = require('lodash')
+const Bluebird = require('bluebird')
+const Octokit = require('@octokit/rest')
+	.plugin(require('@octokit/plugin-retry'))
+	.plugin(require('@octokit/plugin-throttling'))
+const moment = require('moment')
+const packageJSON = require('../../package.json')
+
+const DELAY = 500
+const RETRY_COUNT = 5
+const SINCE = moment.utc().subtract(2, 'days').format('YYYY-MM-DD')
+
+/**
+ * @summary Close old GitHub issues in the Jellyfish test repository
+ * @param {Object} options - required GitHub options
+ * @function
+ *
+ * @returns {Promise<Number>} number of issues closed
+ */
+const closeIssues = async (options) => {
+	const context = {
+		closed: [],
+		owner: options.repo.split('/')[0],
+		repo: options.repo.split('/')[1],
+		octokit: new Octokit({
+			request: {
+				retries: RETRY_COUNT
+			},
+			userAgent: `${packageJSON.name} v${packageJSON.version}`,
+			auth: `token ${options.token}`,
+			throttle: {
+				onRateLimit: (retryAfter, retryOptions) => {
+					return retryOptions.request.RETRY_COUNT <= RETRY_COUNT
+				},
+				onAbuseLimit: (retryAfter, retryOptions) => {
+					return retryOptions.request.RETRY_COUNT <= RETRY_COUNT
+				}
+			}
+		})
+	}
+
+	// Search for old issues.
+	const query = `repo:${options.repo}+is:issue+is:open+created:<${SINCE}`
+
+	while (true) {
+		// Search for old test issues.
+		const results = await context.octokit.search.issuesAndPullRequests({
+			q: query,
+			per_page: 100
+		}).catch((err) => {
+			console.error(err)
+		})
+
+		// Break loop if no issues were found.
+		if (!_.get(results, [ 'data', 'items', 'length' ])) {
+			break
+		}
+
+		await Bluebird.each(results.data.items, async (issue) => {
+			await closeIssue(context, issue)
+		})
+	}
+
+	return context.closed.length
+}
+
+/**
+ * @summary Close a single GitHub issue
+ * @function
+ *
+ * @param {Object} context - Data/objects needed to call GitHub API
+ * @param {Object} issue - Title and number of an issue to close
+ */
+const closeIssue = async (context, issue) => {
+	if (_.includes(context.closed, issue.number)) {
+		return
+	}
+	console.log(`Closing issue ${issue.title} (${issue.number})`)
+	await context.octokit.issues.update({
+		owner: context.owner,
+		repo: context.repo,
+		issue_number: issue.number,
+		state: 'closed'
+	}).then(() => {
+		context.closed.push(issue.number)
+	}).catch((err) => {
+		console.error(err)
+	})
+	await Bluebird.delay(DELAY)
+}
+
+/**
+ * @summary Validate set options
+ * @function
+ *
+ * @param {Object} options - GitHub options
+ */
+const validate = (options) => {
+	// Check that the GitHub token is set.
+	if (!options.token) {
+		handleError('Must set GITHUB_TOKEN')
+	}
+
+	// Check that the GitHub test repository name is set.
+	if (!options.repo) {
+		handleError('Must set GITHUB_REPO')
+	}
+}
+
+/**
+ * @summary Handle errors
+ * @function
+ *
+ * @param {String} msg - error message
+ */
+const handleError = (msg) => {
+	console.error(msg)
+	process.exit(1)
+}
+
+// Set required options and validate them.
+const options = {
+	token: process.env.GITHUB_TOKEN,
+	repo: process.env.GITHUB_REPO
+}
+validate(options)
+
+// Close old issues using provided options.
+closeIssues(options)
+	.then((total) => {
+		console.log(`Successfully closed ${total} issues`)
+	})
+	.catch((err) => {
+		console.error(err)
+	})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add old data clean up scripts:
- Close GitHub issues created on the [test repo](https://github.com/product-os/jellyfish-test-github/issues) that are two or more days older
- Delete Front conversations created in the test inboxes that are two or more days older

This PR will also add two make commands to perform the above and automatically run these scripts in a new CircleCI job.
