### PR TITLE
test: Make queue's afterEach more resilient as its run with ".always"

### DIFF
--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -80,6 +80,11 @@ exports.beforeEach = async (test, options) => {
 }
 
 exports.afterEach = async (test) => {
-	await test.context.queue.consumer.cancel()
-	await helpers.afterEach(test)
+	if (test.context.queue) {
+		await test.context.queue.consumer.cancel()
+	}
+
+	if (test.context.jellyfish) {
+		await helpers.afterEach(test)
+	}
 }


### PR DESCRIPTION
This particular `.afterEach()` clause its run with `.always`, which
means it will run even if the `.beforeEach()` or the test itself
crashes.

If `.beforeEach()` crashes, then the queue or the core might not have
been initialized, and then `.afterEach()` will fail with errors such as:

```
Rejected promise returned by test. Reason:

TypeError {
	message: 'Cannot read property \'consumer\' of undefined',
}

Object.exports.afterEach (test/integration/queue/helpers.js:811:28)
Object.afterEach (test/integration/sync/helpers.js:177:26)
afterEach (test/integration/sync/scenario.js:4321:23)
```

See: https://circleci.com/gh/product-os/jellyfish/78712
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!