### PR TITLE
Dummy change to trigger Balena CI re-deploy

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -43,7 +43,8 @@ const githubRequest = async (fn, arg, options, retries = 5) => {
 }
 
 const getEventRoot = (event) => {
-	return event.data.payload.issue || event.data.payload.pull_request
+	return event.data.payload.issue ||
+		event.data.payload.pull_request
 }
 
 const getEventMirrorId = (event) => {


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!