### PR TITLE
Don't download puppeteer with the `build` job, it's useless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,11 @@ jobs:
       # --unsafe-perm flag allows the postinstall script to run correctly
       - run:
           name: Install Dependencies
-          command: npm ci --unsafe-perm && make build-ui COVERAGE=1 NODE_ENV=test && COVERAGE=1 NODE_ENV=test make build-livechat
+          command: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci --unsafe-perm
+
+      - run:
+          name: Build UI and livechat
+          command: make build-ui COVERAGE=1 NODE_ENV=test && COVERAGE=1 NODE_ENV=test make build-livechat
 
       - save_cache:
           paths:


### PR DESCRIPTION
This should have been part of #3171 but apparently the commit got lost