### PR TITLE
core: Mention explicit columns in Postgres adapter getters

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -15,6 +15,24 @@ const CARDS_TRIGGER_COLUMNS = [
 	'active', 'version', 'name', 'tags', 'markers', 'links', 'requires', 'capabilities', 'data', 'linked_at'
 ]
 
+const CARDS_SELECT = [
+	'id',
+	'slug',
+	'type',
+	'active',
+	'version',
+	'name',
+	'tags',
+	'markers',
+	'created_at',
+	'linked_at',
+	'updated_at',
+	'links',
+	'requires',
+	'capabilities',
+	'data'
+].join(', ')
+
 exports.TABLE = CARDS_TABLE
 exports.TRIGGER_COLUMNS = CARDS_TRIGGER_COLUMNS
 
@@ -138,7 +156,7 @@ exports.getById = async (context, connection, id, options = {}) => {
 
 	const results = await connection.any({
 		name: `cards-getbyid-${table}`,
-		text: `SELECT * FROM ${table} WHERE id = $1 LIMIT 1;`,
+		text: `SELECT ${CARDS_SELECT} FROM ${table} WHERE id = $1 LIMIT 1;`,
 		values: [ id ]
 	})
 
@@ -159,13 +177,13 @@ exports.getBySlug = async (context, connection, slug, options = {}) => {
 	if (!version || version === 'latest') {
 		results = await connection.any({
 			name: `cards-getbyslug-noversion-${table}`,
-			text: `SELECT * FROM ${table} WHERE slug = $1 ORDER BY version DESC LIMIT 1;`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table} WHERE slug = $1 ORDER BY version DESC LIMIT 1;`,
 			values: [ base ]
 		})
 	} else {
 		results = await connection.any({
 			name: `cards-getbyslug-version-${table}`,
-			text: `SELECT * FROM ${table} WHERE slug = $1 AND version = $2 LIMIT 1;`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table} WHERE slug = $1 AND version = $2 LIMIT 1;`,
 			values: [ base, version ]
 		})
 	}
@@ -185,7 +203,7 @@ exports.getManyById = async (context, connection, ids, options = {}) => {
 
 	const results = await connection.any({
 		name: 'cards-getmanybyid',
-		text: `SELECT * FROM ${table} WHERE id = ANY ($1)`,
+		text: `SELECT ${CARDS_SELECT} FROM ${table} WHERE id = ANY ($1)`,
 		values: [ ids ]
 	})
 
@@ -276,7 +294,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 					linked_at = ${table}.linked_at,
 					new_created_at = ${table}.new_created_at,
 					new_updated_at = $17
-				RETURNING *`
+				RETURNING ${CARDS_SELECT}`
 
 			results = await connection.any({
 				name: `cards-upsert-replace-${table}`,
@@ -293,7 +311,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, $14,
 					$15, $16, $17)
-				RETURNING *`
+				RETURNING ${CARDS_SELECT}`
 			results = await connection.any({
 				name: `cards-upsert-insert-${table}`,
 				text: sql,

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -148,27 +148,23 @@ const generateQuery = (table, schema, options) => {
 	}
 
 	if (schema.additionalProperties === true) {
-		if (links.length > 0) {
-			query.unshift(...[
-				`${table}.id,`,
-				`${table}.slug,`,
-				`${table}.type,`,
-				`${table}.active,`,
-				`${table}.version,`,
-				`${table}.name,`,
-				`${table}.tags,`,
-				`${table}.markers,`,
-				`${table}.created_at,`,
-				`${table}.links,`,
-				`${table}.requires,`,
-				`${table}.capabilities,`,
-				`${table}.data,`,
-				`${table}.updated_at,`,
-				`${table}.linked_at`
-			])
-		} else {
-			query.unshift(`${table}.*`)
-		}
+		query.unshift(...[
+			`${table}.id,`,
+			`${table}.slug,`,
+			`${table}.type,`,
+			`${table}.active,`,
+			`${table}.version,`,
+			`${table}.name,`,
+			`${table}.tags,`,
+			`${table}.markers,`,
+			`${table}.created_at,`,
+			`${table}.links,`,
+			`${table}.requires,`,
+			`${table}.capabilities,`,
+			`${table}.data,`,
+			`${table}.updated_at,`,
+			`${table}.linked_at`
+		])
 	} else {
 		const topLevelKeys = []
 		for (const key of expression.keys.entries()) {
@@ -192,11 +188,23 @@ const generateQuery = (table, schema, options) => {
 				})
 				.join(',\n'))
 		} else {
-			query.unshift(`${table}.*`)
-		}
-
-		if (!query[1].startsWith('FROM') && !query[1].startsWith(',') && query[1] !== 'WHERE') {
-			query[0] = `${query[0]}, `
+			query.unshift(...[
+				`${table}.id,`,
+				`${table}.slug,`,
+				`${table}.type,`,
+				`${table}.active,`,
+				`${table}.version,`,
+				`${table}.name,`,
+				`${table}.tags,`,
+				`${table}.markers,`,
+				`${table}.created_at,`,
+				`${table}.links,`,
+				`${table}.requires,`,
+				`${table}.capabilities,`,
+				`${table}.data,`,
+				`${table}.updated_at,`,
+				`${table}.linked_at`
+			])
 		}
 	}
 

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -36,7 +36,21 @@ ava('when querying for jsonb array field that contains string const we use the @
 	})
 
 	const expected = `SELECT
-cards.*
+cards.id,
+cards.slug,
+cards.type,
+cards.active,
+cards.version,
+cards.name,
+cards.tags,
+cards.markers,
+cards.created_at,
+cards.links,
+cards.requires,
+cards.capabilities,
+cards.data,
+cards.updated_at,
+cards.linked_at
 FROM cards
 WHERE
 (cards.type = 'support-thread')
@@ -75,7 +89,21 @@ ava('when querying for jsonb array field that contains number const we use the @
 	})
 
 	const expected = `SELECT
-cards.*
+cards.id,
+cards.slug,
+cards.type,
+cards.active,
+cards.version,
+cards.name,
+cards.tags,
+cards.markers,
+cards.created_at,
+cards.links,
+cards.requires,
+cards.capabilities,
+cards.data,
+cards.updated_at,
+cards.linked_at
 FROM cards
 WHERE
 (cards.type = 'support-thread')
@@ -157,7 +185,21 @@ ava('when querying without filters and additionalProperties=true, query should s
 	})
 
 	const expected = `SELECT
-cards.*
+cards.id,
+cards.slug,
+cards.type,
+cards.active,
+cards.version,
+cards.name,
+cards.tags,
+cards.markers,
+cards.created_at,
+cards.links,
+cards.requires,
+cards.capabilities,
+cards.data,
+cards.updated_at,
+cards.linked_at
 FROM cards
 WHERE
 true`


### PR DESCRIPTION
This gives us more control over the columns we return to make it easier
to add extra columns in a backwards compatible way.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!