### PR TITLE
core: Make TEXT version field obsolete

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -62,7 +62,6 @@ exports.setup = async (context, connection, database, options = {}) => {
 				slug VARCHAR (255) UNIQUE NOT NULL,
 				type TEXT NOT NULL,
 				active BOOLEAN NOT NULL,
-				version TEXT NOT NULL DEFAULT '1.0.0',
 				version_major INTEGER DEFAULT 1,
 				version_minor INTEGER,
 				version_patch INTEGER,
@@ -92,9 +91,6 @@ exports.setup = async (context, connection, database, options = {}) => {
 			ALTER COLUMN links SET STORAGE EXTERNAL,
 			ALTER COLUMN linked_at SET STORAGE EXTERNAL`)
 	}
-
-	await connection.any(`
-		ALTER TABLE ${table} ALTER COLUMN version SET DEFAULT '1.0.0'`)
 
 	if (options.noIndexes) {
 		return
@@ -290,7 +286,6 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		insertedObject.slug,
 		insertedObject.type,
 		insertedObject.active,
-		insertedObject.version,
 		major,
 		minor,
 		patch,
@@ -320,36 +315,35 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		if (options.replace) {
 			const sql = `
 				INSERT INTO ${table}
-					(id, slug, type, active, version,
+					(id, slug, type, active,
 					version_major, version_minor, version_patch,
 					name, tags, markers, created_at, links, requires,
 					capabilities, data, updated_at,
 					linked_at, new_created_at, new_updated_at)
 				VALUES
-					($1, $2, $3, $4, $5,
-					$6, $7, $8,
-					$9, $10, $11, $12, $13, $14,
-					$15, $16, NULL,
-					$18, $19, NULL)
+					($1, $2, $3, $4,
+					$5, $6, $7,
+					$8, $9, $10, $11, $12, $13,
+					$14, $15, NULL,
+					$17, $18, NULL)
 				ON CONFLICT (slug) DO UPDATE SET
 					id = ${table}.id,
 					active = $4,
-					version = $5,
-					version_major = $6,
-					version_minor = $7,
-					version_patch = $8,
-					name = $9,
-					tags = $10,
-					markers = $11,
+					version_major = $5,
+					version_minor = $6,
+					version_patch = $7,
+					name = $8,
+					tags = $9,
+					markers = $10,
 					created_at = ${table}.created_at,
 					links = ${table}.links,
-					requires = $14,
-					capabilities = $15,
-					data = $16,
-					updated_at = $17,
+					requires = $13,
+					capabilities = $14,
+					data = $15,
+					updated_at = $16,
 					linked_at = ${table}.linked_at,
 					new_created_at = ${table}.new_created_at,
-					new_updated_at = $20
+					new_updated_at = $19
 				RETURNING ${CARDS_SELECT}`
 
 			results = await connection.any({
@@ -360,7 +354,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 		} else {
 			const sql = `
 				INSERT INTO ${table}
-					(id, slug, type, active, version,
+					(id, slug, type, active,
 					version_major, version_minor, version_patch,
 					name, tags, markers, created_at, links, requires,
 					capabilities, data, updated_at,
@@ -368,7 +362,7 @@ exports.upsert = async (context, errors, connection, object, options) => {
 				VALUES
 					($1, $2, $3, $4, $5, $6, $7, $8,
 					$9, $10, $11, $12, $13, $14,
-					$15, $16, $17, $18, $19, $20)
+					$15, $16, $17, $18, $19)
 				RETURNING ${CARDS_SELECT}`
 			results = await connection.any({
 				name: `cards-upsert-insert-${table}`,


### PR DESCRIPTION
We will rely on the `INTEGER` counter-parts for better sorting performance.
It will still look like a version string from outside, so we don't break
any interface.

Change-type: patch
Signed-off-by: Juan Cruz Viotti <juan@balena.io>