### PR TITLE
Set correct spacing and width for FreeFieldForm inputs

### DIFF
--- a/lib/ui-components/FreeFieldForm.jsx
+++ b/lib/ui-components/FreeFieldForm.jsx
@@ -128,10 +128,11 @@ export default class FreeFieldForm extends React.Component {
 					hideSubmitButton={true}
 				/>
 
-				<Flex justifyContent="space-between" pt={60}>
-					<Txt mt={9}>Add a new field</Txt>
+				<Flex justifyContent="space-between">
+					<Txt mt={9} mr={2} minWidth={100}>Add a new field</Txt>
 
 					<Input
+						mr={2}
 						value={this.state.key}
 						onChange={this.setFieldTitle}
 						placeholder="Enter the field title"
@@ -139,6 +140,7 @@ export default class FreeFieldForm extends React.Component {
 					/>
 
 					<Select
+						ml={2}
 						value={this.state.fieldType}
 						onChange={this.setFieldType}
 						options={this.dataTypes}
@@ -146,6 +148,7 @@ export default class FreeFieldForm extends React.Component {
 					/>
 
 					<Button
+						ml={2}
 						success
 						onClick={this.addField}
 						icon={<Icon name="plus"/>}


### PR DESCRIPTION
This PR contains some small style fixes in the FreeFieldForm component. The label in front was not displaying correctly and there was no spacing in between the inputs.

## Before
<img width="1003" alt="Screenshot 2020-03-09 at 17 20 18" src="https://user-images.githubusercontent.com/11800807/76234642-468cc300-622a-11ea-907d-f4b64aabd909.png">


## After
<img width="1009" alt="Screenshot 2020-03-09 at 17 19 39" src="https://user-images.githubusercontent.com/11800807/76234617-3b399780-622a-11ea-804a-8987f2dfcd1f.png">


Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>
