### PR TITLE
ui: Fix generation of hashtags

### DIFF
--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -261,7 +261,7 @@ export const createPrefixRegExp = (prefix) => {
  */
 export const findWordsByPrefix = (prefix, source) => {
 	const regExp = createPrefixRegExp(prefix)
-	return _.compact(source.match(regExp))
+	return _.invokeMap(_.compact(source.match(regExp)), 'trim')
 }
 
 /**

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -206,6 +206,11 @@ ava('.findWordsByPrefix() should ignore symbols with no following test', (test) 
 	test.deepEqual(helpers.findWordsByPrefix('!', source), [])
 })
 
+ava('.findWordsByPrefix() should trim leading space', (test) => {
+	const source = 'Test #tag'
+	test.deepEqual(helpers.findWordsByPrefix('#', source), [ '#tag' ])
+})
+
 ava('.getUserStatuses() returns a dictionary of statuses if status is provided in schema', (test) => {
 	const userStatuses = helpers.getUserStatuses(user)
 	const dnd = userStatuses.DoNotDisturb


### PR DESCRIPTION
This fix ensures that support threads tagged with 'discussion' automatically get added to the 'Discussions' tab of the Support Threads list.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3197

Note: This fix can lead to some threads displaying duplicate tags. For example if there was already a tag (incorrectly) saved as `#discussion` and a new messages is sent containing the text `#discussion` you'll end up with two tags: `#discussion` and `discussion`. Both will be rendered by the `Tag` component as `#discussion`. See #3486 - a separate PR will be created to prevent the display of duplicate tags.