### PR TITLE
ui-components: New SlideInPanel component

### DIFF
--- a/lib/ui-components/SlideInPanel.jsx
+++ b/lib/ui-components/SlideInPanel.jsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import styled from 'styled-components'
+import {
+	swallowEvent
+} from './services/helpers'
+
+const px = (val) => {
+	return (typeof val === 'number' ? `${val}px` : val)
+}
+
+const SlideInWrapper = styled.div `
+	position: absolute;
+  overflow: hidden;
+	top: 0;
+	left: 0;
+	height: 100%;
+	width: 100%;
+	visibility: hidden;
+	transition: visibility 0s 0.6s;
+	&.slide-in--open {
+		visibility: visible;
+		transition: visibility 0s 0s;
+		&::after {
+			background: ${(props) => { return props.theme.layer.overlay.background }};
+			transition: background .3s 0s;
+		}
+	}
+	&::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background: 0 0;
+		cursor: pointer;
+		transition: background .3s .3s;
+	}
+`
+
+const SlideInPanelBase = styled.div `
+	position: absolute;
+  background: ${(props) => { return props.theme.global.colors.white }};
+  z-index: 1;
+	transition: transform 0.3s 0.3s;
+	.slide-in--open & {
+		transform: translate3d(0, 0, 0);
+  	transition-delay: 0s;
+	}
+`
+
+const VerticalSlideInPanel = styled(SlideInPanelBase) `
+	height: ${(props) => { return px(props.height) }};
+	width: 100%;
+`
+
+const HorizontalSlideInPanel = styled(SlideInPanelBase) `
+	width: ${(props) => { return px(props.width) }};
+	height: 100%;
+`
+
+const Panels = {
+	bottom: styled(VerticalSlideInPanel) `
+		bottom: 0;
+		transform: translate3d(0, 100%, 0);
+	`,
+	top: styled(VerticalSlideInPanel) `
+		top: 0;
+		transform: translate3d(0, -100%, 0);
+	`,
+	left: styled(HorizontalSlideInPanel) `
+	  left: 0;
+		transform: translate3d(-100%, 0, 0);
+	`,
+	right: styled(HorizontalSlideInPanel) `
+	  right: 0;
+		transform: translate3d(100%, 0, 0);
+	`
+}
+
+export default function SlideIn ({
+	className,
+	from,
+	isOpen,
+	onClose,
+	width,
+	height,
+	disableClickOutsideToClose,
+	children
+}) {
+	const SlideInPanel = Panels[from]
+	if (typeof SlideInPanel === 'undefined') {
+		throw new Error('SlideIn \'from\' prop must be one of: top | bottom | left | right')
+	}
+	return (
+		<SlideInWrapper
+			className={`slide-in--${isOpen ? 'open' : 'closed'}`}
+			onClick={disableClickOutsideToClose ? null : onClose}
+		>
+			<SlideInPanel
+				width={width}
+				height={height}
+				className={className}
+				onClick={swallowEvent}
+			>
+				{children}
+			</SlideInPanel>
+		</SlideInWrapper>
+	)
+}

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -422,3 +422,8 @@ export const patchPath = (card, keyPath, value) => {
 
 	return patch
 }
+
+export const swallowEvent = (event) => {
+	event.preventDefault()
+	event.stopPropagation()
+}


### PR DESCRIPTION
A generic slide-in panel component that can slide in from any direction. Height (for top/bottom direction) or width (for left/right direction) can be specified. Be sure to mark the appropriate parent element with relative position to display the component as desired.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Example usage (used in demo gif below):
```javascript
<SlideInPanel height="50%" isOpen={showPanel} onClose={() => setPanelOpen(false)} from="bottom">
  <Box px={3}>
    <h1>Slide-in content goes here...</h1>
  </Box>
</SlideInPanel>
```

### Notes
1. Clicking on the darkened background part of the slide-in panel will automatically cause it to close - unless the `disableClickOutsideToClose` prop is set to `true`.
2. This is a **controlled component** - the `isOpen` state must be controlled by a parent component.
3. `height` (top/bottom variants) or `width` (left/right variants) may be specified. Default behaviour is to use as much space as the child requires.

_The animation is a lot smoother in real-life than this gif shows!_
![SlideIn](https://user-images.githubusercontent.com/2925657/76275581-37535700-62b6-11ea-96f4-883bdbd7c269.gif) 