### PR TITLE
server: Add statusDescription field to thread cards

### DIFF
--- a/apps/server/default-cards/contrib/sales-thread.json
+++ b/apps/server/default-cards/contrib/sales-thread.json
@@ -38,6 +38,10 @@
             "inbox": {
               "type": "string"
             },
+            "statusDescription": {
+              "title": "Current Status",
+              "type": "string"
+            },
             "status": {
               "title": "Status",
               "type": "string",

--- a/apps/server/default-cards/contrib/support-thread.json
+++ b/apps/server/default-cards/contrib/support-thread.json
@@ -72,6 +72,10 @@
             "inbox": {
               "type": "string"
             },
+            "statusDescription": {
+              "title": "Current Status",
+              "type": "string"
+            },
             "status": {
               "title": "Status",
               "type": "string",


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This new field will be used to describe the current status of a support/sales thread when handing over the thread to someone else.

Currently this field isn't exposed in a special way by the support thread lens - its just displayed with all the other fields when you click the 'More' link in the channel header. We can promote the field to a more prominent display if we want (in a subsequent PR). 