### PR TITLE
ui: new 'Guided Teardown Flow' for closing support threads

### DIFF
--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -63,7 +63,7 @@ const CardLayout = (props) => {
 					flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
 					justifyContent="space-between"
 					alignItems="center">
-					<Flex alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
+					<Flex flex={1} alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
 						{title}
 
 						{!title && (
@@ -78,7 +78,7 @@ const CardLayout = (props) => {
 							</div>
 						)}
 					</Flex>
-					<Flex alignSelf={[ 'flex-end', 'flex-end', 'inherit' ]}>
+					<Flex alignSelf={[ 'flex-end', 'flex-end', 'flex-start' ]}>
 						{!noActions && (
 							<CardActions card={card}>
 								{actionItems}

--- a/apps/ui/lens/full/SupportThread/TeardownFlowPanel/Steps/FinishStep.jsx
+++ b/apps/ui/lens/full/SupportThread/TeardownFlowPanel/Steps/FinishStep.jsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Flex,
+	Card,
+	List,
+	Txt,
+	Heading,
+	Box
+} from 'rendition'
+import * as helpers from '../../../../../../../lib/ui-components/services/helpers'
+
+export default function FinishStep ({
+	flowState
+}) {
+	const filteredLinks = _.filter(flowState.links, (links) => links.results && links.results.length)
+	return (
+		<Box>
+			<Txt mb={2}>Review the details below. Only close the thread when you have fully described the user&apos;s problem
+			and the solution and you have created all necessary artifacts to persist the knowledge contained in this
+			support thread.</Txt>
+			<Flex flexDirection="row">
+				<Card small flex={1} mr={2}>
+					<Heading.h5>Problem</Heading.h5>
+					<Txt>{flowState.problem}</Txt>
+					<Heading.h5 mt={2}>Solution</Heading.h5>
+					<Txt>{flowState.solution}</Txt>
+				</Card>
+				<Card small flex={1} ml={2}>
+					<Heading.h5>Support thread artifacts</Heading.h5>
+					{ _.map(filteredLinks, (links) => {
+						return (
+							<Box mt={2} key={links.label} data-test={`summary--${helpers.slugify(links.label)}`}>
+								<Txt bold>{links.label} ({links.results.length})</Txt>
+								<List>
+									{links.results.map((card) => <Txt key={card.id}>{card.name || card.slug}</Txt>)}
+								</List>
+							</Box>
+						)
+					})}
+				</Card>
+			</Flex>
+		</Box>
+	)
+}

--- a/apps/ui/lens/full/SupportThread/TeardownFlowPanel/Steps/PersistStep.jsx
+++ b/apps/ui/lens/full/SupportThread/TeardownFlowPanel/Steps/PersistStep.jsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Box,
+	Card,
+	Txt
+} from 'rendition'
+import Segment from '../../../SingleCard/Segment'
+import * as helpers from '../../../../../../../lib/ui-components/services/helpers'
+
+const cardLinks = [
+	{
+		id: 'productImprovements',
+		label: 'Product improvements',
+		segment: {
+			title: 'Product improvement',
+			link: 'is attached to',
+			type: 'product-improvement'
+		}
+	},
+	{
+		id: 'githubIssues',
+		label: 'GitHub issues',
+		segment: {
+			title: 'GitHub issue',
+			link: 'support thread is attached to issue',
+			type: 'issue'
+		}
+	},
+	{
+		id: 'supportIssues',
+		label: 'Support issues',
+		segment: {
+			title: 'Support issue',
+			link: 'support thread is attached to support issue',
+			type: 'support-issue'
+		}
+	}
+]
+
+export default function PersistStep ({
+	actions,
+	types,
+	setFlow,
+	flowState: {
+		card,
+		links
+	}
+}) {
+	const onCardsUpdated = (link, results) => {
+		setFlow({
+			links: {
+				...links || {},
+				[link.id]: {
+					label: link.label,
+					results
+				}
+			}
+		})
+	}
+	return (
+		<React.Fragment>
+			<Txt mb={2}>Create all necessary artifacts to persist the knowledge contained in this
+			support thread.
+			</Txt>
+			<Box>
+				{cardLinks.map((link) => {
+					const resultsCache = _.get(links, [ link.id, 'results' ]) || null
+					return (
+						<Card
+							key={link.id}
+							small flex={1}
+							m={1}
+							title={link.label}
+							data-test={`segment-card--${helpers.slugify(link.label)}`}
+						>
+							<Box mx={-3}>
+								<Segment
+									card={card}
+									segment={link.segment}
+									types={types}
+									actions={actions}
+									onCardsUpdated={(results) => { onCardsUpdated(link, results) }}
+									draftCards={resultsCache}
+								/>
+							</Box>
+						</Card>
+					)
+				})}
+			</Box>
+		</React.Fragment>
+	)
+}

--- a/apps/ui/lens/full/SupportThread/TeardownFlowPanel/Steps/index.js
+++ b/apps/ui/lens/full/SupportThread/TeardownFlowPanel/Steps/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as PersistStep
+} from './PersistStep'
+export {
+	default as FinishStep
+} from './FinishStep'

--- a/apps/ui/lens/full/SupportThread/TeardownFlowPanel/TeardownFlowPanel.jsx
+++ b/apps/ui/lens/full/SupportThread/TeardownFlowPanel/TeardownFlowPanel.jsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import Bluebird from 'bluebird'
+import _ from 'lodash'
+import {
+	stepStatus
+} from '../../../../../../lib/ui-components/Flows/flow-utils'
+import * as helpers from '../../../../../../lib/ui-components/services/helpers'
+import StepsFlow from '../../../../../../lib/ui-components/StepsFlow'
+import {
+	TextareaStep
+} from '../../../../../../lib/ui-components/Flows/Steps'
+import {
+	PersistStep,
+	FinishStep
+} from './Steps'
+import {
+	generateTeardownWhisper
+} from './teardown-utils'
+
+export default function TeardownFlowPanel ({
+	flowId,
+	card,
+	flowState,
+	types,
+	actions,
+	analytics,
+	sdk,
+	onClose
+}) {
+	const setFlow = (updatedFlowState) => {
+		return actions.setFlow(flowId, card.id, updatedFlowState)
+	}
+	const removeFlow = () => {
+		return actions.removeFlow(flowId, card.id)
+	}
+	const teardown = async () => {
+		const {
+			problem,
+			solution
+		} = flowState
+		const cardTypeName = helpers.getType(card.type, types).name
+
+		try {
+			const linkActions = []
+
+			const patch = helpers.patchPath(card, [ 'data', 'status' ], 'closed')
+
+			linkActions.push(sdk.card.update(card.id, card.type, patch))
+
+			// Create a whisper
+			const whisper = generateTeardownWhisper(card, cardTypeName, problem, solution)
+			linkActions.push(sdk.event.create(whisper))
+
+			await Bluebird.all(linkActions)
+
+			if (whisper) {
+				analytics.track('element.create', {
+					element: {
+						type: whisper.type
+					}
+				})
+			}
+		} catch (error) {
+			console.error('Failed to tear-down card', error)
+			actions.addNotification('danger', 'Teardown failed. Refresh the page and try again.')
+			return
+		}
+
+		onClose()
+		setTimeout(() => {
+			removeFlow()
+		}, 600)
+	}
+
+	const {
+		problem,
+		solution,
+		links
+	} = flowState
+
+	const cardTypeName = helpers.getType(card.type, types).name
+
+	const completed = {
+		problem: Boolean(problem),
+		solution: Boolean(solution),
+		persist: _.some(links, (link) => { return link.results && link.results.length })
+	}
+
+	return (
+		<StepsFlow
+			title={`Close ${cardTypeName}`}
+			titleIcon="archive"
+			action="Close thread"
+			onDone={teardown}
+			onClose={onClose}
+		>
+			<StepsFlow.Step label="Problem" title="Describe the user's problem" status={stepStatus(completed.problem)}>
+				<TextareaStep
+					placeholder="Describe the problem that the user had"
+					flowStatePropName="problem"
+					rows={6}
+					flowState={flowState}
+					setFlow={setFlow}
+				/>
+			</StepsFlow.Step>
+			<StepsFlow.Step label="Solution" title="Summarize the solution" status={stepStatus(completed.solution)}>
+				<TextareaStep
+					placeholder="Summarize the solution that solved the user's problem"
+					flowStatePropName="solution"
+					rows={6}
+					flowState={flowState}
+					setFlow={setFlow}
+				/>
+			</StepsFlow.Step>
+			<StepsFlow.Step label="Links" title="Persist the knowledge" scrollable status={stepStatus(completed.persist)}>
+				<PersistStep
+					types={types}
+					actions={actions}
+					flowState={flowState}
+					setFlow={setFlow}
+				/>
+			</StepsFlow.Step>
+			<StepsFlow.Step label="Finish!" title="Is everything in order?" scrollable status="none">
+				<FinishStep
+					flowState={flowState}
+				/>
+			</StepsFlow.Step>
+		</StepsFlow>
+	)
+}

--- a/apps/ui/lens/full/SupportThread/TeardownFlowPanel/index.js
+++ b/apps/ui/lens/full/SupportThread/TeardownFlowPanel/index.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import {
+	connect
+} from 'react-redux'
+import {
+	bindActionCreators
+} from 'redux'
+import {
+	actionCreators
+}	from '../../../../core'
+import TeardownFlowPanel from './TeardownFlowPanel'
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+	const teardownActions = bindActionCreators(
+		_.pick(actionCreators, [
+			'addChannel',
+			'createLink',
+			'getLinks'
+		]),
+		dispatch
+	)
+	return {
+		actions: Object.assign({}, ownProps.actions, teardownActions)
+	}
+}
+
+export default connect(null, mapDispatchToProps)(TeardownFlowPanel)

--- a/apps/ui/lens/full/SupportThread/TeardownFlowPanel/teardown-utils.js
+++ b/apps/ui/lens/full/SupportThread/TeardownFlowPanel/teardown-utils.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import uuid from 'uuid/v4'
+
+export const generateTeardownWhisper = (card, cardTypeName, problem, solution) => {
+	const message = `${cardTypeName} closed.\n\n**User's problem**\n>${problem}\n\n**Solution**\n>${solution}`
+	return {
+		target: card,
+		type: 'whisper',
+		slug: `whisper-${uuid()}`,
+		tags: [],
+		payload: {
+			mentionsUser: [],
+			alertsUser: [],
+			message
+		}
+	}
+}

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -28,6 +28,8 @@ import {
 	selectors,
 	sdk
 } from '../../../core'
+import TeardownFlowPanel from './TeardownFlowPanel'
+import SlideInFlowPanel from '../../../components/HOC/SlideInFlowPanel'
 import * as helpers from '../../../../../lib/ui-components/services/helpers'
 import Timeline from '../../list/Timeline'
 import CardLayout from '../../../layouts/CardLayout'
@@ -43,6 +45,9 @@ import {
 } from '../../../../../lib/ui-components/MirrorIcon'
 import ColorHashPill from '../../../../../lib/ui-components/shame/ColorHashPill'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
+import {
+	FLOW_IDS
+} from '../../../../../lib/ui-components/Flows'
 
 const JellyIcon = styled.img.attrs({
 	src: '/icons/jellyfish.svg'
@@ -93,6 +98,8 @@ class SupportThreadBase extends React.Component {
 				})
 				.catch((error) => {
 					this.props.actions.addNotification('danger', error.message || error)
+				})
+				.finally(() => {
 					this.setState({
 						isClosing: false
 					})
@@ -100,27 +107,17 @@ class SupportThreadBase extends React.Component {
 		}
 
 		this.close = () => {
-			this.setState({
-				isClosing: true
-			})
-
 			const {
-				card
+				card,
+				actions: {
+					setFlow
+				}
 			} = this.props
-
-			const patch = helpers.patchPath(card, [ 'data', 'status' ], 'closed')
-
-			sdk.card.update(card.id, card.type, patch)
-				.then(() => {
-					this.props.actions.addNotification('success', 'Closed support thread')
-					this.props.actions.removeChannel(this.props.channel)
-				})
-				.catch((error) => {
-					this.props.actions.addNotification('danger', error.message || error)
-					this.setState({
-						isClosing: false
-					})
-				})
+			const flowState = {
+				isOpen: true,
+				card
+			}
+			setFlow(FLOW_IDS.GUIDED_TEARDOWN, card.id, flowState)
 		}
 
 		this.archiveCard = () => {
@@ -307,7 +304,7 @@ class SupportThreadBase extends React.Component {
 				channel={channel}
 				title={(
 					<Flex flex={1} justifyContent="space-between">
-						<Flex flexWrap="wrap"
+						<Flex flex={1} flexWrap="wrap"
 							style={{
 								transform: 'translateY(2px)'
 							}}
@@ -349,6 +346,7 @@ class SupportThreadBase extends React.Component {
 							<Button
 								plain
 								mr={3}
+								data-test="support-thread__archive-thread"
 								tooltip={{
 									placement: 'bottom',
 									text: 'Archive this support thread'
@@ -367,6 +365,7 @@ class SupportThreadBase extends React.Component {
 							<Button
 								plain
 								mr={3}
+								data-test="support-thread__open-thread"
 								tooltip={{
 									placement: 'bottom',
 									text: 'Open this support thread'
@@ -545,6 +544,15 @@ class SupportThreadBase extends React.Component {
 						tail={_.get(this.props.card.links, [ 'has attached element' ], [])}
 					/>
 				</Box>
+				<SlideInFlowPanel
+					slideInPanelProps={{
+						height: 500
+					}}
+					card={card}
+					flowId={FLOW_IDS.GUIDED_TEARDOWN}
+				>
+					<TeardownFlowPanel/>
+				</SlideInFlowPanel>
 			</CardLayout>
 		)
 	}
@@ -566,6 +574,7 @@ const mapDispatchToProps = (dispatch) => {
 				'addChannel',
 				'getActor',
 				'getCard',
+				'setFlow',
 				'removeChannel'
 			]),
 			dispatch

--- a/lib/ui-components/Flows/flow-utils.js
+++ b/lib/ui-components/Flows/flow-utils.js
@@ -5,7 +5,8 @@
  */
 
 export const FLOW_IDS = {
-	GUIDED_HANDOVER: 'guidedHandover'
+	GUIDED_HANDOVER: 'guidedHandover',
+	GUIDED_TEARDOWN: 'guidedTeardown'
 }
 
 /**

--- a/test/e2e/ui/guided-flow-utils.js
+++ b/test/e2e/ui/guided-flow-utils.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const macros = require('./macros')
+const environment = require('../../../lib/environment')
+
+const selectors = {
+	nextBtn: '[data-test="steps-flow__next-btn"]',
+	actionBtn: '[data-test="steps-flow__action-btn"]'
+}
+
+exports.commonSelectors = selectors
+
+exports.nextStep = (page) => {
+	return macros.waitForThenClickSelector(page, `${selectors.nextBtn}:not(:disabled)`)
+}
+
+exports.action = async (page) => {
+	// Click the action button, wait for it to be disabled and then enabled again
+	await macros.waitForThenClickSelector(page, `${selectors.actionBtn}:not(:disabled)`)
+	await page.waitForSelector(`${selectors.actionBtn}[disabled]`)
+	await page.waitForSelector(selectors.actionBtn)
+}
+
+exports.createSupportThreadAndNavigate = async (page, owner = null) => {
+	const supportThread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'support-thread@1.0.0',
+			data: {
+				inbox: 'S/Paid_Support',
+				status: 'open'
+			}
+		})
+	})
+	if (owner) {
+		await page.evaluate((props) => {
+			return window.sdk.card.link(props.supportThread, props.owner, 'is owned by')
+		}, {
+			supportThread, owner
+		})
+	}
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	return supportThread
+}

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const uuid = require('uuid/v4')
+const helpers = require('./helpers')
+const macros = require('./macros')
+const guidedFlowUtils = require('./guided-flow-utils')
+
+const context = {
+	context: {
+		id: `UI-INTEGRATION-TEST-${uuid()}`,
+		problem: 'This is the problem',
+		solution: 'This is the solution'
+	}
+}
+
+const selectors = {
+	closeThreadBtn: '[data-test="support-thread__close-thread"]',
+	archiveThreadBtn: '[data-test="support-thread__archive-thread"]',
+	closedBadge: '.column--support-thread span[data-test="status-closed"]',
+	addProductImprovement: '[data-test="add-product-improvement"]',
+	linkProductImprovement: '[data-test="link-to-product-improvement"]',
+	linkedProductImprovements: '[data-test="segment-card--product-improvements"] [data-test-component="card-chat-summary"]',
+	summaryProductImprovements: '[data-test="summary--product-improvements"] ul li',
+	problemTextArea: '[data-test="gf__ta-problem"]',
+	solutionTextArea: '[data-test="gf__ta-solution"]',
+	whisper: '.event-card--whisper [data-test="event-card__message"]'
+}
+
+const user = helpers.generateUserDetails()
+
+ava.serial.before(async () => {
+	await helpers.browser.beforeEach({
+		context
+	})
+
+	// Create user and log in to the web browser client
+	const communityUser = await context.createUser(user)
+	await context.addUserToBalenaOrg(communityUser.id)
+	await macros.loginUser(context.page, user)
+
+	context.currentUser = await context.page.evaluate(() => {
+		return window.sdk.auth.whoami()
+	})
+	context.currentUserSlug = context.currentUser.slug.replace('user-', '')
+})
+
+ava.serial.after(async () => {
+	await helpers.browser.afterEach({
+		context
+	})
+})
+
+ava('You can teardown a support thread following a specific flow', async (test) => {
+	const {
+		page,
+		context: {
+			problem,
+			solution
+		}
+	} = context
+
+	const productImprovement1Name = `UI-INTEGRATION-TEST-PI-${uuid()}`
+	const productImprovement2Name = `UI-INTEGRATION-TEST-PI-${uuid()}`
+
+	// Create a product improvement that we'll link later on
+	const productImprovement1 = await page.evaluate((name) => {
+		return window.sdk.card.create({
+			type: 'product-improvement@1.0.0',
+			name,
+			data: {
+				status: 'open'
+			}
+		})
+	}, productImprovement1Name)
+
+	// Create a new support thread
+	await guidedFlowUtils.createSupportThreadAndNavigate(page)
+
+	await macros.waitForThenClickSelector(page, selectors.closeThreadBtn)
+
+	// Enter a problem
+	await page.waitForSelector(selectors.problemTextArea)
+	await page.type(selectors.problemTextArea, problem)
+
+	await guidedFlowUtils.nextStep(page)
+
+	// Enter a solution
+	await page.waitForSelector(selectors.solutionTextArea)
+	await page.type(selectors.solutionTextArea, solution)
+
+	await guidedFlowUtils.nextStep(page)
+
+	// Add a new Product Improvement
+	await macros.waitForThenClickSelector(page, selectors.addProductImprovement)
+	await page.waitForSelector('input#root_name')
+	await page.type('input#root_name', productImprovement2Name)
+	await macros.waitForThenClickSelector(page, '[data-test="card-creator__submit"]')
+
+	await page.waitForSelector(selectors.linkedProductImprovements)
+	let linkedProductImprovements = await page.$$(selectors.linkedProductImprovements)
+	test.is(linkedProductImprovements.length, 1)
+
+	// Link to an existing Product Improvement
+	await macros.waitForThenClickSelector(page, selectors.linkProductImprovement)
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"]')
+	await page.type('.jellyfish-async-select__input input', productImprovement1Name)
+	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
+	await page.keyboard.press('Enter')
+	await page.click('[data-test="card-linker--existing__submit"]')
+
+	const pi1CardChatSummary = `[data-test-component="card-chat-summary"][data-test-id="${productImprovement1.id}"]`
+	await page.waitForSelector(`[data-test="segment-card--product-improvements"] ${pi1CardChatSummary}`)
+	linkedProductImprovements = await page.$$(selectors.linkedProductImprovements)
+	test.is(linkedProductImprovements.length, 2)
+
+	await guidedFlowUtils.nextStep(page)
+
+	const listedProductImprovements = await page.$$(selectors.summaryProductImprovements)
+	test.is(listedProductImprovements.length, 2)
+
+	await guidedFlowUtils.action(page)
+
+	// Check that the thread is now closed
+	await page.waitForSelector(selectors.archiveThreadBtn)
+
+	// Check the whisper
+	const whisperText = await macros.getElementText(page, selectors.whisper)
+	test.true(whisperText.includes(problem))
+	test.true(whisperText.includes(solution))
+})


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch graham@balena.io
***

Closes #3122 

When the user clicks on the 'Close this support thread' button we now display a 'teardown' flow. This flow is contained in a slide-in-panel that slides up from the bottom. The flow consists of 4 steps:
1. Enter a summary of the user's problem
2. Enter a summary of the solution
3. Create links from the support thread to i) Product Improvements, ii) GitHub issues and iii) Support Issues. For each of these you can link to a new or existing card.
4. View the summary and close the thread.

Obviously the UI is pretty horrible on the 3rd and 4th steps (see demo gif below). However it is functional and re-uses the existing `Segment` component thus massively reducing the amount of custom code required! Having said that, I'm very open to suggestions on quick/easy ways to improve this UI. 

![TeardownFlow](https://user-images.githubusercontent.com/2925657/81153045-ba3e1880-8fac-11ea-9f41-046edd9cfd72.gif)
