### PR TITLE
ui: Refactor SetupProvider higher-order-component

### DIFF
--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -22,7 +22,8 @@ import {
 import {
 	analytics,
 	sdk,
-	store
+	store,
+	actionCreators
 } from './core'
 import JellyfishUI from './JellyfishUI'
 import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
@@ -86,8 +87,8 @@ ReactDOM.render(
 					fontSize: 14
 				}}
 			>
-				<SetupProvider sdk={sdk} analytics={analytics}>
-					<Provider store={store}>
+				<Provider store={store}>
+					<SetupProvider sdk={sdk} analytics={analytics} actionCreators={actionCreators}>
 						<React.Fragment>
 							<GlobalStyle />
 
@@ -95,8 +96,8 @@ ReactDOM.render(
 								<JellyfishUI />
 							</ErrorBoundary>
 						</React.Fragment>
-					</Provider>
-				</SetupProvider>
+					</SetupProvider>
+				</Provider>
 			</RProvider>
 		</Router>
 	),

--- a/apps/ui/lens/full/SingleCard/Segment.jsx
+++ b/apps/ui/lens/full/SingleCard/Segment.jsx
@@ -138,7 +138,6 @@ export default class Segment extends React.Component {
 		} = this.state
 
 		const {
-			actions,
 			card,
 			segment,
 			types
@@ -194,7 +193,6 @@ export default class Segment extends React.Component {
 				)}
 
 				<LinkModal
-					actions={actions}
 					card={card}
 					types={[ type ]}
 					show={showLinkModal}

--- a/lib/ui-components/CardLinker/CardLinker.jsx
+++ b/lib/ui-components/CardLinker/CardLinker.jsx
@@ -100,7 +100,6 @@ class CardLinker extends React.Component {
 
 	render () {
 		const {
-			actions,
 			card,
 			connectDragSource,
 			types
@@ -179,7 +178,6 @@ class CardLinker extends React.Component {
 				</span>
 
 				<LinkModal
-					actions={actions}
 					card={card}
 					types={types}
 					show={showLinkModal}

--- a/lib/ui-components/ChannelRenderer.jsx
+++ b/lib/ui-components/ChannelRenderer.jsx
@@ -70,7 +70,6 @@ class ChannelRenderer extends React.Component {
 	render () {
 		const {
 			getLens,
-			actions,
 			channel,
 			connectDropTarget,
 			isOver,
@@ -145,7 +144,6 @@ class ChannelRenderer extends React.Component {
 
 				{showLinkModal && (
 					<LinkModal
-						actions={actions}
 						target={head}
 						card={linkFrom}
 						types={types}

--- a/lib/ui-components/LinkModal/index.js
+++ b/lib/ui-components/LinkModal/index.js
@@ -5,5 +5,8 @@
  */
 
 import LinkModal from './LinkModal'
+import {
+	withSetup
+} from '../SetupProvider'
 
-export default LinkModal
+export default withSetup(LinkModal)

--- a/lib/ui-components/SetupProvider.jsx
+++ b/lib/ui-components/SetupProvider.jsx
@@ -5,19 +5,27 @@
  */
 
 import React from 'react'
+import {
+	bindActionCreators
+} from 'redux'
+import {
+	useDispatch
+} from 'react-redux'
 
 const setupContext = React.createContext(null)
 
 export const SetupProvider = ({
-	analytics, sdk, actions, children
+	analytics, sdk, actionCreators, children
 }) => {
+	const dispatch = useDispatch()
 	const setup = React.useMemo(() => {
+		const actions = bindActionCreators(actionCreators || [], dispatch)
 		return {
 			sdk,
 			analytics,
 			actions
 		}
-	}, [ sdk, analytics, actions ])
+	}, [ sdk, analytics, actionCreators ])
 
 	return (
 		<setupContext.Provider value={setup}>{children}</setupContext.Provider>


### PR DESCRIPTION
This change makes all redux actions available via the withSetup HOC and the useSetup hook.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

The `actions` prop defined in `SetupProvider` was never actually populated - so it could not be used by components using `withSetup` or `useSetup`. This PR remedies this. Note that the React-Redux `Provider` component is now upstream of the `SetupProvider` component to allow the latter to make use of the Redux store.