### PR TITLE
Use the privilegedSession when sending an email and creating the password-reset card

### DIFF
--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -146,13 +146,12 @@ const addPasswordResetCard = async ({
 
 const addLinkCard = async ({
 	context,
-	session,
 	request,
 	passwordResetCard,
 	user
 }) => {
-	const linkTypeCard = await context.getCardBySlug(session, 'link@1.0.0')
-	await context.insertCard(session, linkTypeCard, {
+	const linkTypeCard = await context.getCardBySlug(context.privilegedSession, 'link@1.0.0')
+	await context.insertCard(context.privilegedSession, linkTypeCard, {
 		timestamp: request.timestamp,
 		actor: request.actor,
 		originator: request.originator,
@@ -176,7 +175,6 @@ const addLinkCard = async ({
 }
 
 const sendEmail = async ({
-	session,
 	context,
 	card,
 	user,
@@ -193,7 +191,7 @@ const sendEmail = async ({
 		}
 	}
 
-	return sendEmailHandler(session, context, card, request)
+	return sendEmailHandler(context.privilegedSession, context, card, request)
 }
 
 const handler = async (session, context, card, request) => {
@@ -246,13 +244,11 @@ const handler = async (session, context, card, request) => {
 		})
 		await addLinkCard({
 			context,
-			session,
 			request,
 			passwordResetCard,
 			user
 		})
 		await sendEmail({
-			session,
 			context,
 			card,
 			user,


### PR DESCRIPTION
We are not able to send an email or make the password-reset card because we are using the guest session instead of the privileged session