### PR TITLE
Add full text search capabilities to field data->payload->message

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -76,26 +76,34 @@ exports.setup = async (context, connection, database, options = {}) => {
 	const indexes = _.map(await connection.any(`SELECT * FROM pg_indexes WHERE tablename = '${table}'`), 'indexname')
 
 	await Bluebird.map([ {
-		column: 'slug'
+		name: 'slug',
+		column_or_expression: 'slug'
 	}, {
-		column: 'tags',
-		indexType: 'GIN'
-	}, {
-		column: 'type'
-	}, {
-		column: 'data',
+		name: 'tags',
 		indexType: 'GIN',
-		options: 'jsonb_path_ops'
+		column_or_expression: 'tags'
+	}, {
+		name: 'type',
+		column_or_expression: 'type'
+	}, {
+		name: 'data',
+		indexType: 'GIN',
+		column_or_expression: 'data jsonb_path_ops'
 	}, {
 		name: 'data_mirrors',
-		column: '(data->\'mirrors\')',
 		indexType: 'GIN',
-		options: 'jsonb_path_ops'
+		column_or_expression: '(data->\'mirrors\') jsonb_path_ops'
 	}, {
-		column: 'created_at',
-		options: 'DESC'
+		name: 'created_at',
+		column_or_expression: 'created_at DESC'
 	}, {
-		column: 'updated_at'
+		name: 'updated_at',
+		column_or_expression: 'updated_at'
+	}, {
+		name: 'ts_data_payload_message',
+		indexType: 'GIN',
+		column_or_expression: 'to_tsvector(\'english\', data->\'payload\'->\'message\')',
+		where: 'WHERE jsonb_typeof(data->\'payload\'->\'message\') = \'string\''
 	} ], async (secondaryIndex) => {
 		/*
 		 * This is the actual name of the index that we will create
@@ -105,7 +113,7 @@ exports.setup = async (context, connection, database, options = {}) => {
 		 * not be able to cleanup older indexes with the older
 		 * name convention.
 		 */
-		const fullyQualifiedIndexName = `${secondaryIndex.name || secondaryIndex.column}_${table}_idx`
+		const fullyQualifiedIndexName = `${secondaryIndex.name}_${table}_idx`
 
 		/*
 		 * Lets not create the index if it already exists.
@@ -122,7 +130,8 @@ exports.setup = async (context, connection, database, options = {}) => {
 
 		await connection.any(`
 			CREATE INDEX ${fullyQualifiedIndexName} ON ${table}
-			USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
+			USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column_or_expression})
+			${secondaryIndex.where || ''}`)
 	}, {
 		concurrency: 4
 	})

--- a/lib/core/backend/postgres/jsonschema2sql/builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder.js
@@ -74,6 +74,12 @@ const CARD_FIELDS = {
 	}
 }
 
+const FULL_TEXT_SEARCH_FIELDS = [
+	[ 'data', 'payload', 'message' ]
+].map((path) => {
+	return path.join('/')
+})
+
 exports.valueToPostgres = (value) => {
 	return pgFormat.literal(value)
 }
@@ -348,6 +354,14 @@ exports.everyArray = (property, schema, walk) => {
 
 exports.keys = (property) => {
 	return `ARRAY(SELECT jsonb_object_keys(${exports.getProperty(property)}))`
+}
+
+exports.isFullTextSearchCapable = (path) => {
+	return _.includes(FULL_TEXT_SEARCH_FIELDS, path.slice(1).join('/'))
+}
+
+exports.fullTextSearch = (path, value) => {
+	return `to_tsvector('english', ${exports.getProperty(path)}) @@ websearch_to_tsquery(${exports.valueToPostgres(value.const)})`
 }
 
 exports.shortcuts = {}

--- a/lib/core/backend/postgres/jsonschema2sql/keywords.js
+++ b/lib/core/backend/postgres/jsonschema2sql/keywords.js
@@ -451,6 +451,13 @@ exports.default = (value, path, walk, schema, context, keys, requiredPaths) => {
 }
 
 exports.contains = (value, path, walk, schema, context, keys, requiredPaths) => {
+	if (builder.isFullTextSearchCapable(path)) {
+		return {
+			keys,
+			filter: builder.fullTextSearch(path, value)
+		}
+	}
+
 	return {
 		keys,
 		filter: builder.or(

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -4411,6 +4411,61 @@ ava('.query() should be able to skip', async (test) => {
 	test.not(result1[0].slug, result2[0].slug)
 })
 
+ava('.query() should be able to search using full text search', async (test) => {
+	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
+		slug: 'usersaw',
+		type: 'card@1.0.0',
+		version: '1.0.0',
+		data: {
+			payload: {
+				message: 'This user saw many boards'
+			}
+		}
+	})
+
+	const userSee = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
+		slug: 'usersee',
+		type: 'card@1.0.0',
+		version: '1.0.0',
+		data: {
+			payload: {
+				message: 'This user sees many boards'
+			}
+		}
+	})
+
+	const results = await test.context.kernel.query(
+		test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: true,
+			required: [ 'data' ],
+			properties: {
+				data: {
+					type: 'object',
+					required: [ 'payload' ],
+					properties: {
+						payload: {
+							type: 'object',
+							required: [ 'message' ],
+							properties: {
+								message: {
+									type: 'string',
+									contains: {
+										type: 'string',
+										const: 'Users see BOARDS'
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}, {})
+
+	test.is(results.length, 1)
+	test.deepEqual(results[0].slug, userSee.slug)
+})
+
 ava('.insertCard() should create a user with two email addressses', async (test) => {
 	const card = await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {


### PR DESCRIPTION
Add full text search capabilities to field data->payload->message, use ts_* functions in jsonschema2sql if the target column/field is supported

Deployment notes: index has to be created before PR is merged

Connects-to: #3208
Change-type: minor
Signed-off-by: Federico Fissore <federico@balena.io>
