### PR TITLE
Adds more warning logs to request-password-reset

### DIFF
--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -197,58 +197,76 @@ const sendEmail = async ({
 }
 
 const handler = async (session, context, card, request) => {
-	const user = await getUserByEmail({
-		session: context.privilegedSession,
-		query: context.query,
-		userEmail: request.arguments.email
-	})
-	if (
-		user &&
-		user.data &&
-		user.data.hash !== PASSWORDLESS_USER_HASH) {
-		try {
-			const typeCard = await context.getCardBySlug(context.privilegedSession, 'password-reset@1.0.0')
-			await invalidatePreviousPasswordResets({
-				context,
-				userId: user.id,
-				request,
-				typeCard
-			})
-			const passwordResetCard = await addPasswordResetCard({
-				request,
-				context,
-				user,
-				typeCard
-			})
-			await addLinkCard({
-				context,
-				session,
-				request,
-				passwordResetCard,
-				user
-			})
-			await sendEmail({
-				session,
-				context,
-				card,
-				user,
-				resetToken: passwordResetCard.data.resetToken
-			})
-		} catch (error) {
-			logger.warn(request.context, 'Failed to request password reset', {
-				id: user.id,
-				slug: user.slug,
-				type: user.type,
-				error
-			})
-		}
-	}
-	return {
+	const userEmail = request.arguments.email
+	const response = {
 		id: request.id,
 		type: request.type,
 		version: request.version,
 		slug: request.slug
 	}
+
+	const user = await getUserByEmail({
+		session: context.privilegedSession,
+		query: context.query,
+		userEmail
+	})
+
+	if (!user) {
+		logger.warn(request.context, `Could not find user with email ${userEmail}`)
+		return response
+	}
+
+	if (!user.data || !user.data.hash) {
+		logger.warn(request.context,
+			`Session does not have the correct permissions to request the hash of the user with email ${userEmail}`,
+			{
+				queryReturned: user
+			})
+		return response
+	}
+
+	if (user.data.hash === PASSWORDLESS_USER_HASH) {
+		logger.warn(request.context, `User with email ${userEmail} has no hash set`)
+		return response
+	}
+
+	try {
+		const typeCard = await context.getCardBySlug(context.privilegedSession, 'password-reset@1.0.0')
+		await invalidatePreviousPasswordResets({
+			context,
+			userId: user.id,
+			request,
+			typeCard
+		})
+		const passwordResetCard = await addPasswordResetCard({
+			request,
+			context,
+			user,
+			typeCard
+		})
+		await addLinkCard({
+			context,
+			session,
+			request,
+			passwordResetCard,
+			user
+		})
+		await sendEmail({
+			session,
+			context,
+			card,
+			user,
+			resetToken: passwordResetCard.data.resetToken
+		})
+	} catch (error) {
+		logger.warn(request.context, 'Failed to request password reset', {
+			id: user.id,
+			slug: user.slug,
+			type: user.type,
+			error
+		})
+	}
+	return response
 }
 
 module.exports = {


### PR DESCRIPTION
Currently the request-password-reset action works locally but not on production. No logs seem to be coming through which suggests that the problem is with the data returned by getUserByEmail. Sometimes permission issues means we find the user but there is no hash attached. I've added a bunch of extra internal logs to help debug this problem