### PR TITLE
sdk: Add 'is owned by' link between support-thread and user

### DIFF
--- a/lib/sdk/link-constraints.js
+++ b/lib/sdk/link-constraints.js
@@ -37,6 +37,26 @@ exports.constraints = [
 		}
 	},
 	{
+		slug: 'link-constraint-support-thread-is-owned-by',
+		name: 'is owned by',
+		data: {
+			title: 'Owner',
+			from: 'support-thread',
+			to: 'user',
+			inverse: 'link-constraint-user-is-owner-of-support-thread'
+		}
+	},
+	{
+		slug: 'link-constraint-user-is-owner-of-support-thread',
+		name: 'is owner of',
+		data: {
+			title: 'Support thread',
+			from: 'user',
+			to: 'support-thread',
+			inverse: 'link-constraint-support-thread-is-owned-by'
+		}
+	},
+	{
 		slug: 'link-constraint-support-thread-is-attached-to-support-issue',
 		name: 'support thread is attached to support issue',
 		data: {

--- a/lib/ui-components/LinkModal/LinkModal.jsx
+++ b/lib/ui-components/LinkModal/LinkModal.jsx
@@ -203,10 +203,12 @@ export default class LinkModal extends React.Component {
 					)}
 					{linkTypeTargets.length > 1 && (
 						<Select ml={2}
+							id="card-linker--type-select"
 							value={linkType}
 							onChange={this.handleLinkTypeSelect}
 							labelKey="title"
 							options={linkTypeTargets}
+							data-test="card-linker--type__input"
 						/>
 					)}
 					<Box

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -103,11 +103,19 @@ ava.serial('You should be able to link support threads to existing support issue
 
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker-action--existing"]')
 
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--type__input"]')
+
+	// Select the 'Support issue' option from the dropdown
+	const supportIssueOption = await page.waitForXPath(
+		'//*[@id="card-linker--type-select__select-drop"]//span[text()="Support issue"]'
+	)
+	supportIssueOption.click()
+
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"]')
 
-	await page.type('#react-select-2-input', name)
+	await page.type('.jellyfish-async-select__input input', name)
 
-	await page.waitForSelector('#react-select-2-option-0')
+	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
 
 	await page.keyboard.press('Enter')
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This new link is required before we can assign owners to support threads!