### PR TITLE
core: Don't always lock "cards" at startup with SET STORAGE EXTERNAL

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -44,21 +44,21 @@ exports.setup = async (context, connection, database, options = {}) => {
 				linked_at JSONB NOT NULL,
 				new_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 				new_updated_at TIMESTAMP WITH TIME ZONE)`)
+
+		/*
+		 * Disable compression on the jsonb columns so we can access
+		 * its properties faster.
+		 * See http://erthalion.info/2017/12/21/advanced-json-benchmarks/
+		 */
+		await connection.any(`
+			ALTER TABLE ${table}
+			ALTER COLUMN data SET STORAGE EXTERNAL,
+			ALTER COLUMN links SET STORAGE EXTERNAL,
+			ALTER COLUMN linked_at SET STORAGE EXTERNAL`)
 	}
 
 	if (options.noIndexes) {
 		return
-	}
-
-	/*
-	 * Disable compression on the jsonb columns so we can access
-	 * its properties faster.
-	 * See http://erthalion.info/2017/12/21/advanced-json-benchmarks/
-	 */
-	for (const column of [ 'data', 'links', 'linked_at' ]) {
-		await connection.any(`
-			ALTER TABLE ${table} ALTER COLUMN ${column}
-			SET STORAGE EXTERNAL`)
 	}
 
 	/*


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!