### PR TITLE
github: Instantiate different Octokit clients for translate/mirror

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -156,32 +156,29 @@ const getCommentFromEvent = async (context, event, options) => {
 	]
 }
 
+const octokitOptions = {
+	request: {
+		retries: GITHUB_API_RETRY_COUNT
+	},
+	userAgent: `${packageJSON.name} v${packageJSON.version}`,
+	throttle: {
+		onRateLimit: (retryAfter, retryOptions) => {
+			return retryOptions.request.retryCount <= GITHUB_API_RETRY_COUNT
+		},
+		onAbuseLimit: (retryAfter, retryOptions) => {
+			return retryOptions.request.retryCount <= GITHUB_API_RETRY_COUNT
+		}
+	}
+}
+
 module.exports = class GitHubIntegration {
 	constructor (options) {
 		this.options = options
 		this.context = this.options.context
-		this.github = new Octokit({
-			request: {
-				retries: GITHUB_API_RETRY_COUNT
-			},
-			userAgent: `${packageJSON.name} v${packageJSON.version}`,
-			auth: this.options.token.api,
-			throttle: {
-				onRateLimit: (retryAfter, retryOptions) => {
-					return retryOptions.request.retryCount <= GITHUB_API_RETRY_COUNT
-				},
-				onAbuseLimit: (retryAfter, retryOptions) => {
-					return retryOptions.request.retryCount <= GITHUB_API_RETRY_COUNT
-				}
-			}
-		})
 	}
 
 	// eslint-disable-next-line class-methods-use-this
 	async initialize () {
-		if (!this.options.token.api) {
-			this.context.log.warn('No token set for github integration')
-		}
 		return Bluebird.resolve()
 	}
 
@@ -192,8 +189,13 @@ module.exports = class GitHubIntegration {
 
 	async mirror (card, options) {
 		if (!this.options.token.api) {
+			this.context.log.warn('No token set for github integration')
 			return []
 		}
+
+		const github = new Octokit(Object.assign({}, octokitOptions, {
+			auth: this.options.token.api
+		}))
 
 		const githubUrl = _.find(card.data.mirrors, (mirror) => {
 			return _.startsWith(mirror, 'https://github.com')
@@ -218,7 +220,7 @@ module.exports = class GitHubIntegration {
 					action: 'create'
 				})
 
-				const result = await githubRequest(this.github.issues.create, {
+				const result = await githubRequest(github.issues.create, {
 					owner,
 					repo: repository,
 					title: card.name,
@@ -250,9 +252,9 @@ module.exports = class GitHubIntegration {
 				[baseType === 'pull-request' ? 'pull_number' : 'issue_number']: entityNumber
 			}
 			const result = baseType === 'pull-request'
-				? await githubRequest(this.github.pullRequests.get,
+				? await githubRequest(github.pullRequests.get,
 					getOptions, this.options)
-				: await githubRequest(this.github.issues.get,
+				: await githubRequest(github.issues.get,
 					getOptions, this.options)
 
 			if (result.data.state !== card.data.status ||
@@ -275,7 +277,7 @@ module.exports = class GitHubIntegration {
 						action: 'update'
 					})
 
-					await githubRequest(this.github.issues.update,
+					await githubRequest(github.issues.update,
 						updateOptions, this.options)
 				}
 
@@ -285,7 +287,7 @@ module.exports = class GitHubIntegration {
 						action: 'update'
 					})
 
-					await githubRequest(this.github.pullRequests.update,
+					await githubRequest(github.pullRequests.update,
 						updateOptions, this.options)
 				}
 			}
@@ -324,7 +326,7 @@ module.exports = class GitHubIntegration {
 					action: 'createComment'
 				})
 
-				const result = await githubRequest(this.github.issues.createComment, {
+				const result = await githubRequest(github.issues.createComment, {
 					owner: repoDetails.owner,
 					repo: repoDetails.repository,
 					issue_number: _.parseInt(_.last((issueGithubUrl || issue.data.repository).split('/'))),
@@ -343,7 +345,7 @@ module.exports = class GitHubIntegration {
 			})
 
 			try {
-				const result = await githubRequest(this.github.issues.getComment, {
+				const result = await githubRequest(github.issues.getComment, {
 					owner: repoDetails.owner,
 					repo: repoDetails.repository,
 					comment_id: _.parseInt(_.last(githubUrl.split('-')))
@@ -355,7 +357,7 @@ module.exports = class GitHubIntegration {
 						action: 'updateComment'
 					})
 
-					await githubRequest(this.github.issues.updateComment, {
+					await githubRequest(github.issues.updateComment, {
 						owner: repoDetails.owner,
 						repo: repoDetails.repository,
 						comment_id: result.data.id,
@@ -426,9 +428,9 @@ module.exports = class GitHubIntegration {
 		}
 	}
 
-	async getPRFromEvent (event, options) {
+	async getPRFromEvent (github, event, options) {
 		const root = getEventRoot(event)
-		const prData = await this.generatePRDataFromEvent(event)
+		const prData = await this.generatePRDataFromEvent(github, event)
 		const type = 'pull-request@1.0.0'
 
 		const pr = {
@@ -458,7 +460,7 @@ module.exports = class GitHubIntegration {
 		return pr
 	}
 
-	async generatePRDataFromEvent (event) {
+	async generatePRDataFromEvent (github, event) {
 		let result = {}
 		if (event.data.payload.pull_request) {
 			result = gatherPRInfo(event.data.payload)
@@ -468,7 +470,7 @@ module.exports = class GitHubIntegration {
 				action: 'get'
 			})
 
-			const pr = await githubRequest(this.github.pullRequests.get, {
+			const pr = await githubRequest(github.pullRequests.get, {
 				owner: event.data.payload.organization.login,
 				repo: event.data.payload.repository.name,
 				issue_number: event.data.payload.issue.number
@@ -481,8 +483,9 @@ module.exports = class GitHubIntegration {
 		return result
 	}
 
-	async createPRIfNotExists (event, actor) {
-		const result = await this.createPRorIssueIfNotExists(event, actor, 'pull-request@1.0.0')
+	async createPRIfNotExists (github, event, actor) {
+		const result = await this.createPRorIssueIfNotExists(
+			github, event, actor, 'pull-request@1.0.0')
 
 		if (_.isEmpty(result)) {
 			return []
@@ -555,9 +558,9 @@ module.exports = class GitHubIntegration {
 		])
 	}
 
-	async createPRWithConnectedIssues (event, actor) {
+	async createPRWithConnectedIssues (github, event, actor) {
 		const mirrorID = getEventMirrorId(event)
-		const cards = await this.createPRIfNotExists(event, actor)
+		const cards = await this.createPRIfNotExists(github, event, actor)
 		if (_.isEmpty(cards)) {
 			return []
 		}
@@ -606,24 +609,24 @@ module.exports = class GitHubIntegration {
 		return cards
 	}
 
-	async closePR (event, actor) {
-		return this.closePRorIssue(event, actor, 'pull-request@1.0.0')
+	async closePR (github, event, actor) {
+		return this.closePRorIssue(github, event, actor, 'pull-request@1.0.0')
 	}
 
-	async labelEventPR (event, actor, action) {
-		return this.labelPRorIssue(event, actor, action, 'pull-request@1.0.0')
+	async labelEventPR (github, event, actor, action) {
+		return this.labelPRorIssue(github, event, actor, action, 'pull-request@1.0.0')
 	}
 
-	async updatePR (event, actor) {
+	async updatePR (github, event, actor) {
 		const mirrorID = getEventMirrorId(event)
 		const existingPR = await this.getCardByMirrorId(mirrorID, 'pull-request@1.0.0')
 		const root = getEventRoot(event)
 
 		if (_.isEmpty(existingPR)) {
-			return this.createPRIfNotExists(event, actor)
+			return this.createPRIfNotExists(github, event, actor)
 		}
 
-		const pr = await this.getCardFromEvent(event, {
+		const pr = await this.getCardFromEvent(github, event, {
 			status: 'open'
 		})
 
@@ -660,21 +663,21 @@ module.exports = class GitHubIntegration {
 		return issue
 	}
 
-	async createIssueIfNotExists (event, actor) {
-		return this.createPRorIssueIfNotExists(event, actor, 'issue@1.0.0')
+	async createIssueIfNotExists (github, event, actor) {
+		return this.createPRorIssueIfNotExists(github, event, actor, 'issue@1.0.0')
 	}
 
-	async closeIssue (event, actor) {
-		return this.closePRorIssue(event, actor, 'issue@1.0.0')
+	async closeIssue (github, event, actor) {
+		return this.closePRorIssue(github, event, actor, 'issue@1.0.0')
 	}
 
-	async updateIssue (event, actor, action) {
+	async updateIssue (github, event, actor, action) {
 		const issueMirrorId = getEventMirrorId(event)
 		const issue = await this.getCardByMirrorId(issueMirrorId, 'issue@1.0.0')
 		const root = getEventRoot(event)
 
 		if (issue) {
-			const issueCard = await this.getCardFromEvent(event, {
+			const issueCard = await this.getCardFromEvent(github, event, {
 				id: issue.id,
 				status: 'open'
 			})
@@ -682,7 +685,7 @@ module.exports = class GitHubIntegration {
 			return [ makeCard(issueCard, actor, root.updated_at) ]
 		}
 
-		const issueCard = await this.getCardFromEvent(revertEventChanges(event, 'issue'), {
+		const issueCard = await this.getCardFromEvent(github, revertEventChanges(event, 'issue'), {
 			status: 'open'
 		})
 
@@ -693,7 +696,7 @@ module.exports = class GitHubIntegration {
 				? root.closed_at
 				: new Date(root.updated_at) - 1
 
-			const closedCard = await this.getCardFromEvent(revertEventChanges(event, 'issue'), {
+			const closedCard = await this.getCardFromEvent(github, revertEventChanges(event, 'issue'), {
 				status: 'closed',
 				id: {
 					$eval: 'cards[0].id'
@@ -703,7 +706,7 @@ module.exports = class GitHubIntegration {
 			sequence.push(makeCard(closedCard, actor, time))
 		}
 
-		const openCard = await this.getCardFromEvent(event, {
+		const openCard = await this.getCardFromEvent(github, event, {
 			status: 'open',
 			id: {
 				$eval: 'cards[0].id'
@@ -713,11 +716,11 @@ module.exports = class GitHubIntegration {
 		return sequence.concat([ makeCard(openCard, actor, root.updated_at) ])
 	}
 
-	async labelEventIssue (event, actor, action) {
-		return this.labelPRorIssue(event, actor, action, 'issue@1.0.0')
+	async labelEventIssue (github, event, actor, action) {
+		return this.labelPRorIssue(github, event, actor, action, 'issue@1.0.0')
 	}
 
-	async createIssueComment (event, actor) {
+	async createIssueComment (github, event, actor) {
 		const issueMirrorId = getEventMirrorId(event)
 		const type = eventToCardType(event)
 
@@ -740,7 +743,7 @@ module.exports = class GitHubIntegration {
 		}
 
 		// PR comments are treated as issue comments by github
-		const openCard = await this.getCardFromEvent(event, {
+		const openCard = await this.getCardFromEvent(github, event, {
 			status: 'open'
 		})
 
@@ -756,7 +759,7 @@ module.exports = class GitHubIntegration {
 			sequence.push(makeCard(closedCard, actor, root.closed_at))
 		}
 
-		const upserts = sequence.concat(await this.getCommentsFromIssue(this.context, event, {
+		const upserts = sequence.concat(await this.getCommentsFromIssue(github, this.context, event, {
 			$eval: 'cards[0].id'
 		}, [ getCommentMirrorIdFromEvent(event) ], {
 			actor
@@ -774,7 +777,7 @@ module.exports = class GitHubIntegration {
 		}))
 	}
 
-	async editIssueComment (event, actor) {
+	async editIssueComment (github, event, actor) {
 		const updateTime = event.data.payload.comment.updated_at
 
 		const changes = {
@@ -800,7 +803,7 @@ module.exports = class GitHubIntegration {
 		const sequence = []
 
 		if (!issue) {
-			const openCard = await this.getCardFromEvent(event, {
+			const openCard = await this.getCardFromEvent(github, event, {
 				status: 'open'
 			})
 
@@ -812,7 +815,7 @@ module.exports = class GitHubIntegration {
 		}
 
 		const result = await this.getCommentsFromIssue(
-			this.context, event, target, [], {
+			github, this.context, event, target, [], {
 				actor
 			})
 
@@ -916,7 +919,7 @@ module.exports = class GitHubIntegration {
 		])
 	}
 
-	async closePRorIssue (event, actor, type) {
+	async closePRorIssue (github, event, actor, type) {
 		const issueMirrorId = getEventMirrorId(event)
 		const issue = await this.getCardByMirrorId(issueMirrorId, type)
 		const root = getEventRoot(event)
@@ -931,11 +934,11 @@ module.exports = class GitHubIntegration {
 			return [ makeCard(issue, actor, root.closed_at) ]
 		}
 
-		const prOpened = await this.getCardFromEvent(event, {
+		const prOpened = await this.getCardFromEvent(github, event, {
 			status: 'open'
 		})
 
-		const prClosed = await this.getCardFromEvent(event, {
+		const prClosed = await this.getCardFromEvent(github, event, {
 			status: 'closed',
 			id: {
 				$eval: 'cards[0].id'
@@ -943,14 +946,14 @@ module.exports = class GitHubIntegration {
 		})
 		return [
 			makeCard(prOpened, actor, root.created_at)
-		].concat(await this.getCommentsFromIssue(this.context, event, {
+		].concat(await this.getCommentsFromIssue(github, this.context, event, {
 			$eval: 'cards[0].id'
 		}, [], {
 			actor
 		})).concat([ makeCard(prClosed, actor, root.closed_at) ])
 	}
 
-	async createPRorIssueIfNotExists (event, actor, type) {
+	async createPRorIssueIfNotExists (github, event, actor, type) {
 		const mirrorID = getEventMirrorId(event)
 		const existingCard = await this.getCardByMirrorId(mirrorID, type)
 		const root = getEventRoot(event)
@@ -959,20 +962,20 @@ module.exports = class GitHubIntegration {
 			return []
 		}
 
-		const card = await this.getCardFromEvent(event, {
+		const card = await this.getCardFromEvent(github, event, {
 			status: 'open'
 		})
 
 		return [ makeCard(card, actor, root.created_at) ]
 	}
 
-	async labelPRorIssue (event, actor, action, type) {
+	async labelPRorIssue (github, event, actor, action, type) {
 		const issueMirrorId = getEventMirrorId(event)
 		const issue = await this.getCardByMirrorId(issueMirrorId, type)
 		const root = getEventRoot(event)
 
 		if (issue) {
-			const card = await this.getCardFromEvent(event, {
+			const card = await this.getCardFromEvent(github, event, {
 				status: root.state
 			})
 
@@ -985,7 +988,7 @@ module.exports = class GitHubIntegration {
 		}
 
 		const sequence = []
-		const card = await this.getCardFromEvent(event, {
+		const card = await this.getCardFromEvent(github, event, {
 			status: 'open'
 		})
 
@@ -1034,13 +1037,18 @@ module.exports = class GitHubIntegration {
 
 	async translate (event) {
 		if (!this.options.token.api) {
+			this.context.log.warn('No token set for github integration')
 			return []
 		}
+
+		const github = new Octokit(Object.assign({}, octokitOptions, {
+			auth: this.options.token.api
+		}))
 
 		const type = event.data.headers['X-GitHub-Event'] ||
 			event.data.headers['x-github-event']
 		const action = event.data.payload.action
-		const actor = await this.getLocalUser(event)
+		const actor = await this.getLocalUser(github, event)
 		assert.INTERNAL(null, actor, this.options.errors.SyncNoActor,
 			() => {
 				return `No actor id for ${JSON.stringify(event)}`
@@ -1050,17 +1058,17 @@ module.exports = class GitHubIntegration {
 			case 'pull_request':
 				switch (action) {
 					case 'review_requested':
-						return this.createPRIfNotExists(event, actor)
+						return this.createPRIfNotExists(github, event, actor)
 					case 'opened':
 					case 'assigned':
-						return this.createPRWithConnectedIssues(event, actor)
+						return this.createPRWithConnectedIssues(github, event, actor)
 					case 'closed':
-						return this.closePR(event, actor)
+						return this.closePR(github, event, actor)
 					case 'labeled':
 					case 'unlabeled':
-						return this.labelEventPR(event, actor, action)
+						return this.labelEventPR(github, event, actor, action)
 					case 'synchronize':
-						return this.updatePR(event, actor)
+						return this.updatePR(github, event, actor)
 					default:
 						return []
 				}
@@ -1068,15 +1076,15 @@ module.exports = class GitHubIntegration {
 				switch (action) {
 					case 'opened':
 					case 'assigned':
-						return this.createIssueIfNotExists(event, actor)
+						return this.createIssueIfNotExists(github, event, actor)
 					case 'closed':
-						return this.closeIssue(event, actor)
+						return this.closeIssue(github, event, actor)
 					case 'reopened':
 					case 'edited':
-						return this.updateIssue(event, actor, action)
+						return this.updateIssue(github, event, actor, action)
 					case 'labeled':
 					case 'unlabeled':
-						return this.labelEventIssue(event, actor, action)
+						return this.labelEventIssue(github, event, actor, action)
 					default:
 						return []
 				}
@@ -1084,7 +1092,7 @@ module.exports = class GitHubIntegration {
 			case 'pull_request_review':
 				switch (action) {
 					case 'submitted':
-						return this.createPRIfNotExists(event, actor)
+						return this.createPRIfNotExists(github, event, actor)
 					default:
 						return []
 				}
@@ -1093,7 +1101,7 @@ module.exports = class GitHubIntegration {
 				event.data.payload.comment.deleted = action === 'deleted'
 				switch (action) {
 					case 'created':
-						return this.createIssueComment(event, actor)
+						return this.createIssueComment(github, event, actor)
 					case 'deleted':
 						// Refactor a delete event to look like an edit on a
 						// "deleted" property
@@ -1105,7 +1113,7 @@ module.exports = class GitHubIntegration {
 
 						// Falls through
 					case 'edited':
-						return this.editIssueComment(event, actor)
+						return this.editIssueComment(github, event, actor)
 					default:
 						return []
 				}
@@ -1126,12 +1134,12 @@ module.exports = class GitHubIntegration {
 		return this.context.getElementByMirrorId('message@1.0.0', id)
 	}
 
-	async getCardFromEvent (event, options) {
+	async getCardFromEvent (github, event, options) {
 		switch (eventToCardType(event)) {
 			case 'issue@1.0.0':
 				return this.getIssueFromEvent(event, options)
 			case 'pull-request@1.0.0':
-				return this.getPRFromEvent(event, options)
+				return this.getPRFromEvent(github, event, options)
 			case 'repository@1.0.0':
 				return this.getRepoFromEvent(event, options)
 			default:
@@ -1139,13 +1147,13 @@ module.exports = class GitHubIntegration {
 		}
 	}
 
-	async queryComments (owner, repository, issue, page = 1) {
+	async queryComments (github, owner, repository, issue, page = 1) {
 		this.context.log.debug(GITHUB_API_REQUEST_LOG_TITLE, {
 			category: 'issues',
 			action: 'listComments'
 		})
 
-		const response = await githubRequest(this.github.issues.listComments, {
+		const response = await githubRequest(github.issues.listComments, {
 			owner,
 			repo: repository,
 			issue_number: issue,
@@ -1153,17 +1161,18 @@ module.exports = class GitHubIntegration {
 			page
 		}, this.options)
 
-		if (!this.github.hasNextPage(response)) {
+		if (!github.hasNextPage(response)) {
 			return response.data
 		}
 
-		const next = await this.queryComments(owner, repository, issue, page + 1)
+		const next = await this.queryComments(github, owner, repository, issue, page + 1)
 		return response.data.concat(next)
 	}
 
-	async getCommentsFromIssue (context, event, target, mirrorBlacklist, options) {
+	async getCommentsFromIssue (github, context, event, target, mirrorBlacklist, options) {
 		const root = getEventRoot(event)
 		const response = await this.queryComments(
+			github,
 			event.data.payload.repository.owner.login,
 			event.data.payload.repository.name,
 			root.number)
@@ -1204,8 +1213,8 @@ module.exports = class GitHubIntegration {
 		}, [])
 	}
 
-	async getLocalUser (event) {
-		const remoteUser = await githubRequest(this.github.users.getByUsername, {
+	async getLocalUser (github, event) {
+		const remoteUser = await githubRequest(github.users.getByUsername, {
 			username: event.data.payload.sender.login
 		}, this.options)
 


### PR DESCRIPTION
We can't have a single GitHub Octokit client for the whole integration
once we move to GitHub Apps.

This commit prepares the integration so that we instantiate Octokit
clients on the fly on the `.translate()` and `.mirror()` methods.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!