### PR TITLE
repo: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
-* @lucianbuzzo @jviotti @ffissore @karaxuna @StefKors @joshbwlng @grahammcculloch
-deploy-templates @richbayliss @nazrhom
+* @lucianbuzzo @jviotti @ffissore @karaxuna @StefKors @joshbwlng @grahammcculloch @Ljewalsh
+/deploy-templates/ @nazrhom
+/deploy-templates/cloudformation/ @ab77 @cmfcruz
+/deploy-templates/jellyfish-product/ @richbayliss @nazrhom


### PR DESCRIPTION
- ensure Rich is only a CODEOWNER for Katapult-related templates
- add Lucy-Jane as JF codeowner
- add anton and carlo miguel as codeowners of cloudformation templates


Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>