### PR TITLE
core: Manually set defaults for version columns

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -276,15 +276,19 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active, version, name, tags, markers,
 					created_at, links, requires, capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at)
+					linked_at, new_created_at, new_updated_at,
+					version_major, version_minor, version_patch)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, NULL,
-					$15, $16, NULL)
+					$15, $16, NULL, 1, 0, 0)
 				ON CONFLICT (slug) DO UPDATE SET
 					id = ${table}.id,
 					active = $4,
 					version = $5,
+					version_major = 1,
+					version_minor = 0,
+					version_patch = 0,
 					name = $6,
 					tags = $7,
 					markers = $8,
@@ -309,11 +313,12 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				INSERT INTO ${table}
 					(id, slug, type, active, version, name, tags, markers,
 					created_at, links, requires, capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at)
+					linked_at, new_created_at, new_updated_at,
+					version_major, version_minor, version_patch)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, $14,
-					$15, $16, $17)
+					$15, $16, $17, 1, 0, 0)
 				RETURNING ${CARDS_SELECT}`
 			results = await connection.any({
 				name: `cards-upsert-insert-${table}`,


### PR DESCRIPTION
We should revert this once we can set a default on the Postgres table
definition level.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!