### PR TITLE
core: Use new version fields in card slug getters

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -177,19 +177,55 @@ exports.getBySlug = async (context, connection, slug, options = {}) => {
 	})
 
 	const [ base, version ] = slug.split('@')
+	const [ major, minor, patch ] = version.split('.')
 
 	let results = []
 	if (!version || version === 'latest') {
 		results = await connection.any({
 			name: `cards-getbyslug-noversion-${table}`,
-			text: `SELECT ${CARDS_SELECT} FROM ${table} WHERE slug = $1 ORDER BY version DESC LIMIT 1;`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table}
+				WHERE slug = $1
+				ORDER BY version_major DESC NULLS LAST,
+								 version_minor DESC NULLS LAST,
+								 version_patch DESC NULLS LAST;
+				LIMIT 1;`,
 			values: [ base ]
+		})
+	} else if (!_.isNil(major) && !_.isNil(minor) && !_.isNil(patch)) {
+		results = await connection.any({
+			name: `cards-getbyslug-version-major-minor-patch-${table}`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table}
+				WHERE slug = $1 AND
+				version_major = $2 AND version_minor = $3 AND version_patch = $4
+				LIMIT 1;`,
+			values: [ base, major, minor, patch ]
+		})
+	} else if (!_.isNil(major) && !_.isNil(minor) && _.isNil(patch)) {
+		results = await connection.any({
+			name: `cards-getbyslug-version-major-minor-${table}`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table}
+				WHERE slug = $1 AND
+				version_major = $2 AND version_minor = $3 AND version_patch IS NULL
+				LIMIT 1;`,
+			values: [ base, major, minor ]
+		})
+	} else if (!_.isNil(major) && _.isNil(minor) && _.isNil(patch)) {
+		results = await connection.any({
+			name: `cards-getbyslug-version-major-${table}`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table}
+				WHERE slug = $1 AND
+				version_major = $2 AND version_minor = IS NULL AND version_patch IS NULL
+				LIMIT 1;`,
+			values: [ base, major ]
 		})
 	} else {
 		results = await connection.any({
-			name: `cards-getbyslug-version-${table}`,
-			text: `SELECT ${CARDS_SELECT} FROM ${table} WHERE slug = $1 AND version = $2 LIMIT 1;`,
-			values: [ base, version ]
+			name: `cards-getbyslug-version-null-${table}`,
+			text: `SELECT ${CARDS_SELECT} FROM ${table}
+				WHERE slug = $1 AND
+				version_major IS NULL AND version_minor IS NULL AND version_patch IS NULL
+				LIMIT 1;`,
+			values: [ base ]
 		})
 	}
 


### PR DESCRIPTION
Change-type: minor


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!