### PR TITLE
Add support for querying for multiple link types with a single JSON schema query

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -91,14 +91,9 @@ const generateLinkSubquery = (linkType, fromColumn, toColumn) => {
 
 const generateQuery = (table, schema, options) => {
 	const links = getLinks(schema)
-	assert.INTERNAL(null, links.length <= 1, Error,
-		'The translator only supports traversing one link type for now')
-
-	const link = links.length > 0 ? links[0] : null
-
 	let query = []
 
-	if (link) {
+	for (const link of links) {
 		query.push(...[
 			', (SELECT array(',
 			'SELECT to_jsonb(linked)',
@@ -140,7 +135,7 @@ const generateQuery = (table, schema, options) => {
 	// eg: linked card type
 	// To achieve that effect, we wrap the query with WITH and filter on the 'links.*' column
 	// (see below)
-	if (link) {
+	for (const link of links) {
 		query.push('AND')
 		if (!link.schema) {
 			query.push('NOT')
@@ -153,7 +148,7 @@ const generateQuery = (table, schema, options) => {
 	}
 
 	if (schema.additionalProperties === true) {
-		if (link) {
+		if (links.length > 0) {
 			query.unshift(...[
 				`${table}.id,`,
 				`${table}.slug,`,
@@ -221,17 +216,23 @@ const generateQuery = (table, schema, options) => {
 
 	// We cannot enforce link existence without using a join, and we don't want to use it
 	// So we wrap the query with a WITH and filter on the length of the resulting linked cards array
-	if (link) {
+	if (links.length > 0) {
 		query.unshift('WITH main AS (')
 		query.push(...[
 			')',
-			'SELECT * FROM main'
+			'SELECT * FROM main',
+			'WHERE'
 		])
-		if (link.schema) {
-			query.push(`WHERE array_length("links.${link.slug}", 1) > 0`)
-		} else {
-			query.push(`WHERE array_length("links.${link.slug}", 1) IS NULL`)
+
+		const countCond = []
+		for (const link of links) {
+			if (link.schema) {
+				countCond.push(`array_length("links.${link.slug}", 1) > 0`)
+			} else {
+				countCond.push(`array_length("links.${link.slug}", 1) IS NULL`)
+			}
 		}
+		query.push(countCond.join('\nAND\n'))
 	}
 
 	if (options.skip) {

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -519,7 +519,8 @@ WHERE links.inversename = 'has attached element' AND toId = cards.id
 ORDER BY cards.created_at DESC
 )
 SELECT * FROM main
-WHERE array_length("links.has_attached_element", 1) > 0
+WHERE
+array_length("links.has_attached_element", 1) > 0
 LIMIT 100`
 
 	const query = jsonschema2sql('cards', payload.query, payload.options)
@@ -631,7 +632,8 @@ WHERE links.inversename = 'has attached element' AND toId = cards.id
 ORDER BY cards.created_at DESC
 )
 SELECT * FROM main
-WHERE array_length("links.has_attached_element", 1) IS NULL
+WHERE
+array_length("links.has_attached_element", 1) IS NULL
 LIMIT 100`
 
 	const query = jsonschema2sql('cards', payload.query, payload.options)


### PR DESCRIPTION
Closes #3332

Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>

***

A query for multiple link types will return cards with all link types at the same time.