### PR TITLE
(My Participation pt1) server: Add computed 'participants' property to support thread card

### DIFF
--- a/apps/server/default-cards/contrib/support-thread.json
+++ b/apps/server/default-cards/contrib/support-thread.json
@@ -53,6 +53,10 @@
                 "production"
               ]
             },
+            "participants": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.actor')"
+            },
             "mentionsUser": {
               "type": "array",
               "$$formula": "AGGREGATE($events, 'data.payload.mentionsUser')"

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -257,6 +257,7 @@ class CreateLens extends React.Component {
 
 		// Omit known computed values from the schema
 		const schema = _.omit(selectedTypeTarget.data.schema, [
+			'properties.data.properties.participants',
 			'properties.data.properties.mentionsUser',
 			'properties.data.properties.alertsUser'
 		])

--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -50,6 +50,7 @@ class EditLens extends React.Component {
 
 		// Omit known computed values from the schema
 		const schema = _.omit(cardType ? cardType.data.schema : {}, [
+			'properties.data.properties.participants',
 			'properties.data.properties.mentionsUser',
 			'properties.data.properties.alertsUser',
 

--- a/lib/ui-components/GroupUpdate.jsx
+++ b/lib/ui-components/GroupUpdate.jsx
@@ -35,7 +35,7 @@ class GroupUpdate extends React.Component {
 			// Remove known metadata properties
 			if (flatSchema.properties) {
 				flatSchema.properties = _.omitBy(flatSchema.properties, (value) => {
-					return _.includes([ 'alertsUser', 'mentionsUser', '$$localSchema' ], value.title)
+					return _.includes([ 'participants', 'alertsUser', 'mentionsUser', '$$localSchema' ], value.title)
 				})
 			}
 			const selectedField = _.keys(flatSchema.properties).shift()

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -51,6 +51,7 @@ ava.serial('should be able to run high privilege triggers in response to common 
 		version: '1.0.0',
 		data: {
 			action: 'action-create-card@1.0.0',
+			mode: 'insert',
 			filter: {
 				type: 'object',
 				properties: {


### PR DESCRIPTION
This property is an aggregate of the `data.actor` properties on all 'events' in the thread.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

ref: #3120 

Step 1 of 3 in adding support for a new view of support threads that the authenticated user has participated in.

1. **(THIS PR) Adds the (computed) `participants` property to the `support-thread` card.**
2. @jviotti Data Migration: write and run a script to back-populate the `participants` field in all `support-thread` cards where the `participants` property is undefined.
3. #3193 Adds a new 'Support > My Participation' view to view all support threads that you have participated in.
    * Will need to run the data migration script one more time after deploying this PR to catch any support threads that were created between the last run of the script and the deployment of this PR.