### PR TITLE
ui: new 'Guided Handover Flow' for card ownership changes

### DIFF
--- a/apps/ui/components/HOC/SlideInFlowPanel.jsx
+++ b/apps/ui/components/HOC/SlideInFlowPanel.jsx
@@ -12,33 +12,33 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
+	analytics,
 	actionCreators,
 	sdk,
 	selectors
 }	from '../../core'
-import CardActions from '../../../../lib/ui-components/CardActions'
+import SlideInFlowPanel from '../../../../lib/ui-components/Flows/SlideInFlowPanel'
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, props) => {
 	return {
 		sdk,
+		analytics,
 		types: selectors.getTypes(state),
-		user: selectors.getCurrentUser(state)
+		flowState: selectors.getFlow(props.flowId, props.card.id)(state)
 	}
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch, ownProps) => {
 	return {
 		actions: bindActionCreators(
 			_.pick(actionCreators, [
 				'addNotification',
-				'addChannel',
 				'setFlow',
-				'createLink',
-				'queryAPI'
+				'removeFlow'
 			]),
 			dispatch
 		)
 	}
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CardActions)
+export default connect(mapStateToProps, mapDispatchToProps)(SlideInFlowPanel)

--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -20,8 +20,17 @@ import {
 } from '../../../../lib/ui-components/shame/CloseButton'
 import Column from '../../../../lib/ui-components/shame/Column'
 import CardActions from '../../components/HOC/CardActions'
+import SlideInFlowPanel from '../../components/HOC/SlideInFlowPanel'
 import {
-	selectors
+	FLOW_IDS,
+	HandoverFlowPanel
+} from '../../../../lib/ui-components/Flows'
+import {
+	LinksProvider
+} from '../../../../lib/ui-components/LinksProvider'
+import {
+	selectors,
+	sdk
 } from '../../core'
 
 const CardLayout = (props) => {
@@ -33,7 +42,8 @@ const CardLayout = (props) => {
 		noActions,
 		overflowY,
 		title,
-		types
+		types,
+		user
 	} = props
 
 	const typeBase = card.type && card.type.split('@')[0]
@@ -43,50 +53,62 @@ const CardLayout = (props) => {
 	}), [ 'name' ], null)
 
 	return (
-		<Column
-			className={`column--${typeBase || 'unknown'} column--slug-${card.slug || 'unkown'}`}
-			overflowY={overflowY}
-			data-test={props['data-test']}
-		>
-			<Box p={3} pb={0}>
-				<Flex justifyContent="space-between">
-					{title}
+		<LinksProvider sdk={sdk} cards={typeBase ? [ card ] : []} link="is owned by">
+			<Column
+				className={`column--${typeBase || 'unknown'} column--slug-${card.slug || 'unkown'}`}
+				overflowY={overflowY}
+				data-test={props['data-test']}
+			>
+				<Box p={3} pb={0}>
+					<Flex justifyContent="space-between" alignItems="center">
+						{title}
 
-					{!title && (
-						<div>
-							<Heading.h4>
-								{card.name || card.slug || card.type}
-							</Heading.h4>
+						{!title && (
+							<div>
+								<Heading.h4>
+									{card.name || card.slug || card.type}
+								</Heading.h4>
 
-							{Boolean(typeName) && (
-								<Txt color="text.light" fontSize="0">{typeName}</Txt>
-							)}
-						</div>
-					)}
-
-					<Flex align="baseline">
-						{!noActions && (
-							<CardActions card={card}>
-								{actionItems}
-							</CardActions>
+								{Boolean(typeName) && (
+									<Txt color="text.light" fontSize="0">{typeName}</Txt>
+								)}
+							</div>
 						)}
 
-						<CloseButton
-							onClick={props.onClose}
-							ml={3}
-							channel={channel}
-						/>
-					</Flex>
-				</Flex>
-			</Box>
+						<Flex align="baseline">
+							{!noActions && (
+								<CardActions card={card}>
+									{actionItems}
+								</CardActions>
+							)}
 
-			{children}
-		</Column>
+							<CloseButton
+								onClick={props.onClose}
+								ml={3}
+								channel={channel}
+							/>
+						</Flex>
+					</Flex>
+				</Box>
+
+				{children}
+				<SlideInFlowPanel
+					slideInPanelProps={{
+						height: 480
+					}}
+					card={card}
+					flowId={FLOW_IDS.GUIDED_HANDOVER}
+				>
+					<HandoverFlowPanel user={user} />
+				</SlideInFlowPanel>
+			</Column>
+		</LinksProvider>
 	)
 }
 
 const mapStateToProps = (state) => {
 	return {
+		user: selectors.getCurrentUser(state),
 		types: selectors.getTypes(state)
 	}
 }

--- a/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -52,6 +52,7 @@ export default class AutoCompleteCardSelect extends React.Component {
 
 	async getTargets (value) {
 		const {
+			cardFilter,
 			cardType,
 			types,
 			sdk
@@ -71,6 +72,9 @@ export default class AutoCompleteCardSelect extends React.Component {
 			type: 'string',
 			const: `${typeCard.slug}@${typeCard.version}`
 		})
+
+		// Merge with the provided filter (if given)
+		_.merge(filter, cardFilter)
 
 		// Query the API for results and set them to state so they can be accessed
 		// when an option is selected

--- a/lib/ui-components/CardActions/CardActions.jsx
+++ b/lib/ui-components/CardActions/CardActions.jsx
@@ -11,12 +11,16 @@ import {
 	Flex,
 	Modal
 } from 'rendition'
+import {
+	supportsLink
+} from '@balena/jellyfish-client-sdk/lib/link-constraints'
 import CardLinker from '../CardLinker'
 import ContextMenu from '../ContextMenu'
 import * as helpers from '../../../lib/ui-components/services/helpers'
 import {
 	ActionLink
 } from '../shame/ActionLink'
+import CardOwner from '../CardOwner'
 import Icon from '../shame/Icon'
 
 export default class CardActions extends React.Component {
@@ -75,9 +79,18 @@ export default class CardActions extends React.Component {
 		}
 	}
 	render () {
+		const supportsOwnership = supportsLink(this.props.card.type, 'is owned by')
 		return (
 			<React.Fragment>
 				<Flex alignItems="center" justifyContent="flex-end">
+					{supportsOwnership && (
+						<CardOwner
+							user={this.props.user}
+							types={this.props.types}
+							card={this.props.card}
+							sdk={this.props.sdk}
+							actions={this.props.actions} />
+					)}
 					<Button
 						plain
 						mr={3}

--- a/lib/ui-components/CardField.jsx
+++ b/lib/ui-components/CardField.jsx
@@ -82,7 +82,7 @@ const CardField = ({
 					/>
 				)
 			})
-				: <Txt>{`${payload[field]}`}</Txt>
+				: <Txt data-test={`card-field--${helpers.slugify(field.toString())}`}>{`${payload[field]}`}</Txt>
 			}
 		</React.Fragment>
 	)

--- a/lib/ui-components/CardOwner/CardOwner.jsx
+++ b/lib/ui-components/CardOwner/CardOwner.jsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import path from 'path'
+import {
+	Txt,
+	DropDownButton
+} from 'rendition'
+import _ from 'lodash'
+import {
+	userDisplayName,
+	getType
+} from '../services/helpers'
+import {
+	ActionLink
+} from '../shame/ActionLink'
+import {
+	FLOW_IDS
+} from '../Flows'
+import * as handoverUtils from '../Flows/HandoverFlowPanel/handover-utils'
+
+export default class CardOwner extends React.Component {
+	constructor (props) {
+		super(props)
+		this.assignToMe = this.assignToMe.bind(this)
+		this.unassign = this.unassign.bind(this)
+		this.assign = this.assign.bind(this)
+		this.handover = this.handover.bind(this)
+		this.openOwnerChannel = this.openOwnerChannel.bind(this)
+	}
+
+	async assignToMe () {
+		const {
+			cardOwner,
+			actions,
+			card,
+			sdk,
+			user
+		} = this.props
+		const cardTypeName = getType(card.type).name
+
+		try {
+			if (cardOwner) {
+				await sdk.card.unlink(card, cardOwner, 'is owned by')
+			}
+
+			await sdk.card.link(card, user, 'is owned by')
+
+			this.props.updateCardOwnerCache(user)
+
+			actions.addNotification('success', `${cardTypeName} assigned to me`)
+
+			// Now generate a whisper in this card's timeline to detail the self-assignment
+			const whisper = handoverUtils.getHandoverWhisperEventCard(card, cardOwner, user)
+			if (whisper) {
+				await sdk.event.create(whisper)
+					.catch((err) => {
+						actions.addNotification('danger', 'Failed to create whisper')
+						console.error('Failed to create whisper', err)
+					})
+			}
+		} catch (err) {
+			actions.addNotification('danger', `Failed to assign ${cardTypeName}`)
+			console.error('Failed to create link', err)
+		}
+	}
+
+	handover (unassigned) {
+		const {
+			actions,
+			card
+		} = this.props
+		const flowState = {
+			isOpen: true,
+			card,
+			unassigned
+		}
+		if (unassigned) {
+			flowState.newOwner = null
+			flowState.userError = null
+		}
+		actions.setFlow(FLOW_IDS.GUIDED_HANDOVER, card.id, flowState)
+	}
+
+	unassign () {
+		this.handover(true)
+	}
+
+	assign () {
+		this.handover(false)
+	}
+
+	openOwnerChannel (event) {
+		const {
+			cardOwner,
+			history
+		} = this.props
+		event.preventDefault()
+		event.stopPropagation()
+		history.push(path.join(window.location.pathname, cardOwner.slug))
+	}
+
+	render () {
+		const {
+			card,
+			cardOwner,
+			types,
+			user
+		} = this.props
+
+		const cardTypeName = getType(card.type, types).name
+
+		return (
+			<React.Fragment>
+				<DropDownButton
+					data-test="card-owner-dropdown"
+					mr={3}
+					tertiary={cardOwner && (cardOwner.id === user.id)}
+					quartenary={cardOwner && (cardOwner.id !== user.id)}
+					label={cardOwner ? (
+						<Txt.span
+							bold
+							data-test="card-owner-dropdown__label--assigned"
+							onClick={this.openOwnerChannel}
+							tooltip={{
+								text: `${userDisplayName(cardOwner)} owns this ${cardTypeName}`,
+								placement: 'bottom'
+							}}
+						>
+							{userDisplayName(cardOwner)}
+						</Txt.span>
+					) : (
+						<Txt.span
+							bold
+							italic
+							data-test="card-owner-dropdown__label--unassigned"
+							tooltip={{
+								text: `This ${cardTypeName} is unassigned`,
+								placement: 'bottom'
+							}}
+						>
+						Unassigned
+						</Txt.span>
+					)}
+				>
+					<ActionLink
+						disabled={Boolean(cardOwner && (cardOwner.id === user.id))}
+						onClick={!cardOwner || (cardOwner.id !== user.id) ? this.assignToMe : _.noop}
+						data-test="card-owner-menu__assign-to-me"
+					>
+					Assign to me
+					</ActionLink>
+
+					<ActionLink
+						disabled={!cardOwner}
+						onClick={cardOwner ? () => { this.unassign(false) } : _.noop}
+						data-test="card-owner-menu__unassign"
+					>
+					Unassign
+					</ActionLink>
+
+					<ActionLink
+						onClick={this.assign}
+						data-test="card-owner-menu__assign"
+					>
+					Assign to someone else
+					</ActionLink>
+				</DropDownButton>
+			</React.Fragment>
+		)
+	}
+}

--- a/lib/ui-components/CardOwner/CardOwner.spec.jsx
+++ b/lib/ui-components/CardOwner/CardOwner.spec.jsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import sinon from 'sinon'
+import {
+	shallow,
+	configure
+} from 'enzyme'
+import React from 'react'
+import CardOwner from './CardOwner'
+import Adapter from 'enzyme-adapter-react-16'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+const user = {
+	name: 'User 1',
+	slug: 'user1',
+	type: 'user@1.0.0'
+}
+
+const types = [
+	{
+		name: 'user',
+		slug: 'user'
+	},
+	{
+		name: 'Support Thread',
+		slug: 'support-thread'
+	}
+]
+
+const card = {
+	id: '1',
+	slug: 'support-thread-1',
+	type: 'support-thread@1.0.0'
+}
+
+const sandbox = sinon.createSandbox()
+
+const getActions = () => {
+	return {
+		addNotification: sandbox.stub()
+	}
+}
+
+const getSdk = (owner) => {
+	return {
+		event: {
+			create: sandbox.fake.resolves({
+				slug: 'new-event'
+			})
+		},
+		card: {
+			unlink: sandbox.fake.resolves(true),
+			link: sandbox.fake.resolves({
+				slug: 'new-link'
+			}),
+			getWithLinks: sandbox.fake.resolves({
+				id: '1',
+				links: {
+					'is owned by': owner ? [
+						owner
+					] : []
+				}
+			})
+		}
+	}
+}
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('CardOwner should render', (test) => {
+	test.notThrows(() => {
+		shallow(
+			<CardOwner
+				user={user}
+				types={types}
+				actions={getActions()}
+				card={card}
+				cardOwner={user}
+				sdk={getSdk(user)}
+			/>
+		)
+	})
+})
+
+ava('\'Assign to me\' is disabled if I am the owner', async (test) => {
+	const cardOwner = await shallow(
+		<CardOwner
+			user={user}
+			types={types}
+			actions={getActions()}
+			card={card}
+			cardOwner={user}
+			sdk={getSdk(user)}
+		/>
+	)
+	cardOwner.update()
+	test.true(cardOwner.find('[data-test="card-owner-menu__assign-to-me"]').props().disabled)
+	test.false(cardOwner.find('[data-test="card-owner-menu__unassign"]').props().disabled)
+})
+
+ava('\'Unassign\' is disabled if there is no owner', async (test) => {
+	const cardOwner = await shallow(
+		<CardOwner
+			user={user}
+			types={types}
+			actions={getActions()}
+			card={card}
+			cardOwner={null}
+			sdk={getSdk()}
+		/>
+	)
+	cardOwner.update()
+	test.false(cardOwner.find('[data-test="card-owner-menu__assign-to-me"]').props().disabled)
+	test.true(cardOwner.find('[data-test="card-owner-menu__unassign"]').props().disabled)
+})

--- a/lib/ui-components/CardOwner/index.js
+++ b/lib/ui-components/CardOwner/index.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	withRouter
+} from 'react-router-dom'
+import {
+	compose
+} from 'redux'
+import CardOwner from './CardOwner'
+import {
+	withLink
+} from '../LinksProvider'
+
+export default compose(
+	withRouter,
+	withLink('is owned by', 'cardOwner')
+)(CardOwner)

--- a/lib/ui-components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
+++ b/lib/ui-components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import Bluebird from 'bluebird'
+import {
+	stepStatus
+} from '../flow-utils'
+import * as helpers from '../../services/helpers'
+import StepsFlow from '../../StepsFlow'
+import * as handoverUtils from './handover-utils'
+import {
+	NewOwnerStep
+} from './Steps'
+import {
+	TextareaStep
+} from '../Steps'
+
+export default function HandoverFlowPanel ({
+	flowId,
+	card,
+	cardOwner,
+	updateCardOwnerCache,
+	flowState,
+	user,
+	types,
+	actions,
+	analytics,
+	sdk,
+	onClose
+}) {
+	const setFlow = (updatedFlowState) => {
+		return actions.setFlow(flowId, card.id, updatedFlowState)
+	}
+	const removeFlow = () => {
+		return actions.removeFlow(flowId, card.id)
+	}
+	const transferOwnership = async () => {
+		const {
+			newOwner,
+			unassigned,
+			reason,
+			statusDescription
+		} = flowState
+		const cardTypeName = helpers.getType(card.type, types).name
+
+		try {
+			// Check we're not trying to reasssign the issue to the current owner
+			// (Note: the NewOwnerStep component should prevent this anyway)
+			if (cardOwner && newOwner && cardOwner.id === newOwner.id) {
+				actions.addNotification('danger', `${helpers.userDisplayName(cardOwner)} already owns this ${cardTypeName}`)
+				return
+			}
+
+			const linkActions = []
+
+			// Unassign the current owner
+			if (cardOwner) {
+				await sdk.card.unlink(card, cardOwner, 'is owned by')
+			} else if (unassigned) {
+				console.warn(`No current owner found when unassigning the card ${card.slug}`)
+			}
+
+			if (newOwner) {
+				// Link the new owner to the card
+				linkActions.push(sdk.card.link(card, newOwner, 'is owned by'))
+			}
+
+			if (handoverUtils.schemaSupportsStatusText(types, card)) {
+				// Update the status field of the card
+				const patch = helpers.patchPath(card, [ 'data', 'statusDescription' ], statusDescription.trim())
+				linkActions.push(sdk.card.update(card.id, card.type, patch))
+			}
+
+			// Create a whisper
+			const whisper = handoverUtils.getHandoverWhisperEventCard(card, cardOwner, newOwner, reason.trim())
+			if (whisper) {
+				linkActions.push(sdk.event.create(whisper))
+			}
+
+			await Bluebird.all(linkActions)
+
+			if (whisper) {
+				analytics.track('element.create', {
+					element: {
+						type: whisper.type
+					}
+				})
+			}
+
+			// Finally, update the card owner cache
+			updateCardOwnerCache(newOwner || null)
+		} catch (error) {
+			console.error('Failed to assign card', error)
+			actions.addNotification('danger', 'Handover failed. Refresh the page and try again.')
+			return
+		}
+
+		onClose()
+		setTimeout(() => {
+			removeFlow()
+		}, 600)
+	}
+
+	const {
+		newOwner,
+		userError,
+		unassigned,
+		reason,
+		statusDescription
+	} = flowState
+
+	const cardTypeName = helpers.getType(card.type, types).name
+
+	const newOwnerDisplayName = newOwner ? helpers.userDisplayName(newOwner) : null
+
+	const completed = {
+		ownership: unassigned || (newOwner && !userError),
+		reason: Boolean(reason),
+		statusDescription: Boolean(statusDescription)
+	}
+
+	const supportsStatus = handoverUtils.schemaSupportsStatusText(types, card)
+	return (
+		<StepsFlow
+			title="Transfer Ownership"
+			titleIcon="user-edit"
+			action={
+				unassigned
+					? 'Unassign'
+					: `Transfer ownership${newOwner ? ` to ${newOwnerDisplayName}` : ''}`
+			}
+			onDone={transferOwnership}
+			onClose={onClose}
+		>
+			<StepsFlow.Step label="Ownership" title="Select new owner" status={stepStatus(completed.ownership)}>
+				<NewOwnerStep
+					user={user}
+					currentOwner={cardOwner}
+					types={types}
+					flowState={flowState}
+					setFlow={setFlow}
+				/>
+			</StepsFlow.Step>
+			<StepsFlow.Step label="Reason" title="Give a reason" status={stepStatus(completed.reason)}>
+				<TextareaStep
+					placeholder={
+						unassigned
+							? 'Explain why you are unassigning this issue'
+							: `Explain why you are transferring ownership${
+								newOwnerDisplayName ? ` to ${newOwnerDisplayName}` : ''}`
+					}
+					flowStatePropName="reason"
+					flowState={flowState}
+					setFlow={setFlow}
+				/>
+			</StepsFlow.Step>
+			{supportsStatus && (
+				<StepsFlow.Step label="Status" title="Set the status" status={stepStatus(completed.statusDescription)}>
+					<TextareaStep
+						placeholder={`Fully describe the current status of this ${cardTypeName}`}
+						flowStatePropName="statusDescription"
+						flowState={flowState}
+						setFlow={setFlow}
+					/>
+				</StepsFlow.Step>
+			)}
+		</StepsFlow>
+	)
+}

--- a/lib/ui-components/Flows/HandoverFlowPanel/Steps/NewOwnerStep.jsx
+++ b/lib/ui-components/Flows/HandoverFlowPanel/Steps/NewOwnerStep.jsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Flex,
+	RadioButton,
+	Txt
+} from 'rendition'
+import styled from 'styled-components'
+import * as helpers from '../../../services/helpers'
+import AutoCompleteCardSelect from '../../../AutoCompleteCardSelect'
+
+const UserSelect = styled(AutoCompleteCardSelect) `
+	min-width: 180px;
+`
+
+// In this step you select either another team member to assign
+// the card to or you select to unassign it.
+export default function NewOwnerStep ({
+	currentOwner,
+	user,
+	types,
+	flowState: {
+		card,
+		newOwner,
+		userError,
+		unassigned
+	},
+	setFlow
+}) {
+	const newOwnerValue = newOwner ? {
+		value: newOwner.id,
+		label: newOwner.name || newOwner.slug
+	} : null
+
+	const setNewOwnerTeamMember = (event) => {
+		if (event.target.checked) {
+			setFlow({
+				unassigned: false
+			})
+		}
+	}
+
+	const setNewOwnerUnassigned = (event) => {
+		if (event.target.checked) {
+			setFlow({
+				newOwner: null,
+				userError: null,
+				unassigned: true
+			})
+		}
+	}
+
+	const setNewOwner = (owner) => {
+		const cardTypeName = helpers.getType(card.type, types).name
+		setFlow({
+			newOwner: owner,
+			userError: currentOwner && _.get(owner, [ 'id' ]) === _.get(currentOwner, [ 'id' ])
+				? `${currentOwner.slug} already owns this ${cardTypeName}` : null
+		})
+	}
+
+	const authenticatedUsersOrgFilter = {
+		$$links: {
+			'is member of': {
+				type: 'object',
+				properties: {
+					slug: {
+						type: 'string',
+						const: _.get(user, [ 'links', 'is member of', 0, 'slug' ], 'org-balena')
+					}
+				}
+			}
+		}
+	}
+
+	return (
+		<React.Fragment>
+			<Flex flexDirection="row" alignItems="center">
+				<RadioButton
+					id="rb-ghf-team"
+					data-test="ghf__rb-team"
+					mr={3}
+					label="Another team member"
+					onChange={setNewOwnerTeamMember}
+					checked={!unassigned}
+				/>
+				<UserSelect
+					data-test="ghf__sel-new-owner"
+					classNamePrefix="ghf-async-select"
+					cardType="user"
+					types={types}
+					value={newOwnerValue}
+					isDisabled={unassigned}
+					onChange={setNewOwner}
+					menuPlacement="top"
+					cardFilter={authenticatedUsersOrgFilter}
+				/>
+				{ userError && (
+					<Txt data-test="ghf__user-error" ml={2} color='red'>{userError}</Txt>
+				)}
+			</Flex>
+			<RadioButton
+				id="rb-ghf-unassign"
+				data-test="ghf__rb-unassign"
+				label="Unassign"
+				onChange={setNewOwnerUnassigned}
+				checked={unassigned}
+			/>
+		</React.Fragment>
+	)
+}

--- a/lib/ui-components/Flows/HandoverFlowPanel/Steps/index.js
+++ b/lib/ui-components/Flows/HandoverFlowPanel/Steps/index.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as NewOwnerStep
+} from './NewOwnerStep'

--- a/lib/ui-components/Flows/HandoverFlowPanel/handover-utils.js
+++ b/lib/ui-components/Flows/HandoverFlowPanel/handover-utils.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import uuid from 'uuid/v4'
+import {
+	getUserSlugsByPrefix
+} from '../../services/helpers'
+
+/**
+ * Checks if the given card's type defines the statusDescription field
+ *
+ * @param {Array} types - list of all known card types
+ * @param {Object} card - the card to check
+ *
+ * @returns {Boolean} True if the given card's type schema supports the statusDescription field
+ */
+export const schemaSupportsStatusText = (types, card) => {
+	const typeCard = _.find(types, {
+		slug: card.type.split('@')[0]
+	})
+	return _.has(typeCard, [ 'data', 'schema', 'properties', 'data', 'properties', 'statusDescription' ])
+}
+
+/**
+ * Generates a whisper message for the given reassignment parameters
+ *
+ * @param {Object} currentOwner - the user currently assigned to the card (null if not currently assigned)
+ * @param {Object} newOwner - the user about to be assigned to the card (null if unassigning)
+ * @param {String} reason - the reason for the reassignment
+ *
+ * @returns {String} The whisper message
+ */
+export const generateWhisperMessage = (currentOwner, newOwner, reason) => {
+	const reasonSuffix = reason ? `\n\n>${reason}` : ''
+	const currentOwnerSlug = currentOwner ? currentOwner.slug.replace('user-', '') : null
+	const newOwnerSlug = newOwner ? newOwner.slug.replace('user-', '') : null
+	if (currentOwner) {
+		if (newOwner) {
+			return `Reassigned from @${currentOwnerSlug} to @${newOwnerSlug}${reasonSuffix}`
+		}
+		return `Unassigned from @${currentOwnerSlug}${reasonSuffix}`
+	}
+	if (newOwner) {
+		return `Assigned to @${newOwnerSlug}${reasonSuffix}`
+	}
+
+	// Note: we should never get here as it indicates we're trying to unassign
+	// a card but the card has no current owner. But to cope with race conditions
+	// we just return null which can be interpreted as 'don't send a whisper'
+	return null
+}
+
+/**
+ * Generates a whisper card that represents the ownership handover
+ *
+ * @param {Object} card - the card being handed over
+ * @param {Object} currentOwner - the user currently assigned to the card (null if not currently assigned)
+ * @param {Object} newOwner - the user about to be assigned to the card (null if unassigning)
+ * @param {String} reason - the reason for the reassignment
+ *
+ * @returns {Object} - the whisper card
+ */
+export const getHandoverWhisperEventCard = (card, currentOwner, newOwner, reason) => {
+	let whisper = null
+	const message = generateWhisperMessage(currentOwner, newOwner, reason)
+	if (message) {
+		const mentions = getUserSlugsByPrefix('@', message)
+		const alerts = getUserSlugsByPrefix('!', message)
+
+		whisper = {
+			target: card,
+			type: 'whisper',
+			slug: `whisper-${uuid()}`,
+			tags: [],
+			payload: {
+				mentionsUser: mentions,
+				alertsUser: alerts,
+				message
+			}
+		}
+	}
+	return whisper
+}

--- a/lib/ui-components/Flows/HandoverFlowPanel/handover-utils.spec.js
+++ b/lib/ui-components/Flows/HandoverFlowPanel/handover-utils.spec.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const handoverUtils = require('./handover-utils')
+
+ava('.generateWhisperMessage() works for unassignment', (test) => {
+	const currentOwner = {
+		slug: 'user-Test1'
+	}
+	const newOwner = null
+	const reason = 'A reason'
+	test.is(
+		handoverUtils.generateWhisperMessage(currentOwner, newOwner, reason),
+		'Unassigned from @Test1\n\n>A reason')
+})
+
+ava('.generateWhisperMessage() works for assignment', (test) => {
+	const currentOwner = null
+	const newOwner = {
+		slug: 'user-Test2'
+	}
+	const reason = 'A reason'
+	test.is(
+		handoverUtils.generateWhisperMessage(currentOwner, newOwner, reason),
+		'Assigned to @Test2\n\n>A reason')
+})
+
+ava('.generateWhisperMessage() works for reassignment', (test) => {
+	const currentOwner = {
+		slug: 'user-Test1'
+	}
+	const newOwner = {
+		slug: 'user-Test2'
+	}
+	const reason = 'A reason'
+	test.is(
+		handoverUtils.generateWhisperMessage(currentOwner, newOwner, reason),
+		'Reassigned from @Test1 to @Test2\n\n>A reason')
+})
+
+ava('.generateWhisperMessage() does not require a reason', (test) => {
+	const currentOwner = null
+	const newOwner = {
+		slug: 'user-Test2'
+	}
+	const reason = null
+	test.is(
+		handoverUtils.generateWhisperMessage(currentOwner, newOwner, reason),
+		'Assigned to @Test2')
+})

--- a/lib/ui-components/Flows/HandoverFlowPanel/index.js
+++ b/lib/ui-components/Flows/HandoverFlowPanel/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import HandoverFlowPanel from './HandoverFlowPanel'
+import {
+	withLink
+} from '../../LinksProvider'
+
+export default withLink('is owned by', 'cardOwner')(HandoverFlowPanel)

--- a/lib/ui-components/Flows/SlideInFlowPanel.jsx
+++ b/lib/ui-components/Flows/SlideInFlowPanel.jsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import SlideInPanel from '../SlideInPanel'
+
+export default function SlideInFlowPanel ({
+	flowId,
+	card,
+	slideInPanelProps,
+	flowState,
+	actions,
+	children,
+	...rest
+}) {
+	if (_.isArray(children)) {
+		throw new Error('SlideInFlowPanel only accepts a single child component')
+	}
+	const close = () => {
+		actions.setFlow(flowId, card.id, {
+			isOpen: false
+		})
+	}
+	const isOpen = _.get(flowState, [ 'isOpen' ], false)
+
+	return (
+		<SlideInPanel
+			height="50%"
+			from="bottom"
+			{...slideInPanelProps}
+			isOpen={isOpen}
+			onClose={close}
+		>
+			{Boolean(flowState) && React.cloneElement(children, {
+				flowId,
+				card,
+				flowState,
+				actions,
+				onClose: close,
+				...rest
+			})}
+		</SlideInPanel>
+	)
+}

--- a/lib/ui-components/Flows/Steps/TextareaStep.jsx
+++ b/lib/ui-components/Flows/Steps/TextareaStep.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Textarea
+} from 'rendition'
+import useDebounce from '../../hooks/use-debounce'
+
+// In this step you specify a text value for the flow.
+export default function TextareaStep ({
+	flowStatePropName,
+	flowState,
+	setFlow,
+	...rest
+}) {
+	const [ value, setValue ] = React.useState(flowState[flowStatePropName] || '')
+	const debouncedValue = useDebounce(value, 500)
+
+	// If the flowStatePropName changes, update/reset the value based on the new flowStatePropName
+	React.useEffect(() => {
+		setValue(flowState[flowStatePropName] || '')
+	}, [ flowStatePropName ])
+
+	React.useEffect(() => {
+		setFlow({
+			[flowStatePropName]: debouncedValue
+		})
+	}, [ debouncedValue ])
+
+	const updateValue = (event) => {
+		setValue(event.target.value)
+	}
+
+	return (
+		<Textarea
+			data-test={`gf__ta-${flowStatePropName}`}
+			minRows={4}
+			{...rest}
+			value={value}
+			onChange={updateValue}
+		/>
+	)
+}

--- a/lib/ui-components/Flows/Steps/index.js
+++ b/lib/ui-components/Flows/Steps/index.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as TextareaStep
+} from './TextareaStep'

--- a/lib/ui-components/Flows/flow-utils.js
+++ b/lib/ui-components/Flows/flow-utils.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export const FLOW_IDS = {
+	GUIDED_HANDOVER: 'guidedHandover'
+}
+
+/**
+ * Coverts a boolean isComplete flag to a 'Steps'-compatible status text
+ *
+ * @param {Boolean} isComplete - true if the step is complete
+ * @returns {String}
+ */
+export const stepStatus = (isComplete) => {
+	return isComplete ? 'completed' : 'pending'
+}

--- a/lib/ui-components/Flows/index.js
+++ b/lib/ui-components/Flows/index.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as allGenericSteps from './Steps'
+import {
+	FLOW_IDS as flowIds
+} from './flow-utils'
+export {
+	default as SlideInFlowPanel
+} from './SlideInFlowPanel'
+export {
+	default as HandoverFlowPanel
+} from './HandoverFlowPanel'
+
+export const Steps = allGenericSteps
+
+export const FLOW_IDS = flowIds

--- a/lib/ui-components/StepsFlow.jsx
+++ b/lib/ui-components/StepsFlow.jsx
@@ -11,6 +11,7 @@ import React from 'react'
 import {
 	Box,
 	Button,
+	Divider,
 	Heading,
 	Flex,
 	Steps,
@@ -38,18 +39,29 @@ const nonePending = (stepStatuses) => {
 	)
 }
 
+const StepsHeading = styled(Heading.h3) `
+	line-height: 1;
+`
+
+const StepsBox = styled(Box) `
+	.flow-steps {
+		padding: ${(props) => { return props.theme.space[4] }}px;
+	}
+`
+
 /**
  * Each StepsFlow.Step should define the following props:
- * - 'label' (to be used as the step label and also the title above the step content)
+ * - 'label' (to be used as the step label)
+ * - 'title' (to be used as the title above the step content)
  * - 'status' ('pending', 'completed' or 'none')
  * - 'children' (the step content, to be displayed when the step is active)
  */
 const FlowStep = ({
-	stepIndex, label, status, children, ...rest
+	stepIndex, label, title, status, children, ...rest
 }) => {
 	return (
-		<FlowStepFlex flex={1} {...rest} flexDirection="column">
-			<Heading.h5 data-test={`flow-step-${stepIndex}__heading`} mb={2}>{label}</Heading.h5>
+		<FlowStepFlex pt={4} px={4} flex={1} alignSelf="stretch" {...rest} flexDirection="column">
+			<Heading.h5 data-test={`flow-step-${stepIndex}__heading`} mb={2}>{title || label}</Heading.h5>
 			{children}
 		</FlowStepFlex>
 	)
@@ -63,7 +75,10 @@ const FlowStep = ({
  * Children of StepsFlow must be of type StepsFlow.Step.
  */
 const StepsFlow = ({
+	title,
+	titleIcon,
 	initialStep,
+	onClose,
 	onDone,
 	stepsProps,
 	children,
@@ -86,9 +101,24 @@ const StepsFlow = ({
 	const stepStatuses = _.map(steps, 'props.status')
 	const allComplete = nonePending(stepStatuses)
 	return (
-		<Flex {...rest} flex={1} flexDirection="column">
-			<Box mb={4} flex={0} >
-				<Steps className="flow-steps" {...stepsProps}>
+		<Flex py={4} {...rest} alignItems="flex-start" flex={1} flexDirection="column">
+			<Flex alignItems="center" alignSelf="stretch" justifyContent="space-between" px={4}>
+				{title && (
+					<StepsHeading>
+						{titleIcon && <Box display="inline-block" mr={2}><Icon name={titleIcon} /></Box>}
+						{title}
+					</StepsHeading>
+				)}
+				<Button plain p={2} icon={<Icon name="times" />} onClick={onClose} />
+			</Flex>
+			<StepsBox flex={0}>
+				<Steps
+					className="flow-steps"
+					bordered={false}
+					ordered
+					activeStepIndex={activeStepIndex}
+					{...stepsProps}
+				>
 					{React.Children.map(steps, (step, stepIndex) => {
 						if (step.type !== FlowStep) {
 							throw new Error(
@@ -101,29 +131,23 @@ const StepsFlow = ({
 							)
 						}
 
-						// Link should be active if:
-						// - its a previous step OR
-						// - its not the current step AND all previous steps are not pending
-						const clickHandler = (stepIndex < activeStepIndex) ||
-						(stepIndex !== activeStepIndex && nonePending(stepStatuses.slice(0, stepIndex)))
-							? () => { return setActiveStepIndex(stepIndex) }
-							: null
 						return (
 							<Step
 								key={step.props.label}
 								status={step.props.status}
-								onClick={clickHandler}
+								onClick={() => { return setActiveStepIndex(stepIndex) }}
 							>
 								{step.props.label}
 							</Step>
 						)
 					})}
 				</Steps>
-			</Box>
+			</StepsBox>
+			<Divider m={0} />
 			{React.cloneElement(steps[activeStepIndex], {
 				stepIndex: activeStepIndex
 			})}
-			<Flex flex={0} mt={4} alignItems="center" justifyContent="flex-end">
+			<Flex flex={0} px={4} mt={4} alignSelf="flex-end" alignItems="center" justifyContent="flex-end">
 				<Button
 					mr={3}
 					data-test="steps-flow__prev-btn"

--- a/lib/ui-components/StepsFlow.spec.jsx
+++ b/lib/ui-components/StepsFlow.spec.jsx
@@ -25,7 +25,7 @@ configure({
 })
 
 const stepsProps = {
-	titleText: 'Test flow'
+	title: 'Test flow'
 }
 
 const getStep = (index, stepStatus) => {
@@ -41,7 +41,7 @@ const getShallowStepsFlow = ({
 }) => {
 	const stepStatus = status || 'pending'
 	return shallow(
-		<StepsFlow stepsProps={stepsProps} {...props}>
+		<StepsFlow {...stepsProps} {...props}>
 			{[ 1, 2, 3 ].map((index) => { return getStep(index, stepStatus) })}
 		</StepsFlow>
 	)
@@ -53,7 +53,7 @@ const getMountedStepsFlow = ({
 	const stepStatus = status || 'pending'
 	return mount(
 		<Provider>
-			<StepsFlow stepsProps={stepsProps} {...props}>
+			<StepsFlow {...stepsProps} {...props}>
 				{[ 1, 2, 3 ].map((index) => { return getStep(index, stepStatus) })}
 			</StepsFlow>
 		</Provider>
@@ -134,7 +134,7 @@ ava('initialStep cannot be greater than number of steps', (test) => {
 ava('Invalid child components are not allowed', (test) => {
 	test.throws(() => {
 		shallow(
-			<StepsFlow initialStep={3} stepsProps={stepsProps}>
+			<StepsFlow initialStep={3} {...stepsProps}>
 				<StepsFlow.Step label="Step 1" status="completed">
 					<div className="step1">Step 1</div>
 				</StepsFlow.Step>

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -529,7 +529,22 @@ export const generateActorFromUserCard = (card) => {
 	}
 }
 
+export const swallowEvent = (event) => {
+	event.preventDefault()
+	event.stopPropagation()
+}
+
 export const getRelationshipTargetType = _.memoize((relationship) => {
 	const type = _.get(relationship, [ 'type' ]) || _.get(relationship, [ 'query', 0, 'type' ])
 	return type && type.split('@')[0]
 })
+
+export const getType = _.memoize((typeSlug, types) => {
+	return _.find(types, {
+		slug: typeSlug.split('@')[0]
+	})
+})
+
+export const userDisplayName = (user) => {
+	return user.name || user.slug.replace('user-', '')
+}

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const uuid = require('uuid/v4')
+const helpers = require('./helpers')
+const macros = require('./macros')
+const environment = require('../../../lib/environment')
+
+const context = {
+	context: {
+		id: `UI-INTEGRATION-TEST-${uuid()}`,
+		reason: 'just because',
+		statusDescription: 'solved!'
+	}
+}
+
+const selectors = {
+	rbTeam: 'label[for="rb-ghf-team"]',
+	rbUnassign: 'label[for="rb-ghf-unassign"]',
+	ddAssignToMe: '[data-test="card-owner-menu__assign-to-me"]',
+	ddAssign: '[data-test="card-owner-menu__assign"]',
+	ddUnassign: '[data-test="card-owner-menu__unassign"]',
+	userError: '[data-test="ghf__user-error"]',
+	nextBtn: '[data-test="steps-flow__next-btn"]',
+	actionBtn: '[data-test="steps-flow__action-btn"]',
+	reasonTextArea: '[data-test="gf__ta-reason"]',
+	statusTextTextArea: '[data-test="gf__ta-statusDescription"]',
+	whisper: '.event-card--whisper [data-test="event-card__message"]'
+}
+
+const user = helpers.generateUserDetails()
+
+const otherUser = helpers.generateUserDetails()
+
+const openCardOwnerDropdown = async (page) => {
+	// Slight css selector hack needed to select the toggle button of a Rendition dropdown!
+	return macros.waitForThenClickSelector(
+		page,
+		'[data-test="card-owner-dropdown"] [data-test="card-owner-dropdown"]:nth-child(2)'
+	)
+}
+
+const verifyCardOwner = async (test, page, isAssigned, expectedOwnerText) => {
+	const dataTestAttribute = isAssigned
+		? 'card-owner-dropdown__label--assigned'
+		: 'card-owner-dropdown__label--unassigned'
+	const selector = `//*[@data-test="${dataTestAttribute}"][text()="${expectedOwnerText}"]`
+	const cardOwner = await page.waitForXPath(selector)
+	const text = await page.evaluate((ele) => {
+		return ele.textContent
+	}, cardOwner)
+	test.is(text, expectedOwnerText)
+}
+
+const createSupportThreadAndNavigate = async (page, owner = null) => {
+	const supportThread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'support-thread@1.0.0',
+			data: {
+				inbox: 'S/Paid_Support',
+				status: 'open'
+			}
+		})
+	})
+	if (owner) {
+		await page.evaluate((props) => {
+			return window.sdk.card.link(props.supportThread, props.owner, 'is owned by')
+		}, {
+			supportThread, owner
+		})
+	}
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+
+	// Expand the extra info on the thead
+	await macros.waitForThenClickSelector(page, '[data-test="support-thread__expand"]')
+	return supportThread
+}
+
+const nextStep = (page) => {
+	return macros.waitForThenClickSelector(page, `${selectors.nextBtn}:not(:disabled)`)
+}
+
+const action = async (page) => {
+	// Click the action button, wait for it to be disabled and then enabled again
+	await macros.waitForThenClickSelector(page, `${selectors.actionBtn}:not(:disabled)`)
+	await page.waitForSelector(`${selectors.actionBtn}[disabled]`)
+	await page.waitForSelector(selectors.actionBtn)
+}
+
+const getWhisperText = async (page) => {
+	const whisperText = await macros.getElementText(page, selectors.whisper)
+	return whisperText.trim()
+}
+
+const verifyThreadStatus = async (test, page, expectedStatus) => {
+	const statusDescription = await macros.getElementText(page, '[data-test="card-field--statusdescription"]')
+	test.is(statusDescription, expectedStatus)
+}
+
+ava.serial.before(async () => {
+	await helpers.browser.beforeEach({
+		context
+	})
+
+	// Create user and log in to the web browser client
+	const communityUser = await context.createUser(user)
+	context.otherCommunityUser = await context.createUser(otherUser)
+	context.otherCommunityUserSlug = context.otherCommunityUser.slug.replace('user-', '')
+	await context.addUserToBalenaOrg(communityUser.id)
+	await context.addUserToBalenaOrg(context.otherCommunityUser.id)
+	await macros.loginUser(context.page, user)
+
+	context.currentUser = await context.page.evaluate(() => {
+		return window.sdk.auth.whoami()
+	})
+	context.currentUserSlug = context.currentUser.slug.replace('user-', '')
+})
+
+ava.serial.after(async () => {
+	await helpers.browser.afterEach({
+		context
+	})
+})
+
+ava('You can assign an unassigned thread to yourself', async (test) => {
+	const {
+		page,
+		currentUserSlug
+	} = context
+
+	// Create a new support thread
+	await createSupportThreadAndNavigate(page)
+
+	// Verify its currently unassigned
+	await verifyCardOwner(test, page, false, 'Unassigned')
+
+	await openCardOwnerDropdown(page)
+	await page.waitForSelector(`${selectors.ddUnassign}[disabled]`)
+
+	// Assign the thread to ourselves
+	await macros.waitForThenClickSelector(page, selectors.ddAssignToMe)
+
+	// Verify the new owner is me!
+	await verifyCardOwner(test, page, true, currentUserSlug)
+
+	// Check the whisper
+	const whisperText = await getWhisperText(page)
+	test.is(whisperText, `Assigned to @${currentUserSlug}`)
+})
+
+ava('TEMP You can assign an unassigned thread to another user', async (test) => {
+	const {
+		page,
+		otherCommunityUser,
+		otherCommunityUserSlug
+	} = context
+
+	// Create a new support thread
+	await createSupportThreadAndNavigate(page)
+
+	// Verify its currently unassigned
+	await verifyCardOwner(test, page, false, 'Unassigned')
+
+	// Open the Guided Handover Flow
+	await openCardOwnerDropdown(page)
+	await macros.waitForThenClickSelector(page, selectors.ddAssign)
+
+	// Select the other user
+	await macros.waitForThenClickSelector(page, selectors.rbTeam)
+	await page.type('.ghf-async-select__input input', otherCommunityUser.slug)
+	await page.waitForSelector('.ghf-async-select__option--is-focused')
+	await page.keyboard.press('Enter')
+
+	await nextStep(page)
+
+	// Enter a reason
+	await page.type(selectors.reasonTextArea, context.context.reason)
+
+	await nextStep(page)
+
+	// Enter the statusDescription
+	await page.type(selectors.statusTextTextArea, context.context.statusDescription)
+
+	// Click the action button
+	await action(page)
+
+	// Verify the new owner
+	await verifyCardOwner(test, page, true, otherCommunityUserSlug)
+
+	// Check the whisper
+	const whisperText = await getWhisperText(page)
+	test.is(whisperText, `Assigned to @${otherCommunityUserSlug}\n\n${context.context.reason}`)
+
+	await verifyThreadStatus(test, page, context.context.statusDescription)
+})
+
+ava('You can unassign a thread that was assigned to you', async (test) => {
+	const {
+		page,
+		currentUser,
+		currentUserSlug
+	} = context
+
+	// Create a new support thread (assigned to ourselves)
+	await createSupportThreadAndNavigate(page, currentUser)
+
+	// Verify its currently assigned to us
+	await verifyCardOwner(test, page, true, currentUserSlug)
+
+	// Open the Guided Handover Flow
+	await openCardOwnerDropdown(page)
+	await page.waitForSelector(`${selectors.ddAssignToMe}[disabled]`)
+	await macros.waitForThenClickSelector(page, selectors.ddUnassign)
+
+	// Ensure the 'Unassign' option is selected
+	await macros.waitForThenClickSelector(page, selectors.rbUnassign)
+	await nextStep(page)
+
+	// Enter a reason
+	await page.type(selectors.reasonTextArea, context.context.reason)
+
+	await nextStep(page)
+
+	// Enter the statusDescription
+	await page.type(selectors.statusTextTextArea, context.context.statusDescription)
+
+	// Click the action button
+	await action(page)
+
+	// Verify its now unassigned
+	await verifyCardOwner(test, page, false, 'Unassigned')
+
+	// Check the whisper
+	const whisperText = await getWhisperText(page)
+	test.is(whisperText, `Unassigned from @${currentUserSlug}\n\n${context.context.reason}`)
+
+	await verifyThreadStatus(test, page, context.context.statusDescription)
+})
+
+ava('You can unassign a thread that was assigned to another user', async (test) => {
+	const {
+		page,
+		otherCommunityUser,
+		otherCommunityUserSlug
+	} = context
+
+	// Create a new support thread (assigned to the other user)
+	await createSupportThreadAndNavigate(page, otherCommunityUser)
+
+	// Verify its currently assigned to the other user
+	await verifyCardOwner(test, page, true, otherCommunityUserSlug)
+
+	// Open the Guided Handover Flow
+	await openCardOwnerDropdown(page)
+	await macros.waitForThenClickSelector(page, selectors.ddUnassign)
+
+	// Ensure the 'Unassign' option is selected
+	await macros.waitForThenClickSelector(page, selectors.rbUnassign)
+	await nextStep(page)
+
+	// Enter a reason
+	await page.type(selectors.reasonTextArea, context.context.reason)
+
+	await nextStep(page)
+
+	// Enter the statusDescription
+	await page.type(selectors.statusTextTextArea, context.context.statusDescription)
+
+	// Click the action button
+	await action(page)
+
+	// Verify its now unassigned
+	await verifyCardOwner(test, page, false, 'Unassigned')
+
+	// Check the whisper
+	const whisperText = await getWhisperText(page)
+	test.is(whisperText, `Unassigned from @${otherCommunityUserSlug}\n\n${context.context.reason}`)
+
+	await verifyThreadStatus(test, page, context.context.statusDescription)
+})
+
+ava('You can reassign a thread from yourself to another user', async (test) => {
+	const {
+		page,
+		currentUser,
+		currentUserSlug,
+		otherCommunityUser,
+		otherCommunityUserSlug
+	} = context
+
+	// Create a new support thread (assigned to ourselves)
+	await createSupportThreadAndNavigate(page, currentUser)
+
+	// Verify its currently assigned to us
+	await verifyCardOwner(test, page, true, currentUserSlug)
+
+	// Open the Guided Handover Flow
+	await openCardOwnerDropdown(page)
+	await macros.waitForThenClickSelector(page, selectors.ddAssign)
+
+	// Select the other user
+	await macros.waitForThenClickSelector(page, selectors.rbTeam)
+	await page.type('.ghf-async-select__input input', otherCommunityUser.slug)
+	await page.waitForSelector('.ghf-async-select__option--is-focused')
+	await page.keyboard.press('Enter')
+
+	await nextStep(page)
+
+	// Enter a reason
+	await page.type(selectors.reasonTextArea, context.context.reason)
+
+	await nextStep(page)
+
+	// Enter the statusDescription
+	await page.type(selectors.statusTextTextArea, context.context.statusDescription)
+
+	// Click the action button
+	await action(page)
+
+	// Verify its now assigned to the other user
+	await verifyCardOwner(test, page, true, otherCommunityUserSlug)
+
+	// Check the whisper
+	const whisperText = await getWhisperText(page)
+	test.is(whisperText, `Reassigned from @${currentUserSlug} to @${otherCommunityUserSlug}\n\n${context.context.reason}`)
+
+	// Verify the thread's status
+	await verifyThreadStatus(test, page, context.context.statusDescription)
+})
+
+ava('You can reassign a thread from another user to yourself', async (test) => {
+	const {
+		page,
+		currentUserSlug,
+		otherCommunityUser,
+		otherCommunityUserSlug
+	} = context
+
+	// Create a new support thread (assigned to the other user)
+	await createSupportThreadAndNavigate(page, otherCommunityUser)
+
+	// Verify its currently assigned to the other user
+	await verifyCardOwner(test, page, true, otherCommunityUserSlug)
+
+	// Assign it to ourselves
+	await openCardOwnerDropdown(page)
+	await macros.waitForThenClickSelector(page, selectors.ddAssignToMe)
+
+	// Verify the new owner is me!
+	await verifyCardOwner(test, page, true, currentUserSlug)
+
+	// Check the whisper
+	const whisperText = await getWhisperText(page)
+	test.is(whisperText, `Reassigned from @${otherCommunityUserSlug} to @${currentUserSlug}`)
+})
+
+ava('You cannot assign a thread to its existing owner', async (test) => {
+	const {
+		page,
+		otherCommunityUser,
+		otherCommunityUserSlug
+	} = context
+
+	// Create a new support thread
+	await createSupportThreadAndNavigate(page, otherCommunityUser)
+
+	// Verify its currently assigned to the other user
+	await verifyCardOwner(test, page, true, otherCommunityUserSlug)
+
+	// Open the Guided Handover Flow
+	await openCardOwnerDropdown(page)
+	await macros.waitForThenClickSelector(page, selectors.ddAssign)
+
+	// Select the other user
+	await macros.waitForThenClickSelector(page, selectors.rbTeam)
+	await page.type('.ghf-async-select__input input', otherCommunityUser.slug)
+	await page.waitForSelector('.ghf-async-select__option--is-focused')
+	await page.keyboard.press('Enter')
+
+	// Error message should be displayed and 'Next' button should be disabled
+	await page.waitForSelector(selectors.userError)
+	await page.waitForSelector(`${selectors.nextBtn}[disabled]`)
+	test.pass()
+})


### PR DESCRIPTION
Includes a new CardOwner component in the generic Card Actions section of a lens.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3048 
Fixes #3121
Fixes #3126 

![Transfer Ownership](https://user-images.githubusercontent.com/2925657/80561382-7e381000-8a0e-11ea-98af-e13e231343ee.gif)

This PR introduces two new components:

### 1. `CardOwner`
This is essentially a DropdownButton. The label displays the current card owner (or 'Unassigned' if the card is not owned). The dropdown has three options:
1. Assign to me
2. Unassign
3. Assign to someone else

Option 1 is executed immediately. Options 2 and 3 will open the `HandoverFlowPanel`...

### 2. `HandoverFlowPanel`
The Handover Flow Panel is wrapped by the `SlideInPanel` component and makes use of the `StepsFlow` component. It guides the user through a series of 2 (or 3 of the card type defines a 'statusDescription' field) steps to hand over the card to another user (or to unassign it). When the user clicks the action button to handover the card, the following takes place:
1. The current owner (if any) is unassigned
2. The new owner (if specified) is assigned
3. The `statusDescription` of the card (if defined) is updated 
4. A whisper is added to the card's timeline detailing the ownership transfer, including the reason given.


