### PR TITLE
ui: Add titles to profile fields

### DIFF
--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -102,6 +102,7 @@ module.exports = {
 							minLength: 1
 						},
 						avatar: {
+							title: 'Avatar',
 							type: [
 								'string',
 								'null'
@@ -144,9 +145,11 @@ module.exports = {
 									type: 'object',
 									properties: {
 										first: {
+											title: 'First name',
 											type: 'string'
 										},
 										last: {
+											title: 'Last name',
 											type: 'string'
 										}
 									}


### PR DESCRIPTION
Change-type: minor

***

Add titles to user fields in order to show these titles on profile page.

<img width="583" alt="Screen Shot 2020-03-18 at 11 56 03 PM" src="https://user-images.githubusercontent.com/2152815/77001886-1654cb00-6974-11ea-9f57-a5d6d5738538.png">


**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
