### PR TITLE
front: Cache contact requests

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -14,6 +14,8 @@ const request = require('request-promise')
 const utils = require('./utils')
 const assert = require('../../assert')
 
+const LRU = require('lru-cache')
+
 /**
  * @summary All the thread types we support
  * @constant
@@ -55,6 +57,32 @@ const getThreadType = (inbox) => {
 const getConversationMirrorId = (event) => {
 	// eslint-disable-next-line no-underscore-dangle
 	return event.data.payload.conversation._links.self
+}
+
+/*
+ * Front contact cache, for rate limiting purposes.
+ */
+const FRONT_CONTACT_CACHE = new LRU(200)
+
+const getFrontContact = async (context, front, id) => {
+	const cachedContact = FRONT_CONTACT_CACHE.get(id)
+	if (cachedContact) {
+		return cachedContact
+	}
+
+	const contact = await handleRateLimit(context, () => {
+		context.log.info('Front API request', {
+			type: 'contact.get',
+			id
+		})
+
+		return front.contact.get({
+			contact_id: id
+		})
+	})
+
+	FRONT_CONTACT_CACHE.set(id, contact)
+	return contact
 }
 
 /**
@@ -163,38 +191,18 @@ const getMessageActor = async (context, front, intercom, payload) => {
 		})
 	}
 
-	let contact = await handleRateLimit(context, () => {
-		// eslint-disable-next-line no-underscore-dangle
-		const id = _.last(_.split(from._links.related.contact, '/'))
-		context.log.info('Front API request', {
-			type: 'contact.get',
-			id
-		})
-
-		return front.contact.get({
-			// eslint-disable-next-line no-underscore-dangle
-			contact_id: id
-		})
-	})
+	// eslint-disable-next-line no-underscore-dangle
+	const id = _.last(_.split(from._links.related.contact, '/'))
+	let contact = await getFrontContact(context, front, id)
 
 	if (contact.name === 'S/Community_Custom') {
 		const to = _.find(payload.recipients, {
 			role: 'to'
 		})
 
-		contact = await handleRateLimit(context, () => {
+		contact = await getFrontContact(context, front,
 			// eslint-disable-next-line no-underscore-dangle
-			const id = _.last(_.split(to._links.related.contact, '/'))
-			context.log.info('Front API request', {
-				type: 'contact.get',
-				id
-			})
-
-			return front.contact.get({
-				// eslint-disable-next-line no-underscore-dangle
-				contact_id: id
-			})
-		})
+			_.last(_.split(to._links.related.contact, '/')))
 	}
 
 	if (utils.isEmail(contact.name)) {
@@ -1317,17 +1325,8 @@ module.exports = class FrontIntegration {
 				const contactUrl = event.data.payload.conversation.recipient._links.related.contact
 
 				if (contactUrl) {
-					const contact = await handleRateLimit(this.context, () => {
-						const id = _.last(_.split(contactUrl, '/'))
-						this.context.log.info('Front API request', {
-							type: 'contact.get',
-							id
-						})
-
-						return this.front.contact.get({
-							contact_id: id
-						})
-					})
+					const id = _.last(_.split(contactUrl, '/'))
+					const contact = await getFrontContact(this.context, this.front, id)
 
 					if (contact) {
 						const intercomData = _.find(contact.handles, {
@@ -1426,19 +1425,9 @@ module.exports = class FrontIntegration {
 			})
 
 			if (target) {
-				const contact = await handleRateLimit(this.context, () => {
-					// eslint-disable-next-line no-underscore-dangle
-					const id = _.last(_.split(target._links.related.contact, '/'))
-					this.context.log.info('Front API request', {
-						type: 'contact.get',
-						id
-					})
-
-					return this.front.contact.get({
-						// eslint-disable-next-line no-underscore-dangle
-						contact_id: id
-					})
-				})
+				// eslint-disable-next-line no-underscore-dangle
+				const id = _.last(_.split(target._links.related.contact, '/'))
+				const contact = await getFrontContact(this.context, this.front, id)
 
 				if (contact && contact.name) {
 					return this.context.getActorId({


### PR DESCRIPTION
We do a lot of repetitive contact based HTTP requests that eat our rate
limits. This is not something we can find from the information we have
on Jellyfish, but we can cache it much better at the integration level.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!