### PR TITLE
test: Execute after/before hooks serially

### DIFF
--- a/lib/chat-widget/store/reducer.spec.js
+++ b/lib/chat-widget/store/reducer.spec.js
@@ -10,7 +10,7 @@ const {
 	createReducer
 } = require('./reducer')
 
-ava.beforeEach((test) => {
+ava.serial.beforeEach((test) => {
 	test.context.initialState = {
 		product: 'jelly-chat-test',
 		productTitle: 'Jelly Chat Test',

--- a/lib/sdk/index.spec.js
+++ b/lib/sdk/index.spec.js
@@ -16,7 +16,7 @@ const nock = require('nock')
 
 const API_URL = 'https://test.ly.fish'
 
-ava.before(async (test) => {
+ava.serial.before(async (test) => {
 	test.context.sdk = getSdk({
 		apiPrefix: 'api/v2',
 		apiUrl: API_URL
@@ -43,12 +43,12 @@ ava.before(async (test) => {
 	}
 })
 
-ava.beforeEach((test) => {
+ava.serial.beforeEach((test) => {
 	nock.cleanAll()
 	test.context.sdk.setAuthToken(test.context.token)
 })
 
-ava.afterEach((test) => {
+ava.serial.afterEach((test) => {
 	test.context.sdk.cancelAllStreams()
 	test.context.sdk.cancelAllRequests()
 })

--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -28,13 +28,13 @@ const context = {
 	}
 }
 
-ava.before(async () => {
+ava.serial.before(async () => {
 	await helpers.browser.beforeEach({
 		context
 	})
 })
 
-ava.beforeEach(async () => {
+ava.serial.beforeEach(async () => {
 	const threads = await context.sdk.query({
 		properties: {
 			type: {
@@ -53,7 +53,7 @@ ava.beforeEach(async () => {
 	}))
 })
 
-ava.after(async () => {
+ava.serial.after(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/server/actions/action-increment-tag.spec.js
+++ b/test/e2e/server/actions/action-increment-tag.spec.js
@@ -9,11 +9,11 @@ const Bluebird = require('bluebird')
 const _ = require('lodash')
 const helpers = require('../../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should create a new tag using using action-increment-tag', async (test) => {
 	const name = test.context.generateRandomSlug({

--- a/test/e2e/server/actions/action-increment.spec.js
+++ b/test/e2e/server/actions/action-increment.spec.js
@@ -7,11 +7,11 @@
 const ava = require('ava')
 const helpers = require('../../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should increment a card value using action-increment', async (test) => {
 	const admin = await test.context.sdk.card.get('user-admin')

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const uuid = require('uuid/v4')
 const helpers = require('../../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should elevate external event source', async (test) => {
 	const slug = test.context.generateRandomSlug({

--- a/test/e2e/server/attachments.spec.js
+++ b/test/e2e/server/attachments.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const uuid = require('uuid/v4')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should return 404 given a non existent attachment in a card', async (test) => {
 	const result = await test.context.http(

--- a/test/e2e/server/external-support-user-security.spec.js
+++ b/test/e2e/server/external-support-user-security.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const uuid = require('uuid/v4')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/hooks.spec.js
+++ b/test/e2e/server/hooks.spec.js
@@ -7,11 +7,11 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should post a dummy "none" event', async (test) => {
 	const result = await test.context.http('POST', '/api/v2/hooks/none', {

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -11,11 +11,11 @@ const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 const environment = require('../../../lib/environment')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/integrations.spec.js
+++ b/test/e2e/server/integrations.spec.js
@@ -14,11 +14,11 @@ const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 const environment = require('../../../lib/environment')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 const balenaAvaTest = _.some(_.values(environment.integration['balena-api']), _.isEmpty)
 	? ava.skip

--- a/test/e2e/server/markers.spec.js
+++ b/test/e2e/server/markers.spec.js
@@ -17,7 +17,7 @@ const users = {
 	}
 }
 
-ava.before(async (test) => {
+ava.serial.before(async (test) => {
 	await helpers.before(test)
 
 	await test.context.sdk.action({
@@ -32,10 +32,10 @@ ava.before(async (test) => {
 	})
 })
 
-ava.after(helpers.after)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/messages.spec.js
+++ b/test/e2e/server/messages.spec.js
@@ -7,11 +7,11 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should sanely handle line breaks before tags in messages/whispers', async (test) => {
 	const thread = await test.context.sdk.card.create({

--- a/test/e2e/server/oauth.spec.js
+++ b/test/e2e/server/oauth.spec.js
@@ -7,11 +7,11 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('/api/v2/oauth should return 400 given an unknown oauth integration', async (test) => {
 	const result = await test.context.http(

--- a/test/e2e/server/security.spec.js
+++ b/test/e2e/server/security.spec.js
@@ -9,11 +9,11 @@ const uuid = require('uuid/v4')
 const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/sessions.spec.js
+++ b/test/e2e/server/sessions.spec.js
@@ -7,11 +7,11 @@
 const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava.serial('should fail with a user error given the wrong username during login', async (test) => {
 	const result = await test.context.http('POST', '/api/v2/action', {

--- a/test/e2e/server/users.spec.js
+++ b/test/e2e/server/users.spec.js
@@ -10,11 +10,11 @@ const nock = require('nock')
 const uuid = require('uuid/v4')
 const helpers = require('../sdk/helpers')
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -51,7 +51,7 @@ const generateRandomWords = (number) => {
 	return randomWords(number).join(' ')
 }
 
-ava.before(async (test) => {
+ava.serial.before(async (test) => {
 	await helpers.mirror.before(test)
 	test.context.category = environment.test.integration.discourse.category
 
@@ -234,13 +234,13 @@ ava.before(async (test) => {
 	}
 })
 
-ava.after(helpers.mirror.after)
-ava.beforeEach(async (test) => {
+ava.serial.after(helpers.mirror.after)
+ava.serial.beforeEach(async (test) => {
 	await helpers.mirror.beforeEach(
 		test, environment.integration.discourse.username)
 })
 
-ava.afterEach(helpers.mirror.afterEach)
+ava.serial.afterEach(helpers.mirror.afterEach)
 
 // Skip all tests if there is no Discourse token
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava.serial

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -90,7 +90,7 @@ const getMirrorWaitSchema = (slug) => {
 	}
 }
 
-ava.before(async (test) => {
+ava.serial.before(async (test) => {
 	await helpers.mirror.before(test)
 
 	if (TOKEN) {
@@ -251,8 +251,8 @@ ava.before(async (test) => {
 	}
 })
 
-ava.after(helpers.mirror.after)
-ava.beforeEach(async (test) => {
+ava.serial.after(helpers.mirror.after)
+ava.serial.beforeEach(async (test) => {
 	const teammates = await retryWhile429(() => {
 		return test.context.front.inbox.listTeammates({
 			inbox_id: test.context.inboxes[0]
@@ -271,7 +271,7 @@ ava.beforeEach(async (test) => {
 	await helpers.mirror.beforeEach(test, teammate.username.replace(/_/g, '-'))
 })
 
-ava.afterEach(helpers.mirror.afterEach)
+ava.serial.afterEach(helpers.mirror.afterEach)
 
 // Skip all tests if there is no Front token
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.serial.skip : ava.serial

--- a/test/e2e/sync/github-mirror.spec.js
+++ b/test/e2e/sync/github-mirror.spec.js
@@ -47,7 +47,7 @@ const getMirrorWaitSchema = (slug) => {
 	}
 }
 
-ava.before(async (test) => {
+ava.serial.before(async (test) => {
 	await helpers.mirror.before(test)
 
 	const [ owner, repo ] = environment.test.integration.github.repo.split('/')
@@ -111,12 +111,12 @@ ava.before(async (test) => {
 	})
 })
 
-ava.after(helpers.mirror.after)
-ava.beforeEach(async (test) => {
+ava.serial.after(helpers.mirror.after)
+ava.serial.beforeEach(async (test) => {
 	await helpers.mirror.beforeEach(test, uuid())
 })
 
-ava.afterEach(helpers.mirror.afterEach)
+ava.serial.afterEach(helpers.mirror.afterEach)
 
 // Skip all tests if there is no GitHub token
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.serial.skip : ava.serial

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -30,7 +30,7 @@ const userDetails2 = {
 	password: 'password'
 }
 
-ava.before(async () => {
+ava.serial.before(async () => {
 	await helpers.browser.beforeEach({
 		context
 	})
@@ -71,7 +71,7 @@ ava.before(async () => {
 	context.incognitoPage = incognitoPage
 })
 
-ava.after(async () => {
+ava.serial.after(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -66,7 +66,7 @@ const ensureCommunityLogin = async (page) => {
 	return currentUser
 }
 
-ava.before(async () => {
+ava.serial.before(async () => {
 	await helpers.browser.beforeEach({
 		context
 	})
@@ -75,7 +75,7 @@ ava.before(async () => {
 	await context.addUserToBalenaOrg(user.id)
 })
 
-ava.after(async () => {
+ava.serial.after(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/oauth.spec.js
+++ b/test/e2e/ui/oauth.spec.js
@@ -25,13 +25,13 @@ const userDetails = {
 	password: 'password'
 }
 
-ava.before(async () => {
+ava.serial.before(async () => {
 	await helpers.browser.beforeEach({
 		context
 	})
 })
 
-ava.after(async () => {
+ava.serial.after(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -22,7 +22,7 @@ const user = {
 	password: 'password'
 }
 
-ava.before(async () => {
+ava.serial.before(async () => {
 	await helpers.browser.beforeEach({
 		context
 	})
@@ -32,7 +32,7 @@ ava.before(async () => {
 	await macros.loginUser(context.page, user)
 })
 
-ava.after(async () => {
+ava.serial.after(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -23,7 +23,7 @@ const user = {
 	password: 'password'
 }
 
-ava.before(async () => {
+ava.serial.before(async () => {
 	await helpers.browser.beforeEach({
 		context
 	})
@@ -34,7 +34,7 @@ ava.before(async () => {
 	await macros.loginUser(context.page, user)
 })
 
-ava.after(async () => {
+ava.serial.after(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/integration/core/backend/index.spec.js
+++ b/test/integration/core/backend/index.spec.js
@@ -10,8 +10,8 @@ const Bluebird = require('bluebird')
 const errors = require('../../../../lib/core/errors')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('should only expose the required methods', (test) => {
 	const methods = Object.getOwnPropertyNames(

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -128,7 +128,7 @@ const runner = async ({
 	return connection.any(query)
 }
 
-ava.before(async (test) => {
+ava.serial.before(async (test) => {
 	if (!IS_POSTGRES) {
 		return
 	}

--- a/test/integration/core/backend/postgres/streams/index.spec.js
+++ b/test/integration/core/backend/postgres/streams/index.spec.js
@@ -12,7 +12,7 @@ const pgp = require('../../../../../../lib/core/backend/postgres/pg-promise')
 const streams = require('../../../../../../lib/core/backend/postgres/streams')
 const environment = require('../../../../../../lib/environment')
 
-ava.beforeEach(async (test) => {
+ava.serial.beforeEach(async (test) => {
 	const id = uuid()
 
 	test.context.table = 'test_table'
@@ -61,7 +61,7 @@ ava.beforeEach(async (test) => {
 	test.context.triggerColumns = [ 'id', 'slug' ]
 })
 
-ava.afterEach(async (test) => {
+ava.serial.afterEach(async (test) => {
 	await test.context.destroyConnection(test.context.connection)
 	test.context.connection = null
 })

--- a/test/integration/core/cache/index.spec.js
+++ b/test/integration/core/cache/index.spec.js
@@ -7,8 +7,8 @@
 const ava = require('ava')
 const helpers = require('../helpers')
 
-ava.afterEach(helpers.afterEach)
-ava.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
 
 ava('.set() should be able to retrieve item by id', async (test) => {
 	const element1 = {

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -12,8 +12,8 @@ const errors = require('../../../lib/core/errors')
 const CARDS = require('../../../lib/core/cards')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('should only expose the required methods', (test) => {
 	const methods = Object.getOwnPropertyNames(

--- a/test/integration/core/permission-filter.spec.js
+++ b/test/integration/core/permission-filter.spec.js
@@ -9,8 +9,8 @@ const permissionFilter = require('../../../lib/core/permission-filter')
 const errors = require('../../../lib/core/errors')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('.getSessionUser() should throw if the session is invalid', async (test) => {
 	await test.throwsAsync(permissionFilter.getSessionUser(

--- a/test/integration/core/views.spec.js
+++ b/test/integration/core/views.spec.js
@@ -9,8 +9,8 @@ const views = require('../../../lib/core/views')
 const CARDS = require('../../../lib/core/cards')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('.getSchema() should return null if the card is not a view', (test) => {
 	const schema = views.getSchema(CARDS['user-admin'])

--- a/test/integration/queue/events.spec.js
+++ b/test/integration/queue/events.spec.js
@@ -10,8 +10,8 @@ const Bluebird = require('bluebird')
 const helpers = require('./helpers')
 const events = require('../../../lib/queue/events')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('.post() should insert an active execute card', async (test) => {
 	const event = await events.post(test.context.context, test.context.jellyfish, test.context.session, {

--- a/test/integration/queue/index.spec.js
+++ b/test/integration/queue/index.spec.js
@@ -9,8 +9,8 @@ const ava = require('ava')
 const errors = require('../../../lib/queue/errors')
 const helpers = require('./helpers')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('.dequeue() should return nothing if no requests', async (test) => {
 	const request = await test.context.dequeue()

--- a/test/integration/server/oauth.spec.js
+++ b/test/integration/server/oauth.spec.js
@@ -25,11 +25,11 @@ const balenaApiTest =
 		? ava.serial
 		: ava.serial.skip
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 outreachTest('should be able to associate a user with Outreach', async (test) => {
 	const userCard = await test.context.sdk.card.create({

--- a/test/integration/server/outreach-mirror.spec.js
+++ b/test/integration/server/outreach-mirror.spec.js
@@ -16,8 +16,8 @@ const environment = require('../../../lib/environment')
 const helpers = require('./helpers')
 const TOKEN = environment.integration.outreach
 
-ava.before(helpers.before)
-ava.after(helpers.after)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
 const OAUTH_DETAILS = {
 	access_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3',
@@ -33,7 +33,7 @@ const NOCK_OPTS = {
 	}
 }
 
-ava.beforeEach(async (test) => {
+ava.serial.beforeEach(async (test) => {
 	await helpers.beforeEach(test)
 
 	test.context.getProspect = async (id) => {
@@ -130,7 +130,7 @@ ava.beforeEach(async (test) => {
 	])
 })
 
-ava.afterEach(async (test) => {
+ava.serial.afterEach(async (test) => {
 	await helpers.afterEach(test)
 	nock.cleanAll()
 })

--- a/test/integration/sync/balena-api-translate.spec.js
+++ b/test/integration/sync/balena-api-translate.spec.js
@@ -16,8 +16,8 @@ const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration['balena-api']
 
-ava.beforeEach(scenario.beforeEach)
-ava.afterEach.always(scenario.afterEach)
+ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava.serial
 

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -12,8 +12,8 @@ const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.discourse
 
-ava.beforeEach(scenario.beforeEach)
-ava.afterEach.always(scenario.afterEach)
+ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/flowdock-translate.spec.js
+++ b/test/integration/sync/flowdock-translate.spec.js
@@ -10,8 +10,8 @@ const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.flowdock
 
-ava.beforeEach(scenario.beforeEach)
-ava.afterEach.always(scenario.afterEach)
+ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/front-translate.spec.js
+++ b/test/integration/sync/front-translate.spec.js
@@ -10,8 +10,8 @@ const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.front
 
-ava.beforeEach(scenario.beforeEach)
-ava.afterEach.always(scenario.afterEach)
+ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/github-translate.spec.js
+++ b/test/integration/sync/github-translate.spec.js
@@ -10,8 +10,8 @@ const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.github
 
-ava.beforeEach(scenario.beforeEach)
-ava.afterEach.always(scenario.afterEach)
+ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/outreach-translate.spec.js
+++ b/test/integration/sync/outreach-translate.spec.js
@@ -10,8 +10,8 @@ const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.outreach
 
-ava.beforeEach(scenario.beforeEach)
-ava.afterEach.always(scenario.afterEach)
+ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.afterEach.always(scenario.afterEach)
 
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava
 

--- a/test/integration/sync/pipeline.spec.js
+++ b/test/integration/sync/pipeline.spec.js
@@ -12,8 +12,8 @@ const pipeline = require('../../../lib/sync/pipeline')
 const errors = require('../../../lib/sync/errors')
 const NoOpIntegration = require('./noop-integration')
 
-ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
 
 ava('.importCards() should import no card', async (test) => {
 	const result = await pipeline.importCards(test.context.syncContext, [])

--- a/test/integration/worker/executor.spec.js
+++ b/test/integration/worker/executor.spec.js
@@ -13,7 +13,7 @@ const executor = require('../../../lib/worker/executor')
 const utils = require('../../../lib/worker/utils')
 const Promise = require('bluebird')
 
-ava.beforeEach(async (test) => {
+ava.serial.beforeEach(async (test) => {
 	await helpers.jellyfish.beforeEach(test)
 
 	test.context.triggers = []
@@ -50,7 +50,7 @@ ava.beforeEach(async (test) => {
 	}
 })
 
-ava.afterEach(helpers.jellyfish.afterEach)
+ava.serial.afterEach(helpers.jellyfish.afterEach)
 
 ava('.replaceCard() updating a card must have the correct tail', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -12,11 +12,11 @@ const actionLibrary = require('../../../lib/action-library')
 const Worker = require('../../../lib/worker')
 const uuid = require('../../../lib/uuid')
 
-ava.beforeEach(async (test) => {
+ava.serial.beforeEach(async (test) => {
 	await helpers.worker.beforeEach(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.serial.afterEach(helpers.worker.afterEach)
 
 ava('.getId() should preserve the same id during its lifetime', async (test) => {
 	const id1 = test.context.worker.getId()

--- a/test/integration/worker/triggers.spec.js
+++ b/test/integration/worker/triggers.spec.js
@@ -10,8 +10,8 @@ const triggers = require('../../../lib/worker/triggers')
 const errors = require('../../../lib/worker/errors')
 const Promise = require('bluebird')
 
-ava.beforeEach(helpers.jellyfish.beforeEach)
-ava.afterEach(helpers.jellyfish.afterEach)
+ava.serial.beforeEach(helpers.jellyfish.beforeEach)
+ava.serial.afterEach(helpers.jellyfish.afterEach)
 
 ava('.getRequest() should return null if the filter only has a type but there is no match', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(

--- a/test/integration/worker/utils.spec.js
+++ b/test/integration/worker/utils.spec.js
@@ -8,8 +8,8 @@ const ava = require('ava')
 const helpers = require('./helpers')
 const utils = require('../../../lib/worker/utils')
 
-ava.beforeEach(helpers.jellyfish.beforeEach)
-ava.afterEach(helpers.jellyfish.afterEach)
+ava.serial.beforeEach(helpers.jellyfish.beforeEach)
+ava.serial.afterEach(helpers.jellyfish.afterEach)
 
 ava('.hasCard() id = yes (exists), slug = yes (exists)', async (test) => {
 	const card = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {


### PR DESCRIPTION
According to the docs, before/after hooks run all in parallel unless
they are explicitly prefixed by "serial".

Making them serial will help us debug cases like
https://circleci.com/gh/product-os/jellyfish/74925, where before/after
hooks blow up and we never get a stack trace as we don't enable
`--fail-fast` in the CI.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!