### PR TITLE
worker/action-server: Store trigger slugs

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -45,6 +45,9 @@ const SCHEMA_ACTIVE_TRIGGERS = {
 		id: {
 			type: 'string'
 		},
+		slug: {
+			type: 'string'
+		},
 		active: {
 			type: 'boolean',
 			const: true
@@ -65,7 +68,7 @@ const SCHEMA_ACTIVE_TRIGGERS = {
 			additionalProperties: true
 		}
 	},
-	required: [ 'id', 'active', 'type', 'data' ]
+	required: [ 'id', 'slug', 'active', 'type', 'data' ]
 }
 
 const bootstrap = async (context, library, options) => {
@@ -106,6 +109,7 @@ const bootstrap = async (context, library, options) => {
 		worker.setTriggers(context, triggers.map((trigger) => {
 			const object = {
 				id: trigger.id,
+				slug: trigger.slug,
 				action: trigger.data.action,
 				target: trigger.data.target,
 				arguments: trigger.data.arguments

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -228,6 +228,7 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 			_.remove(options.triggers, (element) => {
 				return fastEquals.deepEqual(element, {
 					id: trigger.id,
+					slug: trigger.slug,
 					action: trigger.data.action,
 					target: trigger.data.target,
 					filter: trigger.data.filter,
@@ -246,6 +247,7 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 
 			const triggerObject = {
 				id: insertedTrigger.id,
+				slug: insertedTrigger.slug,
 				action: trigger.data.action,
 				target: trigger.data.target,
 				filter: trigger.data.filter,

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -181,7 +181,7 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 				const triggerCard = await getInputCard(
 					context, jellyfish, session, identifier)
 				assert.INTERNAL(context, triggerCard, errors.WorkerNoElement,
-					`No such input card for trigger: ${identifier}`)
+					`No such input card for trigger ${trigger.slug}: ${identifier}`)
 				return triggerCard
 			})
 

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -239,6 +239,8 @@ module.exports = class Worker {
 		})
 
 		this.triggers = objects.map((trigger) => {
+			assert.INTERNAL(context, trigger.slug && _.isString(trigger.slug),
+				errors.WorkerInvalidTrigger, `Invalid slug: ${trigger.slug}`)
 			assert.INTERNAL(context, trigger.id && _.isString(trigger.id),
 				errors.WorkerInvalidTrigger, `Invalid id: ${trigger.id}`)
 			assert.INTERNAL(context, trigger.action && _.isString(trigger.action),
@@ -268,6 +270,7 @@ module.exports = class Worker {
 
 			const result = {
 				id: trigger.id,
+				slug: trigger.slug,
 				action: trigger.action,
 				target: trigger.target,
 				arguments: trigger.arguments

--- a/test/integration/worker/executor.spec.js
+++ b/test/integration/worker/executor.spec.js
@@ -1393,6 +1393,7 @@ ava('.insertCard() should pre-register a triggered action if using AGGREGATE', a
 	test.deepEqual(test.context.triggers, [
 		{
 			id: test.context.triggers[0].id,
+			slug: 'triggered-action-test-thread-data-mentions',
 			action: 'action-set-add@1.0.0',
 			target: {
 				$eval: 'source.links[\'is attached to\'][0].id'

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -781,6 +781,7 @@ ava('.insertCard() should pass a triggered action originator', async (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -833,6 +834,7 @@ ava('.insertCard() should take an originator option', async (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -887,6 +889,7 @@ ava('.execute() should execute a triggered action', async (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -966,6 +969,7 @@ ava('a triggered action can update a dynamic list of cards (ids as array of stri
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1052,6 +1056,7 @@ ava('a triggered action can update a dynamic list of cards (ids as array of obje
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1188,6 +1193,7 @@ ava('should fail to set a trigger when the list of card ids contains duplicates'
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1240,6 +1246,7 @@ ava('trigger should fail to update card if triggered by a user not owning the ca
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1348,6 +1355,7 @@ ava('.execute() should execute a triggered action given a matching mode', async 
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1419,6 +1427,7 @@ ava('.execute() should not execute a triggered action given a non matching mode'
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1490,6 +1499,7 @@ ava('.execute() should not execute a triggered action with a future start date',
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1554,6 +1564,7 @@ ava('.execute() should execute a triggered action with a top level anyOf', async
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -2062,6 +2073,7 @@ ava('.setTriggers() should be able to set a trigger with a start date', (test) =
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			startDate: '2008-01-01T00:00:00.000Z',
@@ -2079,6 +2091,7 @@ ava('.setTriggers() should be able to set a trigger with a start date', (test) =
 	test.deepEqual(triggers, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			startDate: '2008-01-01T00:00:00.000Z',
@@ -2096,6 +2109,7 @@ ava('.setTriggers() should be able to set a trigger with an interval', (test) =>
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			interval: 'PT1H',
@@ -2110,6 +2124,7 @@ ava('.setTriggers() should be able to set a trigger with an interval', (test) =>
 	test.deepEqual(triggers, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			interval: 'PT1H',
@@ -2124,6 +2139,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			filter: {
@@ -2135,6 +2151,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 		},
 		{
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
 			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
 			type: 'card@1.0.0',
@@ -2152,6 +2169,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 	test.deepEqual(triggers, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			filter: {
@@ -2163,6 +2181,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 		},
 		{
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
 			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
 			filter: {
@@ -2179,6 +2198,7 @@ ava('.setTriggers() should not store extra properties', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			foo: 'bar',
 			bar: 'baz',
 			action: 'action-foo-bar@1.0.0',
@@ -2197,6 +2217,7 @@ ava('.setTriggers() should not store extra properties', (test) => {
 	test.deepEqual(triggers, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			filter: {
@@ -2213,6 +2234,7 @@ ava('.setTriggers() should store a mode', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			mode: 'update',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2230,6 +2252,7 @@ ava('.setTriggers() should store a mode', (test) => {
 	test.deepEqual(triggers, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			mode: 'update',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2248,6 +2271,7 @@ ava('.setTriggers() should throw if no interval nor filter', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				action: 'action-create-card@1.0.0',
 				arguments: {
@@ -2266,6 +2290,7 @@ ava('.setTriggers() should throw if mode is not a string', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-foo-bar@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				mode: 1,
@@ -2287,6 +2312,7 @@ ava('.setTriggers() should throw if both interval and filter', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				interval: 'PT1H',
 				filter: {
@@ -2309,6 +2335,28 @@ ava('.setTriggers() should throw if no id', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+				slug: 'triggered-action-foo-bar',
+				action: 'action-create-card@1.0.0',
+				filter: {
+					type: 'object'
+				},
+				arguments: {
+					reason: null,
+					foo: 'bar'
+				}
+			}
+		])
+	}, {
+		instanceOf: test.context.worker.errors.WorkerInvalidTrigger
+	})
+})
+
+ava('.setTriggers() should throw if no slug', (test) => {
+	test.throws(() => {
+		test.context.worker.setTriggers(test.context.context, [
+			{
+				id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				action: 'action-create-card@1.0.0',
 				filter: {
 					type: 'object'
@@ -2329,6 +2377,7 @@ ava('.setTriggers() should throw if id is not a string', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 999,
+				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				action: 'action-create-card@1.0.0',
 				filter: {
@@ -2350,6 +2399,7 @@ ava('.setTriggers() should throw if interval is not a string', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				action: 'action-create-card@1.0.0',
 				interval: 999,
@@ -2369,6 +2419,7 @@ ava('.setTriggers() should throw if no action', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
 					type: 'object'
@@ -2388,6 +2439,7 @@ ava('.setTriggers() should throw if action is not a string', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 1,
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -2408,6 +2460,7 @@ ava('.setTriggers() should throw if no target', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
 				filter: {
 					type: 'object'
@@ -2428,6 +2481,7 @@ ava('.setTriggers() should throw if target is not a string', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
 				target: 1,
 				filter: {
@@ -2449,6 +2503,7 @@ ava('.setTriggers() should throw if no filter', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				arguments: {
@@ -2467,6 +2522,7 @@ ava('.setTriggers() should throw if filter is not an object', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: 'foo',
@@ -2486,6 +2542,7 @@ ava('.setTriggers() should throw if no arguments', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -2503,6 +2560,7 @@ ava('.setTriggers() should throw if arguments is not an object', (test) => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				filter: {
@@ -2530,6 +2588,7 @@ ava('.tick() should not enqueue actions if there are no time triggers', async (t
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			filter: {
@@ -2553,6 +2612,7 @@ ava('.tick() should not enqueue an action if there is a time trigger with a futu
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			interval: 'PT1H',
@@ -2577,6 +2637,7 @@ ava('.tick() should evaluate the current timestamp in a time triggered action', 
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: `${actionCard.slug}@${actionCard.version}`,
 			type: 'card@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2613,6 +2674,7 @@ ava('.tick() should enqueue an action if there is a time trigger with a past sta
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: `${actionCard.slug}@${actionCard.version}`,
 			type: 'card@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2666,6 +2728,7 @@ ava('.tick() should enqueue an action if there is a time trigger with a present 
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: `${actionCard.slug}@${actionCard.version}`,
 			type: 'card@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2720,6 +2783,7 @@ ava('.tick() should not enqueue an action using a past timestamp', async (test) 
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: `${actionCard.slug}@${actionCard.version}`,
 			type: 'card@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2750,6 +2814,7 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 	test.context.worker.setTriggers(test.context.context, [
 		test.context.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
 			action: `${actionCard.slug}@${actionCard.version}`,
 			type: 'card@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -2766,6 +2831,7 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 		}),
 		test.context.jellyfish.defaults({
 			id: '673bc300-88f7-4376-92ed-d32543d69429',
+			slug: 'triggered-action-foo-baz',
 			action: `${actionCard.slug}@${actionCard.version}`,
 			type: 'card@1.0.0',
 			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',


### PR DESCRIPTION
The main motivation is to attempt to provide better error messages when
triggered actions fail.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!