### PR TITLE
Use plain subqueries instead of CTEs when querying for links

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -215,12 +215,14 @@ const generateQuery = (table, schema, options) => {
 	}
 
 	// We cannot enforce link existence without using a join, and we don't want to use it
-	// So we wrap the query with a WITH and filter on the length of the resulting linked cards array
+	// So we wrap the query with a SELECT and filter on the length of the resulting linked cards array
 	if (links.length > 0) {
-		query.unshift('WITH main AS (')
+		query.unshift(...[
+			'SELECT *',
+			'FROM ('
+		])
 		query.push(...[
-			')',
-			'SELECT * FROM main',
+			') AS main',
 			'WHERE'
 		])
 

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -461,7 +461,8 @@ ava('when querying cards with linked cards, we fetch links with a subquery, and 
 		}
 	}
 
-	const expected = `WITH main AS (
+	const expected = `SELECT *
+FROM (
 SELECT
 cards.id,
 cards.slug,
@@ -517,8 +518,7 @@ SELECT 1 FROM links
 WHERE links.inversename = 'has attached element' AND toId = cards.id
 )
 ORDER BY cards.created_at DESC
-)
-SELECT * FROM main
+) AS main
 WHERE
 array_length("links.has_attached_element", 1) > 0
 LIMIT 100`
@@ -574,7 +574,8 @@ ava('when querying cards without linked cards, we fetch links with a subquery, a
 		}
 	}
 
-	const expected = `WITH main AS (
+	const expected = `SELECT *
+FROM (
 SELECT
 cards.id,
 cards.slug,
@@ -630,8 +631,7 @@ SELECT 1 FROM links
 WHERE links.inversename = 'has attached element' AND toId = cards.id
 )
 ORDER BY cards.created_at DESC
-)
-SELECT * FROM main
+) AS main
 WHERE
 array_length("links.has_attached_element", 1) IS NULL
 LIMIT 100`


### PR DESCRIPTION
This should reduce DB load when running queries that contain a `$$links`
property

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

(fixing unit tests for `jsonschema2sql`)