### PR TITLE
Fix incorrect translate target for "merged_at" field on github pull requests

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -447,7 +447,7 @@ module.exports = class GitHubIntegration {
 				status: options.status,
 				archived: false,
 				closed_at: event.data.payload.pull_request.closed_at || null,
-				merged_at: event.data.payload.pull_request.merged || null
+				merged_at: event.data.payload.pull_request.merged_at || null
 			}, prData)
 		}
 


### PR DESCRIPTION

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
