### PR TITLE
Fixes request-password-reset and complete-password-reset

### DIFF
--- a/lib/action-library/handlers/action-complete-password-reset.js
+++ b/lib/action-library/handlers/action-complete-password-reset.js
@@ -5,7 +5,6 @@
  */
 
 const bcrypt = require('bcrypt')
-const _ = require('lodash')
 const assert = require('../../assert')
 
 const {
@@ -111,7 +110,7 @@ const handler = async (session, context, card, request) => {
 		actor: request.actor,
 		originator: request.originator,
 		attachEvents: false
-	}, _.omit(card, [ 'type' ]), [
+	}, user, [
 		{
 			op: 'replace',
 			path: '/data/hash',

--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -182,7 +182,7 @@ const sendEmail = async ({
 	user,
 	resetToken
 }) => {
-	const resetPasswordUrl = `https://jel.ly.fish/reset_password/${resetToken}`
+	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${resetToken}`
 
 	const request = {
 		arguments: {
@@ -198,7 +198,7 @@ const sendEmail = async ({
 
 const handler = async (session, context, card, request) => {
 	const user = await getUserByEmail({
-		session,
+		session: context.privilegedSession,
 		query: context.query,
 		userEmail: request.arguments.email
 	})

--- a/test/integration/worker/actions/request-password-reset.spec.js
+++ b/test/integration/worker/actions/request-password-reset.spec.js
@@ -189,7 +189,7 @@ ava('should send a password-reset email when the email in the argument matches a
 		limit: 1
 	})
 
-	const resetPasswordUrl = `https://jel.ly.fish/reset_password/${passwordReset.data.resetToken}`
+	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${passwordReset.data.resetToken}`
 
 	const expectedEmailBody = `<p>Hello,</p><p>We have received a password reset request for the Jellyfish account attached to this email.</p><p>Please use the link below to reset your password:</p><a href="${resetPasswordUrl}">${resetPasswordUrl}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`
 


### PR DESCRIPTION
Several problems found with the reset process:

- We were trying to get the user by email with the guest session which meant we could not see the hash on the user
- We had the password_reset url around the wrong way
- We were passing the wrong card to the patch