### PR TITLE
sdk: Add support for unlinking and re-linking

### DIFF
--- a/lib/sdk/card.js
+++ b/lib/sdk/card.js
@@ -7,10 +7,60 @@
 const {
 	commaListsOr
 } = require('common-tags')
+const Bluebird = require('bluebird')
 const clone = require('deep-copy')
 const jsonpatch = require('fast-json-patch')
 const _ = require('lodash')
 const uuid = require('../uuid')
+
+const getLinkQuery = (verb, fromCard, toCard = null) => {
+	const query = {
+		type: 'object',
+		properties: {
+			name: {
+				type: 'string',
+				const: verb
+			},
+			type: {
+				type: 'string',
+				enum: [ 'link', 'link@1.0.0' ]
+			},
+			active: {
+				type: 'boolean',
+				const: true
+			},
+			data: {
+				type: 'object',
+				properties: {
+					from: {
+						type: 'object',
+						properties: {
+							id: {
+								type: 'string',
+								const: fromCard.id
+							}
+						}
+					}
+				}
+			}
+		},
+		additionalProperties: true
+	}
+
+	if (toCard) {
+		query.properties.data.properties.to = {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'string',
+					const: toCard.id
+				}
+			}
+		}
+	}
+
+	return query
+}
 
 /**
  * @namespace JellyfishSDK.card
@@ -407,7 +457,7 @@ class CardSdk {
 	 *
 	 * @returns {Promise}
 	 */
-	link (fromCard, toCard, verb) {
+	async link (fromCard, toCard, verb) {
 		if (!verb) {
 			throw new Error('No verb provided when creating link')
 		}
@@ -440,6 +490,20 @@ class CardSdk {
 			throw new Error(`No id in "to" card: ${JSON.stringify(toCard)}`)
 		}
 
+		// Check for existing link with this verb between these two cards
+		const links = await this.sdk.query(
+			getLinkQuery(verb, fromCard, toCard),
+			{
+				// There should only be max one existing link in this case
+				limit: 1
+			})
+
+		// If found, just return that object
+		if (links && links.length) {
+			return links[0]
+		}
+
+		// If not found, create the new link
 		const payload = {
 			card: 'link',
 			type: 'type',
@@ -447,7 +511,7 @@ class CardSdk {
 			arguments: {
 				reason: null,
 				properties: {
-					slug: `link-${fromCard.id}-${verb.replace(/\s/g, '-')}-${toCard.id}`,
+					slug: `link-${fromCard.id}-${verb.replace(/\s/g, '-')}-${toCard.id}-${await uuid.random()}`,
 					tags: [],
 					version: '1.0.0',
 					links: {},
@@ -472,26 +536,49 @@ class CardSdk {
 
 		return this.sdk.action(payload)
 			.catch((error) => {
-				if (error.name !== 'JellyfishElementAlreadyExists') {
-					throw error
-				}
-
-				return this.sdk.card.get(payload.arguments.properties.slug)
-					.then((card) => {
-						return this.update(card.id, card.type, [
-							{
-								op: 'replace',
-								path: '/name',
-								value: verb
-							},
-							{
-								op: 'replace',
-								path: '/data',
-								value: payload.arguments.properties.data
-							}
-						])
-					})
+				console.error(`Failed to create link ${payload.arguments.properties.slug}`, error)
+				throw error
 			})
+	}
+
+	/**
+	 * @summary Remove a link card
+	 * @name unlink
+	 * @public
+	 * @function
+	 * @memberof JellyfishSDK.card
+	 *
+	 * @description Un-link two cards
+	 *
+	 * @param {String} fromCard - The id of the card that the link is from
+	 * @param {String} toCard - The id of the card that the link is to
+	 * @param {String} verb - The name of the relationship
+	 *
+	 * @returns {Promise}
+	 */
+	unlink (fromCard, toCard, verb) {
+		if (!verb) {
+			throw new Error('No verb provided when removing link')
+		}
+		if (!fromCard.id) {
+			throw new Error(`No id in "from" card: ${JSON.stringify(fromCard)}`)
+		}
+		if (!toCard.id) {
+			throw new Error(`No id in "to" card: ${JSON.stringify(toCard)}`)
+		}
+
+		// First query for link cards
+		return this.sdk.query(
+			getLinkQuery(verb, fromCard, toCard)).then((linkCards) => {
+			// Then remove the link cards
+			const removeActions = linkCards.map((linkCard) => {
+				return this.remove(linkCard.id, linkCard.type)
+			})
+			return Bluebird.all(removeActions)
+		}).catch((error) => {
+			console.error('Failed to unlink cards', error)
+			throw error
+		})
 	}
 
 	/**

--- a/test/e2e/sdk/card.spec.js
+++ b/test/e2e/sdk/card.spec.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const uuid = require('uuid/v4')
+const helpers = require('./helpers')
+
+// TODO: Possibly move this file to test/integration/sdk if/when
+// we resolve where to place sdk helper methods that are used by
+// both e2e tests and integration tests.
+
+const context = {
+	context: {
+		id: `SDK-CARD-E2E-TEST-${uuid()}`
+	}
+}
+
+const createSupportThread = async (sdk) => {
+	return sdk.card.create({
+		type: 'support-thread',
+		data: {
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
+	})
+}
+
+const createSupportIssue = async (sdk) => {
+	return sdk.card.create({
+		type: 'support-issue',
+		name: `test-support-issue-${uuid()}`,
+		data: {
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
+	})
+}
+
+ava.before(async () => {
+	await helpers.before({
+		context
+	})
+})
+
+ava.after(async () => {
+	await helpers.after({
+		context
+	})
+})
+
+ava.beforeEach(async () => {
+	await helpers.beforeEach({
+		context
+	})
+})
+
+ava.afterEach(async () => {
+	await helpers.afterEach({
+		context
+	})
+})
+
+ava('If you call card.link twice with the same params you will get the same link card back', async (test) => {
+	const {
+		sdk
+	} = context
+
+	// Create a support thread and support issue
+	const supportThread = await createSupportThread(sdk)
+
+	const supportIssue = await createSupportIssue(sdk)
+
+	// Link the support thread to the support issue
+	const link1 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Try to link the same support thread to the same support issue
+	const link2 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Verify the link ID is the same
+	test.is(link1.id, link2.id)
+})
+
+ava('card.link will create a new link if the previous one was deleted', async (test) => {
+	const {
+		sdk
+	} = context
+
+	// Create a support thread and support issue
+	const supportThread = await createSupportThread(sdk)
+
+	const supportIssue = await createSupportIssue(sdk)
+
+	// Link the support thread to the support issue
+	const link1 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Now remove the link
+	await sdk.card.unlink(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Try to link the same support thread to the same support issue
+	const link2 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+
+	// Verify the link ID is not the same
+	test.not(link1.id, link2.id)
+})


### PR DESCRIPTION
This will be needed for ownership changes!

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

When linking cards, we now first check if there is an existing link (with matching from, to and link verb). If an existing link is found, that is returned. Otherwise we create a new link _with a unique slug_.

There's also a new sdk method, `card.unlink(fromCard, toCard, verb)` which is mainly just a convenience function.
