### PR TITLE
ui-components: new re-usable LinksProvider component

### DIFF
--- a/lib/sdk/link-constraints.js
+++ b/lib/sdk/link-constraints.js
@@ -3,6 +3,18 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited.
  * Proprietary and confidential.
  */
+const _ = require('lodash')
+
+exports.supportsLink = _.memoize((cardType, linkName) => {
+	return Boolean(_.find(
+		exports.constraints,
+		// eslint-disable-next-line lodash/matches-shorthand
+		(link) => { return link.name === linkName && link.data.from === cardType.split('@')[0] }
+	))
+}, (cardType, linkName) => {
+	// Create a unique cache key from the link name and card type
+	return `${cardType}-${linkName}`
+})
 
 // TODO Use 'LINK_CONSTRAINTS' on type cards instead of hardcoding lere
 exports.constraints = [

--- a/lib/sdk/link-constraints.spec.js
+++ b/lib/sdk/link-constraints.spec.js
@@ -7,6 +7,7 @@
 const ava = require('ava')
 const _ = require('lodash')
 const {
+	supportsLink,
 	constraints
 } = require('./link-constraints')
 
@@ -23,4 +24,12 @@ ava('link constraints should all have correct inverse verbs', (test) => {
 		test.is(inverseConstraint.data.to, constraint.data.from,
 			`${constraint.slug} has incorrect "from" field or incorrect inverse verb`)
 	}
+})
+
+ava('supportsLink returns true for support-thread and the \'is owned by\' link name', (test) => {
+	test.true(supportsLink('support-thread', 'is owned by'))
+})
+
+ava('supportsLink returns false for support-issue and the \'is owned by\' link name', (test) => {
+	test.false(supportsLink('support-issue', 'is owned by'))
 })

--- a/lib/ui-components/LinksProvider.jsx
+++ b/lib/ui-components/LinksProvider.jsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import Bluebird from 'bluebird'
+import update from 'immutability-helper'
+import {
+	supportsLink
+} from '../sdk/link-constraints'
+const linksContext = React.createContext(null)
+
+// LinksProvider asynchronously fetches the requested links and stores them in React context
+// so they are available for use by child components that subscribe to the context.
+// Note: currently you can request links for multiple cards but only a single link verb is supported
+// by an instance of LinksProvider.
+
+export const LinksProvider = ({
+	sdk, cards, link, children
+}) => {
+	const [ links, setLinks ] = React.useState({})
+
+	const updateLinks = (cardId, linkVerb, newLinks) => {
+		setLinks(
+			update(links, {
+				[cardId]: (linksByCard) => {
+					return update(linksByCard || {}, {
+						[linkVerb]: (linksByVerb) => {
+							return update(linksByVerb || [], {
+								$set: newLinks
+							})
+						}
+					})
+				}
+			})
+		)
+	}
+
+	const fetchLinks = async () => {
+		const actions = _
+			.filter(cards, (card) => { return supportsLink(card.type, link) })
+			.map((card) => {
+				return sdk.card
+					.getWithLinks(card.id, link)
+					.then((cardWithLinks) => {
+						const fetchedLinks = _.get(cardWithLinks, [ 'links', link ])
+						if (fetchedLinks) {
+							updateLinks(card.id, link, fetchedLinks)
+						}
+						return true
+					})
+			})
+		await Bluebird.all(actions)
+	}
+
+	React.useEffect(() => {
+		// Reset the links and then asynchronously fetch them
+		setLinks({})
+		fetchLinks()
+	}, [ _.join(_.map(cards, 'id'), '_'), link ])
+
+	const value = {
+		links,
+		updateLinks
+	}
+	return (
+		<linksContext.Provider value={value}>{children}</linksContext.Provider>
+	)
+}
+
+const capitalizeFirst = (str) => {
+	return `${str.charAt(0).toUpperCase()}${str.slice(1)}`
+}
+
+const getSingleLinkSubscriberProps = (context, linkVerb, linkPropName, cardId) => {
+	const updateLinkPropName = `update${capitalizeFirst(linkPropName)}Cache`
+	return {
+		[linkPropName]: _.get(context, [ 'links', cardId, linkVerb, 0 ], null),
+		[updateLinkPropName]: (newLink) => {
+			return context.updateLinks(cardId, linkVerb, [ newLink ])
+		}
+	}
+}
+
+const getMultipleLinksSubscriberProps = (context, linkVerb, linksPropName, cardId) => {
+	const updateLinksPropName = `update${capitalizeFirst(linksPropName)}Cache`
+	return {
+		[linksPropName]: _.get(context, [ 'links', cardId, linkVerb ], null),
+		[updateLinksPropName]: (newLinks) => {
+			return context.updateLinks(cardId, linkVerb, newLinks)
+		}
+	}
+}
+
+// ############################################################################
+// HOCs
+// Use these React Context consumer higher order components to wrap class
+// components that use the linked cards provided by LinksProvider.
+
+export const withLink = (linkVerb, linkPropName = 'link') => {
+	return (Component) => {
+		return (props) => {
+			return (
+				<linksContext.Consumer>
+					{(context) => {
+						const linkSubscriberProps =
+							getSingleLinkSubscriberProps(context, linkVerb, linkPropName, props.card.id)
+						return <Component {...props} {...linkSubscriberProps} />
+					}}
+				</linksContext.Consumer>
+			)
+		}
+	}
+}
+
+export const withLinks = (linkVerb, linksPropName = 'links') => {
+	return (Component) => {
+		return (props) => {
+			return (
+				<linksContext.Consumer>
+					{(context) => {
+						const subscriberLinkProps =
+							getMultipleLinksSubscriberProps(context, linkVerb, linksPropName, props.card.id)
+						return <Component {...props} {...subscriberLinkProps} />
+					}}
+				</linksContext.Consumer>
+			)
+		}
+	}
+}
+
+// ############################################################################
+// Hooks
+// Use these custom hooks (that internally use the React.useContext hook) in
+// functional components that use the linked cards provided by LinksProvider.
+
+export const useLink = (linkVerb, linkPropName = 'link', cardId) => {
+	const context = React.useContext(linksContext)
+	return getSingleLinkSubscriberProps(context, linkVerb, linkPropName, cardId)
+}
+
+export const useLinks = (linkVerb, linksPropName = 'links', cardId) => {
+	const context = React.useContext(linksContext)
+	return getMultipleLinksSubscriberProps(context, linkVerb, linksPropName, cardId)
+}

--- a/lib/ui-components/LinksProvider.spec.jsx
+++ b/lib/ui-components/LinksProvider.spec.jsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import _ from 'lodash'
+import {
+	mount,
+	configure
+} from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+import {
+	LinksProvider,
+	withLink,
+	withLinks,
+	useLink,
+	useLinks
+} from './LinksProvider'
+import Adapter from 'enzyme-adapter-react-16'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+const sandbox = sinon.createSandbox()
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+const user1 = {
+	id: 'u1',
+	type: 'user@1.0.0',
+	slug: 'user-1'
+}
+
+const user2 = {
+	id: 'u2',
+	type: 'user@1.0.0',
+	slug: 'user-2'
+}
+
+const card = {
+	id: 'a1',
+	type: 'account@1.0.0'
+}
+
+const cardWithOwner = {
+	...card,
+	links: {
+		'has backup owner': [ user1 ]
+	}
+}
+
+const cardWithOwners = {
+	...card,
+	links: {
+		'has backup owner': [ user1, user2 ]
+	}
+}
+
+const TestSubscriberInner = () => {
+	return <div>Subscriber</div>
+}
+
+ava('LinksProvider can be used with withLink', async (test) => {
+	const linkPropName = 'cardOwner'
+	const linkVerb = 'has backup owner'
+	const TestSubscriber = withLink(linkVerb, linkPropName)(TestSubscriberInner)
+	const sdk = {
+		card: {
+			getWithLinks: sandbox.fake.resolves(cardWithOwner)
+		}
+	}
+
+	const provider = await mount(
+		<LinksProvider sdk={sdk} cards={[ card ]} link={linkVerb}>
+			<TestSubscriber card={card} />
+		</LinksProvider>
+	)
+
+	provider.update()
+
+	test.true(sdk.card.getWithLinks.calledOnce)
+	test.deepEqual(sdk.card.getWithLinks.getCall(0).args, [ card.id, linkVerb ])
+	const subscriber = provider.find('TestSubscriberInner')
+	test.deepEqual(subscriber.props()[linkPropName], user1)
+	test.true(_.isFunction(subscriber.props().updateCardOwnerCache))
+})
+
+ava('LinksProvider can be used with withLinks', async (test) => {
+	const linksPropName = 'cardOwners'
+	const linkVerb = 'has backup owner'
+	const TestSubscriber = withLinks(linkVerb, linksPropName)(TestSubscriberInner)
+	const sdk = {
+		card: {
+			getWithLinks: sandbox.fake.resolves(cardWithOwners)
+		}
+	}
+
+	const provider = await mount(
+		<LinksProvider sdk={sdk} cards={[ card ]} link={linkVerb}>
+			<TestSubscriber card={card} />
+		</LinksProvider>
+	)
+
+	provider.update()
+
+	test.true(sdk.card.getWithLinks.calledOnce)
+	test.deepEqual(sdk.card.getWithLinks.getCall(0).args, [ card.id, linkVerb ])
+	const subscriber = provider.find('TestSubscriberInner')
+	test.deepEqual(subscriber.props()[linksPropName], [ user1, user2 ])
+	test.true(_.isFunction(subscriber.props().updateCardOwnersCache))
+})
+
+ava('LinksProvider can be used with useLink', async (test) => {
+	const linkPropName = 'cardOwner'
+	const linkVerb = 'has backup owner'
+	const sdk = {
+		card: {
+			getWithLinks: sandbox.fake.resolves(cardWithOwner)
+		}
+	}
+
+	const subscriberSpy = sandbox.stub()
+
+	const TestHooksSubscriber = () => {
+		const context = useLink(linkVerb, linkPropName, card.id)
+		subscriberSpy(context)
+		return <div>Subscriber</div>
+	}
+
+	await mount(
+		<LinksProvider sdk={sdk} cards={[ card ]} link={linkVerb}>
+			<TestHooksSubscriber card={card} />
+		</LinksProvider>
+	)
+
+	test.true(sdk.card.getWithLinks.calledOnce)
+	test.deepEqual(sdk.card.getWithLinks.getCall(0).args, [ card.id, linkVerb ])
+
+	const context = subscriberSpy.getCall(subscriberSpy.callCount - 1).lastArg
+
+	test.deepEqual(context.cardOwner, user1)
+	test.true(_.isFunction(context.updateCardOwnerCache))
+})
+
+ava('LinksProvider can be used with useLinks', async (test) => {
+	const linksPropName = 'cardOwners'
+	const linkVerb = 'has backup owner'
+	const sdk = {
+		card: {
+			getWithLinks: sandbox.fake.resolves(cardWithOwners)
+		}
+	}
+
+	const subscriberSpy = sandbox.stub()
+
+	const TestHooksSubscriber = () => {
+		const context = useLinks(linkVerb, linksPropName, card.id)
+		subscriberSpy(context)
+		return <div>Subscriber</div>
+	}
+
+	await mount(
+		<LinksProvider sdk={sdk} cards={[ card ]} link={linkVerb}>
+			<TestHooksSubscriber card={card} />
+		</LinksProvider>
+	)
+
+	test.true(sdk.card.getWithLinks.calledOnce)
+	test.deepEqual(sdk.card.getWithLinks.getCall(0).args, [ card.id, linkVerb ])
+
+	const context = subscriberSpy.getCall(subscriberSpy.callCount - 1).lastArg
+
+	test.deepEqual(context.cardOwners, [ user1, user2 ])
+	test.true(_.isFunction(context.updateCardOwnersCache))
+})


### PR DESCRIPTION
Can be used with matching withLinks and withLink higher order components, or useLink and useLinks hooks.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

In some situations (e.g. dealing with card ownership and the guided handover flow) we need to maintain a cache of linked cards that can be accessed and updated by different child components within a certain context. This is where the generic `LinksProvider` component and its associated HOCs and hooks come in.

Example usage:

```javascript
const SomeComponent = ({ card }) => {
  const { cardOwner, updateCardOwner } = useLink('is owned by', 'cardOwner', card.id)
  return <div>...</div>
}
```

```javascript
<LinksProvider sdk={sdk} cards={[ card ]} link="is owned by">
  ...
  <SomeComponent card={card} />
</LinkProvider>
```
