### PR TITLE
Complete password reset

### DIFF
--- a/lib/action-library/actions/action-complete-password-reset.js
+++ b/lib/action-library/actions/action-complete-password-reset.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'action-complete-password-reset',
+	type: 'action@1.0.0',
+	version: '1.0.0',
+	name: 'Complete password reset',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {
+		arguments: {
+			newPassword: {
+				type: 'string'
+			},
+			resetToken: {
+				type: 'string',
+				pattern: '^[0-9a-fA-F]{64}$'
+			}
+		}
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/action-library/handlers/action-complete-password-reset.js
+++ b/lib/action-library/handlers/action-complete-password-reset.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const bcrypt = require('bcrypt')
+const _ = require('lodash')
+const assert = require('../../assert')
+
+const {
+	BCRYPT_SALT_ROUNDS
+} = require('./constants')
+
+const pre = async (session, context, request) => {
+	// Convert the plaintext password into a hash so that we don't have a plain password stored in the DB
+	request.arguments.newPassword = await bcrypt.hash(
+		request.arguments.newPassword, BCRYPT_SALT_ROUNDS)
+	return request.arguments
+}
+
+const getPasswordResetCard = async (context, request) => {
+	const [ passwordReset ] = await context.query(context.privilegedSession, {
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true
+					}
+				}
+			}
+		},
+		type: 'object',
+		required: [ 'type', 'links' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'password-reset@1.0.0'
+			},
+			active: {
+				type: 'boolean',
+				const: true
+			},
+			links: {
+				type: 'object',
+				additionalProperties: true
+			},
+			data: {
+				resetToken: {
+					type: 'string',
+					const: request.arguments.requestToken
+				}
+			}
+		}
+	}, {
+		limit: 1
+	})
+	return passwordReset
+}
+
+const invalidatePasswordReset = async ({
+	session,
+	request,
+	passwordReset,
+	context
+}) => {
+	const typeCard = await context.getCardBySlug(session, 'password-reset@1.0.0')
+	return context.patchCard(session, typeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: true
+	}, passwordReset, [
+		{
+			op: 'replace',
+			path: '/active',
+			value: false
+		}
+	])
+}
+
+const handler = async (session, context, card, request) => {
+	const passwordReset = await getPasswordResetCard(context, request)
+	assert.USER(request.context, passwordReset, context.errors.WorkerAuthenticationError, 'Reset token invalid')
+
+	await invalidatePasswordReset({
+		session: context.privilegedSession,
+		request,
+		passwordReset,
+		context
+	})
+
+	const [ user ] = passwordReset.links['is attached to']
+
+	assert.USER(request.context, user, context.WorkerAuthenticationError, 'Reset token invalid')
+
+	const hasExpired = new Date(passwordReset.data.expiresAt) < new Date()
+	if (hasExpired) {
+		const newError = new context.errors.WorkerAuthenticationError('Password reset token has expired')
+		newError.expected = true
+		throw newError
+	}
+
+	const userTypeCard = await context.getCardBySlug(session, 'user@latest')
+
+	return context.patchCard(context.privilegedSession, userTypeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: false
+	}, _.omit(card, [ 'type' ]), [
+		{
+			op: 'replace',
+			path: '/data/hash',
+			value: request.arguments.newPassword
+		}
+	]).catch((error) => {
+		// A schema mismatch here means that the patch could
+		// not be applied to the card due to permissions.
+		if (error.name === 'JellyfishSchemaMismatch') {
+			const newError = new context.errors.WorkerAuthenticationError(
+				'Password change not allowed')
+			newError.expected = true
+			throw newError
+		}
+
+		throw error
+	})
+}
+
+module.exports = {
+	pre,
+	handler
+}

--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -14,10 +14,7 @@ const {
 } = require('./constants')
 
 const MAILGUN = environment.mail
-
-const {
-	resetPasswordSecretToken
-} = environment.actions
+const ACTIONS = environment.actions
 
 const getUserByEmail = async ({
 	session,
@@ -111,7 +108,7 @@ const invalidatePreviousPasswordResets = async ({
 			}, passwordReset, [
 				{
 					op: 'replace',
-					path: './active',
+					path: '/active',
 					value: false
 				}
 			])
@@ -125,7 +122,7 @@ const addPasswordResetCard = async ({
 	request,
 	typeCard
 }) => {
-	const resetToken = crypto.createHmac('sha256', resetPasswordSecretToken)
+	const resetToken = crypto.createHmac('sha256', ACTIONS.resetPasswordSecretToken)
 		.update(user.data.hash)
 		.digest('hex')
 	const requestedAt = new Date()

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -135,5 +135,10 @@ module.exports = {
 		card: require('./actions/action-request-password-reset'),
 		pre: _.noop,
 		handler: require('./handlers/action-request-password-reset').handler
+	},
+	'action-complete-password-reset': {
+		card: require('./actions/action-complete-password-reset'),
+		pre: require('./handlers/action-complete-password-reset').pre,
+		handler: require('./handlers/action-complete-password-reset').handler
 	}
 }

--- a/test/integration/worker/actions/complete-password-reset.spec.js
+++ b/test/integration/worker/actions/complete-password-reset.spec.js
@@ -1,0 +1,468 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const nock = require('nock')
+const crypto = require('crypto')
+const helpers = require('../helpers')
+const actionLibrary = require('../../../../lib/action-library')
+const environment = require('../../../../lib/environment')
+
+const MAILGUN = environment.mail
+const {
+	resetPasswordSecretToken
+} = environment.actions
+
+ava.beforeEach(async (test) => {
+	await helpers.worker.beforeEach(test, actionLibrary)
+
+	const {
+		queue,
+		worker,
+		session,
+		flush,
+		jellyfish,
+		context
+	} = test.context
+
+	const processAction = async (action) => {
+		const createRequest = await queue.producer.enqueue(worker.getId(), session, action)
+
+		await flush(session)
+		return queue.producer.waitResults(context, createRequest)
+	}
+
+	const userCard = await jellyfish.getCardBySlug(context, session, 'user@latest')
+
+	const userEmail = 'test@test.com'
+	const userPassword = 'original-password'
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			email: userEmail,
+			username: 'user-johndoe',
+			password: userPassword
+		}
+	})
+
+	const userInfo = await processAction(createUserAction)
+	const user = await jellyfish.getCardById(context, session, userInfo.data.id)
+
+	const resetToken = crypto.createHmac('sha256', resetPasswordSecretToken)
+		.update(user.data.hash)
+		.digest('hex')
+
+	nock(`${MAILGUN.baseUrl}/${MAILGUN.domain}`)
+		.persist()
+		.post('/messages')
+		.basicAuth({
+			user: 'api',
+			pass: MAILGUN.TOKEN
+		})
+		.reply(200)
+
+	test.context = {
+		...test.context,
+		user,
+		processAction,
+		userEmail,
+		userPassword,
+		userCard,
+		resetToken
+	}
+})
+
+ava.afterEach(helpers.worker.afterEach)
+
+ava('should replace the user password when the requestToken is valid', async (test) => {
+	const {
+		session,
+		context,
+		worker,
+		processAction,
+		user,
+		userEmail,
+		resetToken,
+		userPassword: originalPassword
+	} = test.context
+
+	const newPassword = 'new-password'
+
+	const requestPasswordReset = {
+		action: 'action-request-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			email: userEmail
+		}
+	}
+
+	const passwordReset = await processAction(requestPasswordReset)
+	test.false(passwordReset.error)
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			resetToken,
+			newPassword
+		}
+	})
+
+	const completePasswordResetResult = await processAction(completePasswordReset)
+	test.false(completePasswordResetResult.error)
+
+	await test.throwsAsync(worker.pre(session, {
+		action: 'action-create-session@1.0.0',
+		card: user.id,
+		type: user.type,
+		context,
+		arguments: {
+			password: originalPassword
+		}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError
+	})
+
+	const newPasswordLoginRequest = await test.context.worker.pre(test.context.session, {
+		action: 'action-create-session@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			password: newPassword
+		}
+	})
+
+	const newPasswordLoginResult = await processAction(newPasswordLoginRequest)
+	test.false(newPasswordLoginResult.error)
+})
+
+ava('should fail when the reset token does not match a valid card', async (test) => {
+	const {
+		session,
+		context,
+		worker,
+		processAction,
+		user
+	} = test.context
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			resetToken: 'fake-reset-token',
+			newPassword: 'new-password'
+		}
+	})
+
+	const error = await test.throwsAsync(processAction(completePasswordReset))
+
+	test.is(error.name, 'WorkerSchemaMismatch')
+	test.is(error.message, `Arguments do not match for action action-complete-password-reset: {
+  "resetToken": "fake-reset-token",
+  "newPassword": "${completePasswordReset.arguments.newPassword}"
+}`)
+})
+
+ava('should fail when the reset token has expired', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		worker,
+		processAction,
+		user,
+		userEmail,
+		resetToken
+	} = test.context
+
+	const newPassword = 'new-password'
+
+	const requestPasswordReset = {
+		action: 'action-request-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			email: userEmail
+		}
+	}
+
+	await processAction(requestPasswordReset)
+
+	const [ passwordReset ] = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'id', 'type' ],
+		additionalProperties: true,
+		properties: {
+			id: {
+				type: 'string'
+			},
+			type: {
+				type: 'string',
+				const: 'password-reset@1.0.0'
+			},
+			data: {
+				type: 'object',
+				additionalProperties: true,
+				properties: {
+					resetToken: {
+						type: 'string',
+						const: resetToken
+					}
+				}
+			}
+		}
+	})
+
+	const now = new Date()
+	const hourInPast = now.setHours(now.getHours() - 1)
+	const newExpiry = new Date(hourInPast)
+
+	const requestUpdateCard = {
+		action: 'action-update-card@1.0.0',
+		context,
+		card: passwordReset.id,
+		type: passwordReset.type,
+		arguments: {
+			reason: 'Expiring token for test',
+			patch: [
+				{
+					op: 'replace',
+					path: '/data/expiresAt',
+					value: newExpiry.toISOString()
+				}
+			]
+		}
+	}
+
+	const updatedCard = await processAction(requestUpdateCard)
+	test.false(updatedCard.error)
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			resetToken,
+			newPassword
+		}
+	})
+
+	await test.throwsAsync(processAction(completePasswordReset), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'Password reset token has expired'
+	})
+})
+
+ava('should fail when the reset token is not active', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		worker,
+		processAction,
+		user,
+		userEmail,
+		resetToken
+	} = test.context
+
+	const newPassword = 'new-password'
+
+	const requestPasswordReset = {
+		action: 'action-request-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			email: userEmail
+		}
+	}
+
+	await processAction(requestPasswordReset)
+
+	const [ passwordReset ] = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'id', 'type' ],
+		additionalProperties: true,
+		properties: {
+			id: {
+				type: 'string'
+			},
+			type: {
+				type: 'string',
+				const: 'password-reset@1.0.0'
+			},
+			data: {
+				type: 'object',
+				additionalProperties: true,
+				properties: {
+					resetToken: {
+						type: 'string',
+						const: resetToken
+					}
+				}
+			}
+		}
+	})
+
+	const requestDeleteCard = {
+		action: 'action-delete-card@1.0.0',
+		context,
+		card: passwordReset.id,
+		type: passwordReset.type,
+		arguments: {}
+	}
+
+	const requestDelete =	await processAction(requestDeleteCard)
+	test.false(requestDelete.error)
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			resetToken,
+			newPassword
+		}
+	})
+
+	await test.throwsAsync(processAction(completePasswordReset), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'Reset token invalid'
+	})
+})
+
+ava('should fail if the user becomes inactive between requesting and completing the password reset', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		user,
+		userEmail,
+		worker,
+		resetToken
+	} = test.context
+
+	const requestPasswordResetAction = {
+		action: 'action-request-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			email: userEmail
+		}
+	}
+
+	const requestPasswordReset = await processAction(requestPasswordResetAction)
+	test.false(requestPasswordReset.error)
+
+	const requestDeleteCard = {
+		action: 'action-delete-card@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {}
+	}
+
+	const requestDelete =	await processAction(requestDeleteCard)
+	test.false(requestDelete.error)
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			resetToken,
+			newPassword: 'new-password'
+		}
+	})
+
+	await test.throwsAsync(processAction(completePasswordReset), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'Reset token invalid'
+	})
+})
+
+ava('should remove the password reset card', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		user,
+		userEmail,
+		worker,
+		jellyfish,
+		resetToken
+	} = test.context
+
+	const requestPasswordResetAction = {
+		action: 'action-request-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			email: userEmail
+		}
+	}
+
+	const requestPasswordReset = await processAction(requestPasswordResetAction)
+	test.false(requestPasswordReset.error)
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-password-reset@1.0.0',
+		context,
+		card: user.id,
+		type: user.type,
+		arguments: {
+			resetToken,
+			newPassword: 'new-password'
+		}
+	})
+
+	await processAction(completePasswordReset)
+
+	const [ passwordReset ] = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'type', 'active' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'password-reset@1.0.0'
+			},
+			active: {
+				type: 'boolean'
+			},
+			data: {
+				resetToken: {
+					type: 'string',
+					contains: {
+						type: 'string',
+						const: resetToken
+					}
+				}
+			}
+		}
+	}, {
+		limit: 1
+	})
+
+	test.false(passwordReset.active)
+})


### PR DESCRIPTION
**NOTE:**
This needs to be merged before the request-password-reset pull request OR the base branch should be changed to master

Action and handler for completing the password reset

- [x] should have a prehook that hashes the submitted password
- [x] should check that the user still exists and has not been disabled
- [x] should check that the token is still valid
- [x] updates user record with new password
- [x] should invalidate the reset-password card (set it to inactive by using the remove card func)
- [x] send success to server
