### PR TITLE
Verify parameters on POST signup

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -626,6 +626,21 @@ module.exports = (application, jellyfish, worker, producer, options) => {
 			password
 		} = request.body
 
+		// Verify parameters
+		const parameters = {
+			username,
+			email,
+			password
+		}
+		for (const [ key, value ] of Object.entries(parameters).sort()) {
+			if (!_.isString(value)) {
+				return response.status(400).json({
+					error: true,
+					data: `Invalid ${key}`
+				})
+			}
+		}
+
 		// Normalize username and email to lower case
 		const name = username.toLowerCase()
 		const mail = email.toLowerCase()

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -885,7 +885,7 @@ ava.serial('/query endpoint should allow you to query using a view\'s id', async
 	})), [ 'view' ])
 })
 
-ava.serial('/view/:slug endpoing should return the list of all views', async (test) => {
+ava.serial('/view/:slug endpoint should return the list of all views', async (test) => {
 	const result = await test.context.http(
 		'POST',
 		'/api/v2/view/view-all-by-type@1.0.0',

--- a/test/e2e/server/signup.spec.js
+++ b/test/e2e/server/signup.spec.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const helpers = require('../sdk/helpers')
+
+ava.before(helpers.before)
+ava.after(helpers.after)
+
+ava.beforeEach(helpers.beforeEach)
+ava.afterEach(helpers.afterEach)
+
+ava.serial('/signup should not allow requests without username parameter', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/signup', {
+			email: 'user@balena.io',
+			password: '1234'
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid username'
+	})
+})
+
+ava.serial('/signup should not allow requests without email parameter', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/signup', {
+			username: 'user',
+			password: '1234'
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid email'
+	})
+})
+
+ava.serial('/signup should not allow requests without password parameter', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/signup', {
+			username: 'user',
+			email: 'user@balena.io'
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid password'
+	})
+})
+
+ava.serial('/signup should not allow non-string username parameter', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/signup', {
+			username: 1,
+			email: 'user@balena.io',
+			password: '1234'
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid username'
+	})
+})
+
+ava.serial('/signup should not allow non-string email parameter', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/signup', {
+			username: 'user',
+			email: 1,
+			password: '1234'
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid email'
+	})
+})
+
+ava.serial('/signup should not allow non-string password parameter', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/signup', {
+			username: 'user',
+			email: 'user@balena.io',
+			password: 1
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid password'
+	})
+})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

ref: https://github.com/product-os/jellyfish/issues/3159

Add some simple string checks on `POST /api/v2/signup` request parameters.