### PR TITLE
worker: Don't sent WorkerNoElement errors to Sentry

### DIFF
--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -448,7 +448,7 @@ exports.run = async (jellyfish, session, context, library, request) => {
 		actor: jellyfish.getCardById(request.context, session, request.actor)
 	})
 
-	assert.INTERNAL(request.context, cards.input, errors.WorkerNoElement,
+	assert.USER(request.context, cards.input, errors.WorkerNoElement,
 		`No such input card: ${request.card}`)
 	assert.INTERNAL(request.context, cards.actor, errors.WorkerNoElement,
 		`No such actor: ${request.actor}`)


### PR DESCRIPTION
They are all legitimate as far as I could see i.e. a user trying to
update an inactive card they can't see, etc, so we should treat it as a
"user" error.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!