### PR TITLE
ui-components: Fix auto-complete card select component

### DIFF
--- a/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -7,16 +7,12 @@
 import _ from 'lodash'
 import React from 'react'
 import Async from 'react-select/lib/Async'
-import {
-	withSetup
-} from './SetupProvider'
-import * as helpers from './services/helpers'
+import * as helpers from '../services/helpers'
 
-class AutoCompleteCardSelect extends React.Component {
+export default class AutoCompleteCardSelect extends React.Component {
 	constructor (props) {
 		super(props)
 		this.state = {
-			selectedValue: null,
 			results: []
 		}
 
@@ -28,8 +24,7 @@ class AutoCompleteCardSelect extends React.Component {
 		// If the card type is changed, we should reset
 		if (prevProps.cardType !== this.props.cardType) {
 			this.setState({
-				results: [],
-				selectedValue: null
+				results: []
 			})
 			this.props.onChange(null)
 		}
@@ -41,16 +36,6 @@ class AutoCompleteCardSelect extends React.Component {
 			? (_.find(this.state.results, {
 				id: option.value
 			}) || null) : null
-
-		// Cache an AsyncSelect-compatible format of the selected option
-		const selectedValue = selectedCard ? {
-			value: selectedCard.id,
-			label: selectedCard.name || selectedCard.slug
-		} : null
-
-		this.setState({
-			selectedValue
-		})
 
 		this.props.onChange(selectedCard)
 	}
@@ -80,6 +65,12 @@ class AutoCompleteCardSelect extends React.Component {
 		// Query the API for results and set them to state so they can be accessed
 		// when an option is selected
 		const results = await sdk.query(filter)
+
+		// If the card type was changed while the request was in-flight, we should discard these results
+		if (cardType !== this.props.cardType) {
+			return []
+		}
+
 		this.setState({
 			results
 		})
@@ -95,25 +86,27 @@ class AutoCompleteCardSelect extends React.Component {
 
 	render () {
 		const {
-			cardType
+			actions,
+			analytics,
+			cardType,
+			sdk,
+			types,
+			onChange,
+			value,
+			...rest
 		} = this.props
-		const {
-			selectedValue
-		} = this.state
 
 		return (
 			<Async
 				key={cardType}
 				classNamePrefix="jellyfish-async-select"
-				value={selectedValue}
+				value={value}
 				isClearable
-				cacheOptions
 				defaultOptions
 				onChange={this.onChange}
 				loadOptions={this.getTargets}
+				{...rest}
 			/>
 		)
 	}
 }
-
-export default withSetup(AutoCompleteCardSelect)

--- a/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.jsx
+++ b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.jsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import {
+	mount,
+	configure
+} from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+import AutoCompleteCardSelect from './AutoCompleteCardSelect'
+import Adapter from 'enzyme-adapter-react-16'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+const types = [
+	{
+		slug: 'user',
+		version: '1.0.0',
+		data: {
+			schema: {}
+		}
+	},
+	{
+		slug: 'issue',
+		version: '1.0.0',
+		data: {
+			schema: {}
+		}
+	}
+]
+
+const users = [
+	{
+		id: 'u1', slug: 'user1'
+	},
+	{
+		id: 'u2', slug: 'user2'
+	}
+]
+
+const issues = [
+	{
+		id: 'i1', slug: 'issue1'
+	},
+	{
+		id: 'i2', slug: 'issue2'
+	}
+]
+
+const sandbox = sinon.createSandbox()
+
+const flushPromises = () => {
+	return new Promise((resolve) => {
+		// eslint-disable-next-line no-undef
+		return setImmediate(resolve)
+	})
+}
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('Results are cleared when card type changes', async (test) => {
+	const onChange = sandbox.fake()
+	let usersQueryResolver = null
+	let issuesQueryResolver = null
+	const usersQueryPromise = new Promise((resolve) => {
+		usersQueryResolver = resolve
+	})
+	const issuesQueryPromise = new Promise((resolve) => {
+		issuesQueryResolver = resolve
+	})
+	const query = sandbox.stub()
+	query.onCall(0).returns(usersQueryPromise)
+	query.onCall(1).returns(issuesQueryPromise)
+	const sdk = {
+		query
+	}
+	const autoComplete = mount(
+		<AutoCompleteCardSelect
+			sdk={sdk}
+			cardType="user"
+			types={types}
+			onChange={onChange}
+		/>
+	)
+
+	// Initially we've got no results but the SDK query has been called
+	test.deepEqual(autoComplete.state('results'), [])
+	test.is(sdk.query.callCount, 1)
+
+	// Now we switch card types
+	autoComplete.setProps({
+		...autoComplete.props(),
+		cardType: 'issue'
+	})
+
+	// Note that we've now called the SDK query a second time
+	test.is(sdk.query.callCount, 2)
+
+	// Before returning the initial SDK query with users
+	usersQueryResolver(users)
+	await flushPromises()
+
+	// The users results should not be saved to state
+	test.deepEqual(autoComplete.state('results'), [])
+
+	// When the SDK query returns with the issues...
+	issuesQueryResolver(issues)
+	await flushPromises()
+
+	// ...we should now have issues in the results state!
+	test.deepEqual(autoComplete.state('results'), issues)
+})

--- a/lib/ui-components/AutoCompleteCardSelect/index.js
+++ b/lib/ui-components/AutoCompleteCardSelect/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import AutoCompleteCardSelect from './AutoCompleteCardSelect'
+import {
+	withSetup
+} from '../SetupProvider'
+
+export default withSetup(AutoCompleteCardSelect)

--- a/lib/ui-components/LinkModal/LinkModal.jsx
+++ b/lib/ui-components/LinkModal/LinkModal.jsx
@@ -99,7 +99,8 @@ export default class LinkModal extends React.Component {
 
 	async handleLinkTypeSelect (payload) {
 		this.setState({
-			linkType: payload.option
+			linkType: payload.option,
+			selectedTarget: this.props.target || null
 		})
 	}
 
@@ -143,7 +144,8 @@ export default class LinkModal extends React.Component {
 			target
 		} = this.props
 		const {
-			linkType
+			linkType,
+			selectedTarget
 		} = this.state
 
 		if (!show) {
@@ -165,6 +167,11 @@ export default class LinkModal extends React.Component {
 
 		const title = `Link this ${typeName} to ${linkTypeTargets.length === 1
 			? linkTypeTargets[0].title : 'another element'}`
+
+		const selectedTargetValue = selectedTarget ? {
+			value: selectedTarget.id,
+			label: selectedTarget.name || selectedTarget.slug
+		} : null
 
 		return (
 			<Modal
@@ -198,6 +205,7 @@ export default class LinkModal extends React.Component {
 						data-test="card-linker--existing__input"
 					>
 						<AutoCompleteCardSelect
+							value={selectedTargetValue}
 							cardType={linkType.data.to}
 							types={types}
 							isDisabled={Boolean(target)}


### PR DESCRIPTION
Three related fixes that handle how the AutoCompleteCardSelect component behaves.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR addresses three issues with the `AutoCompleteCardSelect` component:
1. The `cacheOptions` prop is no longer set on the child `Async` component. When this is set, the results are not refreshed on pressing backspace. See [this recording](https://recordit.co/HiQCDTDfGQ), paying attention to the logged call in the JavaScript console.
2. `AutoCompleteCardSelect` is now a **controlled** component (i.e. `value` is passed in as a prop, rather than being stored in the component's state). This allows the parent component to reset the value as required (e.g. in the `LinkModal` when [changing target type](https://github.com/product-os/jellyfish/blob/805fe7f79fe3b119a335b735506a5857420f746b/lib/ui-components/LinkModal/LinkModal.jsx#L103))
3. If the `cardType` prop changes while the async call to populate filtered results is _in-flight_, the results of the in-flight async call are now [discarded](https://github.com/product-os/jellyfish/blob/805fe7f79fe3b119a335b735506a5857420f746b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx#L69-L72). This fixes an intermittent race-condition bug that was [showing up on CI tests](https://app.circleci.com/pipelines/github/product-os/jellyfish/28465/workflows/a1b868f4-5716-4715-b94c-c8e17ea486a0/jobs/86049) sometimes. A [new unit test](https://github.com/product-os/jellyfish/blob/805fe7f79fe3b119a335b735506a5857420f746b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.jsx) has been added to test for this exact situation (cc @StefKors this unit test demonstrates some interesting aspects of unit testing react components with sinon spys, async calls/promises etc). Ref: #3341 
