### PR TITLE
core: Make JSON Patch errors "user" errors

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -40,8 +40,10 @@ const patchCard = (card, patch, options = {}) => {
 				// This is a schema mismatch as this case tends
 				// to happen when attempting to violate the
 				// permissions filters.
-				throw new errors.JellyfishSchemaMismatch(
+				const error = new errors.JellyfishSchemaMismatch(
 					`Path ${operation.path} does not exist in ${card.slug}`)
+				error.expected = true
+				throw error
 			}
 		}
 
@@ -49,8 +51,10 @@ const patchCard = (card, patch, options = {}) => {
 			return jsonpatch.applyOperation(
 				accumulator, operation, false, options.mutate).newDocument
 		} catch (error) {
-			throw new errors.JellyfishInvalidPatch(
+			const newError = new errors.JellyfishInvalidPatch(
 				`Patch does not apply to ${card.slug}: ${JSON.stringify(patch, null, 2)}`)
+			newError.expected = true
+			throw newError
 		}
 	}, card)
 }


### PR DESCRIPTION
These errors are only caused by malformed patches sent by clients.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!