### PR TITLE
ui-components: Allow 404 channels to be closed

### DIFF
--- a/lib/ui-components/ChannelRenderer.jsx
+++ b/lib/ui-components/ChannelRenderer.jsx
@@ -11,13 +11,15 @@ import {
 } from 'react-dnd'
 import {
 	Alert,
-	Box
+	Box,
+	Flex
 } from 'rendition'
 import styled from 'styled-components'
-
-// TODO: These ui-components -> ui imports should not happen
-import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
-import Icon from '../../lib/ui-components/shame/Icon'
+import ErrorBoundary from './shame/ErrorBoundary'
+import Icon from './shame/Icon'
+import {
+	CloseButton
+} from './shame/CloseButton'
 import LinkModal from './LinkModal'
 
 const ErrorNotFound = styled.h1 `
@@ -114,9 +116,23 @@ class ChannelRenderer extends React.Component {
 
 			if (head === null) {
 				return (
-					<ErrorNotFound>
-						404
-					</ErrorNotFound>
+					<div style={style}>
+						<Flex flexDirection='column' alignItems='center' flex={1}>
+							<Box
+								flex={0}
+								alignSelf='flex-end'
+								mr={3}
+								mt={3}
+							>
+								<CloseButton
+									channel={channel}
+								/>
+							</Box>
+							<ErrorNotFound flex={1}>
+							404
+							</ErrorNotFound>
+						</Flex>
+					</div>
 				)
 			}
 


### PR DESCRIPTION
Added a little close button to the top right of a 404'd channel
Also fixed the layout of a 404 error message when the channel is not the only channel.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3488 

_Note: also tidied up a few import paths_

### Before
![image](https://user-images.githubusercontent.com/2925657/79837475-ad7dca00-83db-11ea-8293-c28943986702.png)

### After
![404](https://user-images.githubusercontent.com/2925657/79837407-8f17ce80-83db-11ea-85fe-97abe69f9949.gif)

