### PR TITLE
(My Participation pt2) ui: New View: 'Support -> My Participation'

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -121,6 +121,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('balena/view-all-specifications.json'),
 		await loadCard('balena/view-all-support-issues.json'),
 		await loadCard('balena/view-support-knowledge-base.json'),
+		await loadCard('balena/view-support-threads-participation.json'),
 		await loadCard('balena/view-all-support-threads.json'),
 		await loadCard('balena/view-all-users.json'),
 		await loadCard('balena/view-architecture-call-topics.json'),

--- a/apps/server/default-cards/balena/view-support-threads-participation.json
+++ b/apps/server/default-cards/balena/view-support-threads-participation.json
@@ -1,0 +1,79 @@
+{
+  "slug": "view-support-threads-participation",
+  "name": "My participation",
+  "version": "1.0.0",
+  "type": "view@1.0.0",
+  "markers": [ "org-balena" ],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "namespace": "Support",
+    "allOf": [
+      {
+        "name": "Active cards",
+        "schema": {
+          "$$links": {
+            "has attached element": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "enum": [
+                    "message",
+                    "create",
+                    "whisper",
+                    "update",
+                    "message@1.0.0",
+                    "create@1.0.0",
+                    "whisper@1.0.0",
+                    "update@1.0.0"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "type": "object",
+          "properties": {
+            "active": {
+              "const": true,
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [ "support-thread", "support-thread@1.0.0" ]
+            },
+            "data": {
+              "type": "object",
+              "required": [
+                "participants"
+              ],
+              "properties": {
+                "participants": {
+                  "type": "array",
+                  "contains": {
+                    "const": {
+                      "$eval": "user.id"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "active",
+            "type"
+          ],
+          "description": "View all support threads I've participated in",
+          "additionalProperties": true
+        }
+      }
+    ],
+    "lenses": [
+      "lens-support-threads",
+      "lens-kanban"
+    ]
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/apps/ui/lens/list/SupportThreads.jsx
+++ b/apps/ui/lens/list/SupportThreads.jsx
@@ -269,7 +269,11 @@ export class SupportThreads extends React.Component {
 									}}
 								>
 									{!(this.props.totalPages > this.props.page + 1) && segment.cards.length === 0 && (
-										<Box p={3}><strong>Good job! There are no support threads here</strong></Box>
+										<Box p={3}>
+											<strong data-test="alt-text--no-support-threads">
+												Good job! There are no support threads here
+											</strong>
+										</Box>
 									)}
 
 									{_.map(segment.cards, (card) => {

--- a/test/e2e/ui/helpers.js
+++ b/test/e2e/ui/helpers.js
@@ -5,8 +5,17 @@
  */
 
 const puppeteer = require('puppeteer')
+const uuid = require('uuid/v4')
 const environment = require('../../../lib/environment')
 const helpers = require('../sdk/helpers')
+
+exports.generateUserDetails = () => {
+	return {
+		username: `johndoe-${uuid()}`,
+		email: `johndoe-${uuid()}@example.com`,
+		password: 'password'
+	}
+}
 
 exports.addPageHandlers = (page, headless = true) => {
 	const onError = (prefix) => {


### PR DESCRIPTION
This new view displays all support issues in which the authenticated user has participated.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

ref: #3120 

Step 3 of 3 in adding support for a new view of support threads that the authenticated user has participated in.

_Note: Step 2 has been [deemed 'value added'](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/xfuh9CHmDTnqd7hg-fK7O9ZXt8a) and therefore has been skipped - for now._

1. ✔️ #3192 Adds the (computed) `participants` property to the `support-thread` card.
2. ~~[ ] @jviotti Data Migration: write and run a script to back-populate the `participants` field in all `support-thread` cards where the `participants` property is undefined.~~
3. **(THIS PR) Adds a new 'Support > My Participation' view to view all support threads that you have participated in.**
    * ~~Will need to run the data migration script one more time after deploying this PR to catch any support threads that were created between the last run of the script and the deployment of this PR.~~

![image](https://user-images.githubusercontent.com/2925657/75510943-1de11e00-5a1f-11ea-8cf9-9fb3b53565ab.png)