### PR TITLE
Replace `name` keyword in query with `title` as the former is not valid in JSON schema

### DIFF
--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -276,8 +276,7 @@ class ViewRenderer extends React.Component {
 			} = options
 
 			const filter = {
-				name: USER_FILTER_NAME,
-				title: 'is',
+				title: USER_FILTER_NAME,
 				description: `${sliceTitle} is ${slice.value}`,
 				type: 'object',
 				properties: {}


### PR DESCRIPTION

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
