### PR TITLE
Support for short semver versions

### DIFF
--- a/lib/action-library/actions/action-create-card.js
+++ b/lib/action-library/actions/action-create-card.js
@@ -40,7 +40,7 @@ module.exports = {
 					},
 					version: {
 						type: 'string',
-						pattern: '^\\d+\\.\\d+\\.\\d+$'
+						pattern: '^\\d+(\\.\\d+)?(\\.\\d+)?$'
 					},
 					slug: {
 						type: 'string',

--- a/lib/core/cards/card.js
+++ b/lib/core/cards/card.js
@@ -23,7 +23,7 @@ module.exports = {
 				},
 				version: {
 					type: 'string',
-					pattern: '^\\d+\\.\\d+\\.\\d+$'
+					pattern: '^\\d+(\\.\\d+)?(\\.\\d+)?$'
 				},
 				slug: {
 					type: 'string',
@@ -34,7 +34,7 @@ module.exports = {
 				},
 				type: {
 					type: 'string',
-					pattern: '^[a-z0-9-]+@\\d+\\.\\d+\\.\\d+$'
+					pattern: '^[a-z0-9-]+@\\d+(\\.\\d+)?(\\.\\d+)?$'
 				},
 				tags: {
 					type: 'array',

--- a/lib/core/cards/link.js
+++ b/lib/core/cards/link.js
@@ -48,7 +48,7 @@ module.exports = {
 								},
 								type: {
 									type: 'string',
-									pattern: '^[a-z0-9-]+@\\d+\\.\\d+\\.\\d+$'
+									pattern: '^[a-z0-9-]+@\\d+(\\.\\d+)?(\\.\\d+)?$'
 								}
 							}
 						},
@@ -62,7 +62,7 @@ module.exports = {
 								},
 								type: {
 									type: 'string',
-									pattern: '^[a-z0-9-]+@\\d+\\.\\d+\\.\\d+$'
+									pattern: '^[a-z0-9-]+@\\d+(\\.\\d+)?(\\.\\d+)?$'
 								}
 							}
 						}

--- a/lib/queue/cards/execute.js
+++ b/lib/queue/cards/execute.js
@@ -53,7 +53,7 @@ module.exports = {
 											format: 'uuid'
 										},
 										{
-											pattern: '^[a-z0-9-]+(@\\d+\\.\\d+\\.\\d+)?$'
+											pattern: '^[a-z0-9-]+(@\\d+)?(\\.\\d+)?(\\.\\d+)?$'
 										}
 									]
 								},

--- a/lib/worker/cards/triggered-action.js
+++ b/lib/worker/cards/triggered-action.js
@@ -30,7 +30,7 @@ module.exports = {
 						},
 						type: {
 							type: 'string',
-							pattern: '^[a-z0-9-]+(@\\d+\\.\\d+\\.\\d+)?$'
+							pattern: '^[a-z0-9-]+@\\d+(\\.\\d+)?(\\.\\d+)?$'
 						},
 						startDate: {
 							type: 'string',


### PR DESCRIPTION
We want to allow versions such as:

- 1.0.0
- 1.0
- 1

To model entities that don't necessarily follow three-component semver.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!