### PR TITLE
Add send-first-time-login-link and handler to action-library

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -59,6 +59,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/feedback-item.json'),
 		await loadCard('contrib/issue.json'),
 		await loadCard('contrib/message.json'),
+		await loadCard('contrib/first-time-login.json'),
 		await loadCard('contrib/opportunity.json'),
 		await loadCard('contrib/password-reset.json'),
 		await loadCard('contrib/ping.json'),

--- a/apps/server/default-cards/contrib/first-time-login.json
+++ b/apps/server/default-cards/contrib/first-time-login.json
@@ -1,0 +1,34 @@
+{
+  "slug": "first-time-login",
+  "name": "first-time login",
+  "version": "1.0.0",
+  "type": "type@1.0.0",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "requestedAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "expiresAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "firstTimeLoginToken": {
+              "type": "string",
+							"format": "uuid"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -38,7 +38,8 @@
                   "type@1.0.0",
                   "user@1.0.0",
                   "view@1.0.0",
-                  "password-reset@1.0.0"
+                  "password-reset@1.0.0",
+				  				"first-time-login@1.0.0"
                 ]
               }
             }
@@ -56,7 +57,8 @@
                   "action",
                   "event",
                   "external-event",
-                  "role"
+                  "role",
+									"first-time-login"
                 ]
               }
             },

--- a/apps/server/default-cards/contrib/role-user-operator.json
+++ b/apps/server/default-cards/contrib/role-user-operator.json
@@ -12,18 +12,34 @@
   "data": {
     "read": {
 			"type": "object",
-			"additionalProperties": true,
-			"required": [ "slug", "type", "data"],
-			"properties": {
-				"type": {
-					"type": "string",
-					"const": "view@1.0.0"
+			"anyOf":[
+				{
+					"type": "object",
+					"additionalProperties": true,
+					"required": [ "slug", "type", "data"],
+					"properties": {
+						"type": {
+							"type": "string",
+							"const": "view@1.0.0"
+						},
+						"slug": {
+							"type": "string",
+							"const": "view-all-users"
+						}
+					}
 				},
-				"slug": {
-					"type": "string",
-					"const": "view-all-users"
+				{
+					"type": "object",
+					"additionalProperties": true,
+				  "required": ["slug"],
+					"properties": {
+						"slug": {
+							"type": "string",
+							"const": "first-time-login"
+						}
+					}
 				}
-    	}
-  	}
-	}
+			]
+    }
+  }
 }

--- a/lib/action-library/actions/action-send-first-time-login-link.js
+++ b/lib/action-library/actions/action-send-first-time-login-link.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'action-send-first-time-login-link',
+	type: 'action@1.0.0',
+	version: '1.0.0',
+	name: 'Send a first-time login link to a user',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {
+		filter: {
+			type: 'object',
+			properties: {
+				type: {
+					type: 'string',
+					const: 'user@1.0.0'
+				}
+			}
+		},
+		arguments: {}
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/action-library/handlers/action-send-first-time-login-link.js
+++ b/lib/action-library/handlers/action-send-first-time-login-link.js
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const Bluebird = require('bluebird')
+const _ = require('lodash')
+const assert = require('../../assert')
+const uuid = require('../../uuid')
+const environment = require('../../environment')
+const sendEmailHandler = require('./action-send-email').handler
+
+const MAILGUN = environment.mail
+
+const queryUserOrgs = async ({
+	userId,
+	context
+}) => {
+	return context.query(context.privilegedSession, {
+		$$links: {
+			'has member': {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string',
+						const: userId
+					},
+					type: {
+						type: 'string',
+						const: 'user@1.0.0'
+					}
+				}
+			}
+		},
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'org@1.0.0'
+			},
+			links: {
+				type: 'object'
+			}
+		}
+	})
+}
+
+const invalidatePreviousFirstTimeLogins = async ({
+	context,
+	request,
+	userId,
+	typeCard
+}) => {
+	const previousFirstTimeLogins = await context.query(context.privilegedSession, {
+		type: 'object',
+		require: [ 'type', 'id' ],
+		additionalProperties: true,
+		properties: {
+			id: {
+				type: 'string'
+			},
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		},
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string',
+						const: userId
+					}
+				}
+			}
+		}
+	})
+
+	if (previousFirstTimeLogins.length > 0) {
+		await Bluebird.all(previousFirstTimeLogins.map((firstTimeLogin) => {
+			return context.patchCard(context.privilegedSession, typeCard, {
+				timestamp: request.timestamp,
+				actor: request.actor,
+				originator: request.originator,
+				attachEvents: true
+			}, firstTimeLogin, [
+				{
+					op: 'replace',
+					path: '/active',
+					value: false
+				}
+			])
+		}))
+	}
+}
+
+const addFirstTimeLogin = async ({
+	context,
+	request,
+	typeCard
+}) => {
+	const firstTimeLoginToken = await uuid.random()
+	const requestedAt = new Date()
+	const hourInFuture = requestedAt.setHours(requestedAt.getHours() + 1)
+	const expiresAt = new Date(hourInFuture)
+	return context.insertCard(context.privilegedSession, typeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: true
+	}, {
+		version: '1.0.0',
+		slug: await context.getEventSlug('first-time-login'),
+		data: {
+			expiresAt: expiresAt.toISOString(),
+			requestedAt: requestedAt.toISOString(),
+			firstTimeLoginToken
+		}
+	})
+}
+
+const addLinkCard = async ({
+	context,
+	request,
+	firstTimeLoginCard,
+	userCard
+}) => {
+	const linkTypeCard = await context.getCardBySlug(context.privilegedSession, 'link@1.0.0')
+	await context.insertCard(context.privilegedSession, linkTypeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: false
+	}, {
+		slug: await context.getEventSlug('link'),
+		type: 'link@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has requested',
+			from: {
+				id: firstTimeLoginCard.id,
+				type: firstTimeLoginCard.type
+			},
+			to: {
+				id: userCard.id,
+				type: userCard.type
+			}
+		}
+	})
+}
+
+const sendEmail = async ({
+	context,
+	card,
+	userCard,
+	firstTimeLoginToken
+}) => {
+	let userEmail = userCard.data.email
+	if (Array.isArray(userEmail)) {
+		userEmail = userEmail[0]
+	}
+
+	const firstTimeLoginUrl = `https://jel.ly.fish/first_time_login/${firstTimeLoginToken}`
+
+	const username = userCard.slug.replace(/^user-/g, '')
+
+	const request = {
+		arguments: {
+			fromAddress: `no-reply@${MAILGUN.domain}`,
+			toAddress: userEmail,
+			subject: 'Jellyfish First Time Login',
+			html: `<p>Hello,</p><p>Here is a link to login to your new Jellyfish account ${username}.</p><p>Please use the link below to set your password and login:</p><a href="${firstTimeLoginUrl}">${firstTimeLoginUrl}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`
+		}
+	}
+
+	return sendEmailHandler(context.priviledgedSession, context, card, request)
+}
+
+const checkOrgs = async ({
+	context,
+	request,
+	userCard
+}) => {
+	const requesterOrgs = await queryUserOrgs({
+		context,
+		userId: request.actor
+	})
+	assert.USER(request.context, requesterOrgs.length > 0, context.errors.WorkerNoElement,
+		'You do not belong to an organisation and thus cannot send a first-time login link to any users')
+
+	const userOrgs = await queryUserOrgs({
+		context,
+		userId: userCard.id
+	})
+	assert.USER(request.context, userOrgs.length > 0, context.errors.WorkerNoElement,
+		`User with slug ${userCard.slug} is not a member of any organisations`)
+
+	const sharedOrgs = _.intersectionBy(userOrgs, requesterOrgs, 'id')
+	assert.USER(request.context, sharedOrgs.length > 0, context.errors.WorkerAuthenticationError,
+		`User with slug ${userCard.slug} is not a member of any of your organisations`)
+}
+
+const handler = async (session, context, userCard, request) => {
+	const typeCard = await context.getCardBySlug(session, 'first-time-login@latest')
+
+	assert.USER(request.context, typeCard, context.errors.WorkerNoElement, 'No such type: first-time-login')
+
+	assert.USER(request.context, userCard.active, context.errors.WorkerNoElement, `User with slug ${userCard.slug} is not active`)
+
+	await checkOrgs({
+		request,
+		userCard,
+		context
+	})
+
+	await invalidatePreviousFirstTimeLogins({
+		context,
+		userId: userCard.id,
+		typeCard,
+		request
+	})
+	const firstTimeLoginCard = await addFirstTimeLogin({
+		request,
+		context,
+		typeCard
+	})
+	await addLinkCard({
+		context,
+		request,
+		firstTimeLoginCard,
+		userCard
+	})
+	await sendEmail({
+		context,
+		userCard,
+		firstTimeLoginToken: firstTimeLoginCard.data.firstTimeLoginToken
+	})
+	return {
+		id: userCard.id,
+		type: userCard.type,
+		version: userCard.version,
+		slug: userCard.slug
+	}
+}
+
+module.exports = {
+	handler
+}

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -140,5 +140,10 @@ module.exports = {
 		card: require('./actions/action-complete-password-reset'),
 		pre: require('./handlers/action-complete-password-reset').pre,
 		handler: require('./handlers/action-complete-password-reset').handler
+	},
+	'action-send-first-time-login-link': {
+		card: require('./actions/action-send-first-time-login-link'),
+		pre: _.noop,
+		handler: require('./handlers/action-send-first-time-login-link').handler
 	}
 }

--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -30,7 +30,8 @@ exports.beforeEach = async (test, options) => {
 		require('../../../apps/server/default-cards/contrib/role-user-community.json'))
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
 		require('../../../apps/server/default-cards/contrib/password-reset.json'))
-
+	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
+		require('../../../apps/server/default-cards/contrib/first-time-login.json'))
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session,
 		actionLibrary['action-create-card'].card)
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session,

--- a/test/integration/worker/actions/send-first-time-login-link.spec.js
+++ b/test/integration/worker/actions/send-first-time-login-link.spec.js
@@ -1,0 +1,646 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const nock = require('nock')
+const helpers = require('../helpers')
+const uuid = require('../../../../lib/uuid')
+const actionLibrary = require('../../../../lib/action-library')
+const environment = require('../../../../lib/environment')
+
+const MAILGUN = environment.mail
+
+const checkForKeyValue = (key, value, text) => {
+	const pattern = new RegExp(`name="${key}"\\s*${value}`, 'm')
+	const regex = text.search(pattern)
+	return regex !== -1
+}
+
+const createOrgLinkAction = async ({
+	fromId,
+	toId,
+	context
+}) => {
+	return {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: 'link',
+		type: 'type',
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				slug: `link-${fromId}-has-member-${toId}-${await uuid.random()}`,
+				version: '1.0.0',
+				name: 'has member',
+				data: {
+					inverseName: 'is member of',
+					to: {
+						id: toId,
+						type: 'user@1.0.0'
+					},
+					from: {
+						id: fromId,
+						type: 'org@1.0.0'
+					}
+				}
+			}
+		}
+	}
+}
+
+ava.beforeEach(async (test) => {
+	await helpers.worker.beforeEach(test, actionLibrary)
+	const {
+		worker,
+		session,
+		context,
+		jellyfish,
+		processAction
+	} = test.context
+
+	const nockRequest = (fn) => {
+		nock(`${MAILGUN.baseUrl}/${MAILGUN.domain}`)
+			.persist()
+			.post('/messages')
+			.basicAuth({
+				user: 'api',
+				pass: MAILGUN.TOKEN
+			})
+			.reply(200, (uri, sendBody) => {
+				fn ? fn(sendBody) : null
+			})
+	}
+
+	const userCard = await jellyfish.getCardBySlug(context, session, 'user@latest')
+
+	const userEmail = 'test@test.com'
+	const username = 'johndoe'
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			username: `user-${username}`,
+			password: 'foobarbaz',
+			email: userEmail
+		}
+	})
+
+	const user = await processAction(session, createUserAction)
+
+	// Creates org
+
+	const orgCard = await jellyfish.getCardBySlug(context, session, 'org@latest')
+
+	const org = await processAction(session, {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: orgCard.id,
+		type: orgCard.type,
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				name: 'foobar'
+			}
+		}
+	})
+
+	// Links user to org
+
+	const userOrgLinkAction = await createOrgLinkAction({
+		toId: user.data.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, userOrgLinkAction)
+
+	// Gets admin user and links org to it
+
+	const adminUser = await jellyfish.getCardBySlug(context, session, 'user-admin@1.0.0')
+
+	const adminOrgLinkAction = await createOrgLinkAction({
+		toId: adminUser.id,
+		fromId: org.data.id,
+		context
+	})
+
+	const adminOrgLink = await processAction(session, adminOrgLinkAction)
+
+	test.context = {
+		...test.context,
+		user,
+		userEmail,
+		username,
+		userCard,
+		orgCard,
+		org,
+		adminOrgLink,
+		nockRequest
+	}
+})
+
+ava.afterEach(async (test) => {
+	nock.cleanAll()
+	await helpers.worker.afterEach(test)
+})
+
+ava('should create a first-time login card and user link for a user', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		processAction,
+		user,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	const sendFirstTimeLogin = await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context: test.context.context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+	test.false(sendFirstTimeLogin.error)
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'type' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		},
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string',
+						const: user.data.id
+					}
+				}
+			}
+		}
+	}, {
+		limit: 1
+	})
+
+	test.true(firstTimeLogin !== undefined)
+	test.true(new Date(firstTimeLogin.data.expiresAt) > new Date())
+	test.is(firstTimeLogin.links['is attached to'].id, user.id)
+})
+
+ava('should send a first-time-login email to a user', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		processAction,
+		user,
+		userEmail,
+		username,
+		nockRequest
+	} = test.context
+
+	let mailBody
+	const saveBody = (body) => {
+		mailBody = body
+	}
+
+	nockRequest(saveBody)
+
+	const sendFirstTimeLoginAction = {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context: test.context.context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	}
+
+	const sendFirstTimeLogin = await processAction(session, sendFirstTimeLoginAction)
+	test.false(sendFirstTimeLogin.error)
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'type', 'data' ],
+		additionalProperties: false,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			},
+			data: {
+				type: 'object',
+				properties: {
+					firstTimeLoginToken: {
+						type: 'string'
+					}
+				}
+			}
+		}
+	}, {
+		limit: 1
+	})
+
+	const firstTimeLoginUrl = `https://jel.ly.fish/first_time_login/${firstTimeLogin.data.firstTimeLoginToken}`
+
+	const expectedEmailBody = `<p>Hello,</p><p>Here is a link to login to your new Jellyfish account ${username}.</p><p>Please use the link below to set your password and login:</p><a href="${firstTimeLoginUrl}">${firstTimeLoginUrl}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`
+
+	const fromIsInBody = checkForKeyValue('from', 'no-reply@mail.ly.fish', mailBody)
+	const toIsInBody = checkForKeyValue('to', userEmail, mailBody)
+	const subjectIsInBody = checkForKeyValue('subject', 'Jellyfish First Time Login', mailBody)
+	const htmlIsInBody = checkForKeyValue('html', expectedEmailBody, mailBody)
+
+	test.true(toIsInBody)
+	test.true(fromIsInBody)
+	test.true(subjectIsInBody)
+	test.true(htmlIsInBody)
+})
+
+ava('should throw error if the user is inactive', async (test) => {
+	const {
+		context,
+		processAction,
+		user,
+		session,
+		username,
+		nockRequest,
+		worker
+	} = test.context
+
+	nockRequest()
+
+	const requestDelete = await processAction(session, {
+		action: 'action-delete-card@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+	test.false(requestDelete.error)
+
+	const sendFirstTimeLoginAction = {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	}
+
+	await test.throwsAsync(processAction(session, sendFirstTimeLoginAction), {
+		instanceOf: worker.errors.WorkerNoElement,
+		message: `User with slug user-${username} is not active`
+	})
+})
+
+ava('should invalidate previous first-time logins', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		processAction,
+		user,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	const sendFirstTimeLoginAction = {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context: test.context.context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	}
+
+	const firstPasswordResetRequest = await processAction(session, sendFirstTimeLoginAction)
+	test.false(firstPasswordResetRequest.error)
+
+	const secondPasswordResetRequest = await processAction(session, sendFirstTimeLoginAction)
+	test.false(secondPasswordResetRequest.error)
+
+	const firstTimeLogins = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'type' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	}, {
+		sortBy: 'created_at'
+	})
+
+	test.is(firstTimeLogins.length, 2)
+	test.is(firstTimeLogins[0].active, false)
+	test.is(firstTimeLogins[1].active, true)
+})
+
+ava('should not invalidate previous first-time logins from other users', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		processAction,
+		user,
+		userCard,
+		org,
+		worker,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	const otherUsername = 'janedoe'
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			email: 'other@user.com',
+			username: `user-${otherUsername}`,
+			password: 'apassword'
+		}
+	})
+
+	const otherUser = await processAction(session, createUserAction)
+	test.false(otherUser.error)
+
+	const linkAction = await createOrgLinkAction({
+		toId: otherUser.data.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, linkAction)
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context: test.context.context,
+		card: otherUser.data.id,
+		type: otherUser.data.type,
+		arguments: {}
+	})
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context: test.context.context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const firstTimeLogins = await jellyfish.query(context, session, {
+		type: 'object',
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			},
+			active: {
+				type: 'boolean'
+			}
+		}
+	}, {
+		sortBy: 'created_at'
+	})
+
+	test.is(firstTimeLogins.length, 2)
+	test.true(firstTimeLogins[0].active)
+})
+
+ava('successfully sends an email to a user with an array of emails', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		processAction,
+		userCard,
+		worker,
+		org,
+		nockRequest
+	} = test.context
+
+	let mailBody
+	const saveBody = (body) => {
+		mailBody = body
+	}
+	nockRequest(saveBody)
+
+	const firstEmail = 'first@email.com'
+	const secondEmail = 'second@email.com'
+	const newUsername = 'janedoe'
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			email: firstEmail,
+			username: `user-${newUsername}`,
+			password: 'foobarbaz'
+		}
+	})
+
+	const newUser = await processAction(session, createUserAction)
+	test.false(newUser.error)
+
+	const sendUpdateCard = {
+		action: 'action-update-card@1.0.0',
+		context,
+		card: newUser.data.id,
+		type: newUser.data.type,
+		arguments: {
+			reason: 'Making email an array for test',
+			patch: [ {
+				op: 'replace',
+				path: '/data/email',
+				value: [ firstEmail, secondEmail ]
+			} ]
+		}
+	}
+
+	const sendUpdate = await processAction(session, sendUpdateCard)
+	test.false(sendUpdate.error)
+
+	const userWithEmailArray = await jellyfish.getCardById(context, session, newUser.data.id)
+
+	test.deepEqual(userWithEmailArray.data.email, [ firstEmail, secondEmail ])
+
+	const linkAction = await createOrgLinkAction({
+		toId: newUser.data.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, linkAction)
+
+	const firstTimeLoginRequest = {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: newUser.data.id,
+		type: newUser.data.type,
+		arguments: {}
+	}
+
+	const firstTimeLogin = await processAction(session, firstTimeLoginRequest)
+	test.false(firstTimeLogin.error)
+
+	const toIsInBody = checkForKeyValue('to', firstEmail, mailBody)
+	test.true(toIsInBody)
+})
+
+ava('throws an error when the first-time-login user has no org', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		userCard,
+		worker,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	const userSlug = 'user-janedoe'
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			email: 'new@email.com',
+			username: userSlug,
+			password: 'foobarbaz'
+		}
+	})
+
+	const newUser = await processAction(session, createUserAction)
+	test.false(newUser.error)
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: newUser.data.id,
+		type: newUser.data.type,
+		arguments: {}
+	}), {
+		instanceOf: worker.errors.WorkerNoElement,
+		message: `User with slug ${userSlug} is not a member of any organisations`
+	})
+})
+
+ava('throws an error when the first-time-login requester has no org', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		adminOrgLink,
+		user,
+		worker,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	await processAction(session, {
+		action: 'action-delete-card@1.0.0',
+		context,
+		card: adminOrgLink.data.id,
+		type: adminOrgLink.data.type,
+		arguments: {}
+	})
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	}), {
+		instanceOf: worker.errors.WorkerNoElement,
+		message: 'You do not belong to an organisation and thus cannot send a first-time login link to any users'
+	})
+})
+
+ava('throws an error when the first-time-login user does not belong to the requester\'s org', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		userCard,
+		orgCard,
+		worker,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	const userSlug = 'user-janedoe'
+	const userPassword = 'foobarbaz'
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			email: 'new@email.com',
+			username: userSlug,
+			password: userPassword
+		}
+	})
+
+	const newUser = await processAction(session, createUserAction)
+	test.false(newUser.error)
+
+	const newOrg = await processAction(session, {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: orgCard.id,
+		type: orgCard.type,
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				name: 'foobar'
+			}
+		}
+	})
+
+	const linkAction = await createOrgLinkAction({
+		toId: newUser.data.id,
+		fromId: newOrg.data.id,
+		context
+	})
+
+	await processAction(session, linkAction)
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: newUser.data.id,
+		type: newUser.data.type,
+		arguments: {}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: `User with slug ${userSlug} is not a member of any of your organisations`
+	})
+})

--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -72,6 +72,16 @@ exports.worker = {
 				throw error
 			}
 		}
+
+		test.context.processAction = async (session, action) => {
+			const createRequest = await test.context.queue.producer.enqueue(
+				test.context.worker.getId(),
+				session,
+				action
+			)
+			await test.context.flush(session)
+			return test.context.queue.producer.waitResults(test.context, createRequest)
+		}
 	},
 	afterEach: helpers.afterEach
 }


### PR DESCRIPTION
At the moment, when a user is created in Jellyfish, we have to go into the db at setup a temporary hash and send this to the user over flowdock. We then ask them to reset their password once they have logged in.

This action will be available to users with the operator-role so that they can send a one-time-link to the user when they are first created. This way they no longer need to send a temporary password hash over flowdock

The handle should:
- [x]     Confirm that the user belongs to the same organisation as the requester
- [x]     Confirm that the requester has an operator role
- [x]     Confirm that the user is active (not disabled)
