### PR TITLE
Add first name and last name to profile page

### DIFF
--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -219,7 +219,7 @@ export default class ActionCreator {
 			'removeNotification',
 			'removeViewDataItem',
 			'removeViewNotice',
-			'setAvatarUrl',
+			'updateUser',
 			'setAuthToken',
 			'setChannels',
 			'setChatWidgetOpen',
@@ -864,22 +864,17 @@ export default class ActionCreator {
 		}
 	}
 
-	setAvatarUrl (url) {
+	updateUser (patches) {
 		return async (dispatch, getState) => {
 			try {
 				const user = selectors.getCurrentUser(getState())
-				await this.sdk.card.update(user.id, 'user', [
-					{
-						op: _.has(user, [ 'data', 'avatar' ]) ? 'replace' : 'add',
-						path: '/data/avatar',
-						value: url
-					}
-				])
+
+				await this.sdk.card.update(user.id, 'user', patches)
 
 				const updatedUser = await this.sdk.getById(user.id)
 
 				dispatch(this.setUser(updatedUser))
-				dispatch(this.addNotification('success', 'Successfully changed avatar'))
+				dispatch(this.addNotification('success', 'Successfully updated user'))
 			} catch (error) {
 				dispatch(this.addNotification('danger', error.message || error))
 			}


### PR DESCRIPTION
Change-type: minor

***

We are adding name fields, because we want to set a full name to the agent that is doing support, instead of showing handle or email. See [flowdock message](https://www.flowdock.com/app/rulemotion/p-cyclops/messages/136177).

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
