### PR TITLE
ui-components: Display user-friendly field labels

### DIFF
--- a/lib/ui-components/CardField.jsx
+++ b/lib/ui-components/CardField.jsx
@@ -70,7 +70,7 @@ const CardField = ({
 	}
 	return (
 		<React.Fragment>
-			<Label my={3}>{field}</Label>
+			<Label my={3}>{schema.title || field}</Label>
 
 			{_.isObject(payload[field]) ? _.map(payload[field], (item, key) => {
 				return (


### PR DESCRIPTION
If the field's schema has a title property, use that as the field label, rather than the fiend name itself. 

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3395 

**Before:**
![Before-schema-title](https://user-images.githubusercontent.com/2925657/77390024-4c0c1080-6dc7-11ea-8131-abf39c36b74f.png)


**After:**
![Schema-title](https://user-images.githubusercontent.com/2925657/77390035-50382e00-6dc7-11ea-85ec-07788d42290a.png)

