### PR TITLE
ui: Behind the scenes improvements to the display of tags

### DIFF
--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -35,6 +35,7 @@ import CardFields from '../../../../../lib/ui-components/CardFields'
 import Event from '../../../../../lib/ui-components/Event'
 import RouterLink from '../../../../../lib/ui-components/Link'
 import {
+	TagList,
 	Tag
 } from '../../../../../lib/ui-components/Tag'
 import {
@@ -319,12 +320,10 @@ class SupportThreadBase extends React.Component {
 								mb={1}
 							/>
 
-							{Boolean(card.tags) && _.map(card.tags, (tag) => {
-								if (tag === 'status' || tag === 'summary' || tag === 'pendinguserresponse') {
-									return null
-								}
-								return <Tag key={tag} mr={2} mb={1}>{tag}</Tag>
-							})}
+							<TagList
+								tags={card.tags}
+								blacklist={[ 'status', 'summary', 'pendinguserresponse' ]}
+							/>
 						</Flex>
 
 						{status === 'open' && (

--- a/apps/ui/lens/full/Thread.jsx
+++ b/apps/ui/lens/full/Thread.jsx
@@ -18,7 +18,7 @@ import {
 } from 'rendition'
 import CardFields from '../../../../lib/ui-components/CardFields'
 import {
-	Tag
+	TagList
 } from '../../../../lib/ui-components/Tag'
 import {
 	selectors
@@ -57,13 +57,10 @@ class Thread extends React.Component {
 				)}
 			>
 				<Box px={3} pb={0}>
-					{Boolean(card.tags) && card.tags.length > 0 && (
-						<Box mb={1}>
-							{_.map(card.tags, (tag) => {
-								return <Tag mr={1}>#{tag}</Tag>
-							})}
-						</Box>
-					)}
+					<TagList
+						tags={card.tags}
+						mb={1}
+					/>
 
 					<CardFields
 						card={card}

--- a/apps/ui/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lens/snippet/SingleCard/SingleCard.jsx
@@ -17,7 +17,7 @@ import {
 import CardFields from '../../../../../lib/ui-components/CardFields'
 import Link from '../../../../../lib/ui-components/Link'
 import {
-	Tag
+	TagList
 } from '../../../../../lib/ui-components/Tag'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
 
@@ -58,13 +58,10 @@ export default class SingleCard extends React.Component {
 					)}
 				</Flex>
 
-				{Boolean(card.tags) && card.tags.length > 0 && (
-					<Box mb={1}>
-						{_.map(card.tags, (tag) => {
-							return <Tag key={tag} mr={1}>#{tag}</Tag>
-						})}
-					</Box>
-				)}
+				<TagList
+					tags={card.tags}
+					mb={1}
+				/>
 
 				<CardFields
 					card={card}

--- a/apps/ui/lens/snippet/Specification/Specification.jsx
+++ b/apps/ui/lens/snippet/Specification/Specification.jsx
@@ -15,7 +15,7 @@ import {
 } from 'rendition/dist/extra/Markdown'
 import Link from '../../../../../lib/ui-components/Link'
 import {
-	Tag
+	TagList
 } from '../../../../../lib/ui-components/Tag'
 
 export default function SingleCard (props) {
@@ -33,13 +33,10 @@ export default function SingleCard (props) {
 				</Link>
 			</Txt>
 
-			{Boolean(card.tags) && card.tags.length > 0 && (
-				<Box mb={1}>
-					{_.map(card.tags, (tag) => {
-						return <Tag key={tag} mr={1}>#{tag}</Tag>
-					})}
-				</Box>
-			)}
+			<TagList
+				tags={card.tags}
+				mb={1}
+			/>
 
 			<Markdown>{blurb}</Markdown>
 		</Box>

--- a/lib/ui-components/CardChatSummary/index.jsx
+++ b/lib/ui-components/CardChatSummary/index.jsx
@@ -25,7 +25,7 @@ import * as helpers from '../services/helpers'
 import ColorHashPill from '../shame/ColorHashPill'
 import Icon from '../shame/Icon'
 import {
-	Tag
+	TagList
 } from '../Tag'
 
 const SummaryWrapper = styled(Link) `
@@ -135,27 +135,17 @@ export class CardChatSummary extends React.Component {
 					<Flex alignItems="flex-start">
 						<ColorHashPill value={_.get(card, [ 'data', 'inbox' ])} mr={2} />
 						<ColorHashPill value={_.get(card, [ 'data', 'status' ])} mr={2} />
-						{Boolean(card.tags) && _.map(card.tags, (tag) => {
-							if (
-								tag === 'status' ||
-								tag === 'summary' ||
-								tag.includes('pending')
-							) {
-								return null
-							}
-							return (
-								<Tag
-									key={tag}
-									mr={2}
-									style={{
-										lineHeight: 1.5,
-										fontSize: 10,
-										letterSpacing: 0.5
-									}}>
-									{tag}
-								</Tag>
-							)
-						})}
+						<TagList
+							tags={card.tags.filter((tag) => { return !tag.includes('pending') })}
+							blacklist={[ 'status', 'summary' ]}
+							tagProps={{
+								style: {
+									lineHeight: 1.5,
+									fontSize: 10,
+									letterSpacing: 0.5
+								}
+							}}
+						/>
 					</Flex>
 
 					<Txt color="text.light" fontSize={12}>

--- a/lib/ui-components/Tag/Tag.jsx
+++ b/lib/ui-components/Tag/Tag.jsx
@@ -31,12 +31,12 @@ const StyledTag = styled(Txt.span) `
 	${tagStyle}
 `
 
-const TAG_SYMBOL = '#'
+export const TAG_SYMBOL = '#'
 
-export const Tag = ({
+export default function Tag ({
 	children,
 	...rest
-}) => {
+}) {
 	let content = children
 
 	if (content && typeof content === 'string' && !content.startsWith(TAG_SYMBOL)) {

--- a/lib/ui-components/Tag/TagList.jsx
+++ b/lib/ui-components/Tag/TagList.jsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Flex
+} from 'rendition'
+import Tag, {
+	TAG_SYMBOL
+} from './Tag'
+
+const hashTagRegExp = new RegExp(`^${TAG_SYMBOL}`)
+
+export default function TagList ({
+	tags, blacklist, tagProps, ...restProps
+}) {
+	if (!tags || !tags.length) {
+		return null
+	}
+	const trimmmedTags = _.invokeMap(tags || [], 'replace', hashTagRegExp, '')
+	const filteredTags = _.without(trimmmedTags, ...(blacklist || []))
+	const uniqueTags = _.uniq(filteredTags)
+	if (!uniqueTags.length) {
+		return null
+	}
+	return (
+		<Flex alignItems="center" flexWrap="wrap" {...restProps}>
+			{uniqueTags.map((tag) => { return <Tag mr={2} mb={1} key={tag} {...tagProps}>{tag}</Tag> })}
+		</Flex>
+	)
+}

--- a/lib/ui-components/Tag/index.js
+++ b/lib/ui-components/Tag/index.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as Tag,
+	tagStyle
+} from './Tag'
+export {
+	default as TagList
+} from './TagList'

--- a/lib/ui-components/Tag/tests/TagList.spec.jsx
+++ b/lib/ui-components/Tag/tests/TagList.spec.jsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import {
+	shallow,
+	mount,
+	configure
+} from 'enzyme'
+import React from 'react'
+import {
+	Provider
+} from 'rendition'
+import {
+	TagList
+} from '../'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+ava('Tags are filtered if they appear in the blacklist', (test) => {
+	const tagList = shallow(<TagList tags={[ 'tag1', 'tag2' ]} blacklist={[ 'tag1' ]} />)
+	const tags = tagList.find('Tag')
+	test.is(tags.length, 1)
+
+	// Note: because this is a shallow render, the child of the Tag doesn't have the # prefix yet
+	test.is(tags.at(0).children().text(), 'tag2')
+})
+
+ava('Tags are automatically prefixed with a hashtag', (test) => {
+	const tagList = mount(
+		<TagList tags={[ '#tag1', 'tag2' ]} />,
+		{
+			wrappingComponent: Provider
+		})
+	const tags = tagList.find('Tag')
+	test.is(tags.length, 2)
+	test.is(tags.at(0).children().text(), '#tag1')
+	test.is(tags.at(1).children().text(), '#tag2')
+})
+
+ava('#tag1 and tag1 are considered the same and de-duplicated', (test) => {
+	const tagList = shallow(<TagList tags={[ 'tag1', '#tag1' ]} />)
+	const tags = tagList.find('Tag')
+	test.is(tags.length, 1)
+})


### PR DESCRIPTION
Added a new `TagList` component that ensures consistent handling of a list of tags. Main functional difference is that `#tag1` and `tag1` are now considered the same and are de-duplicated.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3486
Relates to #3485

Hopefully this just makes sure we handle lists of tags in a consistent and simplified way.

Unit tests demo the functionality of the new `TagList` component  😄 