### PR TITLE
Server: Setup Opportunity Owners and Backup Owners

### DIFF
--- a/apps/server/default-cards/contrib/opportunity.json
+++ b/apps/server/default-cards/contrib/opportunity.json
@@ -75,6 +75,16 @@
           "title": "Account",
           "link": "is attached to",
           "type": "account"
+        },
+        {
+          "title": "Owner",
+          "link": "is owned by",
+          "type": "user"
+        },
+        {
+          "title": "Backup owners",
+          "link": "has backup owner",
+          "type": "user"
         }
       ]
     }

--- a/lib/sdk/link-constraints.js
+++ b/lib/sdk/link-constraints.js
@@ -227,6 +227,46 @@ exports.constraints = [
 		}
 	},
 	{
+		slug: 'link-constraint-opportunity-is-owned-by-user',
+		name: 'is owned by',
+		data: {
+			title: 'Owner',
+			from: 'opportunity',
+			to: 'user',
+			inverse: 'link-constraint-user-owns-opportunity'
+		}
+	},
+	{
+		slug: 'link-constraint-user-owns-opportunity',
+		name: 'owns',
+		data: {
+			title: 'Owner',
+			from: 'user',
+			to: 'opportunity',
+			inverse: 'link-constraint-opportunity-is-owned-by-user'
+		}
+	},
+	{
+		slug: 'link-constraint-opportunity-has-backup-owner',
+		name: 'has backup owner',
+		data: {
+			title: 'Backup owner',
+			from: 'opportunity',
+			to: 'user',
+			inverse: 'link-constraint-user-is-backup-owner-of-opportunity'
+		}
+	},
+	{
+		slug: 'link-constraint-user-is-backup-owner-of-opportunity',
+		name: 'is backup owner of',
+		data: {
+			title: 'Backup owner',
+			from: 'user',
+			to: 'opportunity',
+			inverse: 'link-constraint-opportunity-has-backup-owner'
+		}
+	},
+	{
 		slug: 'link-constraint-support-thread-is-source-for-feedback-item',
 		name: 'is source for',
 		data: {


### PR DESCRIPTION
This PR adds `Owners` and `Backup Owners` to the Opportunity card.

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>
