### PR TITLE
ui: Small improvements in card-linking UX

### DIFF
--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -270,7 +270,7 @@ class CreateLens extends React.Component {
 		}
 
 		if (onDone.callback) {
-			onDone.callback()
+			onDone.callback(newCard)
 		}
 	}
 
@@ -461,7 +461,7 @@ class CreateLens extends React.Component {
 									types={allTypes}
 									actions={actions}
 									onSave={this.saveLink}
-									toBeLinkedCards={_.map(links[key], 'target')}
+									draftCards={_.map(links[key], 'target')}
 								/>
 							</Card>
 						)


### PR DESCRIPTION
A collection of related improvements to the functionality of the core React components used for linking cards:
- The CreateLens onDone callback now includes the created card as an argument
- LinkModal now waits until the link is created before closing. The modal action button is disabled with a spinning cog icon during this time.
- LinkModal now calls the 'onSaved' callback prop (if set) after creating the link.
- Segment now combines existing links with 'draft' (unsaved) links (rather than operating with one or the other). 
- Segment now calls the 'onCardsUpdated' callback prop (if set) whenever its list of cards is updated.
- Segment always refreshes its data when a link is created via CreateLens or LinkModal. This means the list of cards in a Segment will always be updated after a link is added.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
