### PR TITLE
sync: Add bigger test timeouts in mirror tests

### DIFF
--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -236,6 +236,7 @@ ava.serial.before(async (test) => {
 
 ava.serial.after(helpers.mirror.after)
 ava.serial.beforeEach(async (test) => {
+	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(
 		test, environment.integration.discourse.username)
 })

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -270,6 +270,7 @@ ava.serial.before(async (test) => {
 
 ava.serial.after(helpers.mirror.after)
 ava.serial.beforeEach(async (test) => {
+	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(test, test.context.teammate.replace(/_/g, '-'))
 })
 

--- a/test/e2e/sync/github-mirror.spec.js
+++ b/test/e2e/sync/github-mirror.spec.js
@@ -113,6 +113,7 @@ ava.serial.before(async (test) => {
 
 ava.serial.after(helpers.mirror.after)
 ava.serial.beforeEach(async (test) => {
+	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(test, uuid())
 })
 


### PR DESCRIPTION
Looks like some test cases may take a really long time due to rate
limiting, but they will still pass given enough time.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!