### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-* @lucianbuzzo @jviotti @ffissore @karaxuna @StefKors @joshbwlng @grahammcculloch @Ljewalsh
-/deploy-templates/ @nazrhom
-/deploy-templates/cloudformation/ @ab77 @cmfcruz
-/deploy-templates/jellyfish-product/ @richbayliss @nazrhom


### PR DESCRIPTION
The use of CODEOWNERS is not well defined and generates a lot of noise. At this point the functionality is causing more harm than good, we're better off selectively choosing reviewers.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>