### PR TITLE
Revert "Use plain subqueries instead of CTEs when querying for links"

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -215,14 +215,12 @@ const generateQuery = (table, schema, options) => {
 	}
 
 	// We cannot enforce link existence without using a join, and we don't want to use it
-	// So we wrap the query with a SELECT and filter on the length of the resulting linked cards array
+	// So we wrap the query with a WITH and filter on the length of the resulting linked cards array
 	if (links.length > 0) {
-		query.unshift(...[
-			'SELECT *',
-			'FROM ('
-		])
+		query.unshift('WITH main AS (')
 		query.push(...[
-			') AS main',
+			')',
+			'SELECT * FROM main',
 			'WHERE'
 		])
 

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -461,8 +461,7 @@ ava('when querying cards with linked cards, we fetch links with a subquery, and 
 		}
 	}
 
-	const expected = `SELECT *
-FROM (
+	const expected = `WITH main AS (
 SELECT
 cards.id,
 cards.slug,
@@ -518,7 +517,8 @@ SELECT 1 FROM links
 WHERE links.inversename = 'has attached element' AND toId = cards.id
 )
 ORDER BY cards.created_at DESC
-) AS main
+)
+SELECT * FROM main
 WHERE
 array_length("links.has_attached_element", 1) > 0
 LIMIT 100`
@@ -574,8 +574,7 @@ ava('when querying cards without linked cards, we fetch links with a subquery, a
 		}
 	}
 
-	const expected = `SELECT *
-FROM (
+	const expected = `WITH main AS (
 SELECT
 cards.id,
 cards.slug,
@@ -631,7 +630,8 @@ SELECT 1 FROM links
 WHERE links.inversename = 'has attached element' AND toId = cards.id
 )
 ORDER BY cards.created_at DESC
-) AS main
+)
+SELECT * FROM main
 WHERE
 array_length("links.has_attached_element", 1) IS NULL
 LIMIT 100`


### PR DESCRIPTION
This reverts commit 46ab4123d09b74522acad9a570d9198dab7ad932.

The DB is not behaving as expected