### PR TITLE
discourse: Don't log event "post_stream" property

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -1027,6 +1027,10 @@ module.exports = class DiscourseIntegration {
 			return []
 		}
 
+		// The "post_stream" property is huge and adds a lot of noise
+		// to the logs. We can safely remove it here as we never use it.
+		Reflect.deleteProperty(event.data.payload, 'post_stream')
+
 		const eventId = _.parseInt(event.data.headers['x-discourse-event-id'])
 		const eventActor = await getActor(
 			this.context, options.actor, this.options, baseUrl, event.data.payload)


### PR DESCRIPTION
Just to reduce the noise in the logs. That property is so huge that
Rapid7 ends up truncating part of the remaining of the object, limiting
our debugging attempts.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!