### PR TITLE
ui-components: Catch errors thrown in a slide-in-panel

### DIFF
--- a/lib/ui-components/SlideInPanel.jsx
+++ b/lib/ui-components/SlideInPanel.jsx
@@ -12,6 +12,7 @@ import {
 import {
 	swallowEvent
 } from './services/helpers'
+import ErrorBoundary from './shame/ErrorBoundary'
 
 // Slide-in delay in seconds
 const DELAY = 0.6
@@ -132,7 +133,7 @@ export default function SlideIn ({
 				className={className}
 				onClick={swallowEvent}
 			>
-				{(!lazyLoadContent || isContentLoaded) && children}
+				{(!lazyLoadContent || isContentLoaded) && <ErrorBoundary>{children}</ErrorBoundary>}
 			</SlideInPanel>
 		</SlideInWrapper>
 	)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Very simple PR - just ensures that any error thrown by a child of a `SlideInPanel` is caught and the 'Error Jellyfish' is shown in the slide in panel (instead of the parent channel).