### PR TITLE
tests: Fix flaky e2e sales test

### DIFF
--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -452,6 +452,7 @@ class CreateLens extends React.Component {
 								p={3}
 								mt={3}
 								key={key}
+								data-test={`segment-card--${_.get(segment, [ 'type' ])}`}
 								title={segment.title}
 							>
 								<Segment

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -166,10 +166,12 @@ ava.serial('should let users create new opportunities and directly link existing
 	// Create new Link to Account
 	await macros.waitForThenClickSelector(page, '[data-test="link-to-account"]')
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"]')
-	await page.type('#react-select-2-input', 'test')
-	await page.waitForSelector('#react-select-2-option-0')
+	await page.type('.jellyfish-async-select__input input', 'test')
+	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
 	await page.keyboard.press('Enter')
 	await page.click('[data-test="card-linker--existing__submit"]')
+
+	await page.waitForSelector('[data-test="segment-card--account"] [data-test-component="card-chat-summary"]')
 
 	// Submit CreateLens
 	await macros.waitForThenClickSelector(page, '[data-test="card-creator__submit"]')


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

An attempt to fix a flaky sales test. This change does two things:

1. Uses the more generic class-based (as opposed to ID-based) CSS selectors for manipulating the `Async` select element via puppeteer.
2. Waits for the added Account to show up in the CreateLens UI before proceeding with submitting the form
