### PR TITLE
ChatWidget: Fix support logo

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -38,7 +38,8 @@ const config = {
 					{
 						loader: 'file-loader',
 						options: {
-							name: '[name].[ext]'
+							name: '[name].[ext]',
+							esModule: false
 						}
 					}
 				]


### PR DESCRIPTION
Change-type: patch

***

<img width="391" alt="Screen Shot 2020-03-23 at 10 35 35 PM" src="https://user-images.githubusercontent.com/2152815/77350999-acaf3500-6d56-11ea-9178-4a432c971ebc.png">

<img width="390" alt="Screen Shot 2020-03-23 at 10 37 14 PM" src="https://user-images.githubusercontent.com/2152815/77351205-e2ecb480-6d56-11ea-8d61-d6a3e355fd71.png">

[Commit](https://github.com/product-os/jellyfish/commit/e78835c257f542236fbdec9094803adf6e9de82a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) that broke the url.


**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
