### PR TITLE
Update role schema within user card - require community role to be present alongside the operator role

### DIFF
--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -116,8 +116,21 @@ module.exports = {
 								not: {
 									const: 'user-admin'
 								}
-							}
-						},
+							},
+								anyOf: [ {
+									contains: {
+										type: 'string',
+										const: 'user-community'
+									}
+								}, {
+									not: {
+										contains: {
+											type: 'string',
+											const: 'user-operator'
+										}
+									}
+								} ]
+							},
 						oauth: {
 							description: 'Linked accounts',
 							type: 'object'


### PR DESCRIPTION
the operator role has been designed to build upon the community role for a user. Giving a user the operator role without also giving them the community role will mean they have access to much more than we intend.

This PR updates the user schema so that it expects the community role to be present when the operator role is added to a user