### PR TITLE
Add Prometheus ports/paths to deploy templates

### DIFF
--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -38,7 +38,9 @@ properties:
     type: string?
   LOGLEVEL:
     type: string?
-  WORKER_PORT:
+  METRICS_PORT:
+    type: number
+  SOCKET_METRICS_PORT:
     type: number
   INTEGRATION_BALENA_API_PRIVATE_KEY:
     type: string?
@@ -88,3 +90,5 @@ properties:
     type: string?
   RESET_PASSWORD_SECRET_TOKEN:
     type: string?
+  MONITOR_SECRET_TOKEN:
+    type: string

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -46,8 +46,8 @@ spec:
           value: {{{LOGENTRIES_TOKEN}}}
         - name: LOGLEVEL
           value: {{{LOGLEVEL}}}
-        - name: WORKER_PORT
-          value: '{{{WORKER_PORT}}}'
+        - name: METRICS_PORT
+          value: '{{{METRICS_PORT}}}'
         - name: INTEGRATION_BALENA_API_APP_ID
           value: '{{{INTEGRATION_BALENA_API_APP_ID}}}'
         - name: INTEGRATION_BALENA_API_APP_SECRET
@@ -96,6 +96,8 @@ spec:
           value: {{{MAILGUN_BASE_URL}}}
         - name: RESET_PASSWORD_SECRET_TOKEN
           value: {{{RESET_PASSWORD_SECRET_TOKEN}}}
+        - name: MONITOR_SECRET_TOKEN
+          value: {{{MONITOR_SECRET_TOKEN}}}
         ports:
           - containerPort: 8888
             name: worker

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-service.tpl.yml
@@ -2,16 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-api
+    name: action-server
   namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
-  name: jellyfish-api
+  name: action-server
 spec:
   selector:
-    app: jellyfish
+    app: action-server
   ports:
-  - port: 8000
   - name: prometheus-A
     port: 8888
-  - name: prometheus-B
-    port: 8889
   sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-deployment.tpl.yml
@@ -126,7 +126,19 @@ spec:
           value: user-community
         - name: SERVER_PORT
           value: '8000'
+        - name: METRICS_PORT
+          value: '8888'
+        - name: SOCKET_METRICS_PORT
+          value: '8889'
+        - name: MONITOR_SECRET_TOKEN
+          value: '{{{MONITOR_SECRET_TOKEN}}}'
         ports:
         - containerPort: 8000
+        - containerPort: 8888
+          name: prometheus-A
+          protocol: TCP
+        - containerPort: 8889
+          name: prometheus-B
+          protocol: TCP
       imagePullSecrets:
         - name: com.docker.hub.travisciresin


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add Prometheus metrics ports and paths to production deploy templates.