### PR TITLE
core: Fix caching of actors

### DIFF
--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -288,7 +288,7 @@ export default class ActionCreator {
 					}
 
 					const card = await loadingCardCache[id]
-					actor = generateActorFromUserCard(card)
+					actor = card ? generateActorFromUserCard(card) : null
 
 					dispatch({
 						type: actions.SET_ACTOR,


### PR DESCRIPTION
Fixes a bug where sometimes the user card for an actor can't be found

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

**HOT-FIX** for #3234