### PR TITLE
ui: Update corresponding channel when event is updated

### DIFF
--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -21,6 +21,7 @@ import {
 	getQueue
 } from './async-dispatch-queue'
 import {
+	updateThreadChannels,
 	generateActorFromUserCard
 } from './helpers'
 
@@ -642,6 +643,21 @@ export default class ActionCreator {
 										value: clonedChannel
 									})
 								}
+							}
+
+							// If we receive a card that targets another card...
+							const targetId = _.get(card, [ 'data', 'target' ])
+							if (targetId) {
+								// ...update all channels that have this card in their links
+								const channelsToUpdate = updateThreadChannels(targetId, card, allChannels)
+								for (const updatedChannel of channelsToUpdate) {
+									dispatch({
+										type: actions.UPDATE_CHANNEL,
+										value: updatedChannel
+									})
+								}
+
+								// TODO (FUTURE): Also update view channels that have a list of threads in them
 							}
 
 							// If we receive a user card...

--- a/apps/ui/core/store/helpers.js
+++ b/apps/ui/core/store/helpers.js
@@ -5,6 +5,7 @@
  */
 
 import _ from 'lodash'
+import update from 'immutability-helper'
 
 export const generateActorFromUserCard = (card) => {
 	let name = 'unknown user'
@@ -41,4 +42,55 @@ export const generateActorFromUserCard = (card) => {
 		proxy,
 		card
 	}
+}
+
+/**
+ * Given a target card id and a card that's been updated, finds all channels
+ * representing the target card. For each matching channel, the
+ * linked card is updated with the new card.
+ *
+ * Note: allChannels is not mutated.
+ *
+ * @param {String} targetId - the ID of the card's target
+ * @param {Object} card - the card to update
+ * @param {Array} allChannels - an array of all channels
+ *
+ * @returns {Array} - an array of updated channels
+ */
+export const updateThreadChannels = (targetId, card, allChannels) => {
+	const updatedChannels = []
+	const matchingChannels = _.filter(allChannels, (item) => {
+		const headId = _.get(item, [ 'data', 'head', 'id' ])
+		return headId === targetId
+	})
+	_.forEach(matchingChannels, (channel) => {
+		const links = _.get(channel, [ 'data', 'head', 'links' ])
+		_.forEach(links, (linkedCards, linkName) => {
+			const cardIndex = _.findIndex(linkedCards, {
+				id: card.id
+			})
+			if (cardIndex !== -1) {
+				const updatedChannel = update(channel, {
+					data: {
+						head: {
+							links: {
+								[linkName]: {
+									[cardIndex]: {
+										$set: card
+									}
+								}
+							}
+						}
+					}
+				})
+				updatedChannels.push(updatedChannel)
+
+				// Assume a card will only be found once in a channel
+				// i.e. a card won't appear under multiple link names (when this is supported)
+				return false
+			}
+			return true
+		})
+	})
+	return updatedChannels
 }

--- a/apps/ui/core/store/helpers.spec.js
+++ b/apps/ui/core/store/helpers.spec.js
@@ -4,9 +4,34 @@
  * Proprietary and confidential.
  */
 const ava = require('ava')
+const uuid = require('uuid').v4
+const update = require('immutability-helper')
 const {
+	updateThreadChannels,
 	generateActorFromUserCard
 } = require('./helpers')
+
+const getMessageCard = (target) => {
+	return {
+		id: uuid(),
+		data: {
+			target
+		}
+	}
+}
+
+const getThreadChannel = (id, messages) => {
+	return {
+		data: {
+			head: {
+				id,
+				links: {
+					'has attached element': messages
+				}
+			}
+		}
+	}
+}
 
 ava('generateActorFromUserCard can generate name from slug', (test) => {
 	const card = {
@@ -58,4 +83,34 @@ ava('generateActorFromUserCard generates proxy, email and avatarUrl from card', 
 	test.is(actor.avatarUrl, 'https://www.example.com')
 	test.is(actor.email, 'user@test.com')
 	test.is(actor.proxy, true)
+})
+
+ava('updateThreadChannels updates the corresponding channel', (test) => {
+	// Setup:
+	const messageT1a = getMessageCard('t1')
+	const messageT1b = getMessageCard('t1')
+	const messageT2a = getMessageCard('t2')
+	const channel1 = getThreadChannel('t1', [ messageT1a, messageT1b ])
+	const channel2 = getThreadChannel('t2', [ messageT2a ])
+	const allChannels = [ channel1, channel2 ]
+	const updatedMessageT1b = update(messageT1b, {
+		data: {
+			mirrors: {
+				$set: [ 'www.google.com' ]
+			}
+		}
+	})
+
+	// Action:
+	// - Update the second event in the first channel
+	const updatedChannels = updateThreadChannels('t1', updatedMessageT1b, allChannels)
+
+	// Verify
+	// - Only channel 't1' is updated
+	test.is(updatedChannels.length, 1)
+	test.is(updatedChannels[0].data.head.id, 't1')
+
+	// - the second event in the updated channel now has the mirrors field set
+	const mirrors = updatedChannels[0].data.head.links['has attached element'][1].data.mirrors
+	test.deepEqual(mirrors, [ 'www.google.com' ])
 })


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Ref: #3355 

### Abstract summary
If the web socket receives a card that 'targets' another card, we attempt to update any channels that correspond to the targeted card, updating the linked card within that channel.

### Real-life summary
What this means is that if a message is updated (e.g. when it's successfully mirrored), this change will be immediately reflected in the UI.

### Notes
* As noted in a code comment, this PR does not attempt to update channels that represent a view of multiple cards. That can/will be done as a separate (similar) PR.