### PR TITLE
front: Increase rate limit retries

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -570,7 +570,7 @@ const getThread = async (context, front, event, inbox, threadType) => {
 	}
 }
 
-const handleRateLimit = async (context, fn, times = 50) => {
+const handleRateLimit = async (context, fn, times = 100) => {
 	try {
 		return fn()
 	} catch (error) {

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -29,7 +29,7 @@ const retryWhile404 = async (fn, times = 5) => {
 	}
 }
 
-const retryWhile429 = async (fn, times = 50) => {
+const retryWhile429 = async (fn, times = 100) => {
 	try {
 		return fn()
 	} catch (error) {


### PR DESCRIPTION
We don't want this number to be infinite, but looks like we still get
some rate limiting issues sometimes, so lets try to be a bit more
aggressive on it.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!