### PR TITLE
Wait more time when "flushing" the queue during tests

### DIFF
--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -65,7 +65,7 @@ exports.beforeEach = async (test, options) => {
 				return null
 			}
 
-			await Bluebird.delay(1)
+			await Bluebird.delay(10)
 			return test.context.dequeue(times - 1)
 		}
 

--- a/test/integration/sync/balena-api-translate.spec.js
+++ b/test/integration/sync/balena-api-translate.spec.js
@@ -119,7 +119,7 @@ avaTest('should change the remote username to an existing unsynced user', async 
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -236,7 +236,7 @@ avaTest('should change the remote username to an existing user', async (test) =>
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -351,7 +351,7 @@ avaTest('should change the remote username to an existing user while removing ex
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -474,7 +474,7 @@ avaTest('should change the remote username to an existing user and add a name', 
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -595,7 +595,7 @@ avaTest('should change the remote username to an existing user while removing th
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -717,7 +717,7 @@ avaTest('should change the remote username to an existing user while removing th
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -848,7 +848,7 @@ avaTest('should change the remote username to an existing user with a name', asy
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -954,7 +954,7 @@ avaTest('should change the remote username', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1037,7 +1037,7 @@ avaTest('should change the remote username while filling in the company', async 
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1119,7 +1119,7 @@ avaTest('should change the remote username while filling in the first name', asy
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1203,7 +1203,7 @@ avaTest('should change the remote username while filling in the last name', asyn
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1286,7 +1286,7 @@ avaTest('should change the remote username while not changing anything else', as
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1363,7 +1363,7 @@ avaTest('should add a company and email to an existing user', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1448,7 +1448,7 @@ avaTest('should add a first name to an existing user', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1535,7 +1535,7 @@ avaTest('should add a last name to an existing user', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -1621,7 +1621,7 @@ avaTest('should link an existing user by adding no data', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -71,7 +71,7 @@ avaTest('should not change the same user email', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)
@@ -148,7 +148,7 @@ avaTest('should add a new e-mail to a user', async (test) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)

--- a/test/integration/sync/pipeline.spec.js
+++ b/test/integration/sync/pipeline.spec.js
@@ -466,8 +466,6 @@ ava('.importCards() should add create events', async (test) => {
 		}
 	])
 
-	await test.context.flush(test.context.session)
-
 	const timeline = await test.context.jellyfish.query(test.context.context, test.context.session, {
 		type: 'object',
 		additionalProperties: true,

--- a/test/integration/sync/scenario.js
+++ b/test/integration/sync/scenario.js
@@ -140,7 +140,7 @@ const webhookScenario = async (test, testCase, integration, stub) => {
 				arguments: {}
 			})
 
-		await test.context.flush(test.context.session, 1)
+		await test.context.flush(test.context.session)
 		const result = await test.context.queue.producer.waitResults(
 			test.context.context, request)
 		test.false(result.error)

--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -52,14 +52,10 @@ exports.worker = {
 			test.context.queue.producer)
 		await test.context.worker.initialize(test.context.context)
 
-		test.context.flush = async (session, expect = 0) => {
+		test.context.flush = async (session) => {
 			const request = await test.context.dequeue()
 
 			if (!request) {
-				if (expect <= 0) {
-					return
-				}
-
 				throw new Error('No message dequeued')
 			}
 
@@ -75,8 +71,6 @@ exports.worker = {
 				error.stack = errio.fromObject(result.data).stack
 				throw error
 			}
-
-			await test.context.flush(session, expect - 1)
 		}
 	},
 	afterEach: helpers.afterEach

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -176,7 +176,7 @@ ava('should not store the password in the queue when using action-create-user', 
 		test.context.worker.getId(), test.context.session, request)
 	test.not(createUserRequest.data.arguments.password.string, password)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(result.error)
@@ -201,7 +201,7 @@ ava('should not store the password in the queue when using action-create-session
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(result.error)
@@ -248,7 +248,7 @@ ava('should not store the passwords in the queue when using action-set-password'
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(result.error)
@@ -363,7 +363,7 @@ ava('should change the password of a password-less user given no password', asyn
 
 	const resetRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, resetRequestPre)
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const resetResult = await test.context.queue.producer.waitResults(
 		test.context.context, resetRequest)
 	test.false(resetResult.error)
@@ -380,7 +380,7 @@ ava('should change the password of a password-less user given no password', asyn
 
 	const loginRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, loginRequestPre)
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const loginResult = await test.context.queue.producer.waitResults(
 		test.context.context, loginRequest)
 	test.false(loginResult.error)
@@ -409,7 +409,7 @@ ava('should change a user password', async (test) => {
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const signupResult = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(signupResult.error)
@@ -429,7 +429,7 @@ ava('should change a user password', async (test) => {
 
 	const request = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request2)
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -458,7 +458,7 @@ ava('should change a user password', async (test) => {
 
 	const loginRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request3)
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const loginResult = await test.context.queue.producer.waitResults(
 		test.context.context, loginRequest)
 	test.false(loginResult.error)
@@ -483,7 +483,7 @@ ava('should not change a user password given invalid current password', async (t
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const signupResult = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(signupResult.error)
@@ -521,7 +521,7 @@ ava('should not change a user password given a null current password', async (te
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const signupResult = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(signupResult.error)
@@ -559,7 +559,7 @@ ava('should change the hash when updating a user password', async (test) => {
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const signupResult = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(signupResult.error)
@@ -582,7 +582,7 @@ ava('should change the hash when updating a user password', async (test) => {
 
 	const request = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request2)
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -638,7 +638,7 @@ ava('should fail to create an event with an action-create-card', async (test) =>
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const typeResult = await test.context.queue.producer.waitResults(
 		test.context.context, id)
 	test.false(typeResult.error)
@@ -660,7 +660,7 @@ ava('should fail to create an event with an action-create-card', async (test) =>
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const threadResult = await test.context.queue.producer.waitResults(
 		test.context.context, threadId)
 	test.false(threadResult.error)
@@ -688,7 +688,7 @@ ava('should fail to create an event with an action-create-card', async (test) =>
 	})
 
 	await test.throwsAsync(
-		test.context.flush(test.context.session, 1),
+		test.context.flush(test.context.session),
 		{
 			message: 'You may not use card actions to create an event'
 		}
@@ -715,7 +715,7 @@ ava('.execute() should execute an action', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -746,7 +746,7 @@ ava('.execute() should add an execution event to the action request', async (tes
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -933,7 +933,7 @@ ava('.execute() should execute a triggered action', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1022,7 +1022,7 @@ ava('a triggered action can update a dynamic list of cards (ids as array of stri
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1119,7 +1119,7 @@ ava('a triggered action can update a dynamic list of cards (ids as array of obje
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1333,7 +1333,7 @@ ava('trigger should fail to update card if triggered by a user not owning the ca
 			}
 		})
 
-	await test.throwsAsync(test.context.flush(sessionIdOfJohnDoe, 1),
+	await test.throwsAsync(test.context.flush(sessionIdOfJohnDoe),
 		{
 			instanceOf: test.context.worker.errors.WorkerNoElement
 		})
@@ -1395,7 +1395,7 @@ ava('.execute() should execute a triggered action given a matching mode', async 
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1466,7 +1466,7 @@ ava('.execute() should not execute a triggered action given a non matching mode'
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1536,7 +1536,7 @@ ava('.execute() should not execute a triggered action with a future start date',
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1610,7 +1610,7 @@ ava('.execute() should execute a triggered action with a top level anyOf', async
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1643,7 +1643,7 @@ ava('.execute() should add a create event when creating a card', async (test) =>
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -1713,7 +1713,7 @@ ava('.execute() should be able to AGGREGATE based on the card timeline', async (
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const typeResult = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(typeResult.error)
@@ -1736,7 +1736,7 @@ ava('.execute() should be able to AGGREGATE based on the card timeline', async (
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const threadResult = await test.context.queue.producer.waitResults(
 		test.context.context, threadRequest)
 	test.false(threadResult.error)
@@ -1771,7 +1771,8 @@ ava('.execute() should be able to AGGREGATE based on the card timeline', async (
 			}
 		})
 
-	await test.context.flush(test.context.session, 2)
+	await test.context.flush(test.context.session)
+	await test.context.flush(test.context.session)
 	const messageResult1 = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest1)
 	const messageResult2 = await test.context.queue.producer.waitResults(
@@ -1827,7 +1828,7 @@ ava('.execute() AGGREGATE should create a property on the target if it does not 
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const typeResult = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(typeResult.error)
@@ -1847,7 +1848,7 @@ ava('.execute() AGGREGATE should create a property on the target if it does not 
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const threadResult = await test.context.queue.producer.waitResults(
 		test.context.context, threadRequest)
 	test.false(threadResult.error)
@@ -1867,7 +1868,7 @@ ava('.execute() AGGREGATE should create a property on the target if it does not 
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -1917,7 +1918,7 @@ ava('.execute() AGGREGATE should work with $$ prefixed properties', async (test)
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const typeResult = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(typeResult.error)
@@ -1939,7 +1940,7 @@ ava('.execute() AGGREGATE should work with $$ prefixed properties', async (test)
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const threadResult = await test.context.queue.producer.waitResults(
 		test.context.context, threadRequest)
 	test.false(threadResult.error)
@@ -1959,7 +1960,7 @@ ava('.execute() AGGREGATE should work with $$ prefixed properties', async (test)
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -2000,7 +2001,7 @@ ava('.execute() should create a message with tags', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const typeResult = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(typeResult.error)
@@ -2019,7 +2020,7 @@ ava('.execute() should create a message with tags', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const threadResult = await test.context.queue.producer.waitResults(
 		test.context.context, threadRequest)
 	test.false(threadResult.error)
@@ -2039,7 +2040,7 @@ ava('.execute() should create a message with tags', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -2875,7 +2876,7 @@ ava('should be able to login as a user with a password', async (test) => {
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const signupResult = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(signupResult.error)
@@ -2893,7 +2894,7 @@ ava('should be able to login as a user with a password', async (test) => {
 	const loginRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request2)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const loginResult = await test.context.queue.producer.waitResults(
 		test.context.context, loginRequest)
 	test.false(loginResult.error)
@@ -2943,7 +2944,7 @@ ava('should not be able to login as a password-less user', async (test) => {
 		})
 
 	await test.throwsAsync(
-		test.context.flush(test.context.session, 1),
+		test.context.flush(test.context.session),
 		{
 			instanceOf: test.context.worker.errors.WorkerSchemaMismatch
 		})
@@ -2999,7 +3000,7 @@ ava('should not be able to login as a password-less non-disallowed user', async 
 		})
 
 	await test.throwsAsync(
-		test.context.flush(test.context.session, 1),
+		test.context.flush(test.context.session),
 		{
 			instanceOf: test.context.worker.errors.WorkerSchemaMismatch
 		})
@@ -3029,7 +3030,7 @@ ava('should not be able to login as a password-less disallowed user', async (tes
 		})
 
 	await test.throwsAsync(
-		test.context.flush(test.context.session, 1),
+		test.context.flush(test.context.session),
 		{
 			instanceOf: test.context.worker.errors.WorkerSchemaMismatch
 		})
@@ -3054,7 +3055,7 @@ ava('should fail if signing up with the wrong password', async (test) => {
 	const createUserRequest = await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, request1)
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const signupResult = await test.context.queue.producer.waitResults(
 		test.context.context, createUserRequest)
 	test.false(signupResult.error)
@@ -3092,7 +3093,7 @@ ava('should fail to update a card if the schema does not match', async (test) =>
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -3115,7 +3116,7 @@ ava('should fail to update a card if the schema does not match', async (test) =>
 	})
 
 	await test.throwsAsync(
-		test.context.flush(test.context.session, 1),
+		test.context.flush(test.context.session),
 		{
 			instanceOf: test.context.jellyfish.errors.JellyfishSchemaMismatch
 		})
@@ -3141,7 +3142,7 @@ ava('should update a card to add an extra property', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3163,7 +3164,7 @@ ava('should update a card to add an extra property', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3209,7 +3210,7 @@ ava('should update a card to set active to false', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3231,7 +3232,7 @@ ava('should update a card to set active to false', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3270,7 +3271,7 @@ ava('should update a card along with a reason', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3293,7 +3294,7 @@ ava('should update a card along with a reason', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3344,7 +3345,7 @@ ava('should create a new card along with a reason', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3395,7 +3396,7 @@ ava('should update a card to set active to false using the card slug as input', 
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3418,7 +3419,7 @@ ava('should update a card to set active to false using the card slug as input', 
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3459,7 +3460,7 @@ ava('should update a card to override an array property', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3482,7 +3483,7 @@ ava('should update a card to override an array property', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3526,7 +3527,7 @@ ava('should add an update event if updating a card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3548,7 +3549,7 @@ ava('should add an update event if updating a card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3642,7 +3643,7 @@ ava('should delete a card using action-delete-card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3655,7 +3656,7 @@ ava('should delete a card using action-delete-card', async (test) => {
 		arguments: {}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const deleteResult = await test.context.queue.producer.waitResults(
 		test.context.context, deleteRequest)
 	test.false(deleteResult.error)
@@ -3693,7 +3694,7 @@ ava('should delete a card using action-update-card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -3716,7 +3717,7 @@ ava('should delete a card using action-update-card', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -3770,7 +3771,7 @@ ava('action-create-event should create a link card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const cardResult = await test.context.queue.producer.waitResults(
 		test.context.context, cardRequest)
 	test.false(cardResult.error)
@@ -3789,7 +3790,7 @@ ava('action-create-event should create a link card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -3857,7 +3858,7 @@ ava('action-create-event: should be able to add an event name', async (test) => 
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const cardResult = await test.context.queue.producer.waitResults(
 		test.context.context, cardRequest)
 	test.false(cardResult.error)
@@ -3877,7 +3878,7 @@ ava('action-create-event: should be able to add an event name', async (test) => 
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -3917,7 +3918,7 @@ ava('events should always inherit their parent\'s markers', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const cardResult = await test.context.queue.producer.waitResults(
 		test.context.context, cardRequest)
 	test.false(cardResult.error)
@@ -3937,7 +3938,7 @@ ava('events should always inherit their parent\'s markers', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -3974,7 +3975,7 @@ ava('Updating a cards markers should update the markers of attached events', asy
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(session)
 	const cardResult = await test.context.queue.producer.waitResults(
 		test.context.context, cardRequest)
 	test.false(cardResult.error)
@@ -4081,7 +4082,7 @@ ava('should be able to insert a deeply nested card', async (test) => {
 		}
 	})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -4151,7 +4152,7 @@ ava('should be able to upsert a deeply nested card', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const createResult = await test.context.queue.producer.waitResults(
 		test.context.context, createRequest)
 	test.false(createResult.error)
@@ -4254,7 +4255,7 @@ ava('should be able to upsert a deeply nested card', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const updateResult = await test.context.queue.producer.waitResults(
 		test.context.context, updateRequest)
 	test.false(updateResult.error)
@@ -4289,7 +4290,7 @@ ava('should post a broadcast message to an empty thread', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -4365,7 +4366,7 @@ ava('should post a broadcast message to a non empty thread', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -4381,7 +4382,7 @@ ava('should post a broadcast message to a non empty thread', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result = await test.context.queue.producer.waitResults(
 		test.context.context, request)
 	test.false(result.error)
@@ -4470,7 +4471,7 @@ ava('should not broadcast the same message twice', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result1 = await test.context.queue.producer.waitResults(
 		test.context.context, request1)
 	test.false(result1.error)
@@ -4489,7 +4490,7 @@ ava('should not broadcast the same message twice', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -4505,7 +4506,7 @@ ava('should not broadcast the same message twice', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result2 = await test.context.queue.producer.waitResults(
 		test.context.context, request2)
 	test.false(result2.error)
@@ -4594,7 +4595,7 @@ ava('should broadcast different messages', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result1 = await test.context.queue.producer.waitResults(
 		test.context.context, request1)
 	test.false(result1.error)
@@ -4613,7 +4614,7 @@ ava('should broadcast different messages', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const messageResult = await test.context.queue.producer.waitResults(
 		test.context.context, messageRequest)
 	test.false(messageResult.error)
@@ -4629,7 +4630,7 @@ ava('should broadcast different messages', async (test) => {
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result2 = await test.context.queue.producer.waitResults(
 		test.context.context, request2)
 	test.false(result2.error)
@@ -4757,7 +4758,7 @@ ava('should broadcast the same message twice given different actors', async (tes
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result1 = await test.context.queue.producer.waitResults(
 		test.context.context, request1)
 	test.false(result1.error)
@@ -4773,7 +4774,7 @@ ava('should broadcast the same message twice given different actors', async (tes
 			}
 		})
 
-	await test.context.flush(test.context.session, 1)
+	await test.context.flush(test.context.session)
 	const result2 = await test.context.queue.producer.waitResults(
 		test.context.context, request2)
 	test.false(result2.error)


### PR DESCRIPTION
This change is to avoid erratic test failures because of "No message dequeued"

Solution involve
- waiting more when nothing comes from the queue (from 1 to 10 ms)
- not flushing a second time in `flush`
- make flush a non optional operation: if you (human writing a test) expect something from the queue, you call `flush`, if you don't , you don't call it

Since we were previously calling flush twice, the second call being always useless, we have also shaved 50ms from each test, which is nice

For the reviewer: the important changes are in [test/integration/queue/helpers.js](https://github.com/product-os/jellyfish/pull/3217/files#diff-a4e96cbe22dc25414f3c3fc8a86aad24) and in [test/integration/worker/helpers.js](https://github.com/product-os/jellyfish/pull/3217/files#diff-f92fbd2f0e9b7356d450837c01bb9df3)