### PR TITLE
Configure Kanban Lens for opportunities

### DIFF
--- a/apps/server/default-cards/contrib/opportunity.json
+++ b/apps/server/default-cards/contrib/opportunity.json
@@ -1,8 +1,8 @@
 {
   "slug": "opportunity",
-  "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Opportunity",
+  "version": "1.0.0",
+  "type": "type@1.0.0",
   "markers": [],
   "tags": [],
   "links": {},
@@ -48,6 +48,9 @@
         }
       }
     },
+    "slices": [
+      "properties.data.properties.status"
+    ],
     "meta": {
       "relationships": [
         {


### PR DESCRIPTION
A small change to the Opportunity schema to configure the Kanban lens. It creates Kanban boards based on the Opportunity stage.

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

<img width="1792" alt="Screenshot 2020-03-02 at 10 33 19" src="https://user-images.githubusercontent.com/11800807/75663623-6db72380-5c71-11ea-9614-f0f0a05c6bf5.png">


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
