### PR TITLE
server: Rename primary and secondary owner links

### DIFF
--- a/apps/server/default-cards/contrib/account.json
+++ b/apps/server/default-cards/contrib/account.json
@@ -92,13 +92,13 @@
           "type": "contact"
         },
         {
-          "title": "Primary owner",
-          "link": "has primary owner",
+          "title": "Owner",
+          "link": "is owned by",
           "type": "user"
         },
         {
-          "title": "Secondary owners",
-          "link": "has secondary owner",
+          "title": "Backup owners",
+          "link": "has backup owner",
           "type": "user"
         }
       ]

--- a/apps/server/default-cards/contrib/contact.json
+++ b/apps/server/default-cards/contrib/contact.json
@@ -96,13 +96,13 @@
           "type": "account"
         },
         {
-          "title": "Primary owner",
-          "link": "has primary owner",
+          "title": "Owner",
+          "link": "is owned by",
           "type": "user"
         },
         {
-          "title": "Secondary owners",
-          "link": "has secondary owner",
+          "title": "Backup owners",
+          "link": "has backup owner",
           "type": "user"
         },
         {

--- a/lib/sdk/link-constraints.js
+++ b/lib/sdk/link-constraints.js
@@ -127,83 +127,83 @@ exports.constraints = [
 		}
 	},
 	{
-		slug: 'link-constraint-contact-has-primary-owner',
-		name: 'has primary owner',
+		slug: 'link-constraint-contact-is-owned-by-user',
+		name: 'is owned by',
 		data: {
-			title: 'Primary owner',
+			title: 'Owner',
 			from: 'contact',
 			to: 'user',
-			inverse: 'link-constraint-user-is-primary-owner-of-contact'
+			inverse: 'link-constraint-user-owns-contact'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-primary-owner-of-contact',
-		name: 'is primary owner of',
+		slug: 'link-constraint-user-owns-contact',
+		name: 'owns',
 		data: {
-			title: 'Primary owner',
+			title: 'Owner',
 			from: 'user',
 			to: 'contact',
-			inverse: 'link-constraint-contact-has-primary-owner'
+			inverse: 'link-constraint-contact-is-owned-by-user'
 		}
 	},
 	{
-		slug: 'link-constraint-contact-has-secondary-owner',
-		name: 'has secondary owner',
+		slug: 'link-constraint-contact-has-backup-owner',
+		name: 'has backup owner',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'contact',
 			to: 'user',
-			inverse: 'link-constraint-user-is-secondary-owner-of-contact'
+			inverse: 'link-constraint-user-is-backup-owner-of-contact'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-secondary-owner-of-contact',
-		name: 'is secondary owner of',
+		slug: 'link-constraint-user-is-backup-owner-of-contact',
+		name: 'is backup owner of',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'user',
 			to: 'contact',
-			inverse: 'link-constraint-contact-has-secondary-owner'
+			inverse: 'link-constraint-contact-has-backup-owner'
 		}
 	},
 	{
-		slug: 'link-constraint-account-has-primary-owner',
-		name: 'has primary owner',
+		slug: 'link-constraint-account-is-owned-by-user',
+		name: 'is owned by',
 		data: {
-			title: 'Primary owner',
+			title: 'Owner',
 			from: 'account',
 			to: 'user',
-			inverse: 'link-constraint-user-is-primary-owner-of-account'
+			inverse: 'link-constraint-user-owns-account'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-primary-owner-of-account',
-		name: 'is primary owner of',
+		slug: 'link-constraint-user-owns-account',
+		name: 'owns',
 		data: {
-			title: 'Primary owner',
+			title: 'Owner',
 			from: 'user',
 			to: 'account',
-			inverse: 'link-constraint-account-has-primary-owner'
+			inverse: 'link-constraint-account-is-owned-by-user'
 		}
 	},
 	{
-		slug: 'link-constraint-account-has-secondary-owner',
-		name: 'has secondary owner',
+		slug: 'link-constraint-account-has-backup-owner',
+		name: 'has backup owner',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'account',
 			to: 'user',
-			inverse: 'link-constraint-user-is-secondary-owner-of-account'
+			inverse: 'link-constraint-user-is-backup-owner-of-account'
 		}
 	},
 	{
-		slug: 'link-constraint-user-is-secondary-owner-of-account',
-		name: 'is secondary owner of',
+		slug: 'link-constraint-user-is-backup-owner-of-account',
+		name: 'is backup owner of',
 		data: {
-			title: 'Secondary owner',
+			title: 'Backup owner',
 			from: 'user',
 			to: 'account',
-			inverse: 'link-constraint-account-has-secondary-owner'
+			inverse: 'link-constraint-account-has-backup-owner'
 		}
 	},
 	{


### PR DESCRIPTION
Primary owner is now Owner and Secondary owners is now Backup owners

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR replaces the concept of 'Primary owner' and 'Secondary owners' with 'Owner' and 'Backup owners'. This is a breaking change in so far as any existing 'primary' and 'secondary' owners will no longer be shown in the UI. But the understanding is that these links (used on just Projects, Accounts and Contacts) were not being used yet anyway.

* The 'Primary owner' tab has been renamed to 'Owner'. In due course it will be removed when the new generic 'Card Owner' component/control is rolled out.
* The 'Secondary owners' tab has been renamed to 'Backup owners'
