### PR TITLE
chat-widget: Add dev-only support for Redux Dev Tools

### DIFF
--- a/lib/chat-widget/environment.js
+++ b/lib/chat-widget/environment.js
@@ -10,6 +10,10 @@ export const isTest = () => {
 	return env.NODE_ENV === 'test'
 }
 
+export const isProduction = () => {
+	return env.NODE_ENV === 'production'
+}
+
 export const api = {
 	prefix: env.API_PREFIX || 'api/v2',
 	url: env.API_URL

--- a/lib/chat-widget/store/index.js
+++ b/lib/chat-widget/store/index.js
@@ -4,18 +4,33 @@
  * Proprietary and confidential.
  */
 
+/* eslint-disable no-underscore-dangle */
+
 import {
-	applyMiddleware, createStore as createReduxStore
+	applyMiddleware,
+	compose,
+	createStore as createReduxStore
 } from 'redux'
 import thunkMiddleware from 'redux-thunk'
+import {
+	isProduction
+} from '../environment'
 import {
 	createReducer
 } from './reducer'
 
+const composeEnhancers =
+	typeof window !== 'undefined' &&
+	!isProduction() &&
+	window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+		? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+			name: 'Jellychat'
+		}) : compose
+
 export const createStore = (initialState) => {
 	const store = createReduxStore(
 		createReducer(initialState),
-		applyMiddleware(thunkMiddleware)
+		composeEnhancers(applyMiddleware(thunkMiddleware))
 	)
 
 	return store


### PR DESCRIPTION
Redux Dev Tools is a Chrome Extension that is very useful for debugging the Redux store. Its already supported by the main Jellyfish app. This commit adds the same change to the chat widget, explicitly providing a name for the chat-widget's Redux store so you can distinguish it from the 'Jellyfish' one in the main app.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![image](https://user-images.githubusercontent.com/2925657/77026758-0a462900-69c7-11ea-98dd-bcd07268c8fc.png)
