### PR TITLE
core: Automatically add versions to link types if needed

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -232,6 +232,20 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		})
 	}
 
+	// TODO: Remove this once we completely migrate links
+	// to have versioned types in the "from" and the "to"
+	// See: https://github.com/product-os/jellyfish/pull/3088
+	if (insertedObject.type === 'link@1.0.0' &&
+		insertedObject.data.from &&
+		insertedObject.data.to &&
+		insertedObject.data.from.type &&
+		insertedObject.data.to.type &&
+		!_.includes(insertedObject.data.from.type, '@') &&
+		!_.includes(insertedObject.data.to.type, '@')) {
+		insertedObject.data.from.type = `${insertedObject.data.from.type}@1.0.0`
+		insertedObject.data.from.to = `${insertedObject.data.to.type}@1.0.0`
+	}
+
 	const payload = [
 		elementId,
 		insertedObject.slug,


### PR DESCRIPTION
To let the system help with the migration we're doing.

See: https://github.com/product-os/jellyfish/pull/3088
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!