### PR TITLE
core: Let version fragments be null

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -50,9 +50,9 @@ exports.setup = async (context, connection, database, options = {}) => {
 				type TEXT NOT NULL,
 				active BOOLEAN NOT NULL,
 				version TEXT NOT NULL,
-				version_major INTEGER NOT NULL DEFAULT 1 CHECK (version_major >= 0),
-				version_minor INTEGER NOT NULL DEFAULT 0 CHECK (version_minor >= 0),
-				version_patch INTEGER NOT NULL DEFAULT 0 CHECK (version_patch >= 0),
+				version_major INTEGER DEFAULT 1,
+				version_minor INTEGER,
+				version_patch INTEGER,
 				name TEXT,
 				tags TEXT[] NOT NULL,
 				markers TEXT[] NOT NULL,
@@ -64,7 +64,9 @@ exports.setup = async (context, connection, database, options = {}) => {
 				updated_at TEXT,
 				linked_at JSONB NOT NULL,
 				new_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-				new_updated_at TIMESTAMP WITH TIME ZONE)`)
+				new_updated_at TIMESTAMP WITH TIME ZONE,
+				CONSTRAINT version_positive
+					CHECK (version_major >= 0 AND version_minor >= 0 AND version_patch >= 0))`)
 
 		/*
 		 * Disable compression on the jsonb columns so we can access

--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -244,12 +244,17 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		})
 	}
 
+	const [ major, minor, patch ] = insertedObject.version.split('.')
+
 	const payload = [
 		elementId,
 		insertedObject.slug,
 		insertedObject.type,
 		insertedObject.active,
 		insertedObject.version,
+		major,
+		minor,
+		patch,
 		typeof insertedObject.name === 'string'
 			? insertedObject.name
 			: null,
@@ -276,33 +281,36 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		if (options.replace) {
 			const sql = `
 				INSERT INTO ${table}
-					(id, slug, type, active, version, name, tags, markers,
-					created_at, links, requires, capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at,
-					version_major, version_minor, version_patch)
+					(id, slug, type, active, version,
+					version_major, version_minor, version_patch,
+					name, tags, markers, created_at, links, requires,
+					capabilities, data, updated_at,
+					linked_at, new_created_at, new_updated_at)
 				VALUES
-					($1, $2, $3, $4, $5, $6, $7, $8,
-					$9, $10, $11, $12, $13, NULL,
-					$15, $16, NULL, 1, 0, 0)
+					($1, $2, $3, $4, $5,
+					$6, $7, $8,
+					$9, $10, $11, $12, $13, $14,
+					$15, $16, NULL,
+					$18, $19, NULL)
 				ON CONFLICT (slug) DO UPDATE SET
 					id = ${table}.id,
 					active = $4,
 					version = $5,
-					version_major = 1,
-					version_minor = 0,
-					version_patch = 0,
-					name = $6,
-					tags = $7,
-					markers = $8,
+					version_major = $6,
+					version_minor = $7,
+					version_patch = $8,
+					name = $9,
+					tags = $10,
+					markers = $11,
 					created_at = ${table}.created_at,
 					links = ${table}.links,
-					requires = $11,
-					capabilities = $12,
-					data = $13,
-					updated_at = $14,
+					requires = $14,
+					capabilities = $15,
+					data = $16,
+					updated_at = $17,
 					linked_at = ${table}.linked_at,
 					new_created_at = ${table}.new_created_at,
-					new_updated_at = $17
+					new_updated_at = $20
 				RETURNING ${CARDS_SELECT}`
 
 			results = await connection.any({
@@ -313,14 +321,15 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		} else {
 			const sql = `
 				INSERT INTO ${table}
-					(id, slug, type, active, version, name, tags, markers,
-					created_at, links, requires, capabilities, data, updated_at,
-					linked_at, new_created_at, new_updated_at,
-					version_major, version_minor, version_patch)
+					(id, slug, type, active, version,
+					version_major, version_minor, version_patch,
+					name, tags, markers, created_at, links, requires,
+					capabilities, data, updated_at,
+					linked_at, new_created_at, new_updated_at)
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, $14,
-					$15, $16, $17, 1, 0, 0)
+					$15, $16, $17, $18, $19, $20)
 				RETURNING ${CARDS_SELECT}`
 			results = await connection.any({
 				name: `cards-upsert-insert-${table}`,


### PR DESCRIPTION
The top level version field will correspond to component versions, so we
are happy to let some fragments be null, to model entities like Ubuntu,
which only use two fragments, i.e. 16.04.

Change-type: minor


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!