### PR TITLE
ui-components: Improve styling of whisper file attachment buttons

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -586,7 +586,7 @@ export default class Event extends React.Component {
 									key={attachment.url}
 									data-attachmentslug={attachment.slug}
 									onClick={this.downloadAttachment}
-									light={card.type === 'whisper' || card.type === 'whisper@1.0.0'}
+									secondary={card.type.split('@')[0] === 'whisper'}
 									data-test="event-card__file"
 									mr={2}
 									mb={2}


### PR DESCRIPTION
These buttons now have the same styling as whisper messages.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3241

Before:
![AttachmentBefore](https://user-images.githubusercontent.com/2925657/78518314-5c21e800-77ea-11ea-99d7-e8954ae27a53.png)

After:
![AttachmentAfter](https://user-images.githubusercontent.com/2925657/78518255-2da40d00-77ea-11ea-8126-1e7505483dde.png)
