### PR TITLE
Fix slugify helper methods

### DIFF
--- a/lib/action-library/handlers/action-create-card.js
+++ b/lib/action-library/handlers/action-create-card.js
@@ -10,6 +10,7 @@ const assert = require('../../assert')
 
 const slugify = (string) => {
 	return string
+		.trim()
 		.toLowerCase()
 		.replace(/[^a-z0-9-]/g, '-')
 		.replace(/-{1,}/g, '-')

--- a/lib/jellyscript/index.js
+++ b/lib/jellyscript/index.js
@@ -94,6 +94,8 @@ exports.evaluateObject = (schema, object) => {
 
 const slugify = (string) => {
 	return string
+		.trim()
+		.toLowerCase()
 		.replace(/[^a-z0-9-]/g, '-')
 		.replace(/-{1,}/g, '-')
 }

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -22,6 +22,8 @@ export const createPermaLink = (card) => {
 
 export const slugify = (value) => {
 	return value
+		.trim()
+		.toLowerCase()
 		.replace(/[^a-z0-9-]/g, '-')
 		.replace(/-{1,}/g, '-')
 }

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -83,6 +83,18 @@ const user = {
 	}
 }
 
+ava('.slugify replaces non text with hyphens', (test) => {
+	test.is(helpers.slugify('balena []{}#@io'), 'balena-io')
+})
+
+ava('.slugify converts text to lowercase', (test) => {
+	test.is(helpers.slugify('Balena IO'), 'balena-io')
+})
+
+ava('.slugify strips any trailing spaces', (test) => {
+	test.is(helpers.slugify('balena '), 'balena')
+})
+
 ava('.createPrefixRegExp() match underscore characters', (test) => {
 	const matchRE = helpers.createPrefixRegExp('@')
 	const match = matchRE.exec('Lorem ipsum @user_name dolor sit amet')


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3405 

_Note: I know its not ideal to have multiple `slugify` methods floating around our code base as we currently do. If I understood the rules of dependencies between all our various modules and packages I might attempt to refactor them into one place that is referenced from everywhere else. But I'm leaving that for a separate task._

**Before:**
```javascript
slugify('Balena IO') === '-alena-'
slugify('balena ') === 'balena-'
```

**After:**
```javascript
slugify('Balena IO') === 'balena-io'
slugify('balena ') === 'balena'
```