### PR TITLE
Fix: #3031 inherit chevron color style from container

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -627,7 +627,8 @@ export default class Event extends React.Component {
 										py={1}
 										onClick={this.expand}
 										style={this.state.expanded ? {} : {
-											boxShadow: '0 -5px 5px -5px rgba(0,0,0,0.5)'
+											boxShadow: '0 -5px 5px -5px rgba(0,0,0,0.5)',
+											color: 'inherit'
 										}}
 									>
 										<Icon name={`chevron-${this.state.expanded ? 'up' : 'down'}`} />


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

## Before
<img width="994" alt="Screenshot 2020-04-27 at 15 40 55" src="https://user-images.githubusercontent.com/11800807/80378816-8290eb80-889d-11ea-9f42-76005a663a44.png">

## After
<img width="997" alt="Screenshot 2020-04-27 at 15 35 42" src="https://user-images.githubusercontent.com/11800807/80378776-77d65680-889d-11ea-9bc6-ccf85370a17d.png">
