### PR TITLE
Allow schema.title on CardField component to be undefined when reading

### DIFF
--- a/lib/ui-components/CardField.jsx
+++ b/lib/ui-components/CardField.jsx
@@ -70,7 +70,7 @@ const CardField = ({
 	}
 	return (
 		<React.Fragment>
-			<Label my={3}>{schema.title || field}</Label>
+			<Label my={3}>{_.get(schema, [ 'title' ]) || field}</Label>
 
 			{_.isObject(payload[field]) ? _.map(payload[field], (item, key) => {
 				return (


### PR DESCRIPTION
PR #3389 introduced a bug on the CardField component. Visible when viewing the knowledge base low severity items on production. This fix allows the schema object title to be undefined instead of failing.

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
