### PR TITLE
ui-components: Add new `StepsFlow` component

### DIFF
--- a/lib/ui-components/StepsFlow.jsx
+++ b/lib/ui-components/StepsFlow.jsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/* eslint-disable valid-jsdoc */
+/* eslint-disable jsdoc/require-param */
+
+import React from 'react'
+import {
+	Box,
+	Heading,
+	Steps,
+	Step
+} from 'rendition'
+
+const VALID_STEP_STATUSES = {
+	pending: true,
+	completed: true,
+	none: true
+}
+
+/**
+ * Each StepsFlow.Step should define the following props:
+ * - 'label' (to be used as the step label and also the title above the step content)
+ * - 'status' ('pending', 'completed' or 'none')
+ * - 'children' (the step content, to be displayed when the step is active)
+ */
+const FlowStep = ({
+	stepIndex, label, status, children, ...rest
+}) => {
+	return (
+		<Box my={3} {...rest}>
+			<Heading.h5 data-test={`flow-step-${stepIndex}__heading`} mb={2}>{label}</Heading.h5>
+			{children}
+		</Box>
+	)
+}
+
+/**
+ * The StepsFlow component is a light wrapper around the Rendition 'Steps'
+ * component. It manages the rendering of the active step's content as
+ * well as handling the user clicking on a step to select a different step.
+ *
+ * Children of StepsFlow must be of type StepsFlow.Step.
+ */
+const StepsFlow = ({
+	initialStep,
+	stepsProps,
+	children,
+	...rest
+}) => {
+	if (initialStep > children.length - 1 || initialStep < 0) {
+		throw new Error('initialStep is out of bounds')
+	}
+	const [ activeStepIndex, setActiveStepIndex ] = React.useState(initialStep || 0)
+	return (
+		<Box {...rest}>
+			<Steps className="flow-steps" {...stepsProps}>
+				{React.Children.map(children, (step, stepIndex) => {
+					if (step.type !== FlowStep) {
+						throw new Error(
+							'You can only use StepsFlow.Step components as children of StepsFlow.'
+						)
+					}
+					if (!VALID_STEP_STATUSES[step.props.status]) {
+						throw new Error(
+							`Invalid step status: ${step.props.status}`
+						)
+					}
+					return (
+						<Step
+							key={step.props.label}
+							status={step.props.status}
+							onClick={
+								stepIndex === activeStepIndex
+									? null
+									: () => { return setActiveStepIndex(stepIndex) }
+							}
+						>
+							{step.props.label}
+						</Step>
+					)
+				})}
+			</Steps>
+			{React.cloneElement(children[activeStepIndex], {
+				stepIndex: activeStepIndex
+			})}
+		</Box>
+	)
+}
+
+StepsFlow.Step = FlowStep
+
+export default StepsFlow

--- a/lib/ui-components/StepsFlow.spec.jsx
+++ b/lib/ui-components/StepsFlow.spec.jsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import {
+	mount,
+	shallow,
+	configure
+} from 'enzyme'
+import React from 'react'
+import {
+	Provider
+} from 'rendition'
+import StepsFlow from './StepsFlow'
+import Adapter from 'enzyme-adapter-react-16'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+const stepsProps = {
+	titleText: 'Test flow'
+}
+
+ava('StepsFlow should render', (test) => {
+	test.notThrows(() => {
+		shallow(
+			<StepsFlow stepsProps={stepsProps}>
+				<StepsFlow.Step label="Step 1" status="completed">
+					<div className="step1">Step 1</div>
+				</StepsFlow.Step>
+				<StepsFlow.Step label="Step 2" status="pending">
+					<div className="step2">Step 2</div>
+				</StepsFlow.Step>
+			</StepsFlow>
+		)
+	})
+})
+
+ava('initialStep is respected', (test) => {
+	const component = mount(
+		<Provider>
+			<StepsFlow initialStep={1} stepsProps={stepsProps}>
+				<StepsFlow.Step label="Step 1" status="completed">
+					<div className="step1">Step 1</div>
+				</StepsFlow.Step>
+				<StepsFlow.Step label="Step 2" status="pending">
+					<div className="step2">Step 2</div>
+				</StepsFlow.Step>
+			</StepsFlow>
+		</Provider>
+	)
+
+	const stepHeading = component.find('h5[data-test="flow-step-1__heading"]')
+	test.is(stepHeading.text(), 'Step 2')
+})
+
+ava('initialStep cannot be greater than number of steps', (test) => {
+	test.throws(() => {
+		shallow(
+			<StepsFlow initialStep={3} stepsProps={stepsProps}>
+				<StepsFlow.Step label="Step 1" status="completed">
+					<div className="step1">Step 1</div>
+				</StepsFlow.Step>
+				<StepsFlow.Step label="Step 2" status="pending">
+					<div className="step2">Step 2</div>
+				</StepsFlow.Step>
+			</StepsFlow>
+		)
+	})
+})
+
+ava('Invalid child components are not allowed', (test) => {
+	test.throws(() => {
+		shallow(
+			<StepsFlow initialStep={3} stepsProps={stepsProps}>
+				<StepsFlow.Step label="Step 1" status="completed">
+					<div className="step1">Step 1</div>
+				</StepsFlow.Step>
+				<div>Illegal!</div>
+			</StepsFlow>
+		)
+	})
+})
+
+ava('Invalid status values are not allowed', (test) => {
+	test.throws(() => {
+		shallow(
+			<StepsFlow initialStep={3} stepsProps={stepsProps}>
+				<StepsFlow.Step label="Step 1" status="unknown">
+					<div className="step1">Step 1</div>
+				</StepsFlow.Step>
+			</StepsFlow>
+		)
+	})
+})


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

The `StepsFlow` component wraps Rendition's `Steps` component, keeping track of the 'active' step and rendering the content of the active step immediately below the `Steps` component.

Example usage:
```javascript
<StepsFlow
  stepsProps={{
    titleText: 'Test flow',
    titleIcon: <Icon name="user" />
  }}
>
  <StepsFlow.Step label="Do this" status={isStep1Complete ? 'completed' : 'pending'}>
    ...
  </StepsFlow.Step>
  <StepsFlow.Step label="Then this" status={isStep2Complete ? 'completed' : 'pending'}>
    ...
  </StepsFlow.Step>
  <StepsFlow.Step label="And then this" status={isStep3Complete ? 'completed' : 'pending'}>
    ...
  </StepsFlow.Step>
  <StepsFlow.Step label="Finish!" status="None">
    ...
  </StepsFlow.Step>
</StepsFlow>
```

### Notes

1. Sadly it's not currently possible to improve the styling of Rendition's `Steps` component to make the 'active' step more prominent 😢.
1. The initial step can be set using the `initialStep` prop.

![StepsFlow](https://user-images.githubusercontent.com/2925657/76284719-a9d13080-62d0-11ea-8bdc-ff433bb4cf95.gif)

_(It is intended to use this component for various flows including the [guided card handover flow](https://github.com/product-os/jellyfish/issues/3121))_