### PR TITLE
server: Gracefully fail if query object is invalid

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -564,6 +564,11 @@ module.exports = (application, jellyfish, worker, producer, options) => {
 				error: true,
 				data: 'No query schema'
 			})
+		} else if (_.isPlainObject(request.body) && !request.body.query) {
+			return response.status(400).json({
+				error: true,
+				data: 'Invalid request body'
+			})
 		}
 
 		return queryFacade.queryAPI(

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -610,6 +610,21 @@ ava.serial('should limit the amount of get elements by type endpoint', async (te
 	test.is(result.response.length, 100)
 })
 
+ava.serial('should fail to query with an invalid query object', async (test) => {
+	const result = await test.context.http(
+		'POST', '/api/v2/query', {
+			foo: 'bar'
+		}, {
+			Authorization: `Bearer ${test.context.token}`
+		})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: 'Invalid request body'
+	})
+})
+
 ava.serial('should get all elements by type', async (test) => {
 	const result = await test.context.http(
 		'GET', '/api/v2/type/user', null, {


### PR DESCRIPTION
Fixes: https://sentry.io/share/issue/fb767e9b794f452ab605c6b84b8a5cea/
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!