### PR TITLE
outreach: Add more logging to prospect find by email logic

### DIFF
--- a/lib/sync/integrations/outreach.js
+++ b/lib/sync/integrations/outreach.js
@@ -91,6 +91,10 @@ const getProspectByEmail = async (context, actor, errors, baseUrl, emails) => {
 	}
 
 	for (const email of _.castArray(emails)) {
+		context.log.info('Searching for propect by email', {
+			email
+		})
+
 		const searchResult = await context.request(actor, {
 			method: 'GET',
 			json: true,
@@ -114,8 +118,18 @@ const getProspectByEmail = async (context, actor, errors, baseUrl, emails) => {
 			errors.SyncExternalRequestError,
 			`Cannot find prospect by email ${emails}: ${searchResult.code}`)
 
-		return _.first(searchResult.body.data)
+		const result = _.first(searchResult.body.data)
+		context.log.info('Found prospect by email', {
+			email,
+			prospect: result
+		})
+
+		return result
 	}
+
+	context.log.info('Could not find prospect by emails', {
+		emails
+	})
 
 	return null
 }


### PR DESCRIPTION
We keep hitting weird cases where we try to insert a prospect into
Outreach, Outreach complains that the email already belongs to another
prospect, but then we query Outreach to find the prospect that has that
e-mail and the result is none.

Hopefully these extra logs will shed some light.

Change-type: patch
See: https://sentry.io/share/issue/300732926e9e4f2fb0aa347d3d9a045d/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!