### PR TITLE
Update Opportunity card data fields

### DIFF
--- a/apps/server/default-cards/contrib/opportunity.json
+++ b/apps/server/default-cards/contrib/opportunity.json
@@ -31,20 +31,27 @@
               ]
             },
             "dueDate": {
-              "title": "Due date",
+              "title": "Expected close date",
               "type": "string",
               "format": "date"
             },
-            "value": {
-              "title": "Value",
+            "recurringValue": {
+              "title": "Estimated recurring value",
               "type": "number",
               "format": "currency",
               "minimum": 0
             },
-            "arr": {
-              "title": "Estimated ARR",
+            "nonRecurringValue": {
+              "title": "Estimated non-recurring value",
               "type": "number",
               "format": "currency",
+              "minimum": 0
+            },
+            "totalValue": {
+              "title": "Total value",
+              "type": "number",
+              "format": "currency",
+              "$$formula": "SUM([this.data.recurringValue, this.data.nonRecurringValue])",
               "minimum": 0
             },
             "device": {
@@ -53,11 +60,13 @@
             },
             "usecase": {
               "title": "Use case(s)",
-              "type": "string"
+              "type": "string",
+              "format": "markdown"
             },
             "stack": {
               "title": "Tech stack",
-              "type": "string"
+              "type": "string",
+              "format": "markdown"
             }
           },
           "required": [

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -307,6 +307,7 @@ class CreateLens extends React.Component {
 		const schema = _.omit(selectedTypeTarget.data.schema, [
 			'properties.data.properties.participants',
 			'properties.data.properties.mentionsUser',
+			'properties.data.properties.totalValue',
 			'properties.data.properties.alertsUser'
 		])
 		const uiSchema = _.get(schema, [ 'properties', 'name' ])

--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -53,6 +53,7 @@ class EditLens extends React.Component {
 			'properties.data.properties.participants',
 			'properties.data.properties.mentionsUser',
 			'properties.data.properties.alertsUser',
+			'properties.data.properties.totalValue',
 
 			// Omit user password object
 			// TODO: replace this with dynamic comparison against user permissions


### PR DESCRIPTION
Depends-on: #3458 
Fixes: #3428
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

This PR updates the opportunities type card based on feedback from the sales team.
- `due date` renamed to `expected close date`
 - `Estimated ARR` renamed to `Expected recurring value`
- `Value` renamed to `Expected non-recurring value`
- Computed `Total value` based on the sum of `Expected recurring value` and `Expected non-recurring value`
- `Techstack` and `use-cases` type should be markdown

<img width="683" alt="Screenshot 2020-04-03 at 11 48 32" src="https://user-images.githubusercontent.com/11800807/78347977-8e8cd480-75a1-11ea-8712-8adf31626ab0.png">
