### PR TITLE
Configure dependabot to send PRs that versionbot can understand

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "patch"


### PR DESCRIPTION
Fixes product-os/jellyfish#3344

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>