### PR TITLE
Explicity set the locale in `make start-postgres`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ dist:
 	mkdir $@
 
 postgres_data:
-	initdb --pgdata $@
+	initdb --locale=en_US.UTF8 --pgdata $@
 
 lint:
 	./node_modules/.bin/eslint --ext .js,.jsx $(ESLINT_OPTION_FIX) \


### PR DESCRIPTION
Locale is not explicit set when `initdb` is executed, possibly causing collation issues. This commit unconditionally sets the database locale to `en_US.UTF8`, which is the same used by the database container.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>