### PR TITLE
Fix failing format{Maximum,Minimum} integration test

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/keywords.js
+++ b/lib/core/backend/postgres/jsonschema2sql/keywords.js
@@ -294,23 +294,37 @@ exports.minimum = (value, path, walk, schema, context, keys, requiredPaths) => {
 	}
 }
 
+const formatToPostgresType = (format) => {
+	if (format === 'date') {
+		return 'date'
+	} else if (format === 'time') {
+		return 'time'
+	} else if (format === 'date-time') {
+		return 'timestamp'
+	}
+
+	throw new Error(`Format '${format}' can't be converted to a postgres type`)
+}
+
 exports.formatMaximum = (value, path, walk, schema, context, keys, requiredPaths) => {
 	const postgresValue = builder.valueToPostgres(value)
+	const postgresType = formatToPostgresType(schema.format)
 	return {
 		keys,
 		filter: builder.or(
 			builder.isNotOfType(path, 'string'),
-			`(${builder.getProperty(path)})::text <= ${postgresValue}`)
+			`(${builder.getProperty(path)})::text::${postgresType} <= ${postgresValue}`)
 	}
 }
 
 exports.formatMinimum = (value, path, walk, schema, context, keys, requiredPaths) => {
 	const postgresValue = builder.valueToPostgres(value)
+	const postgresType = formatToPostgresType(schema.format)
 	return {
 		keys,
 		filter: builder.or(
 			builder.isNotOfType(path, 'string'),
-			`(${builder.getProperty(path)})::text >= ${postgresValue}`)
+			`(${builder.getProperty(path)})::text::${postgresType} >= ${postgresValue}`)
 	}
 }
 

--- a/test/integration/core/backend/postgres/jsonschema2sql/format-max-min.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/format-max-min.js
@@ -30,9 +30,9 @@ module.exports = {
 					valid: true
 				},
 				{
-					description: 'data that is > is ivalid',
+					description: 'data that is > is invalid',
 					data: '2020-08-08T00:00:00.000Z',
-					valid: true
+					valid: false
 				}
 			]
 		},
@@ -40,7 +40,7 @@ module.exports = {
 			description: 'formatMinimum can filter date-time correctly',
 			schema: {
 				format: 'date-time',
-				formatMaximum: '2019-08-08T00:00:00.000Z'
+				formatMinimum: '2019-08-08T00:00:00.000Z'
 			},
 			tests: [
 				{
@@ -56,7 +56,7 @@ module.exports = {
 				{
 					description: 'data that is < is invalid',
 					data: '2018-08-08T00:00:00.000Z',
-					valid: true
+					valid: false
 				}
 			]
 		}


### PR DESCRIPTION
This commit includes two changes:
- Fix the test itself to do what it says it does
- Changes format{Maximum,Minimum} to use the appropriate date/time/timestamp cast instead of string comparison

Closes #3161

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>