### PR TITLE
Automatically create partial indexes based on type cards

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -6,6 +6,7 @@
 
 const _ = require('lodash')
 const Bluebird = require('bluebird')
+const pgFormat = require('pg-format')
 const logger = require('../../../logger').getLogger(__filename)
 const uuid = require('../../../uuid')
 const assert = require('../../../assert')
@@ -425,4 +426,69 @@ exports.materializeLink = async (context, errors, connection, card, options = {}
 
 		throw new errors.JellyfishDatabaseError(error.message)
 	}
+}
+
+/**
+ * @param {Object} context - Session contect
+ * @param {Object} connection - Database connection
+ * @param {String[]} fields - Fields to use as an index
+ * @param {String} type - The card type to constrain the index by
+ *
+ * @example
+ * const fields = [ 'name',	'data.from.id',	'data.to.id' ]
+ * await cards.createTypeIndex(context, connection, 'cards', fields, 'link')
+ */
+exports.createTypeIndex = async (context, connection, fields, type) => {
+	/*
+	 * This query will give us a list of all the indexes
+	 * on a particular table.
+	 */
+	const indexes = _.map(await connection.any(`SELECT * FROM pg_indexes WHERE tablename = '${CARDS_TABLE}'`), 'indexname')
+
+	/*
+	 * This is the actual name of the index that we will create
+	 * in Postgres.
+	 *
+	 * Keep in mind that if you change this, then this code will
+	 * not be able to cleanup older indexes with the older
+	 * name convention.
+	 */
+	const fullyQualifiedIndexName = `${type}__${fields.join('__').replace(/\./g, '_')}__idx`
+
+	/*
+	 * Lets not create the index if it already exists.
+	 */
+	if (indexes.includes(fullyQualifiedIndexName)) {
+		return
+	}
+
+	logger.debug(context, 'Creating cards table type index', {
+		index: fields,
+		type
+	})
+
+	const columns = []
+	for (const path of fields) {
+		// Make the assumption that if the index is dot seperated, it is a json path
+		const keys = path.split('.').map((value, arrayIndex) => {
+			// Escape input before sending it to the DB
+			return arrayIndex === 0 ? pgFormat.ident(value) : pgFormat.literal(value)
+		})
+
+		if (keys.length === 1) {
+			columns.push(keys[0])
+		} else {
+			const final = keys.pop()
+			columns.push(`(${keys.join('->')}->>${final})`)
+		}
+	}
+
+	const versionedType = type.includes('@') ? type : `${type}@1.0.0`
+
+	// Statement timeout is set to 0 to prevent large index creations from timing out
+	await connection.task(async (task) => {
+		await task.any('SET statement_timeout=0')
+		await task.any(`CREATE INDEX CONCURRENTLY "${fullyQualifiedIndexName}" ON ${CARDS_TABLE}
+		(${columns.join(',')}) WHERE type=${pgFormat.literal(versionedType)}`)
+	})
 }

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -281,6 +281,16 @@ const upsertObject = async (context, backend, object, options) => {
 		})
 	}
 
+	// If a type was inserted, any indexed fields declared on the type card should be
+	// created
+	if (baseType === 'type') {
+		if (insertedObject.data.indexed_fields) {
+			for (const fields of insertedObject.data.indexed_fields) {
+				await backend.createTypeIndex(context, fields, insertedObject.slug)
+			}
+		}
+	}
+
 	return insertedObject
 }
 
@@ -836,5 +846,12 @@ module.exports = class PostgresBackend {
 				waiting: this.streamClient.getWaitingCount()
 			}
 		}
+	}
+
+	/*
+	 * Creates a partial index on "fields" constrained by the provided "type"
+	 */
+	async createTypeIndex (context, fields, type) {
+		await cards.createTypeIndex(context, this.connection, fields, type)
 	}
 }

--- a/lib/core/cards/link.js
+++ b/lib/core/cards/link.js
@@ -80,7 +80,10 @@ module.exports = {
 				'links',
 				'data'
 			]
-		}
+		},
+		indexed_fields: [
+			[ 'data.from.id', 'name', 'data.to.id' ]
+		]
 	},
 	requires: [],
 	capabilities: []

--- a/lib/core/cards/type.js
+++ b/lib/core/cards/type.js
@@ -36,6 +36,16 @@ module.exports = {
 							items: {
 								type: 'string'
 							}
+						},
+						indexed_fields: {
+							description: 'Fields, or groups of fields that should be indexed for improved performance',
+							type: 'array',
+							items: {
+								type: 'array',
+								items: {
+									type: 'string'
+								}
+							}
 						}
 					},
 					required: [


### PR DESCRIPTION
A new `indexed_fields` field is added to type cards, this field's value
is an array of arrays of strings. Each sub-array of strings represents
columns in the database. If the column to be indexed is a jsonb column,
it is represented using a '.' delimiter.
On create or update, if a type card has an `indexed_fields` property,
partial indexes will be created for that type using the columns named.

For example, if the link type card has `indexed_fields` set to:
```
[
	[ 'data.from.id', 'name', 'data.to.id' ]
]
```
A single multi-column partial index will be created, constrained to
cards where the type is "link".

Change-type: minor
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
