### PR TITLE
github: Use github.pulls instead of github.pullRequests

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -288,7 +288,7 @@ module.exports = class GitHubIntegration {
 				[baseType === 'pull-request' ? 'pull_number' : 'issue_number']: entityNumber
 			}
 			const result = baseType === 'pull-request'
-				? await githubRequest(github.pullRequests.get,
+				? await githubRequest(github.pulls.get,
 					getOptions, this.options)
 				: await githubRequest(github.issues.get,
 					getOptions, this.options)
@@ -323,7 +323,7 @@ module.exports = class GitHubIntegration {
 						action: 'update'
 					})
 
-					await githubRequest(github.pullRequests.update,
+					await githubRequest(github.pulls.update,
 						updateOptions, this.options)
 				}
 			}
@@ -506,10 +506,10 @@ module.exports = class GitHubIntegration {
 				action: 'get'
 			})
 
-			const pr = await githubRequest(github.pullRequests.get, {
+			const pr = await githubRequest(github.pulls.get, {
 				owner: event.data.payload.organization.login,
 				repo: event.data.payload.repository.name,
-				issue_number: event.data.payload.issue.number
+				pull_number: event.data.payload.issue.number
 			}, this.options)
 			result = gatherPRInfo({
 				pull_request: pr.data


### PR DESCRIPTION
We recently upgraded `octokit` and production is complaining that
`github.pullRequests` doesn't exist. Sadly we don't have tests at the
moment that confirm that this part of the code works.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!