### PR TITLE
Add the first_time_login endpoint to the ui

### DIFF
--- a/apps/server/default-cards/contrib/role-user-guest.json
+++ b/apps/server/default-cards/contrib/role-user-guest.json
@@ -115,7 +115,8 @@
                 "action-create-event",
                 "action-oauth-authorize",
                 "action-request-password-reset",
-                "action-complete-password-reset"
+                "action-complete-password-reset",
+								"action-complete-first-time-login"
               ]
             },
             "type": {

--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -34,6 +34,7 @@ import Oauth from './components/HOC/Oauth'
 import Login from './components/HOC/Login'
 import RequestPasswordReset from './components/HOC/RequestPasswordReset'
 import CompletePasswordReset from './components/HOC/CompletePasswordReset'
+import CompleteFirstTimeLogin from './components/HOC/CompleteFirstTimeLogin'
 import MermaidEditor from '../../lib/ui-components/shame/MermaidEditor'
 import Splash from '../../lib/ui-components/Splash'
 import AuthContainer from '../../lib/ui-components/Auth'
@@ -109,6 +110,7 @@ class JellyfishUI extends React.Component {
 					<Switch>
 						<Route path='/request_password_reset' component={RequestPasswordReset} />
 						<Route path='/password_reset/:resetToken' component={CompletePasswordReset} />
+						<Route path='/first_time_login/:firstTimeLoginToken' component={CompleteFirstTimeLogin} />
 						<Route path="/*" component={Login} />
 					</Switch>
 					<Notifications />

--- a/apps/ui/components/HOC/CompleteFirstTimeLogin.jsx
+++ b/apps/ui/components/HOC/CompleteFirstTimeLogin.jsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import {
+	connect
+} from 'react-redux'
+import {
+	bindActionCreators
+} from 'redux'
+import {
+	actionCreators
+} from '../../core'
+import CompleteFirstTimeLogin from '../../../../lib/ui-components/Auth/CompleteFirstTimeLogin'
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, [
+				'addNotification',
+				'completeFirstTimeLogin'
+			]), dispatch)
+	}
+}
+
+export default connect(null, mapDispatchToProps)(CompleteFirstTimeLogin)

--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -198,6 +198,7 @@ export default class ActionCreator {
 			'authorizeIntegration',
 			'bootstrap',
 			'clearViewData',
+			'completeFirstTimeLogin',
 			'completePasswordReset',
 			'createLink',
 			'dumpState',
@@ -955,6 +956,24 @@ export default class ActionCreator {
 				arguments: {
 					newPassword: password,
 					resetToken
+				}
+			})
+		}
+	}
+
+	completeFirstTimeLogin ({
+		password,
+		firstTimeLoginToken
+	}) {
+		return async (dispatch, getState) => {
+			const userType = await this.sdk.getBySlug('user@latest')
+			return this.sdk.action({
+				card: userType.id,
+				action: 'action-complete-first-time-login@1.0.0',
+				type: userType.type,
+				arguments: {
+					newPassword: password,
+					firstTimeLoginToken
 				}
 			})
 		}

--- a/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
+++ b/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
@@ -15,7 +15,7 @@ import {
 } from 'rendition'
 import Icon from '../../shame/Icon'
 
-class CompletePasswordReset extends React.Component {
+class CompleteFirstTimeLogin extends React.Component {
 	constructor (props) {
 		super(props)
 
@@ -25,7 +25,7 @@ class CompletePasswordReset extends React.Component {
 		}
 
 		this.handleInputChange = this.handleInputChange.bind(this)
-		this.completePasswordReset = this.completePasswordReset.bind(this)
+		this.completeFirstTimeLogin = this.completeFirstTimeLogin.bind(this)
 	}
 
 	handleInputChange (event) {
@@ -34,26 +34,26 @@ class CompletePasswordReset extends React.Component {
 		})
 	}
 
-	completePasswordReset (event) {
+	completeFirstTimeLogin (event) {
 		event.preventDefault()
 		const {
 			password
 		} = this.state
 
 		this.setState({
-			completingPasswordReset: true
+			completingFirstTimeLogin: true
 		}, async () => {
 			try {
-				await this.props.actions.completePasswordReset({
+				await this.props.actions.completeFirstTimeLogin({
 					password,
-					resetToken: this.props.match.params.resetToken
+					firstTimeLoginToken: this.props.match.params.firstTimeLoginToken
 				})
-				this.props.actions.addNotification('success', 'Successfully reset password')
+				this.props.actions.addNotification('success', 'Successfully set password')
 				this.props.history.push('/')
 			} catch (error) {
 				this.props.actions.addNotification('danger', error.message || error)
 				this.setState({
-					completePasswordReset: false
+					completingFirstTimeLogin: false
 				})
 			}
 		})
@@ -63,25 +63,25 @@ class CompletePasswordReset extends React.Component {
 		const {
 			password,
 			passwordConfirmation,
-			completingPasswordReset
+			completingFirstTimeLogin
 		} = this.state
 
 		return (
 			<React.Fragment>
 				<Txt align="center" mb={4}>
-					<Heading.h2 mb={2}>Reset Password</Heading.h2>
-					<span>{'Enter your new password below'}</span>
+					<Heading.h2 mb={2}>Set Password</Heading.h2>
+					<span>{'Enter your password below'}</span>
 				</Txt>
 
 				<Divider color="#eee" mb={4}/>
 
 				<form
-					data-test="completePasswordReset-page__form"
-					onSubmit={this.completePasswordReset}>
+					data-test="completeFirstTimeLogin-page__form"
+					onSubmit={this.completeFirstTimeLogin}>
 
 					<Txt fontSize={1} mb={1}>Password</Txt>
 					<Input
-						data-test="completePasswordReset-page__password"
+						data-test="completeFirstTimeLogin-page__password"
 						mb={5}
 						width="100%"
 						emphasized={true}
@@ -93,7 +93,7 @@ class CompletePasswordReset extends React.Component {
 					/>
 					<Txt fontSize={1} mb={1}>Password Confirmation</Txt>
 					<Input
-						data-test="completePasswordReset-page__password-confirmation"
+						data-test="completeFirstTimeLogin-page__password-confirmation"
 						mb={5}
 						width="100%"
 						emphasized={true}
@@ -105,14 +105,14 @@ class CompletePasswordReset extends React.Component {
 					/>
 					<Box>
 						<Button
-							data-test="completePasswordReset-page__submit"
+							data-test="completeFirstTimeLogin-page__submit"
 							width="100%"
 							primary={true}
 							emphasized={true}
 							type="submit"
-							disabled={!password || passwordConfirmation !== password || completingPasswordReset}
+							disabled={!password || passwordConfirmation !== password || completingFirstTimeLogin}
 						>
-							{completingPasswordReset ? <Icon spin name="cog"/> : 'Reset password'}
+							{completingFirstTimeLogin ? <Icon spin name="cog"/> : 'Set password'}
 						</Button>
 					</Box>
 				</form>
@@ -121,4 +121,4 @@ class CompletePasswordReset extends React.Component {
 	}
 }
 
-export default CompletePasswordReset
+export default CompleteFirstTimeLogin

--- a/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.spec.jsx
+++ b/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.spec.jsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import {
+	mount,
+	configure
+} from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+import {
+	Provider,
+	Img
+} from 'rendition'
+import CompleteFirstTimeLogin from './CompleteFirstTimeLogin.jsx'
+
+import Adapter from 'enzyme-adapter-react-16'
+
+const MATCH = {
+	params: {
+		firstTimeLoginToken: '123456'
+	}
+}
+
+const DATA_TEST_PREFIX = 'completeFirstTimeLogin-page'
+
+const browserEnv = require('browser-env')
+browserEnv([ 'window', 'document', 'navigator' ])
+
+configure({
+	adapter: new Adapter()
+})
+
+const sandbox = sinon.createSandbox()
+
+const flushPromises = () => {
+	return new Promise((resolve) => {
+		// eslint-disable-next-line no-undef
+		return setImmediate(resolve)
+	})
+}
+
+ava.before(() => {
+	sandbox.stub(Img)
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('Submit button is disabled if the new password input is empty', async (test) => {
+	const completeFirstTimeLogin = mount(
+		<CompleteFirstTimeLogin
+			match={MATCH}
+		/>, {
+			wrappingComponent: Provider
+		})
+
+	await flushPromises()
+	completeFirstTimeLogin.update()
+
+	const passwordInput = completeFirstTimeLogin.find(`input[data-test="${DATA_TEST_PREFIX}__password"]`)
+
+	test.is(passwordInput.prop('value'), '')
+
+	const submitButton = completeFirstTimeLogin.find(`button[data-test="${DATA_TEST_PREFIX}__submit"]`)
+
+	test.true(submitButton.prop('disabled'))
+})
+
+ava('Submit button is disabled if the new password does not match the password confirmation', async (test) => {
+	const completeFirstTimeLogin = mount(
+		<CompleteFirstTimeLogin
+			match={MATCH}
+		/>, {
+			wrappingComponent: Provider
+		})
+
+	await flushPromises()
+	completeFirstTimeLogin.update()
+
+	const passwordInput = completeFirstTimeLogin.find(`input[data-test="${DATA_TEST_PREFIX}__password"]`)
+
+	const passwordConfirmationInput = completeFirstTimeLogin.find(`input[data-test="${DATA_TEST_PREFIX}__password-confirmation"]`)
+
+	passwordInput.simulate('change', {
+		target: {
+			name: 'password', value: 'newPassword'
+		}
+	})
+	passwordConfirmationInput.simulate('change', {
+		target: {
+			name: 'passwordConfirmation', value: 'aDifferentPassword'
+		}
+	})
+
+	const submitButton = completeFirstTimeLogin.find(`button[data-test="${DATA_TEST_PREFIX}__submit"]`)
+
+	test.true(submitButton.prop('disabled'))
+})
+
+ava('Fires the completeFirstTimeLogin and then the addNotification action when the form is submitted -' +
+'redirects to login on success', async (test) => {
+	const completeFirstTimeLoginAction = sandbox.stub()
+	completeFirstTimeLoginAction.resolves(200)
+
+	const addNotification = sandbox.stub()
+	addNotification.resolves()
+
+	const push = sandbox.stub()
+
+	const completeFirstTimeLogin = mount(
+		<CompleteFirstTimeLogin
+			actions={{
+				completeFirstTimeLogin: completeFirstTimeLoginAction,
+				addNotification
+			}}
+			history={{
+				push
+			}}
+			match={MATCH}
+		/>, {
+			wrappingComponent: Provider
+		})
+
+	await flushPromises()
+	completeFirstTimeLogin.update()
+
+	const passwordInput = completeFirstTimeLogin.find(`input[data-test="${DATA_TEST_PREFIX}__password"]`)
+	const passwordConfirmationInput = completeFirstTimeLogin.find(`input[data-test="${DATA_TEST_PREFIX}__password-confirmation"]`)
+
+	passwordInput.simulate('change', {
+		target: {
+			name: 'password', value: 'newPassword'
+		}
+	})
+	passwordConfirmationInput.simulate('change', {
+		target: {
+			name: 'passwordConfirmation', value: 'newPassword'
+		}
+	})
+
+	const form = completeFirstTimeLogin.find(`form[data-test="${DATA_TEST_PREFIX}__form"]`)
+	form.simulate('submit', {
+		target: {}
+	})
+
+	await flushPromises()
+	completeFirstTimeLogin.update()
+
+	test.is(completeFirstTimeLoginAction.callCount, 1)
+	test.is(addNotification.callCount, 1)
+	test.deepEqual(addNotification.args, [ [ 'success', 'Successfully set password' ] ])
+
+	// Redirects to login
+	test.is(push.callCount, 1)
+	test.deepEqual(push.args, [ [ '/' ] ])
+
+	completeFirstTimeLoginAction.reset()
+	addNotification.reset()
+	completeFirstTimeLoginAction.rejects(new Error('Could not update'))
+
+	form.simulate('submit', {
+		target: {}
+	})
+
+	await flushPromises()
+	completeFirstTimeLogin.update()
+
+	test.is(completeFirstTimeLoginAction.callCount, 1)
+	test.is(addNotification.callCount, 1)
+	test.deepEqual(addNotification.args, [ [ 'danger', 'Could not update' ] ])
+})

--- a/lib/ui-components/Auth/CompleteFirstTimeLogin/index.jsx
+++ b/lib/ui-components/Auth/CompleteFirstTimeLogin/index.jsx
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import CompleteFirstTimeLogin from './CompleteFirstTimeLogin'
+
+export default CompleteFirstTimeLogin


### PR DESCRIPTION
Enables a user to click on a first-time-login link and set their password

Should:

- [x] include the firstTimeLoginToken
- [x] take a password + password confirmation
- [x] fire the completeFirstTimeLogin action when submitted, passing along the firstTimeLoginToken and new password
- [x] pass success or failure messages onto the user
- [x] redirect to login on success