### PR TITLE
Add check for role to send-first-time-login-link

### DIFF
--- a/lib/action-library/handlers/action-send-first-time-login-link.js
+++ b/lib/action-library/handlers/action-send-first-time-login-link.js
@@ -9,6 +9,7 @@ const _ = require('lodash')
 const assert = require('../../assert')
 const uuid = require('../../uuid')
 const environment = require('../../environment')
+const logger = require('../../logger').getLogger(__filename)
 const sendEmailHandler = require('./action-send-email').handler
 
 const MAILGUN = environment.mail
@@ -202,6 +203,28 @@ const checkOrgs = async ({
 		`User with slug ${userCard.slug} is not a member of any of your organisations`)
 }
 
+const addCommunityRoleToUser = async ({
+	session,
+	context,
+	userCard,
+	request
+}) => {
+	const typeCard = await context.getCardBySlug(session, 'user@latest')
+	await context.patchCard(session, typeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: true
+	}, userCard, [
+		{
+			op: 'replace',
+			path: '/data/roles',
+			value: [ 'user-community' ]
+		}
+	])
+	logger.info(request.context, `Added community role to user with slug ${userCard.slug}`)
+}
+
 const handler = async (session, context, userCard, request) => {
 	const typeCard = await context.getCardBySlug(session, 'first-time-login@latest')
 
@@ -214,6 +237,15 @@ const handler = async (session, context, userCard, request) => {
 		userCard,
 		context
 	})
+	if (userCard.data.roles.length === 0) {
+		logger.info(request.context, `User with slug ${userCard.slug} has no role set. Adding community role now`)
+		await addCommunityRoleToUser({
+			session,
+			context,
+			userCard,
+			request
+		})
+	}
 
 	await invalidatePreviousFirstTimeLogins({
 		context,


### PR DESCRIPTION
Sometimes when accounts are synced from external services, we don't have a role set on them. All users receiving a first-time-login link should have the community role set otherwise they wont be able to set their password and login. 

This PR adds a check for the user's role to the send-first-time-login-link action and adds the community role to the user when there is no role set
