### PR TITLE
ui: Skip notifications if user status is DoNotDisturb

### DIFF
--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -131,6 +131,7 @@ export const selectors = {
 	getAppCodename: (state) => { return _.get(state.core, [ 'config', 'codename' ]) || null },
 	getChannels: (state) => { return state.core.channels },
 	getCurrentUser: (state) => { return _.get(state.core, [ 'session', 'user' ]) || null },
+	getCurrentUserStatus: (state) => { return _.get(state.core, [ 'session', 'user', 'data', 'status' ]) || null },
 	getNotifications: (state) => { return state.core.notifications || [] },
 	getSessionToken: (state) => { return _.get(state.core, [ 'session', 'authToken' ]) || null },
 	getStatus: (state) => { return state.core.status },

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -10,6 +10,7 @@ import {
 import * as _ from 'lodash'
 import {
 	actionCreators,
+	selectors,
 	store
 } from '../core'
 
@@ -37,6 +38,12 @@ export const createNotification = ({
 	target
 }) => {
 	if (!canUseNotifications) {
+		return
+	}
+
+	// Skip notifications if the user's status is set to 'Do Not Disturb'
+	const userStatus = selectors.getCurrentUserStatus(store.getState())
+	if (_.get(userStatus, [ 'value' ]) === 'DoNotDisturb') {
 		return
 	}
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Very simple change to skip sending a notification if the user's status is set to 'Do Not Disturb'.

_Note: this is hard to add a test for as I don't know of a way of testing desktop notifications and unit testing is tricky as it references the Redux store - which drags in a bunch of other dependencies. But I've manually verified the behaviour is correct._
