### PR TITLE
Add the complete-first-time-login action and handler

### DIFF
--- a/lib/action-library/actions/action-complete-first-time-login.js
+++ b/lib/action-library/actions/action-complete-first-time-login.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'action-complete-first-time-login',
+	type: 'action@1.0.0',
+	version: '1.0.0',
+	name: 'Complete the first time login of a user',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {
+		arguments: {
+			newPassword: {
+				type: 'string'
+			},
+			firstTimeLoginToken: {
+				type: 'string',
+				format: 'uuid'
+			}
+		}
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/action-library/handlers/action-complete-first-time-login.js
+++ b/lib/action-library/handlers/action-complete-first-time-login.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const assert = require('../../assert')
+const {
+	PASSWORDLESS_USER_HASH
+} = require('./constants')
+
+const getFirstTimeLoginCard = async (context, request) => {
+	const [ firstTimeLogin ] = await context.query(context.privilegedSession, {
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true
+					}
+				}
+			}
+		},
+		type: 'object',
+		required: [ 'type', 'links', 'active', 'data' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			},
+			active: {
+				type: 'boolean',
+				const: true
+			},
+			links: {
+				type: 'object',
+				additionalProperties: true
+			},
+			data: {
+				type: 'object',
+				properties: {
+					firstTimeLoginToken: {
+						type: 'string',
+						const: request.arguments.firstTimeLoginToken
+					}
+				},
+				required: [ 'firstTimeLoginToken' ]
+			}
+		}
+	}, {
+		limit: 1
+	})
+	return firstTimeLogin
+}
+
+const invalidateFirstTimeLogin = async ({
+	session,
+	request,
+	firstTimeLogin,
+	context
+}) => {
+	const typeCard = await context.getCardBySlug(session, 'first-time-login@latest')
+	return context.patchCard(session, typeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: true
+	}, firstTimeLogin, [
+		{
+			op: 'replace',
+			path: '/active',
+			value: false
+		}
+	])
+}
+
+const handler = async (session, context, card, request) => {
+	const firstTimeLogin = await getFirstTimeLoginCard(context, request)
+	assert.USER(request.context, firstTimeLogin, context.errors.WorkerAuthenticationError, 'First-time login token invalid')
+
+	await invalidateFirstTimeLogin({
+		session: context.privilegedSession,
+		request,
+		firstTimeLogin,
+		context
+	})
+
+	const [ user ] = firstTimeLogin.links['is attached to']
+
+	assert.USER(request.context, user, context.errors.WorkerAuthenticationError, 'First-time login token invalid')
+
+	const hasExpired = new Date(firstTimeLogin.data.expiresAt) < new Date()
+	if (hasExpired) {
+		const newError = new context.errors.WorkerAuthenticationError('First-time login token has expired')
+		newError.expected = true
+		throw newError
+	}
+
+	const isFirstTimeLogin = user.data.hash === PASSWORDLESS_USER_HASH
+
+	assert.USER(request.context, isFirstTimeLogin, context.errors.WorkerAuthenticationError, 'User already has a password set')
+
+	const userTypeCard = await context.getCardBySlug(session, 'user@latest')
+
+	return context.patchCard(context.privilegedSession, userTypeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: false
+	}, user, [
+		{
+			op: 'replace',
+			path: '/data/hash',
+			value: request.arguments.newPassword
+		}
+	]).catch((error) => {
+		console.dir(error, {
+			depth: null
+		})
+
+		// A schema mismatch here means that the patch could
+		// not be applied to the card due to permissions.
+		if (error.name === 'JellyfishSchemaMismatch') {
+			const newError = new context.errors.WorkerAuthenticationError(
+				'Password change not allowed')
+			newError.expected = true
+			throw newError
+		}
+
+		throw error
+	})
+}
+
+module.exports = {
+	handler
+}

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -145,5 +145,10 @@ module.exports = {
 		card: require('./actions/action-send-first-time-login-link'),
 		pre: _.noop,
 		handler: require('./handlers/action-send-first-time-login-link').handler
+	},
+	'action-complete-first-time-login': {
+		card: require('./actions/action-complete-first-time-login'),
+		pre: require('./handlers/action-complete-password-reset').pre,
+		handler: require('./handlers/action-complete-first-time-login').handler
 	}
 }

--- a/test/integration/worker/actions/complete-first-time-login.spec.js
+++ b/test/integration/worker/actions/complete-first-time-login.spec.js
@@ -1,0 +1,525 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const nock = require('nock')
+const helpers = require('../helpers')
+const actionLibrary = require('../../../../lib/action-library')
+const uuid = require('../../../../lib/uuid')
+const environment = require('../../../../lib/environment')
+
+const MAILGUN = environment.mail
+
+const createOrgLinkAction = async ({
+	fromId,
+	toId,
+	context
+}) => {
+	return {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: 'link',
+		type: 'type',
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				slug: `link-${fromId}-has-member-${toId}-${await uuid.random()}`,
+				version: '1.0.0',
+				name: 'has member',
+				data: {
+					inverseName: 'is member of',
+					to: {
+						id: toId,
+						type: 'user@1.0.0'
+					},
+					from: {
+						id: fromId,
+						type: 'org@1.0.0'
+					}
+				}
+			}
+		}
+	}
+}
+
+ava.beforeEach(async (test) => {
+	await helpers.worker.beforeEach(test, actionLibrary)
+	const {
+		session,
+		jellyfish,
+		context,
+		processAction
+	} = test.context
+
+	nock(`${MAILGUN.baseUrl}/${MAILGUN.domain}`)
+		.persist()
+		.post('/messages')
+		.basicAuth({
+			user: 'api',
+			pass: MAILGUN.TOKEN
+		})
+		.reply(200)
+
+	const userCard = await jellyfish.getCardBySlug(context, session, 'user@latest')
+
+	const user = await processAction(session, {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				slug: 'user-johndoe',
+				data: {
+					email: 'test@test.com',
+					hash: 'PASSWORDLESS',
+					roles: [ 'user-community' ]
+				}
+			}
+		}
+	})
+
+	// Creates org
+	const orgCard = await jellyfish.getCardBySlug(context, session, 'org@latest')
+
+	const org = await processAction(session, {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: orgCard.id,
+		type: orgCard.type,
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				name: 'foobar'
+			}
+		}
+	})
+
+	// Links user to org
+	const userOrgLinkAction = await createOrgLinkAction({
+		toId: user.data.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, userOrgLinkAction)
+
+	// Gets admin user and links org to it
+	const adminUser = await jellyfish.getCardBySlug(context, session, 'user-admin@1.0.0')
+
+	const adminOrgLinkAction = await createOrgLinkAction({
+		toId: adminUser.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, adminOrgLinkAction)
+
+	test.context = {
+		...test.context,
+		user,
+		org,
+		processAction,
+		userCard
+	}
+})
+
+ava.afterEach(helpers.worker.afterEach)
+
+ava('should update the user\'s password when the firstTimeLoginToken is valid', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		jellyfish,
+		user,
+		worker
+	} = test.context
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	})
+
+	const newPassword = 'newPassword'
+
+	const completeFirstTimeLoginAction = await worker.pre(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
+			newPassword
+		}
+	})
+
+	await processAction(session, completeFirstTimeLoginAction)
+
+	await test.throwsAsync(worker.pre(session, {
+		action: 'action-create-session@1.0.0',
+		card: user.data.id,
+		type: user.data.type,
+		context,
+		arguments: {
+			password: 'PASSWORDLESS'
+		}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'Invalid password'
+	})
+
+	const newPasswordLoginRequest = await test.context.worker.pre(test.context.session, {
+		action: 'action-create-session@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			password: newPassword
+		}
+	})
+
+	const newPasswordLoginResult = await processAction(session, newPasswordLoginRequest)
+	test.false(newPasswordLoginResult.error)
+})
+
+ava('should fail when the first-time login does not match a valid card', async (test) => {
+	const {
+		session,
+		context,
+		worker,
+		processAction,
+		user
+	} = test.context
+
+	const fakeToken = await uuid.random()
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: fakeToken,
+			newPassword: 'new-password'
+		}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'First-time login token invalid'
+	})
+})
+
+ava('should fail when the first-time login token has expired', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		worker,
+		processAction,
+		user
+	} = test.context
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	})
+
+	const now = new Date()
+	const hourInPast = now.setHours(now.getHours() - 1)
+	const newExpiry = new Date(hourInPast)
+
+	await processAction(session, {
+		action: 'action-update-card@1.0.0',
+		context,
+		card: firstTimeLogin.id,
+		type: firstTimeLogin.type,
+		arguments: {
+			reason: 'Expiring for test',
+			patch: [
+				{
+					op: 'replace',
+					path: '/data/expiresAt',
+					value: newExpiry.toISOString()
+				}
+			]
+		}
+	})
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
+			newPassword: 'new-password'
+		}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'First-time login token has expired'
+	})
+})
+
+ava('should fail when the first-time login is not active', async (test) => {
+	const {
+		jellyfish,
+		session,
+		context,
+		worker,
+		processAction,
+		user
+	} = test.context
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	})
+
+	await processAction(session, {
+		action: 'action-delete-card@1.0.0',
+		context,
+		card: firstTimeLogin.id,
+		type: firstTimeLogin.type,
+		arguments: {}
+	})
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
+			newPassword: 'new-password'
+		}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'First-time login token invalid'
+	})
+})
+
+ava('should fail if the user becomes inactive between requesting and completing the first-time login', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		user,
+		username,
+		worker,
+		jellyfish
+	} = test.context
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			username
+		}
+	})
+
+	await processAction(session, {
+		action: 'action-delete-card@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	})
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
+			newPassword: 'new-password'
+		}
+	})
+
+	await test.throwsAsync(processAction(session, completePasswordReset), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'First-time login token invalid'
+	})
+})
+
+ava('should invalidate the first-time-login card', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		user,
+		worker,
+		jellyfish
+	} = test.context
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	})
+
+	const completePasswordReset = await worker.pre(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
+			newPassword: 'new-password'
+		}
+	})
+
+	await processAction(session, completePasswordReset)
+
+	const [ updatedFirstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		required: [ 'type', 'active' ],
+		additionalProperties: true,
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			},
+			active: {
+				type: 'boolean'
+			}
+		}
+	}, {
+		limit: 1
+	})
+
+	test.false(updatedFirstTimeLogin.active)
+})
+
+ava('should throw an error when the user already has a password set', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		worker,
+		jellyfish,
+		userCard,
+		org
+	} = test.context
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-user@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			email: 'test@test.com',
+			password: 'a-very-dumb-password',
+			username: 'user-janedoe'
+		}
+	})
+
+	const user = await processAction(session, createUserAction)
+
+	const orgLinkAction = await createOrgLinkAction({
+		toId: user.data.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, orgLinkAction)
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {}
+	})
+
+	const [ firstTimeLogin ] = await jellyfish.query(context, session, {
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				const: 'first-time-login@1.0.0'
+			}
+		}
+	})
+
+	await test.throwsAsync(processAction(session, {
+		action: 'action-complete-first-time-login@1.0.0',
+		context,
+		card: user.data.id,
+		type: user.data.type,
+		arguments: {
+			firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
+			newPassword: 'new-password'
+		}
+	}), {
+		instanceOf: worker.errors.WorkerAuthenticationError,
+		message: 'User already has a password set'
+	})
+})


### PR DESCRIPTION
As required by the account management spec. This allows a user with no password set to set their password, given a valid first-time-login-token has been sent to them previously.

- [x] checks the token corresponds to a first-time-login card
- [x] checks the token has not expired
- [x] checks that the user is still active
- [x] checks that the user has not already set their password
- [x] invalidates the token when it is used