### PR TITLE
ui-components: Add prev/next/action buttons to StepsFlow component

### DIFF
--- a/lib/ui-components/StepsFlow.jsx
+++ b/lib/ui-components/StepsFlow.jsx
@@ -10,15 +10,25 @@
 import React from 'react'
 import {
 	Box,
+	Button,
 	Heading,
+	Flex,
 	Steps,
 	Step
 } from 'rendition'
+import _ from 'lodash'
 
 const VALID_STEP_STATUSES = {
 	pending: true,
 	completed: true,
 	none: true
+}
+
+const nonePending = (stepStatuses) => {
+	return _.every(
+		stepStatuses,
+		(status) => { return status !== 'pending' }
+	)
 }
 
 /**
@@ -47,17 +57,21 @@ const FlowStep = ({
  */
 const StepsFlow = ({
 	initialStep,
+	onDone,
 	stepsProps,
 	children,
+	action,
 	...rest
 }) => {
 	if (initialStep > children.length - 1 || initialStep < 0) {
 		throw new Error('initialStep is out of bounds')
 	}
 	const [ activeStepIndex, setActiveStepIndex ] = React.useState(initialStep || 0)
+	const stepStatuses = _.map(children, 'props.status')
+	const allComplete = nonePending(stepStatuses)
 	return (
-		<Box {...rest}>
-			<Steps className="flow-steps" {...stepsProps}>
+		<Flex {...rest} flex={1} flexDirection="column">
+			<Steps flex={0} className="flow-steps" {...stepsProps}>
 				{React.Children.map(children, (step, stepIndex) => {
 					if (step.type !== FlowStep) {
 						throw new Error(
@@ -69,26 +83,65 @@ const StepsFlow = ({
 							`Invalid step status: ${step.props.status}`
 						)
 					}
+
+					// Link should be active if:
+					// - its a previous step OR
+					// - its not the current step AND all previous steps are not pending
+					const clickHandler = (stepIndex < activeStepIndex) ||
+						(stepIndex !== activeStepIndex && nonePending(stepStatuses.slice(0, stepIndex)))
+						? () => { return setActiveStepIndex(stepIndex) }
+						: null
 					return (
 						<Step
 							key={step.props.label}
 							status={step.props.status}
-							onClick={
-								stepIndex === activeStepIndex
-									? null
-									: () => { return setActiveStepIndex(stepIndex) }
-							}
+							onClick={clickHandler}
 						>
 							{step.props.label}
 						</Step>
 					)
 				})}
 			</Steps>
-			{React.cloneElement(children[activeStepIndex], {
-				stepIndex: activeStepIndex
-			})}
-		</Box>
+			<Box flex={1}>
+				{React.cloneElement(children[activeStepIndex], {
+					stepIndex: activeStepIndex
+				})}
+			</Box>
+			<Flex flex={0} alignItems="center" justifyContent="space-between">
+				<Button
+					data-test="steps-flow__prev-btn"
+					disabled={activeStepIndex === 0}
+					onClick={() => { return setActiveStepIndex(activeStepIndex - 1) }}
+				>
+					Previous
+				</Button>
+				{ activeStepIndex < children.length - 1 && (
+					<Button
+						data-test="steps-flow__next-btn"
+						disabled={children[activeStepIndex].props.status === 'pending'}
+						onClick={() => { return setActiveStepIndex(activeStepIndex + 1) }}
+					>
+						Next
+					</Button>
+				)}
+				{ activeStepIndex === children.length - 1 && (
+					<Button
+						disabled={!allComplete}
+						data-test="steps-flow__action-btn"
+						onClick={onDone}
+						primary
+					>
+						{action}
+					</Button>
+				)}
+			</Flex>
+		</Flex>
 	)
+}
+
+StepsFlow.defaultProps = {
+	initialStep: 0,
+	action: 'Go!'
 }
 
 StepsFlow.Step = FlowStep

--- a/lib/ui-components/StepsFlow.spec.jsx
+++ b/lib/ui-components/StepsFlow.spec.jsx
@@ -28,51 +28,106 @@ const stepsProps = {
 	titleText: 'Test flow'
 }
 
+const getStep = (index, stepStatus) => {
+	return (
+		<StepsFlow.Step key={index} label={`Step ${index}`} status={stepStatus}>
+			<div className={`step${index}`}>Step {index}</div>
+		</StepsFlow.Step>
+	)
+}
+
+const getShallowStepsFlow = ({
+	status, ...props
+}) => {
+	const stepStatus = status || 'pending'
+	return shallow(
+		<StepsFlow stepsProps={stepsProps} {...props}>
+			{[ 1, 2, 3 ].map((index) => { return getStep(index, stepStatus) })}
+		</StepsFlow>
+	)
+}
+
+const getMountedStepsFlow = ({
+	status, ...props
+}) => {
+	const stepStatus = status || 'pending'
+	return mount(
+		<Provider>
+			<StepsFlow stepsProps={stepsProps} {...props}>
+				{[ 1, 2, 3 ].map((index) => { return getStep(index, stepStatus) })}
+			</StepsFlow>
+		</Provider>
+	)
+}
+
 ava('StepsFlow should render', (test) => {
 	test.notThrows(() => {
-		shallow(
-			<StepsFlow stepsProps={stepsProps}>
-				<StepsFlow.Step label="Step 1" status="completed">
-					<div className="step1">Step 1</div>
-				</StepsFlow.Step>
-				<StepsFlow.Step label="Step 2" status="pending">
-					<div className="step2">Step 2</div>
-				</StepsFlow.Step>
-			</StepsFlow>
-		)
+		getShallowStepsFlow({})
 	})
 })
 
 ava('initialStep is respected', (test) => {
-	const component = mount(
-		<Provider>
-			<StepsFlow initialStep={1} stepsProps={stepsProps}>
-				<StepsFlow.Step label="Step 1" status="completed">
-					<div className="step1">Step 1</div>
-				</StepsFlow.Step>
-				<StepsFlow.Step label="Step 2" status="pending">
-					<div className="step2">Step 2</div>
-				</StepsFlow.Step>
-			</StepsFlow>
-		</Provider>
-	)
+	const component = getMountedStepsFlow({
+		initialStep: 1
+	})
 
 	const stepHeading = component.find('h5[data-test="flow-step-1__heading"]')
 	test.is(stepHeading.text(), 'Step 2')
 })
 
+ava('Previous button is disabled on first step', (test) => {
+	const component = getMountedStepsFlow({
+		status: 'completed'
+	})
+
+	let prevButton = component.find('button[data-test="steps-flow__prev-btn"]')
+	test.is(prevButton.prop('disabled'), true)
+
+	const nextButton = component.find('button[data-test="steps-flow__next-btn"]')
+	test.is(nextButton.prop('disabled'), false)
+
+	nextButton.simulate('click')
+
+	prevButton = component.find('button[data-test="steps-flow__prev-btn"]')
+	test.is(prevButton.prop('disabled'), false)
+})
+
+ava('Next button is disabled if step is not completed', (test) => {
+	const component = getMountedStepsFlow({
+		status: 'pending'
+	})
+
+	const nextButton = component.find('button[data-test="steps-flow__next-btn"]')
+	test.is(nextButton.prop('disabled'), true)
+})
+
+ava('Action button is displayed on last step', (test) => {
+	const component = getMountedStepsFlow({
+		initialStep: 2
+	})
+
+	const actionButton = component.find('button[data-test="steps-flow__action-btn"]')
+	test.is(actionButton.prop('disabled'), true)
+
+	const nextButton = component.find('button[data-test="steps-flow__next-btn"]')
+	test.false(nextButton.exists())
+})
+
+ava('Action button is enabled if all steps are completed', (test) => {
+	const component = getMountedStepsFlow({
+		initialStep: 2,
+		status: 'completed'
+	})
+
+	const actionButton = component.find('button[data-test="steps-flow__action-btn"]')
+	test.is(actionButton.prop('disabled'), false)
+})
+
 ava('initialStep cannot be greater than number of steps', (test) => {
 	test.throws(() => {
-		shallow(
-			<StepsFlow initialStep={3} stepsProps={stepsProps}>
-				<StepsFlow.Step label="Step 1" status="completed">
-					<div className="step1">Step 1</div>
-				</StepsFlow.Step>
-				<StepsFlow.Step label="Step 2" status="pending">
-					<div className="step2">Step 2</div>
-				</StepsFlow.Step>
-			</StepsFlow>
-		)
+		getShallowStepsFlow({
+			initialStep: 3
+		})
 	})
 })
 
@@ -91,12 +146,8 @@ ava('Invalid child components are not allowed', (test) => {
 
 ava('Invalid status values are not allowed', (test) => {
 	test.throws(() => {
-		shallow(
-			<StepsFlow initialStep={3} stepsProps={stepsProps}>
-				<StepsFlow.Step label="Step 1" status="unknown">
-					<div className="step1">Step 1</div>
-				</StepsFlow.Step>
-			</StepsFlow>
-		)
+		getShallowStepsFlow({
+			status: 'foobar'
+		})
 	})
 })


### PR DESCRIPTION
Added unit tests to verify behaviour.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
The `Steps` link behaviour is also slightly modified to align with these buttons. Basically you can only progress through the flow if the current step (and, implicitly, previous steps) are complete. 

The following logic is applied
- Previous button is disabled when you're on the first step
- Next button is disabled if the current step is not 'completed'
- Next button is replaced by the action button on the last step
- Action button is disabled if not all the steps are 'completed'
- A step's link is enabled if:
  -  its a previous step OR
  - its not the current step AND all previous steps are not pending

(Ignore the step content in the following screenshots - focus on the buttons!)

Previous and Next buttons:
![NextPrev](https://user-images.githubusercontent.com/2925657/76483366-75cd4b00-6449-11ea-9db4-88bb12638ee7.png)

Previous and Action buttons:
![ActionPrev](https://user-images.githubusercontent.com/2925657/76483372-78c83b80-6449-11ea-8832-d0510d8d6625.png)

