### PR TITLE
No default link type when linking cards

### DIFF
--- a/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/lib/ui-components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -117,6 +117,15 @@ export default class AutoCompleteCardSelect extends React.Component {
 				defaultOptions
 				onChange={this.onChange}
 				loadOptions={this.getTargets}
+				menuPortalTarget={document.body}
+				styles={{
+					// Ensure the menu portal shows on top of a modal
+					menuPortal: (base) => {
+						return {
+							...base, zIndex: 100
+						}
+					}
+				}}
 				{...rest}
 			/>
 		)

--- a/lib/ui-components/LinkModal/LinkModal.jsx
+++ b/lib/ui-components/LinkModal/LinkModal.jsx
@@ -80,7 +80,7 @@ export default class LinkModal extends React.Component {
 		const fromType = this.getFromType(card)
 		const availableTypeSlugs = this.getAvailableTypeSlugs(types)
 		const linkTypeTargets = this.filterLinks(linkVerb, availableTypeSlugs, target, fromType)
-		const linkType = _.first(linkTypeTargets)
+		const linkType = linkTypeTargets.length === 1 ? linkTypeTargets[0] : null
 
 		this.state = {
 			submitting: false,
@@ -185,7 +185,7 @@ export default class LinkModal extends React.Component {
 				title={title}
 				cancel={this.props.onHide}
 				primaryButtonProps={{
-					disabled: !linkType || submitting,
+					disabled: !linkType || !selectedTargetValue || submitting,
 					'data-test': 'card-linker--existing__submit'
 				}}
 				action={submitting ? <Icon spin name="cog"/> : 'OK'}
@@ -200,7 +200,7 @@ export default class LinkModal extends React.Component {
 					{linkTypeTargets.length > 1 && (
 						<Select ml={2}
 							id="card-linker--type-select"
-							value={linkType}
+							value={linkType || ''}
 							onChange={this.handleLinkTypeSelect}
 							labelKey="title"
 							options={linkTypeTargets}
@@ -214,9 +214,9 @@ export default class LinkModal extends React.Component {
 					>
 						<AutoCompleteCardSelect
 							value={selectedTargetValue}
-							cardType={linkType.data.to}
+							cardType={_.get(linkType, [ 'data', 'to' ])}
 							types={types}
-							isDisabled={Boolean(target)}
+							isDisabled={Boolean(target) || !linkType}
 							onChange={this.handleTargetSelect}
 						/>
 					</Box>


### PR DESCRIPTION

ui-components: Ensure Select options not cllipped

Set the menu portal's target to the document body and set the z-index so that it appears above (for example) a modal.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
ui-components: No link type selected by default when linking cards
Also:
* Disable the target select element until a link type has been selected
* Disable the action button until a target has been selected

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3526 
Fixes #3533 
