### PR TITLE
ui-components: Add mirror icon to message display

### DIFF
--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -294,6 +294,8 @@ class SupportThreadBase extends React.Component {
 
 		const status = _.get(card, [ 'data', 'status' ], 'open')
 
+		const isMirrored = !_.isEmpty(_.get(card, [ 'data', 'mirrors' ]))
+
 		return (
 			<CardLayout
 				card={card}
@@ -503,6 +505,7 @@ class SupportThreadBase extends React.Component {
 												getActor={this.props.actions.getActor}
 												addNotification={this.props.actions.addNotification}
 												mb={1}
+												threadIsMirrored={isMirrored}
 											/>
 										)
 									})}

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -38,6 +38,7 @@ import {
 } from '../shame/ActionLink'
 import Avatar from '../shame/Avatar'
 import Icon from '../shame/Icon'
+import MirrorIcon from '../MirrorIcon'
 import {
 	HIDDEN_ANCHOR
 } from '../Timeline'
@@ -405,7 +406,8 @@ export default class Event extends React.Component {
 		const {
 			card,
 			actor,
-			addNotification
+			addNotification,
+			threadIsMirrored
 		} = this.props
 		const props = _.omit(this.props, [
 			'card',
@@ -470,7 +472,7 @@ export default class Event extends React.Component {
 						}}
 					>
 						<Flex justifyContent="space-between" mb={1}>
-							<Flex mt={isMessage ? 0 : 1} align="center" style={{
+							<Flex mt={isMessage ? 0 : 1} alignItems="center" style={{
 								lineHeight: 1.75
 							}}>
 								{isMessage && (
@@ -504,7 +506,7 @@ export default class Event extends React.Component {
 										{helpers.formatTimestamp(timestamp, true)}
 									</Txt>
 								)}
-								{card.pending &&
+								{card.pending ? (
 									<Txt color={Theme.colors.text.light} fontSize={1} ml="6px">
 										sending...
 										<Icon
@@ -515,7 +517,12 @@ export default class Event extends React.Component {
 											name="cog"
 										/>
 									</Txt>
-								}
+								) : (
+									<MirrorIcon
+										mirrors={_.get(card, [ 'data', 'mirrors' ])}
+										threadIsMirrored={threadIsMirrored}
+									/>
+								)}
 							</Flex>
 
 							<span>

--- a/lib/ui-components/MirrorIcon.jsx
+++ b/lib/ui-components/MirrorIcon.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import styled from 'styled-components'
+import {
+	Flex
+} from 'rendition'
+import Icon from './shame/Icon'
+
+const MirrorIconWrapper = styled(Flex) `
+	margin: 0 0 2px 6px;
+	font-size: 80%;
+	opacity: 0.3;
+	transition: opacity linear 0.5s
+	color: ${(props) => { return props.theme.colors.info.main }};
+	&.synced {
+		opacity: 1;
+	}
+`
+
+export default function MirrorIcon ({
+	threadIsMirrored, mirrors
+}) {
+	if (!threadIsMirrored) {
+		return null
+	}
+	const synced = !_.isEmpty(mirrors)
+	return (
+		<MirrorIconWrapper
+			data-test="mirror-icon"
+			className={synced ? 'synced' : 'unsynced'}
+			tooltip={synced ? 'Synced' : 'Not yet synced'}
+		>
+			<Icon name="check" />
+		</MirrorIconWrapper>
+	)
+}

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -450,6 +450,8 @@ class Timeline extends React.Component {
 
 		const sendCommand = getSendCommand(this.props.user)
 
+		const isMirrored = !_.isEmpty(_.get(this.props.card, [ 'data', 'mirrors' ]))
+
 		return (
 			<Column>
 				<Flex my={2} mr={2} justifyContent="flex-end">
@@ -549,6 +551,7 @@ class Timeline extends React.Component {
 									user={this.props.user}
 									getActor={this.props.getActor}
 									addNotification={this.props.addNotification}
+									threadIsMirrored={isMirrored}
 								/>
 							</Box>
 						)
@@ -562,6 +565,7 @@ class Timeline extends React.Component {
 									card={item}
 									getActor={this.props.getActor}
 									addNotification={this.props.addNotification}
+									threadIsMirrored={isMirrored}
 								/>
 							</Box>
 						)


### PR DESCRIPTION
Mirror icon is only shown if the thread is mirrored. Icon has reduced opacity until the message has been mirrored.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Ref: #3355 

Adds a very small tick ( ✔️ ) icon on messages and whispers. Hovering over the icon displays an explanatory tooltip.

* This icon is only shown if the thread itself is mirrored (i.e. if no mirroring is expected no icon is shown).
* When the message hasn't yet been mirrored the tick icon will show with reduced opacity (indicating that mirroring is expected but not yet completed).
* When the message has been mirrored, the tick icon will show with full opacity.
* I've avoided the term 'mirror' in the UI as this technical term isn't particularly user-friendly

**Message has not yet been mirrored:**
![image](https://user-images.githubusercontent.com/2925657/76926552-41590380-690f-11ea-9317-0c7611a4f75f.png)

**Message has been mirrored:**
![image](https://user-images.githubusercontent.com/2925657/76926743-b2002000-690f-11ea-8d52-be9f88d4d34e.png)

