### PR TITLE
ui-components: Improve StepsFlow UX

### DIFF
--- a/lib/ui-components/SlideInPanel.jsx
+++ b/lib/ui-components/SlideInPanel.jsx
@@ -7,6 +7,9 @@
 import React from 'react'
 import styled from 'styled-components'
 import {
+	Flex
+} from 'rendition'
+import {
 	swallowEvent
 } from './services/helpers'
 
@@ -44,7 +47,7 @@ const SlideInWrapper = styled.div `
 	}
 `
 
-const SlideInPanelBase = styled.div `
+const SlideInPanelBase = styled(Flex) `
 	position: absolute;
   background: ${(props) => { return props.theme.global.colors.white }};
   z-index: 1;


### PR DESCRIPTION
Add spinner icon when the action is busy.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

## Notes
* `StepsFlow` and `SlideInPanel` are not currently used anywhere so this PR is fairly safe!
* The edit to `SlideInPanel` is a small improvement to allow the SlideInPanel's children to define flex values

