### PR TITLE
Adds user to warning

### DIFF
--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -226,7 +226,7 @@ const handler = async (session, context, card, request) => {
 	}
 
 	if (user.data.hash === PASSWORDLESS_USER_HASH) {
-		logger.warn(request.context, `User with email ${userEmail} has no hash set`)
+		logger.warn(request.context, `User with email ${userEmail} has no hash set`, user)
 		return response
 	}
 


### PR DESCRIPTION
Not ideal because we probably don't want to print out the PASSWORDLESS_USER_HASH all the time (even internally and hashed). I suspect the user password will be null or undefined anyway. I'll remove this once we have figured out what's going on