### PR TITLE
Apply permissions to all links in `permissionFilter.getQuery()`

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -286,8 +286,7 @@ exports.getQuery = async (context, backend, session, schema) => {
 	const mask = await getUserMask(context, backend, user)
 
 	// Apply permission mask to links
-	if (schema.$$links) {
-		const linkName = Object.keys(schema.$$links)[0]
+	for (const linkName in schema.$$links) {
 		if (schema.$$links[linkName]) {
 			schema.$$links[linkName] =
 				jsonSchema.merge([ mask, schema.$$links[linkName] ])


### PR DESCRIPTION
This fixes an oversight in PR #3372

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>