### PR TITLE
ui-components: Sanitize code blocks in card chat summaries

### DIFF
--- a/lib/ui-components/CardChatSummary/index.jsx
+++ b/lib/ui-components/CardChatSummary/index.jsx
@@ -117,6 +117,7 @@ export class CardChatSummary extends React.Component {
 			const typeBase = event.type.split('@')[0]
 			if (typeBase === 'message' || typeBase === 'whisper') {
 				latestMessageText = _.get(event, [ 'data', 'payload', 'message' ], '')
+					.replace(/```[^`]*```/, '`<code block>`')
 					.split('\n')
 					.shift()
 				break


### PR DESCRIPTION
Code blocks are now replaced with <code block> static text.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Just a small fix to improve the display of messages with just a code block in them in the chat summary.

Fixes #3479 

### Before
![CodeBlock - before](https://user-images.githubusercontent.com/2925657/79840502-2e3ec500-83e0-11ea-99c1-694359c09a3d.png)

### After
![CodeBlock - after](https://user-images.githubusercontent.com/2925657/79840515-33037900-83e0-11ea-9c65-68cb99ce728a.png)
