### PR TITLE
Links in permissions

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -290,6 +290,10 @@ exports.getQuery = async (context, backend, session, schema) => {
 		if (schema.$$links[linkName]) {
 			schema.$$links[linkName] =
 				jsonSchema.merge([ mask, schema.$$links[linkName] ])
+
+			// Recursive `$$links` not supported, so remove them because
+			// they are most likely being added by the mask
+			Reflect.deleteProperty(schema.$$links[linkName], '$$links')
 		}
 	}
 
@@ -298,5 +302,33 @@ exports.getQuery = async (context, backend, session, schema) => {
 		evalSchema(schema, {
 			user
 		})
-	])
+	], {
+		// Resolvers are custom functions called by the `merge()` function to
+		// merge specific keywords. Because the format of the `$$links`
+		// property is not a valid schema we need a resolver for that
+		resolvers: {
+			// To merge `$$links`, we want to merge link types that are defined
+			// in the query schema plus add all other unconstrained links in the
+			// query. But we don't want to add link types from the `mask` to the
+			// final query as it changes the meaning of the query itself
+			$$links: ([ maskLinks, schemaLinks ], path, mergeSchemas) => {
+				const merged = {}
+				for (const verb in schemaLinks) {
+					const maskLink = maskLinks[verb]
+					const schemaLink = schemaLinks[verb]
+					if (maskLink) {
+						// Avoid adding recursive `$$links` from permissions to
+						// queries
+						Reflect.deleteProperty(maskLink, '$$links')
+
+						merged[verb] = mergeSchemas([ maskLink, schemaLink ])
+					} else {
+						merged[verb] = schemaLink
+					}
+				}
+
+				return merged
+			}
+		}
+	})
 }


### PR DESCRIPTION
Currently, `$$links` entries in the permissions defined in role cards are not accepted. Permissions can only be specified for individual cards (i.e. I can only query session cards that have `data.actor` equal to my user id), and adding constraints that span multiple linked cards is not supported (i.e. I can only query session cards that are linked through the 'is owned by' verb to my user card).

This commit enables support for defining `$$links` in permissions.

Closes #3403

Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>
