### PR TITLE
server: Increase ping timeout on web socket

### DIFF
--- a/apps/server/socket/index.js
+++ b/apps/server/socket/index.js
@@ -12,6 +12,7 @@ const uuid = require('../../../lib/uuid')
 
 module.exports = (jellyfish, server) => {
 	const socketServer = socketIo(server, {
+		pingTimeout: 60000,
 		transports: [ 'websocket', 'polling' ]
 	})
 


### PR DESCRIPTION
If the web socket is being flooded with 'update' messages, it doesn't ping quickly enough. The socket times out and closes down. It may re-open(?) but some streamed updates may not make it to the client (UI). This can cause e2e stress tests to fail.

Ref: https://github.com/socketio/socket.io/issues/3259#issuecomment-448058937

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Ref: #3204 

_TBD: do we rely on a small ping timeout (the default is 5 seconds) on our websocket? Or is increasing it to 60 seconds acceptable? The increase is primarily to allow our stress tests to pass, rather than for actual day-to-day use by real clients._