### PR TITLE
package.json: Require Node.js >=12.15.0 instead of >=12.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=12.16.0"
+    "node": ">=12.15.0"
   },
   "deplint": {
     "files": [


### PR DESCRIPTION
We have v12.15.0 in the base images, which is making our compose build
jobs crash:

```
ERROR: The current node version v12.15.0 does not satisfy the required version >=12.16.0.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! *********@26.5.8 requirements-check: `node scripts/check_node_version.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the *********@26.5.8 requirements-check script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

See: https://circleci.com/gh/product-os/jellyfish/77187
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!