### PR TITLE
ui: new 'Do Not Disturb' user menu item

### DIFF
--- a/apps/ui/components/HOC/HomeChannel.jsx
+++ b/apps/ui/components/HOC/HomeChannel.jsx
@@ -42,6 +42,7 @@ const mapDispatchToProps = (dispatch) => {
 				'loadViewResults',
 				'logout',
 				'removeViewNotice',
+				'updateUser',
 				'setChatWidgetOpen',
 				'setDefault',
 				'setUIState',

--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -869,7 +869,7 @@ export default class ActionCreator {
 		}
 	}
 
-	updateUser (patches) {
+	updateUser (patches, successNotification) {
 		return async (dispatch, getState) => {
 			try {
 				const user = selectors.getCurrentUser(getState())
@@ -879,7 +879,7 @@ export default class ActionCreator {
 				const updatedUser = await this.sdk.getById(user.id)
 
 				dispatch(this.setUser(updatedUser))
-				dispatch(this.addNotification('success', 'Successfully updated user'))
+				dispatch(this.addNotification('success', successNotification || 'Successfully updated user'))
 			} catch (error) {
 				dispatch(this.addNotification('danger', error.message || error))
 			}

--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -21,6 +21,7 @@ import {
 } from 'rendition'
 import MentionsCount from '../MentionsCount'
 import TreeMenu from './TreeMenu'
+import UserStatusMenuItem from '../UserStatusMenuItem'
 import RouterLink from '../Link'
 import ViewLink from '../ViewLink'
 import Avatar from '../shame/Avatar'
@@ -289,8 +290,14 @@ export default class HomeChannel extends React.Component {
 				</Flex>
 
 				{this.state.showMenu && (
-					<Fixed top={true} right={true} bottom={true} left={true} z={9999999} onClick={this.hideMenu}>
+					<Fixed top={true} right={true} bottom={true} left={true} z={10} onClick={this.hideMenu}>
 						<MenuPanel className="user-menu" mx={3} p={3}>
+							{user && (
+								<Box mb={2}>
+									<UserStatusMenuItem user={user} actions={actions} types={types} />
+								</Box>
+							)}
+
 							{user && (
 								<div>
 									<RouterLink

--- a/lib/ui-components/UserStatusMenuItem.jsx
+++ b/lib/ui-components/UserStatusMenuItem.jsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Box,
+	Button,
+	Flex,
+	Txt
+} from 'rendition'
+import styled from 'styled-components'
+import _ from 'lodash'
+import Icon from './shame/Icon'
+import {
+	patchPath,
+	getUserStatuses
+} from './services/helpers'
+
+const UserStatusButton = styled(Button) `
+	display: flex;
+	width: 100%;
+`
+
+export default function UserStatusMenuItem ({
+	user,
+	actions,
+	types,
+	...rest
+}) {
+	const userType = _.find(types, {
+		slug: 'user'
+	})
+	const userStatusOptions = getUserStatuses(userType)
+
+	const status = _.get(user, [ 'data', 'status' ], userStatusOptions.Available)
+	const isDnd = status.value === userStatusOptions.DoNotDisturb.value
+	const toggleStatus = () => {
+		const newStatus = isDnd
+			? userStatusOptions.Available
+			: userStatusOptions.DoNotDisturb
+		const patches = patchPath(user, [ 'data', 'status' ], newStatus)
+		const successNotification = `Your status is now '${newStatus.title}'`
+		actions.updateUser(patches, successNotification)
+	}
+	const buttonProps = {
+		...rest,
+		plain: true,
+		'data-test': 'button-dnd',
+		tooltip: {
+			text: isDnd ? 'Turn off Do Not Disturb' : 'Turn off notifications',
+			placement: 'right'
+		},
+		onClick: toggleStatus
+	}
+	return (
+		<UserStatusButton {...buttonProps}>
+			<Flex flex={1} alignItems="center" justifyContent="space-between">
+				<Txt>{userStatusOptions.DoNotDisturb.title}</Txt>
+				<Box>{ isDnd && <Icon name="check" /> }</Box>
+			</Flex>
+		</UserStatusButton>
+	)
+}

--- a/lib/ui-components/UserStatusMenuItem.spec.jsx
+++ b/lib/ui-components/UserStatusMenuItem.spec.jsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import ava from 'ava'
+import {
+	shallow,
+	configure
+} from 'enzyme'
+import sinon from 'sinon'
+import Adapter from 'enzyme-adapter-react-16'
+import UserStatusMenuItem from './UserStatusMenuItem'
+import user from '../core/cards/user'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+const DND = {
+	title: 'Do Not Disturb',
+	value: 'DoNotDisturb'
+}
+
+const Available = {
+	title: 'Available',
+	value: 'Available'
+}
+
+const types = [ user ]
+
+const getUser = (status) => {
+	return {
+		id: '1',
+		data: {
+			status
+		}
+	}
+}
+
+const sandbox = sinon.createSandbox()
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('It should render', (test) => {
+	const actions = {
+		updateUser: sandbox.fake()
+	}
+	test.notThrows(() => {
+		shallow(
+			<UserStatusMenuItem
+				user={getUser(DND)}
+				actions={actions}
+				types={types}
+			/>
+		)
+	})
+})
+
+ava('Tooltip and icon set correctly if status is DoNotDisturb', (test) => {
+	const actions = {
+		updateUser: sandbox.stub()
+	}
+	const component = shallow(
+		<UserStatusMenuItem
+			user={getUser(DND)}
+			actions={actions}
+			types={types}
+		/>
+	)
+
+	const btn = component.find('[data-test="button-dnd"]')
+	test.is(btn.props().tooltip.text, 'Turn off Do Not Disturb')
+
+	const icon = component.find('Icon')
+	test.is(icon.props().name, 'check')
+})
+
+ava('Tooltip and icon set correctly if status is NOT DoNotDisturb', (test) => {
+	const actions = {
+		updateUser: sandbox.stub()
+	}
+	const component = shallow(
+		<UserStatusMenuItem
+			user={getUser(Available)}
+			actions={actions}
+			types={types}
+		/>
+	)
+
+	const btn = component.find('[data-test="button-dnd"]')
+	test.is(btn.props().tooltip.text, 'Turn off notifications')
+
+	const icon = component.find('Icon')
+	test.is(icon.length, 0)
+})
+
+ava('Clicking button sets status to Available if currently DoNotDisturb', (test) => {
+	const actions = {
+		updateUser: sandbox.stub()
+	}
+	const component = shallow(
+		<UserStatusMenuItem
+			user={getUser(DND)}
+			actions={actions}
+			types={types}
+		/>
+	)
+
+	const btn = component.find('[data-test="button-dnd"]')
+	btn.simulate('click')
+
+	test.true(actions.updateUser.calledOnce)
+	test.deepEqual(actions.updateUser.getCall(0).args[0], [
+		{
+			op: 'replace',
+			path: '/data/status/value',
+			value: Available.value
+		},
+		{
+			op: 'replace',
+			path: '/data/status/title',
+			value: Available.title
+		}
+	])
+})
+
+ava('Clicking button sets status to DoNotDisturb if currently Available', (test) => {
+	const actions = {
+		updateUser: sandbox.stub()
+	}
+	const component = shallow(
+		<UserStatusMenuItem
+			user={getUser(Available)}
+			actions={actions}
+			types={types}
+		/>
+	)
+
+	const btn = component.find('[data-test="button-dnd"]')
+	btn.simulate('click')
+
+	test.true(actions.updateUser.calledOnce)
+	test.deepEqual(actions.updateUser.getCall(0).args[0], [
+		{
+			op: 'replace',
+			path: '/data/status/value',
+			value: DND.value
+		},
+		{
+			op: 'replace',
+			path: '/data/status/title',
+			value: DND.title
+		}
+	])
+})

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -423,6 +423,36 @@ export const patchPath = (card, keyPath, value) => {
 	return patch
 }
 
+/**
+ * Returns a dictionary of user status options, keyed by
+ * the user status value. For example:
+ * {
+ *   DoNotDisturb: {
+ *     title: 'Do Not Disturb',
+ *     value: 'DoNotDisturb'
+ *   },
+ *   {
+ *     ...
+ *   }
+ * }
+ */
+export const getUserStatuses = _.memoize((userType) => {
+	const userStatusOptionsList = _.get(
+		userType,
+		[ 'data', 'schema', 'properties', 'data', 'properties', 'status', 'oneOf' ],
+		[]
+	)
+	return _.reduce(userStatusOptionsList, (opts, opt) => {
+		if (_.has(opt, [ 'properties', 'value', 'const' ])) {
+			opts[opt.properties.value.const] = {
+				title: opt.properties.title.const,
+				value: opt.properties.value.const
+			}
+		}
+		return opts
+	}, {})
+})
+
 export const getActorIdFromCard = _.memoize((card) => {
 	let actorId = _.get(card, [ 'data', 'actor' ])
 	if (!actorId) {

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -5,7 +5,83 @@
  */
 
 const ava = require('ava')
+const _ = require('lodash')
 const helpers = require('./helpers')
+
+const user = {
+	slug: 'user',
+	type: 'type@1.0.0',
+	version: '1.0.0',
+	name: 'Jellyfish User',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				data: {
+					type: 'object',
+					properties: {
+						status: {
+							oneOf: [
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'Do Not Disturb'
+										},
+										value: {
+											type: 'string',
+											const: 'DoNotDisturb'
+										}
+									}
+								},
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'On Annual Leave'
+										},
+										value: {
+											type: 'string',
+											const: 'AnnualLeave'
+										}
+									}
+								},
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'In a Meeting'
+										},
+										value: {
+											type: 'string',
+											const: 'Meeting'
+										}
+									}
+								},
+								{
+									type: 'object',
+									properties: {
+										title: {
+											type: 'string',
+											const: 'Available'
+										},
+										value: {
+											type: 'string',
+											const: 'Available'
+										}
+									}
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+}
 
 ava('.createPrefixRegExp() match underscore characters', (test) => {
 	const matchRE = helpers.createPrefixRegExp('@')
@@ -109,6 +185,18 @@ ava('.findWordsByPrefix() should ignore symbols with no following test', (test) 
 	const source = '!'
 
 	test.deepEqual(helpers.findWordsByPrefix('!', source), [])
+})
+
+ava('.getUserStatuses() returns a dictionary of statuses if status is provided in schema', (test) => {
+	const userStatuses = helpers.getUserStatuses(user)
+	const dnd = userStatuses.DoNotDisturb
+	test.is(dnd.title, 'Do Not Disturb')
+	test.is(dnd.value, 'DoNotDisturb')
+})
+
+ava('.getUserStatuses() returns an empty object if status is missing from schema', (test) => {
+	const userType = _.omit(user, 'data.schema.properties.data.properties.status')
+	test.deepEqual(helpers.getUserStatuses(userType), {})
 })
 
 ava('.getRelationshipTargetType() returns top level type if defined', (test) => {

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -460,6 +460,45 @@ ava.serial('lens: A lens selection should be remembered', async (test) => {
 	test.pass()
 })
 
+// User Status
+// =============================================================================
+ava.serial('user status: You should be able to enable and disable Do Not Disturb', async (test) => {
+	const {
+		page
+	} = context
+
+	await ensureCommunityLogin(page)
+
+	const verifyDndState = async (expectedOn) => {
+		// Open the user menu
+		await macros.waitForThenClickSelector(page, '.user-menu-toggle')
+
+		const doNotDisturbButton = await page.waitForSelector('[data-test="button-dnd"]')
+
+		// A 'check' icon implies 'Do Not Disturb' is ON
+		const checkIcon = await doNotDisturbButton.$('i')
+		test.is(Boolean(checkIcon), expectedOn)
+
+		// The user's avatar should also have a status icon if 'Do Not Disturb' is ON
+		const statusIcon = await page.$('.user-menu-toggle .user-status-icon i')
+		test.is(Boolean(statusIcon), expectedOn)
+		return doNotDisturbButton
+	}
+
+	const toggleDnd = async (doNotDisturbButton) => {
+		doNotDisturbButton.click()
+		await macros.waitForThenDismissAlert(page, 'success')
+	}
+
+	let dndButton = await verifyDndState(false)
+	await toggleDnd(dndButton)
+	dndButton = await verifyDndState(true)
+	await toggleDnd(dndButton)
+	dndButton = await verifyDndState(false)
+
+	test.pass()
+})
+
 // User Profile
 // =============================================================================
 

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -177,3 +177,7 @@ exports.waitForSelectorToDisappear = async (page, selector, retryCount = 30) => 
 		throw new Error(`Element still exists: ${selector}`)
 	})
 }
+
+exports.waitForThenDismissAlert = async (page, alertType) => {
+	await exports.waitForThenClickSelector(page, `[data-test="alert--${alertType}"] button`)
+}


### PR DESCRIPTION
This menu item toggles the user status between 'Do Not Disturb' and 'Available'.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![DND](https://user-images.githubusercontent.com/2925657/77385284-4b20b200-6dba-11ea-9d57-deb483d2e63d.gif)

A toast notification is displayed when the user's status is updated, and a tick is displayed next to the 'Do Not Disturb' menu item if 'Do Not Disturb' is turned on.

Each display of a user's Avatar throughout the Jellyfish UI is automatically updated when that user's status changes - even if its changed remotely.