### PR TITLE
ui-components: Small CSS fix that corrects the color of the mirror icon

### DIFF
--- a/lib/ui-components/MirrorIcon.jsx
+++ b/lib/ui-components/MirrorIcon.jsx
@@ -16,8 +16,8 @@ const MirrorIconWrapper = styled(Flex) `
 	margin: 0 0 2px 6px;
 	font-size: 80%;
 	opacity: 0.3;
-	transition: opacity linear 0.5s
-	color: ${(props) => { return props.theme.colors.info.main }};
+	transition: opacity linear 0.5s;
+	color: ${(props) => { return props.theme.colors.primary.light }};
 	&.synced {
 		opacity: 1;
 	}


### PR DESCRIPTION
Missing semi-colon. Also lightened the overall color a bit to make it less prominent.

Change-type: patch/minor/major
Signed-off-by: Graham McCulloch <graham@balena.io>

***