### PR TITLE
Fix meta relationship on org card

### DIFF
--- a/lib/core/cards/org.js
+++ b/lib/core/cards/org.js
@@ -57,7 +57,8 @@ module.exports = {
 			relationships: [
 				{
 					title: 'Members',
-					link: 'user'
+					link: 'has member',
+					type: 'user'
 				}
 			]
 		}


### PR DESCRIPTION
Fixes meta-relationship on the org card so that members link correctly and can be viewed on the ui