### PR TITLE
Prevent users from seeing the "create" cards that create users

### DIFF
--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -30,6 +30,7 @@
               "not": {
                 "enum": [
                   "action-request@1.0.0",
+                  "create@1.0.0",
                   "event@1.0.0",
                   "external-event@1.0.0",
                   "role@1.0.0",
@@ -133,6 +134,38 @@
                 "profile": {
                   "type": "object",
                   "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "User can view create cards that don't create users",
+          "additionalProperties": true,
+          "required": [ "data", "type" ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "create@1.0.0"
+            },
+            "data": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "not": {
+                        "enum": [
+                          "user@1.0.0",
+                          "user"
+                        ]
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/test/e2e/server/security.spec.js
+++ b/test/e2e/server/security.spec.js
@@ -1400,3 +1400,24 @@ ava.serial('Users should not be able to create action requests', async (test) =>
 
 	test.is(error.name, 'JellyfishSchemaMismatch')
 })
+
+ava.serial('Users should not be able to view create cards that create users', async (test) => {
+	const {
+		sdk
+	} = test.context
+
+	const user1Details = createUserDetails()
+	const user2Details = createUserDetails()
+
+	await sdk.auth.signup(user1Details)
+	await sdk.auth.signup(user2Details)
+
+	await sdk.auth.login(user1Details)
+
+	const user2 = await sdk.card.getWithTimeline(`user-${user1Details.username}`)
+	const createCard = _.find(user2.links['has attached element'], {
+		type: 'create@1.0.0'
+	})
+
+	test.falsy(createCard)
+})


### PR DESCRIPTION
If you can view the "create" card, you can also see the exposed user
hash that the user was created with.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
