### PR TITLE
core: Prepare to handle new version columns in a safe way

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -50,6 +50,9 @@ exports.setup = async (context, connection, database, options = {}) => {
 				type TEXT NOT NULL,
 				active BOOLEAN NOT NULL,
 				version TEXT NOT NULL,
+				version_major INTEGER NOT NULL DEFAULT 1 CHECK (version_major >= 0),
+				version_minor INTEGER NOT NULL DEFAULT 0 CHECK (version_minor >= 0),
+				version_patch INTEGER NOT NULL DEFAULT 0 CHECK (version_patch >= 0),
 				name TEXT,
 				tags TEXT[] NOT NULL,
 				markers TEXT[] NOT NULL,
@@ -347,6 +350,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 	insertedObject.created_at = results[0].created_at
 	insertedObject.updated_at = results[0].updated_at
 	insertedObject.linked_at = results[0].linked_at
+	insertedObject.version = results[0].version
 
 	utils.convertDatesToISOString(insertedObject)
 

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -111,12 +111,14 @@ const queryTable = async (context, backend, table, schema, options) => {
 		if (_.isNil(schema.$$links)) {
 			elements = results
 				.map(utils.convertDatesToISOString)
+				.map(utils.removeVersionFields)
 		} else {
 			elements = []
 			const elementsById = {}
 
 			results
 				.map(utils.convertDatesToISOString)
+				.map(utils.removeVersionFields)
 				.forEach((element) => {
 					elementsById[element.id] = element
 
@@ -164,6 +166,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 	} else {
 		elements = results
 			.map(utils.convertDatesToISOString)
+			.map(utils.removeVersionFields)
 			.map((element) => {
 				for (const linkType of Object.keys(schema.$$links || {})) {
 					const linkSlug = links.getLinkTypeSlug(linkType)
@@ -181,6 +184,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 					element.links[linkType] = utils
 						.filter(linkSchema, element[`links.${linkSlug}`])
 						.map(utils.convertDatesToISOString)
+						.map(utils.removeVersionFields)
 
 					Reflect.deleteProperty(element, `links.${linkSlug}`)
 				}

--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -142,6 +142,8 @@ exports.attach = async (context, instance, schema, options) => {
 
 		utils.convertDatesToISOString(before)
 		utils.convertDatesToISOString(after)
+		utils.removeVersionFields(before)
+		utils.removeVersionFields(after)
 
 		if (change.table !== instance.table) {
 			return

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -62,3 +62,13 @@ exports.removeLinkMetadataFields = (row) => {
 	Reflect.deleteProperty(row, '$link type$')
 	Reflect.deleteProperty(row, '$parent id$')
 }
+
+exports.removeVersionFields = (row) => {
+	if (row) {
+		Reflect.deleteProperty(row, 'version_major')
+		Reflect.deleteProperty(row, 'version_minor')
+		Reflect.deleteProperty(row, 'version_patch')
+	}
+
+	return row
+}


### PR DESCRIPTION
This PR ensures the logic in "core" doesn't get confused by the addition
of the new version columns, while still not making any use of them, so
we can start rolling out the feature in a completely backwards
compatible way.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!