### PR TITLE
sync: Retry external service OAuth POST on 500

### DIFF
--- a/lib/sync/oauth.js
+++ b/lib/sync/oauth.js
@@ -9,6 +9,7 @@ const _ = require('lodash')
 const request = require('request')
 const typedErrors = require('typed-errors')
 const url = require('url')
+const errors = require('./errors')
 const assert = require('../assert')
 
 exports.OAuthRequestError =
@@ -30,10 +31,11 @@ exports.OAuthUnsuccessfulResponse =
  *
  * @param {(Object|Undefined)} accessToken - Access token
  * @param {Object} options - Request options (passed to `request`)
+ * @param {Number} [retries] - Number of retries
  * @returns {Object} HTTP response (code, body)
  */
-exports.request = async (accessToken, options) => {
-	return new Bluebird((resolve, reject) => {
+exports.request = async (accessToken, options, retries = 10) => {
+	const result = await new Bluebird((resolve, reject) => {
 		// Use access token if available
 		if (accessToken) {
 			_.set(options, [
@@ -53,6 +55,18 @@ exports.request = async (accessToken, options) => {
 			})
 		})
 	})
+
+	// Automatically retry on server failures
+	if (result.code >= 500) {
+		assert.USER(null, retries > 0,
+			errors.SyncExternalRequestError,
+			`External service responded with ${result.code} to OAuth request`)
+
+		await Bluebird.delay(2000)
+		return exports.request(accessToken, options, retries - 1)
+	}
+
+	return result
 }
 
 /**
@@ -113,15 +127,15 @@ const oauthPost = async (baseUrl, path, data) => {
 
 	assert.INTERNAL(null, code < 500, exports.OAuthRequestError,
 		() => {
-			return `POST ${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
+			return `POST ${baseUrl}${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
 		})
 
 	assert.USER(null, code < 400, exports.OAuthUnsuccessfulResponse,
-		`POST ${path} responded with ${body.error_description}`)
+		`POST ${baseUrl}${path} responded with ${body.error_description}`)
 
 	assert.INTERNAL(null, code === 200, exports.OAuthRequestError,
 		() => {
-			return `POST ${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
+			return `POST ${baseUrl}${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
 		})
 
 	return body


### PR DESCRIPTION
This indicates a transient issue on the external service that we are
trying to integrate with, and retrying usually fixes the problem.

We also improve the error messages a bit, so we display the base URL of
the service that's actually failing.

Change-type: patch
Fixes: https://sentry.io/share/issue/c76b14909a1249ef8cbf13841377bf44/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!