### PR TITLE
server: Add limit to /api/v2/type/:type endpoint

### DIFF
--- a/apps/server/http/routes.js
+++ b/apps/server/http/routes.js
@@ -289,6 +289,8 @@ module.exports = (application, jellyfish, worker, producer, options) => {
 					const: `${base}@${version || '1.0.0'}`
 				}
 			}
+		}, {
+			limit: 100
 		}).then((results) => {
 			return response.status(200).json(results)
 		}).catch((error) => {

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -589,6 +589,27 @@ ava.serial('should fail with a user error given no input card', async (test) => 
 	})
 })
 
+ava.serial('should limit the amount of get elements by type endpoint', async (test) => {
+	for (const time of _.range(0, 200)) {
+		await test.context.sdk.card.create({
+			type: 'card',
+			slug: test.context.generateRandomSlug({
+				prefix: `test-card-${time}`
+			}),
+			version: '1.0.0',
+			data: {}
+		})
+	}
+
+	const result = await test.context.http(
+		'GET', '/api/v2/type/card', null, {
+			Authorization: `Bearer ${test.context.token}`
+		})
+
+	test.is(result.code, 200)
+	test.is(result.response.length, 100)
+})
+
 ava.serial('should get all elements by type', async (test) => {
 	const result = await test.context.http(
 		'GET', '/api/v2/type/user', null, {


### PR DESCRIPTION
Querying for instances of a very used type (such as `action-request`)
can easily choke the system with a large enough database.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!