### PR TITLE
Update request password reset action and ui to take username instead of email

### DIFF
--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -894,7 +894,7 @@ export default class ActionCreator {
 	}
 
 	requestPasswordReset ({
-		email
+		username
 	}) {
 		return async (dispatch, getState) => {
 			const userType = await this.sdk.getBySlug('user@latest')
@@ -903,7 +903,7 @@ export default class ActionCreator {
 				action: 'action-request-password-reset@1.0.0',
 				type: userType.type,
 				arguments: {
-					email
+					username
 				}
 			})
 		}

--- a/lib/action-library/actions/action-request-password-reset.js
+++ b/lib/action-library/actions/action-request-password-reset.js
@@ -15,9 +15,9 @@ module.exports = {
 	active: true,
 	data: {
 		arguments: {
-			email: {
+			username: {
 				type: 'string',
-				format: 'email'
+				pattern: '[a-z0-9-]+$'
 			}
 		}
 	},

--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -16,14 +16,14 @@ const {
 const MAILGUN = environment.mail
 const ACTIONS = environment.actions
 
-const getUserByEmail = async ({
+const getUserBySlug = async ({
 	session,
 	query,
-	userEmail
+	username
 }) => {
 	const [ user ] = await query(session, {
 		type: 'object',
-		required: [ 'id', 'type', 'active', 'data' ],
+		required: [ 'id', 'data' ],
 		additionalProperties: false,
 		properties: {
 			id: {
@@ -37,23 +37,28 @@ const getUserByEmail = async ({
 				type: 'boolean',
 				const: true
 			},
+			slug: {
+				type: 'string',
+				const: `user-${username}`
+			},
 			data: {
 				type: 'object',
 				required: [ 'hash', 'email' ],
 				additionalProperties: false,
 				properties: {
+					hash: {
+						type: 'string'
+					},
 					email: {
 						anyOf: [
 							{
 								type: 'array',
 								contains: {
-									type: 'string',
-									const: userEmail
+									type: 'string'
 								}
 							},
 							{
-								type: 'string',
-								const: userEmail
+								type: 'string'
 							}
 						]
 					}
@@ -180,12 +185,17 @@ const sendEmail = async ({
 	user,
 	resetToken
 }) => {
+	let userEmail = user.data.email
+	if (Array.isArray(userEmail)) {
+		userEmail = userEmail[0]
+	}
+
 	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${resetToken}`
 
 	const request = {
 		arguments: {
 			fromAddress: `no-reply@${MAILGUN.domain}`,
-			toAddress: user.data.email,
+			toAddress: userEmail,
 			subject: 'Jellyfish Password Reset',
 			html: `<p>Hello,</p><p>We have received a password reset request for the Jellyfish account attached to this email.</p><p>Please use the link below to reset your password:</p><a href="${resetPasswordUrl}">${resetPasswordUrl}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`
 		}
@@ -195,7 +205,7 @@ const sendEmail = async ({
 }
 
 const handler = async (session, context, card, request) => {
-	const userEmail = request.arguments.email
+	const username = request.arguments.username
 	const response = {
 		id: request.id,
 		type: request.type,
@@ -203,20 +213,20 @@ const handler = async (session, context, card, request) => {
 		slug: request.slug
 	}
 
-	const user = await getUserByEmail({
+	const user = await getUserBySlug({
 		session: context.privilegedSession,
 		query: context.query,
-		userEmail
+		username
 	})
 
 	if (!user) {
-		logger.warn(request.context, `Could not find user with email ${userEmail}`)
+		logger.warn(request.context, `Could not find user with username ${username}`)
 		return response
 	}
 
 	if (!user.data || !user.data.hash) {
 		logger.warn(request.context,
-			`Session does not have the correct permissions to request the hash of the user with email ${userEmail}`,
+			`Session does not have the correct permissions to request the hash of the user with username ${username}`,
 			{
 				queryReturned: user
 			})
@@ -224,7 +234,7 @@ const handler = async (session, context, card, request) => {
 	}
 
 	if (user.data.hash === PASSWORDLESS_USER_HASH) {
-		logger.warn(request.context, `User with email ${userEmail} has no hash set`, user)
+		logger.warn(request.context, `User with username ${username} has no hash set`)
 		return response
 	}
 
@@ -255,12 +265,14 @@ const handler = async (session, context, card, request) => {
 			resetToken: passwordResetCard.data.resetToken
 		})
 	} catch (error) {
-		logger.warn(request.context, 'Failed to request password reset', {
-			id: user.id,
-			slug: user.slug,
-			type: user.type,
-			error
-		})
+		logger.warn(request.context,
+			`Failed to request password reset for user with username ${username}`,
+			{
+				id: user.id,
+				slug: user.slug,
+				type: user.type,
+				error
+			})
 	}
 	return response
 }

--- a/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
+++ b/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
@@ -26,24 +26,24 @@ export default class RequestPasswordReset extends React.Component {
 		super(props)
 
 		this.state = {
-			email: '',
+			username: '',
 			requestingPasswordReset: false
 		}
 
-		this.handleEmailChange = this.handleEmailChange.bind(this)
+		this.handleUsernameChange = this.handleUsernameChange.bind(this)
 		this.requestPasswordReset = this.requestPasswordReset.bind(this)
 	}
 
-	handleEmailChange (event) {
+	handleUsernameChange (event) {
 		this.setState({
-			email: event.target.value
+			username: event.target.value
 		})
 	}
 
 	requestPasswordReset (event) {
 		event.preventDefault()
 		const {
-			email
+			username
 		} = this.state
 
 		this.setState({
@@ -51,14 +51,14 @@ export default class RequestPasswordReset extends React.Component {
 		})
 
 		this.props.actions.requestPasswordReset({
-			email
+			username
 		})
 			.then(() => {
-				this.props.actions.addNotification('success', `Thanks! Please check ${email} for a link to reset your password`)
+				this.props.actions.addNotification('success', 'Thanks! Please check your email for a link to reset your password')
 			})
 			.catch(() => {
 				this.props.actions.addNotification('danger',
-					`Whoops! Something went wrong while trying to request a password reset for email ${email}`)
+					`Whoops! Something went wrong while trying to request a password reset for username ${username}`)
 			})
 			.finally(() => {
 				this.setState({
@@ -69,7 +69,7 @@ export default class RequestPasswordReset extends React.Component {
 
 	render () {
 		const {
-			email,
+			username,
 			requestingPasswordReset
 		} = this.state
 
@@ -77,7 +77,7 @@ export default class RequestPasswordReset extends React.Component {
 			<React.Fragment>
 				<Txt align="center" mb={4}>
 					<Heading.h2 mb={2}>Request a password reset</Heading.h2>
-					<span>Enter your email below</span>
+					<span>Enter your username below</span>
 				</Txt>
 
 				<Divider color="#eee" mb={4}/>
@@ -86,15 +86,15 @@ export default class RequestPasswordReset extends React.Component {
 					onSubmit={this.requestPasswordReset}
 					data-test="requestPasswordReset-page__form"
 				>
-					<Txt fontSize={1} mb={1}>Email</Txt>
+					<Txt fontSize={1} mb={1}>Username</Txt>
 					<Input
-						data-test="requestPasswordReset-page__email"
+						data-test="requestPasswordReset-page__username"
 						mb={5}
 						width="100%"
 						emphasized={true}
-						placeholder="Email"
-						value={email}
-						onChange={this.handleEmailChange}
+						placeholder="Username"
+						value={username}
+						onChange={this.handleUsernameChange}
 					/>
 					<Box>
 						<Button
@@ -103,7 +103,7 @@ export default class RequestPasswordReset extends React.Component {
 							primary={true}
 							emphasized={true}
 							type="submit"
-							disabled={!email || requestingPasswordReset}
+							disabled={!username || requestingPasswordReset}
 						>
 							{requestingPasswordReset ? <Icon spin name="cog"/> : 'Submit'}
 						</Button>

--- a/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.spec.jsx
+++ b/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.spec.jsx
@@ -41,7 +41,7 @@ ava.afterEach(() => {
 	sandbox.restore()
 })
 
-ava('Submit button is disabled if the email input is empty', async (test) => {
+ava('Submit button is disabled if the username input is empty', async (test) => {
 	sandbox.stub(Img)
 
 	const requestPasswordReset = mount(
@@ -51,9 +51,9 @@ ava('Submit button is disabled if the email input is empty', async (test) => {
 
 	await flushPromises()
 
-	const emailInput = requestPasswordReset.find(`input[data-test="${DATA_TEST_PREFIX}__email"]`)
+	const usernameInput = requestPasswordReset.find(`input[data-test="${DATA_TEST_PREFIX}__username"]`)
 
-	test.is(emailInput.prop('value'), '')
+	test.is(usernameInput.prop('value'), '')
 
 	const submitButton = requestPasswordReset.find(`button[data-test="${DATA_TEST_PREFIX}__submit"]`)
 
@@ -61,7 +61,7 @@ ava('Submit button is disabled if the email input is empty', async (test) => {
 })
 
 ava('Fires the requirePasswordReset action followed by a success notification when the form is submitted', async (test) => {
-	const email = 'fake@email.com'
+	const username = 'fake@username.com'
 
 	sandbox.stub(Img)
 
@@ -84,11 +84,11 @@ ava('Fires the requirePasswordReset action followed by a success notification wh
 	await flushPromises()
 	requestPasswordReset.update()
 
-	const emailInput = requestPasswordReset.find(`input[data-test="${DATA_TEST_PREFIX}__email"]`)
+	const usernameInput = requestPasswordReset.find(`input[data-test="${DATA_TEST_PREFIX}__username"]`)
 
-	emailInput.simulate('change', {
+	usernameInput.simulate('change', {
 		target: {
-			name: 'email', value: email
+			name: 'username', value: username
 		}
 	})
 
@@ -102,11 +102,11 @@ ava('Fires the requirePasswordReset action followed by a success notification wh
 
 	test.is(requestPasswordResetAction.callCount, 1)
 	test.is(addNotification.callCount, 1)
-	test.deepEqual(addNotification.args, [ [ 'success', `Thanks! Please check ${email} for a link to reset your password` ] ])
+	test.deepEqual(addNotification.args, [ [ 'success', 'Thanks! Please check your email for a link to reset your password' ] ])
 })
 
 ava('Sends a danger notification if the action throws an error', async (test) => {
-	const email = 'fake@email.com'
+	const username = 'fake@username.com'
 
 	sandbox.stub(Img)
 
@@ -129,11 +129,11 @@ ava('Sends a danger notification if the action throws an error', async (test) =>
 	await flushPromises()
 	requestPasswordReset.update()
 
-	const emailInput = requestPasswordReset.find(`input[data-test="${DATA_TEST_PREFIX}__email"]`)
+	const usernameInput = requestPasswordReset.find(`input[data-test="${DATA_TEST_PREFIX}__username"]`)
 
-	emailInput.simulate('change', {
+	usernameInput.simulate('change', {
 		target: {
-			name: 'email', value: email
+			name: 'username', value: username
 		}
 	})
 
@@ -148,5 +148,5 @@ ava('Sends a danger notification if the action throws an error', async (test) =>
 	test.is(requestPasswordResetAction.callCount, 1)
 	test.is(addNotification.callCount, 1)
 	test.deepEqual(addNotification.args, [ [ 'danger',
-		`Whoops! Something went wrong while trying to request a password reset for email ${email}` ] ])
+		`Whoops! Something went wrong while trying to request a password reset for username ${username}` ] ])
 })

--- a/test/integration/worker/actions/complete-password-reset.spec.js
+++ b/test/integration/worker/actions/complete-password-reset.spec.js
@@ -39,6 +39,7 @@ ava.beforeEach(async (test) => {
 
 	const userEmail = 'test@test.com'
 	const userPassword = 'original-password'
+	const username = 'johndoe'
 
 	const createUserAction = await worker.pre(session, {
 		action: 'action-create-user@1.0.0',
@@ -47,8 +48,8 @@ ava.beforeEach(async (test) => {
 		type: userCard.type,
 		arguments: {
 			email: userEmail,
-			username: 'user-johndoe',
-			password: userPassword
+			password: userPassword,
+			username: `user-${username}`
 		}
 	})
 
@@ -74,6 +75,7 @@ ava.beforeEach(async (test) => {
 		processAction,
 		userEmail,
 		userPassword,
+		username,
 		userCard,
 		resetToken
 	}
@@ -88,7 +90,7 @@ ava('should replace the user password when the requestToken is valid', async (te
 		worker,
 		processAction,
 		user,
-		userEmail,
+		username,
 		resetToken,
 		userPassword: originalPassword
 	} = test.context
@@ -101,7 +103,7 @@ ava('should replace the user password when the requestToken is valid', async (te
 		card: user.id,
 		type: user.type,
 		arguments: {
-			email: userEmail
+			username
 		}
 	}
 
@@ -185,7 +187,7 @@ ava('should fail when the reset token has expired', async (test) => {
 		worker,
 		processAction,
 		user,
-		userEmail,
+		username,
 		resetToken
 	} = test.context
 
@@ -197,7 +199,7 @@ ava('should fail when the reset token has expired', async (test) => {
 		card: user.id,
 		type: user.type,
 		arguments: {
-			email: userEmail
+			username
 		}
 	}
 
@@ -277,7 +279,7 @@ ava('should fail when the reset token is not active', async (test) => {
 		worker,
 		processAction,
 		user,
-		userEmail,
+		username,
 		resetToken
 	} = test.context
 
@@ -289,7 +291,7 @@ ava('should fail when the reset token is not active', async (test) => {
 		card: user.id,
 		type: user.type,
 		arguments: {
-			email: userEmail
+			username
 		}
 	}
 
@@ -354,7 +356,7 @@ ava('should fail if the user becomes inactive between requesting and completing 
 		context,
 		processAction,
 		user,
-		userEmail,
+		username,
 		worker,
 		resetToken
 	} = test.context
@@ -365,7 +367,7 @@ ava('should fail if the user becomes inactive between requesting and completing 
 		card: user.id,
 		type: user.type,
 		arguments: {
-			email: userEmail
+			username
 		}
 	}
 
@@ -406,7 +408,7 @@ ava('should remove the password reset card', async (test) => {
 		context,
 		processAction,
 		user,
-		userEmail,
+		username,
 		worker,
 		jellyfish,
 		resetToken
@@ -418,7 +420,7 @@ ava('should remove the password reset card', async (test) => {
 		card: user.id,
 		type: user.type,
 		arguments: {
-			email: userEmail
+			username
 		}
 	}
 


### PR DESCRIPTION
We made the assumption that emails are unique to users when creating the request-password-reset functionality. Unfortunately this is not true and because of syncing there are often multiple users under our Balena emails.

This is technical debt we should probably fix but in the meantime we want people to be able to reset their passwords. So I have shifted our UI and backend to use the username instead
