### PR TITLE
github: Make INTEGRATION_GITHUB_PRIVATE_KEY a base64 string

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -196,7 +196,7 @@ module.exports = class GitHubIntegration {
 			octokitOptions.authStrategy = authApp.createAppAuth
 			octokitOptions.auth = {
 				id: _.parseInt(this.options.token.appId),
-				privateKey: this.options.token.key
+				privateKey: Buffer.from(this.options.token.key, 'base64').toString()
 			}
 
 			const github = new Octokit(octokitOptions)


### PR DESCRIPTION
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/p-cyclops/threads/qq1KOBcXqr-mNPd-1tG5-f17ToX


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!