### PR TITLE
Configure independent readiness and liveness endpoints

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -20,14 +20,14 @@ spec:
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
-            path: /health
+            path: /liveness
             port: 8000
           initialDelaySeconds: 20
           periodSeconds: 10
           timeoutSeconds: 8
         readinessProbe:
           httpGet:
-            path: /health
+            path: /readiness
             port: 8000
           initialDelaySeconds: 20
           periodSeconds: 10


### PR DESCRIPTION
This commit also changes the webserver so that it starts returning 503
status for the readiness probe very early in the boostrap phase. Once
boostrap is complete, the readiness probe will return 200 status,
indicating the server is ready to accept traffic.

Change-type: minor
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
