### PR TITLE
jsonschema2sql: Translate version to match version fragment fields

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder.js
@@ -96,6 +96,16 @@ exports.getProperty = (property, options = {}) => {
 		: pgFormat.ident(property[1])
 
 	if (property.length === 2) {
+		if (property[1] === 'version') {
+			const fragments = [
+				`COALESCE(${property[0]}.version_major, '1')::text`,
+				`COALESCE(${property[0]}.version_minor, '0')::text`,
+				`COALESCE(${property[0]}.version_patch, '0')::text`
+			].join(',\n  ')
+
+			return `CONCAT_WS('.', ${fragments})`
+		}
+
 		return root
 	}
 

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -332,7 +332,7 @@ exports.insertCard = async (context, jellyfish, session, typeCard, options, obje
 	let card = null
 	if (object.slug) {
 		card = await jellyfish.getCardBySlug(
-			context, session, `${object.slug}@${object.version}`)
+			context, session, `${object.slug}@${object.version || 'latest'}`)
 	}
 	if (!card && object.id) {
 		card = await jellyfish.getCardById(


### PR DESCRIPTION
Change-type: minor


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!