### PR TITLE
Temporarily remove server previous dump test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,8 +355,8 @@ workflows:
             - e2e_tests_server:
                 <<: *workflow_filter
 
-            - e2e_tests_server_previous_dump:
-                <<: *workflow_filter
+#            - e2e_tests_server_previous_dump:
+#                <<: *workflow_filter
 
             - sync_tests_front_mirror:
                 <<: *workflow_filter
@@ -381,7 +381,7 @@ workflows:
                 requires:
                   - unit_and_sync_tests
                   - e2e_tests_server
-                  - e2e_tests_server_previous_dump
+#                  - e2e_tests_server_previous_dump
                   - sync_tests_front_translate
                   - sync_tests_discourse_translate
                   - sync_tests_front_mirror


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Running into consistent failures for the `e2e_tests_server_previous_dump` test for all PRs on CirlceCI. The cause is that the `get_statuses()` function in `postgres-get-previous-dump.sh` is getting the following error JSON instead of expected JSON:
```
{
  "message": "Not Found",
  "documentation_url": "https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref"
}
```

This is currently blocking all PRs from being merged, and as we are no longer running previous dump tests for ui and livechat, the idea is to temporarily disable the server previous dump test and continue to debug the problem on another branch to unblock everyone.