### PR TITLE
Recast the `actor` property in `session` cards as an `is owned by` link

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -29,14 +29,31 @@ const getActorKey = async (context, jellyfish, session, actorId) => {
 		actor: actorId
 	})
 
-	return jellyfish.replaceCard(context, session, jellyfish.defaults({
+	const actorSession = await jellyfish.replaceCard(context, session, jellyfish.defaults({
 		slug: keySlug,
 		version: '1.0.0',
-		type: 'session@1.0.0',
-		data: {
-			actor: actorId
-		}
+		type: 'session@1.0.0'
 	}))
+	await jellyfish.replaceCard(context, session, {
+		slug: `link-${keySlug}-is-owned-by-${actorId}`,
+		type: 'link@1.0.0',
+		name: 'is owned by',
+		data: {
+			inverseName: 'owns',
+			from: {
+				id: actorSession.id,
+				type: actorSession.type
+			},
+			to: {
+				id: actorId,
+
+				// TODO: find a way to make sure this is actually the case
+				type: 'user@1.0.0'
+			}
+		}
+	})
+
+	return actorSession
 }
 
 const SCHEMA_ACTIVE_TRIGGERS = {

--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -24,11 +24,24 @@ module.exports = async (context, jellyfish, worker, session) => {
 		context, session, jellyfish.defaults({
 			slug: 'session-guest',
 			version: '1.0.0',
-			type: 'session@1.0.0',
-			data: {
-				actor: guestUser.id
-			}
+			type: 'session@1.0.0'
 		}))
+	await jellyfish.replaceCard(context, session, {
+		slug: 'link-session-guest-is-owned-by-user-guest',
+		type: 'link@1.0.0',
+		name: 'is owned by',
+		data: {
+			inverseName: 'owns',
+			from: {
+				id: guestUserSession.id,
+				type: guestUserSession.type
+			},
+			to: {
+				id: guestUser.id,
+				type: guestUser.type
+			}
+		}
+	})
 
 	logger.info(context, 'Done setting up guest session')
 	logger.info(context, 'Setting default cards')

--- a/lib/action-library/handlers/action-broadcast.js
+++ b/lib/action-library/handlers/action-broadcast.js
@@ -10,10 +10,9 @@ const assert = require('../../assert')
 const handler = async (session, context, card, request) => {
 	const eventBaseType = 'message'
 	const eventType = `${eventBaseType}@1.0.0`
-	const sessionCard = await context.getCardById(
-		context.privilegedSession, context.privilegedSession)
+	const user = await context.getSessionUser(context.privilegedSession)
 
-	assert.INTERNAL(request.context, sessionCard,
+	assert.INTERNAL(request.context, user,
 		context.errors.WorkerNoElement, 'Privileged session is invalid')
 
 	const messages = await context.query(context.privilegedSession, {
@@ -43,7 +42,7 @@ const handler = async (session, context, card, request) => {
 				properties: {
 					actor: {
 						type: 'string',
-						const: sessionCard.data.actor
+						const: user.id
 					},
 					payload: {
 						type: 'object',

--- a/lib/action-library/handlers/action-create-session.js
+++ b/lib/action-library/handlers/action-create-session.js
@@ -48,10 +48,15 @@ const handler = async (session, context, card, request) => {
 
 	const sessionTypeCard = await context.getCardBySlug(
 		session, 'session@1.0.0')
+	const linkTypeCard = await context.getCardBySlug(
+		session, 'link@1.0.0')
 
 	assert.USER(request.context,
 		sessionTypeCard,
 		context.errors.WorkerNoElement, 'No such type: session')
+	assert.USER(request.context,
+		linkTypeCard,
+		context.errors.WorkerNoElement, 'No such type: link')
 
 	// Set the expiration date to be 7 days from now
 	const expirationDate = new Date()
@@ -73,12 +78,38 @@ const handler = async (session, context, card, request) => {
 			version: '1.0.0',
 			slug: `session-${user.slug}-${request.epoch}-${suffix}`,
 			data: {
-				actor: card.id,
 				expiration: expirationDate.toISOString()
 			}
 		})
 
 	if (!result) {
+		return null
+	}
+
+	const linkResult = await context.insertCard(
+		context.privilegedSession, linkTypeCard, {
+			timestamp: request.timestamp,
+			actor: request.actor,
+			originator: request.originator,
+			attachEvents: false
+		}, {
+			slug: `link-${result.id}-is-owned-by-${user.id}-${suffix}`,
+			type: 'link@1.0.0',
+			name: 'is owned by',
+			data: {
+				inverseName: 'owns',
+				from: {
+					id: result.id,
+					type: result.type
+				},
+				to: {
+					id: user.id,
+					type: user.type
+				}
+			}
+		})
+
+	if (!linkResult) {
 		return null
 	}
 

--- a/lib/core/cards/session.js
+++ b/lib/core/cards/session.js
@@ -20,18 +20,12 @@ module.exports = {
 				data: {
 					type: 'object',
 					properties: {
-						actor: {
-							type: 'string',
-							format: 'uuid'
-						},
 						expiration: {
 							type: 'string',
 							format: 'date-time'
 						}
 					},
-					required: [
-						'actor'
-					]
+					additionalProperties: false
 				}
 			},
 			required: [

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -181,9 +181,22 @@ module.exports = class Kernel {
 		const adminUser = await unsafeUpsert(CARDS['user-admin'])
 		const adminSession = await unsafeUpsert({
 			slug: 'session-admin-kernel',
-			type: `${CARDS.session.slug}@${CARDS.session.version}`,
+			type: `${CARDS.session.slug}@${CARDS.session.version}`
+		})
+		await unsafeUpsert({
+			slug: 'link-session-admin-kernel-is-owned-by-user-admin',
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: adminUser.id
+				inverseName: 'owns',
+				from: {
+					id: adminSession.id,
+					type: adminSession.type
+				},
+				to: {
+					id: adminUser.id,
+					type: adminUser.type
+				}
 			}
 		})
 
@@ -630,5 +643,10 @@ module.exports = class Kernel {
 		return {
 			backend: await this.backend.getStatus()
 		}
+	}
+
+	// TODO: temporary helper function until we get a server SDK
+	async getSessionUser (context, session) {
+		return permissionFilter.getSessionUser(context, this.backend, session)
 	}
 }

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -153,9 +153,46 @@ exports.unsafeUpsertCard = async (context, backend, card) => {
  * @returns {Object} user card
  */
 exports.getSessionUser = async (context, backend, session) => {
-	const sessionCard = await backend.getElementById(context, session, {
-		type: 'session'
+	let sessionCard = await backend.query(context, {
+		type: 'object',
+		$$links: {
+			'is owned by': {
+				type: 'object',
+				required: [ 'slug' ],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'user@1.0.0'
+					}
+				}
+			}
+		},
+		required: [ 'id', 'type', 'links' ],
+		properties: {
+			id: {
+				type: 'string',
+				const: session
+			},
+			type: {
+				type: 'string',
+				const: 'session@1.0.0'
+			},
+			links: {
+				type: 'object'
+			},
+			data: {
+				type: 'object',
+				properties: {
+					expiration: {
+						type: 'string'
+					}
+				}
+			}
+		}
+	}, {
+		limit: 1
 	})
+	sessionCard = sessionCard[0]
 
 	assert.USER(context, sessionCard, errors.JellyfishInvalidSession,
 		`Invalid session: ${session}`)
@@ -166,15 +203,7 @@ exports.getSessionUser = async (context, backend, session) => {
 		errors.JellyfishSessionExpired,
 		`Session expired at: ${sessionCard.data.expiration}`)
 
-	const actor = await backend.getElementById(
-		context, sessionCard.data.actor, {
-			type: 'user@1.0.0'
-		})
-
-	assert.INTERNAL(context, actor, errors.JellyfishNoElement,
-		`Invalid actor: ${sessionCard.data.actor}`)
-
-	return actor
+	return sessionCard.links['is owned by'][0]
 }
 
 /**

--- a/lib/queue/producer.js
+++ b/lib/queue/producer.js
@@ -55,11 +55,10 @@ module.exports = class Producer {
 
 			action: this.jellyfish.getCardBySlug(
 				options.context, session, options.action),
-			session: this.jellyfish.getCardById(
-				options.context, session, session)
+			actor: this.jellyfish.getSessionUser(options.context, session)
 		})
 
-		assert.INTERNAL(options.context, cards.session,
+		assert.INTERNAL(options.context, cards.actor,
 			errors.QueueInvalidSession,
 			`No such session: ${session}`)
 		assert.USER(options.context, cards.action,
@@ -81,7 +80,7 @@ module.exports = class Producer {
 				timestamp: date.toISOString(),
 				context: options.context,
 				originator: options.originator,
-				actor: cards.session.data.actor,
+				actor: cards.actor.id,
 				action: `${cards.action.slug}@${cards.action.version}`,
 				input: {
 					id: cards.target.id

--- a/lib/sdk/auth.js
+++ b/lib/sdk/auth.js
@@ -180,26 +180,22 @@ class AuthSdk {
 	 * 		console.log('New token', token)
 	 * 	})
 	 */
-	refreshToken () {
-		return this.whoami()
-			.then((user) => {
-				const expirationDate = new Date()
-				expirationDate.setDate(expirationDate.getDate() + 7)
+	async refreshToken () {
+		const user = await this.whoami()
+		const expirationDate = new Date()
+		expirationDate.setDate(expirationDate.getDate() + 7)
 
-				return this.sdk.card.create({
-					slug: `session-ui-${user.slug}-${Date.now()}-${uuid()}`,
-					type: 'session',
-					data: {
-						actor: user.id,
-						expiration: expirationDate.toISOString()
-					}
-				})
-			})
-			.then((session) => {
-				this.sdk.setAuthToken(session.id)
+		const session = await this.sdk.card.create({
+			slug: `session-ui-${user.slug}-${Date.now()}-${await uuid()}`,
+			type: 'session',
+			data: {
+				expiration: expirationDate.toISOString()
+			}
+		})
+		await this.sdk.card.link(session, user, 'is owned by')
+		this.sdk.setAuthToken(session.id)
 
-				return session.id
-			})
+		return session.id
 	}
 
 	/**

--- a/lib/sdk/link-constraints.js
+++ b/lib/sdk/link-constraints.js
@@ -57,6 +57,26 @@ exports.constraints = [
 		}
 	},
 	{
+		slug: 'link-constraint-session-is-owned-by-user',
+		name: 'is owned by',
+		data: {
+			title: 'Owner',
+			from: 'session',
+			to: 'user',
+			inverse: 'link-constraint-user-owns-session'
+		}
+	},
+	{
+		slug: 'link-constraint-user-owns-session',
+		name: 'owns',
+		data: {
+			title: 'Session',
+			from: 'user',
+			to: 'session',
+			inverse: 'link-constraint-session-is-owned-by-user'
+		}
+	},
+	{
 		slug: 'link-constraint-support-thread-is-attached-to-support-issue',
 		name: 'support thread is attached to support issue',
 		data: {

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -130,6 +130,9 @@ module.exports = class Worker {
 			getCardBySlug: _.bind(function (lsession, slug) {
 				return this.jellyfish.getCardBySlug(context, lsession, slug)
 			}, this),
+			getSessionUser: _.bind(function (lsession) {
+				return this.jellyfish.getSessionUser(context, lsession)
+			}, this),
 			query: _.bind(function (lsession, schema, options) {
 				return this.jellyfish.query(context, lsession, schema, options)
 			}, this),

--- a/test/e2e/server/actions/action-increment.spec.js
+++ b/test/e2e/server/actions/action-increment.spec.js
@@ -21,11 +21,9 @@ ava.serial('should increment a card value using action-increment', async (test) 
 		slug: test.context.generateRandomSlug({
 			prefix: 'session'
 		}),
-		version: '1.0.0',
-		data: {
-			actor: admin.id
-		}
+		version: '1.0.0'
 	})
+	await test.context.sdk.card.link(session, admin, 'is owned by')
 
 	const result1 = await test.context.http(
 		'POST', '/api/v2/action', {

--- a/test/e2e/server/sessions.spec.js
+++ b/test/e2e/server/sessions.spec.js
@@ -38,10 +38,10 @@ ava.serial('should fail with a user error when querying an id with an expired se
 		}),
 		version: '1.0.0',
 		data: {
-			actor: admin.id,
 			expiration: '2015-04-10T23:00:00.000Z'
 		}
 	})
+	await test.context.sdk.card.link(session, admin, 'is owned by')
 
 	const result = await test.context.http(
 		'GET', '/api/v2/id/4a962ad9-20b5-4dd8-a707-bf819593cc84', null, {
@@ -69,10 +69,10 @@ ava.serial('should fail with a user error when querying a slug with an expired s
 		}),
 		version: '1.0.0',
 		data: {
-			actor: admin.id,
 			expiration: '2015-04-10T23:00:00.000Z'
 		}
 	})
+	await test.context.sdk.card.link(session, admin, 'is owned by')
 
 	const result = await test.context.http(
 		'GET', '/api/v2/slug/user-admin', null, {
@@ -100,10 +100,10 @@ ava.serial('should fail with a user error when querying with an expired session'
 		}),
 		version: '1.0.0',
 		data: {
-			actor: admin.id,
 			expiration: '2015-04-10T23:00:00.000Z'
 		}
 	})
+	await test.context.sdk.card.link(session, admin, 'is owned by')
 
 	const result = await test.context.http(
 		'POST', '/api/v2/query', {
@@ -147,10 +147,10 @@ ava.serial('should fail with a user error when posting an action with an expired
 		}),
 		version: '1.0.0',
 		data: {
-			actor: admin.id,
 			expiration: '2015-04-10T23:00:00.000Z'
 		}
 	})
+	await test.context.sdk.card.link(session, admin, 'is owned by')
 
 	const result = await test.context.http(
 		'POST', '/api/v2/action', {

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -36,7 +36,10 @@ ava('should only expose the required methods', (test) => {
 		'query',
 		'stream',
 		'defaults',
-		'getStatus'
+		'getStatus',
+
+		// TODO to be removed, see the method decl
+		'getSessionUser'
 	])
 })
 
@@ -694,9 +697,25 @@ ava('.patchCardBySlug() should be able to patch cards hidden to the user', async
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: userCard.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
 			}
 		})
 
@@ -722,6 +741,9 @@ ava('.patchCardBySlug() should be able to patch cards hidden to the user', async
 		test.context.context, test.context.kernel.sessions.admin, `${userCard.slug}@${userCard.version}`, {
 			type: userCard.type
 		})
+
+	// Clear the `linked_at` field since it is not deterministic
+	result.linked_at = {}
 
 	test.deepEqual(result, userCard)
 })
@@ -797,9 +819,25 @@ ava('.patchCardBySlug() should not allow updates in hidden fields', async (test)
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: userCard.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
 			}
 		})
 
@@ -827,6 +865,9 @@ ava('.patchCardBySlug() should not allow updates in hidden fields', async (test)
 		test.context.context, test.context.kernel.sessions.admin, `${userCard.slug}@${userCard.version}`, {
 			type: userCard.type
 		})
+
+	// Clear the `linked_at` field since it is not deterministic
+	result.linked_at = {}
 
 	test.deepEqual(result, userCard)
 })
@@ -902,9 +943,25 @@ ava('.patchCardBySlug() should not return the full card', async (test) => {
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: userCard.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
 			}
 		})
 
@@ -1010,9 +1067,25 @@ ava('.patchCardBySlug() should not allow a patch that makes a card inaccessible'
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: userCard.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
 			}
 		})
 
@@ -1126,9 +1199,25 @@ ava('.patchCardBySlug() should not remove inaccessible fields', async (test) => 
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: userCard.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
 			}
 		})
 
@@ -1157,6 +1246,9 @@ ava('.patchCardBySlug() should not remove inaccessible fields', async (test) => 
 		test.context.context, test.context.kernel.sessions.admin, `${userCard.slug}@${userCard.version}`, {
 			type: userCard.type
 		})
+
+	// Clear the `linked_at` field since it is not deterministic
+	result.linked_at = {}
 
 	test.deepEqual(result, userCard)
 })
@@ -1232,9 +1324,25 @@ ava('.patchCardBySlug() should not add an inaccesible field', async (test) => {
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: userCard.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
 			}
 		})
 
@@ -1265,6 +1373,9 @@ ava('.patchCardBySlug() should not add an inaccesible field', async (test) => {
 		test.context.kernel.sessions.admin, `${userCard.slug}@${userCard.version}`, {
 			type: userCard.type
 		})
+
+	// Clear the `linked_at` field since it is not deterministic
+	result.linked_at = {}
 
 	test.deepEqual(result, userCard)
 })
@@ -1658,11 +1769,27 @@ ava('.insertCard() read access on a property should not allow to write other pro
 			prefix: 'session'
 		}),
 		type: 'session@1.0.0',
-		version: '1.0.0',
-		data: {
-			actor: userCard.id
-		}
+		version: '1.0.0'
 	})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
+			data: {
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: userCard.id,
+					type: userCard.type
+				}
+			}
+		})
 
 	await test.throwsAsync(test.context.kernel.replaceCard(test.context.context, session.id, {
 		id: targetUserCard.id,
@@ -2017,7 +2144,8 @@ ava('.query() should be able to limit and skip the results', async (test) => {
 		required: [ 'type' ]
 	}, {
 		limit: 1,
-		skip: 1
+		skip: 1,
+		sortBy: 'data'
 	})
 
 	test.deepEqual(_.sortBy(results, [ 'data', 'test' ]), [ result2 ])
@@ -2191,11 +2319,12 @@ ava('.query() should be able to describe a property that starts with $', async (
 ava('.query() should take roles into account', async (test) => {
 	const actor = await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {
-			slug: 'johndoe',
-			type: 'card@1.0.0',
+			slug: 'user-johndoe',
+			type: 'user@1.0.0',
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.io',
+				hash: 'PASSWORDLESS',
 				roles: [ 'foo' ]
 			}
 		})
@@ -2206,9 +2335,25 @@ ava('.query() should take roles into account', async (test) => {
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: actor.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: actor.id,
+					type: actor.type
+				}
 			}
 		})
 
@@ -2275,11 +2420,12 @@ ava('.query() should take roles into account', async (test) => {
 
 ava('.query() should ignore queries to properties not whitelisted by a role', async (test) => {
 	const actor = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'johndoe',
-		type: 'card@1.0.0',
+		slug: 'user-johndoe',
+		type: 'user@1.0.0',
 		version: '1.0.0',
 		data: {
 			email: 'johndoe@example.io',
+			hash: 'PASSWORDLESS',
 			roles: [ 'foo' ]
 		}
 	})
@@ -2289,11 +2435,27 @@ ava('.query() should ignore queries to properties not whitelisted by a role', as
 			prefix: 'session'
 		}),
 		type: 'session@1.0.0',
-		version: '1.0.0',
-		data: {
-			actor: actor.id
-		}
+		version: '1.0.0'
 	})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
+			data: {
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: actor.id,
+					type: actor.type
+				}
+			}
+		})
 
 	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 		slug: 'role-foo',
@@ -2344,11 +2506,12 @@ ava('.query() should ignore queries to properties not whitelisted by a role', as
 ava('.query() should ignore $id properties in roles', async (test) => {
 	const actor = await test.context.kernel.insertCard(
 		test.context.context, test.context.kernel.sessions.admin, {
-			slug: 'johndoe',
-			type: 'card@1.0.0',
+			slug: 'user-johndoe',
+			type: 'user@1.0.0',
 			version: '1.0.0',
 			data: {
 				email: 'johndoe@example.io',
+				hash: 'PASSWORDLESS',
 				roles: [ 'foo' ]
 			}
 		})
@@ -2359,9 +2522,25 @@ ava('.query() should ignore $id properties in roles', async (test) => {
 				prefix: 'session'
 			}),
 			type: 'session@1.0.0',
-			version: '1.0.0',
+			version: '1.0.0'
+		})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: actor.id
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: actor.id,
+					type: actor.type
+				}
 			}
 		})
 
@@ -2417,11 +2596,12 @@ ava('.query() should ignore $id properties in roles', async (test) => {
 
 ava('.query() should ignore queries to disallowed properties with additionalProperties: true', async (test) => {
 	const actor = await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
-		slug: 'johndoe',
-		type: 'card@1.0.0',
+		slug: 'user-johndoe',
+		type: 'user@1.0.0',
 		version: '1.0.0',
 		data: {
 			email: 'johndoe@example.io',
+			hash: 'PASSWORDLESS',
 			roles: [ 'foo' ]
 		}
 	})
@@ -2431,11 +2611,27 @@ ava('.query() should ignore queries to disallowed properties with additionalProp
 			prefix: 'session'
 		}),
 		type: 'session@1.0.0',
-		version: '1.0.0',
-		data: {
-			actor: actor.id
-		}
+		version: '1.0.0'
 	})
+	await test.context.kernel.insertCard(
+		test.context.context, test.context.kernel.sessions.admin, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
+			data: {
+				inverseName: 'owns',
+				from: {
+					id: session.id,
+					type: session.type
+				},
+				to: {
+					id: actor.id,
+					type: actor.type
+				}
+			}
+		})
 
 	await test.context.kernel.insertCard(test.context.context, test.context.kernel.sessions.admin, {
 		slug: 'role-foo',

--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -19,11 +19,6 @@ exports.beforeEach = async (test, options) => {
 	test.context.jellyfish = test.context.kernel
 	test.context.session = test.context.jellyfish.sessions.admin
 
-	const session = await test.context.jellyfish.getCardById(
-		test.context.context, test.context.session, test.context.session)
-	test.context.actor = await test.context.jellyfish.getCardById(
-		test.context.context, test.context.session, session.data.actor)
-
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
 		require('../../../apps/server/default-cards/contrib/message.json'))
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session,

--- a/test/integration/queue/index.spec.js
+++ b/test/integration/queue/index.spec.js
@@ -20,8 +20,8 @@ ava('.dequeue() should return nothing if no requests', async (test) => {
 ava('.enqueue() should include the actor from the passed session', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
-	const session = await test.context.jellyfish.getCardById(
-		test.context.context, test.context.session, test.context.session)
+	const actor = await test.context.jellyfish.getSessionUser(
+		test.context.context, test.context.session)
 	await test.context.queue.producer.enqueue(test.context.queueActor, test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -39,7 +39,7 @@ ava('.enqueue() should include the actor from the passed session', async (test) 
 	})
 
 	const request = await test.context.dequeue()
-	test.is(session.data.actor, request.data.actor)
+	test.is(actor.id, request.data.actor)
 })
 
 ava('.enqueue() should include the whole passed action', async (test) => {

--- a/test/integration/worker/actions/broadcast.spec.js
+++ b/test/integration/worker/actions/broadcast.spec.js
@@ -483,9 +483,25 @@ ava('should broadcast the same message twice given different actors', async (tes
 		test.context.context, test.context.session, {
 			type: 'session@1.0.0',
 			version: '1.0.0',
-			slug: 'session-rogue-user-test',
+			slug: 'session-rogue-user-test'
+		})
+	await test.context.jellyfish.insertCard(
+		test.context.context, test.context.session, {
+			slug: test.context.generateRandomSlug({
+				prefix: 'link'
+			}),
+			type: 'link@1.0.0',
+			name: 'is owned by',
 			data: {
-				actor: rogueUser.id
+				inverseName: 'owns',
+				from: {
+					id: rogueSession.id,
+					type: rogueSession.type
+				},
+				to: {
+					id: rogueUser.id,
+					type: rogueUser.type
+				}
 			}
 		})
 

--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -12,6 +12,9 @@ exports.jellyfish = {
 	beforeEach: async (test) => {
 		await helpers.beforeEach(test)
 
+		test.context.actor = await test.context.jellyfish.getSessionUser(
+			test.context.context, test.context.session)
+
 		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
 			require('../../../lib/worker/cards/update'))
 		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
@@ -30,6 +33,9 @@ exports.worker = {
 		await helpers.beforeEach(test, {
 			suffix: options.suffix
 		})
+
+		test.context.actor = await test.context.jellyfish.getSessionUser(
+			test.context.context, test.context.session)
 
 		test.context.worker = new Worker(
 			test.context.jellyfish,


### PR DESCRIPTION
This is part 1 of a series of PRs aimed at closing #3263.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>

Current concerns:
- Ergonomy loss due to lack of link-aware functions in `core/kernel`
- Lack of a low-level constraint checking for links may lead to subtle bugs
- The `linked_at` field becomes extra noise that needs to be filtered in some tests
- Blocked on #3325
- Enqueuing is now a bottleneck because we need to wait for the a card to be created so we can link it
- A refactor is needed for code dealing with sessions.  Multiple code paths are doing similar things in slightly different ways.