### PR TITLE
core: Make card table creation not lock if not needed

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -21,41 +21,30 @@ exports.TRIGGER_COLUMNS = CARDS_TRIGGER_COLUMNS
 exports.setup = async (context, connection, database, options = {}) => {
 	const table = options.table || exports.TABLE
 
-	/*
-	 * Create the table if it doesn't exist.
-	 *
-	 * TODO(jviotti): Keep in mind that if we change
-	 * this structure and deploy to production, then
-	 * the new structure won't be applied, as we would
-	 * see that the table already exists and move
-	 * one without applying the changes.
-	 */
-	await connection.any(`
-		CREATE TABLE IF NOT EXISTS ${table} (
-			id UUID PRIMARY KEY NOT NULL,
-			slug VARCHAR (255) UNIQUE NOT NULL,
-			type TEXT NOT NULL,
-			active BOOLEAN NOT NULL,
-			version TEXT NOT NULL,
-			name TEXT,
-			tags TEXT[] NOT NULL,
-			markers TEXT[] NOT NULL,
-			created_at TEXT NOT NULL,
-			links JSONB NOT NULL,
-			requires JSONB[] NOT NULL,
-			capabilities JSONB[] NOT NULL,
-			data JSONB NOT NULL,
-			updated_at TEXT,
-			linked_at JSONB NOT NULL,
-			new_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-			new_updated_at TIMESTAMP WITH TIME ZONE
-		);
-
-		ALTER TABLE ${table} ADD IF NOT EXISTS updated_at TEXT;
-		ALTER TABLE ${table} ADD IF NOT EXISTS linked_at JSONB;
-		ALTER TABLE ${table} ADD IF NOT EXISTS new_created_at TIMESTAMP WITH TIME ZONE;
-		ALTER TABLE ${table} ADD IF NOT EXISTS new_updated_at TIMESTAMP WITH TIME ZONE;
-		`)
+	const tables = _.map(await connection.any(`
+		SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`),
+	'table_name')
+	if (!tables.includes(table)) {
+		await connection.any(`
+			CREATE TABLE IF NOT EXISTS ${table} (
+				id UUID PRIMARY KEY NOT NULL,
+				slug VARCHAR (255) UNIQUE NOT NULL,
+				type TEXT NOT NULL,
+				active BOOLEAN NOT NULL,
+				version TEXT NOT NULL,
+				name TEXT,
+				tags TEXT[] NOT NULL,
+				markers TEXT[] NOT NULL,
+				created_at TEXT NOT NULL,
+				links JSONB NOT NULL,
+				requires JSONB[] NOT NULL,
+				capabilities JSONB[] NOT NULL,
+				data JSONB NOT NULL,
+				updated_at TEXT,
+				linked_at JSONB NOT NULL,
+				new_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				new_updated_at TIMESTAMP WITH TIME ZONE)`)
+	}
 
 	if (options.noIndexes) {
 		return


### PR DESCRIPTION
Looks like `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE <XXX> ADD IF
NOT EXISTS` will take exclusive locks on the table even if they are
no-ops.

After this commit, we approximate `CREATE TABLE IF NOT EXISTS` in a
non-locking way by first fetching the list of existing tables. Of
course, this is a non-atomic operation that will prevent the lock
altogether in the best case, or will end up in the current no-op
blocking situation in the worst case.

I think its also safe to remove the `ALTER TABLE` statements below as
all the environments we care about have been already migrated, and we
need a better migration story anyways.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!