### PR TITLE
Explicitly enable CTE materialization when querying for links

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -238,7 +238,7 @@ const generateQuery = (table, schema, options) => {
 	// We cannot enforce link existence without using a join, and we don't want to use it
 	// So we wrap the query with a WITH and filter on the length of the resulting linked cards array
 	if (links.length > 0) {
-		query.unshift('WITH main AS (')
+		query.unshift('WITH main AS MATERIALIZED (')
 		query.push(...[
 			')',
 			'SELECT * FROM main',

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -503,7 +503,7 @@ ava('when querying cards with linked cards, we fetch links with a subquery, and 
 		}
 	}
 
-	const expected = `WITH main AS (
+	const expected = `WITH main AS MATERIALIZED (
 SELECT
 cards.id,
 cards.slug,
@@ -616,7 +616,7 @@ ava('when querying cards without linked cards, we fetch links with a subquery, a
 		}
 	}
 
-	const expected = `WITH main AS (
+	const expected = `WITH main AS MATERIALIZED (
 SELECT
 cards.id,
 cards.slug,


### PR DESCRIPTION
In PG 12, CTEs are not optimization barriers anymore and can be trated
as unmaterialized plain SELECTs. This unfortunately leads to a bad query
plan. This PR explicitly forces the CTE to be materialized so that PG 12
doesn't pessimize the query plan.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>