### PR TITLE
ui-components: AutoCompleteCardSelect - only set state if mounted

### DIFF
--- a/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+/* eslint-disable no-underscore-dangle */
+
 import _ from 'lodash'
 import React from 'react'
 import AsyncSelect from 'react-select/async'
@@ -18,6 +20,14 @@ export default class AutoCompleteCardSelect extends React.Component {
 
 		this.getTargets = this.getTargets.bind(this)
 		this.onChange = this.onChange.bind(this)
+	}
+
+	componentDidMount () {
+		this._isMounted = true
+	}
+
+	componentWillUnmount () {
+		this._isMounted = false
 	}
 
 	componentDidUpdate (prevProps) {
@@ -71,9 +81,11 @@ export default class AutoCompleteCardSelect extends React.Component {
 			return []
 		}
 
-		this.setState({
-			results
-		})
+		if (this._isMounted) {
+			this.setState({
+				results
+			})
+		}
 
 		// Return the results in a format understood by the AsyncSelect component
 		return results.map((card) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

The asynchronous `AutoCompleteCardSelect.getTargets` method can return results and set component state after the `AutoCompleteCardSelect` component has been unmounted. Although React handles this situation safely, it does generate a warning about updating state on an unmounted component _and creates a slight memory leak_. This PR just ensures we don't try to call `setState` after the component has been unmounted.

Background reading about this issue: https://www.robinwieruch.de/react-warning-cant-call-setstate-on-an-unmounted-component