### PR TITLE
test: Use the Redis mock on integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,6 @@ jobs:
       - run:
           name: Start PostgreSQL
           command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
 
       - run:
           name: Unit Tests
@@ -160,9 +157,6 @@ jobs:
       - run:
           name: Start PostgreSQL
           command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
 
       - run:
           name: Integration Tests
@@ -232,9 +226,6 @@ jobs:
       - run:
           name: Start PostgreSQL
           command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
 
       - run:
           name: Sync Tests
@@ -315,9 +306,6 @@ jobs:
       - run:
           name: Start PostgreSQL
           command: service postgresql start && su - postgres -c "psql -U postgres -d postgres -c \"alter user postgres with password 'postgres';\""
-      - run:
-          name: Start Redis
-          command: service redis-server start
 
       - run:
           name: Sync Tests

--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -71,9 +71,9 @@ const SCHEMA_ACTIVE_TRIGGERS = {
 	required: [ 'id', 'slug', 'active', 'type', 'data' ]
 }
 
-const bootstrap = async (context, library, options) => {
+const bootstrap = async (context, library, options = {}) => {
 	logger.info(context, 'Setting up cache')
-	const cache = new core.MemoryCache(environment.redis)
+	const cache = options.cache || new core.MemoryCache(environment.redis)
 	if (cache) {
 		await cache.connect(context)
 	}
@@ -197,6 +197,7 @@ const bootstrap = async (context, library, options) => {
 exports.worker = async (context, options) => {
 	return bootstrap(context, actionLibrary, {
 		enablePriorityBuffer: true,
+		cache: options.cache,
 		onError: options.onError,
 		onActionRequest: async (serverContext, jellyfish, worker, queue, session, actionRequest, errorHandler) => {
 			return getActorKey(serverContext, jellyfish, session, actionRequest.data.actor)
@@ -212,6 +213,7 @@ exports.worker = async (context, options) => {
 exports.tick = async (context, options) => {
 	return bootstrap(context, actionLibrary, {
 		enablePriorityBuffer: false,
+		cache: options.cache,
 		delay: 2000,
 		onError: options.onError,
 		onLoop: async (serverContext, worker, session) => {

--- a/apps/server/bootstrap.js
+++ b/apps/server/bootstrap.js
@@ -17,9 +17,9 @@ const cardLoader = require('./card-loader')
 const http = require('./http')
 const socket = require('./socket')
 
-module.exports = async (context) => {
+module.exports = async (context, options = {}) => {
 	logger.info(context, 'Setting up cache')
-	const cache = new core.MemoryCache(environment.redis)
+	const cache = options.cache || new core.MemoryCache(environment.redis)
 	if (cache) {
 		await cache.connect(context)
 	}

--- a/test/integration/core/backend/helpers.js
+++ b/test/integration/core/backend/helpers.js
@@ -16,6 +16,7 @@ exports.beforeEach = async (test, options = {}) => {
 
 	test.context.cache = new Cache(
 		Object.assign({}, environment.redis, {
+			mock: true,
 			namespace: dbName
 		}))
 


### PR DESCRIPTION
We sometimes see weird flaky tests due to Redis going down on the
CircleCI integration tests for an still unknown reason. The Redis cache
mock module is very well supported and we still run the real redis on
e2e tests, so I think its safe to use the mock on integration tests and
avoid the issue altogether.

See: https://circleci.com/gh/product-os/jellyfish/78712
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!