### PR TITLE
Stop docker compose from rebuilding images unnecessarily

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: balena/jellyfish
     build:
       context: .
       dockerfile: apps/server/Dockerfile
@@ -144,6 +145,7 @@ services:
       timeout: 10s
     restart: always
   tick:
+    image: balena/jellyfish-tick-server
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.tick
@@ -217,6 +219,7 @@ services:
       - internal
   {{#workers}}
   worker_{{idx}}:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: balena/jellyfish
     build:
       context: .
       dockerfile: apps/server/Dockerfile
@@ -144,6 +145,7 @@ services:
       timeout: 10s
     restart: always
   tick:
+    image: balena/jellyfish-tick-server
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.tick
@@ -216,6 +218,7 @@ services:
     networks:
       - internal
   worker_1:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker
@@ -271,6 +274,7 @@ services:
     networks:
       - internal
   worker_2:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker
@@ -326,6 +330,7 @@ services:
     networks:
       - internal
   worker_3:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker


### PR DESCRIPTION
Providing an image name for containers built by docker compose should
make compose choose the correct images from local cache

Fixes product-os/jellyfish#3578

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>