### PR TITLE
Fix front urls in messages

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -88,7 +88,8 @@ const EventButton = styled.button `
 	border-left-width: 3px;
 `
 
-const FRONT_IMG_RE = /^\[\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+\]$/
+const FRONT_MARKDOWN_IMG_RE = /\[\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+\]/g
+const FRONT_HTML_IMG_RE = /\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+/g
 
 const getTargetId = (card) => {
 	return _.get(card, [ 'data', 'target' ]) || card.id
@@ -99,20 +100,17 @@ export const getMessage = (card) => {
 
 	// Fun hack to extract attached images embedded in HTML from synced front messages
 	if (message.includes('<img src="/api/1/companies/resin_io/attachments')) {
-		const match = message.match(/\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+/)
-		let formatted = message
-		match.forEach((source) => {
-			const index = formatted.indexOf(match)
-			formatted = `${formatted.slice(0, index)}https://app.frontapp.com${formatted.slice(index)}`
+		return message.replace(FRONT_HTML_IMG_RE, (source) => {
+			return `https://app.frontapp.com${source}`
 		})
-
-		return formatted
 	}
 
 	// Fun hack to extract attached images from synced front messages embedded in
 	// a different way
-	if (message.match(FRONT_IMG_RE)) {
-		return `![Attached image](https://app.frontapp.com${message.slice(1, -1)})`
+	if (message.match(FRONT_MARKDOWN_IMG_RE)) {
+		return message.replace(FRONT_MARKDOWN_IMG_RE, (source) => {
+			return `![Attached image](https://app.frontapp.com${source.slice(1, -1)})`
+		})
 	}
 
 	return message

--- a/lib/ui-components/Event/tests/Event.spec.jsx
+++ b/lib/ui-components/Event/tests/Event.spec.jsx
@@ -61,7 +61,7 @@ ava('It should display the actor\'s details', (test) => {
 	test.is(actorLabel.props().tooltip, actor.email)
 })
 
-ava('getMessage() should prefix Front images embedded in img tags', (test) => {
+ava('getMessage() should prefix Front image embedded in img tags', (test) => {
 	const url = '/api/1/companies/resin_io/attachments/8381633c052e15b96c3a25581f7869b5332c032b?resource_link_id=14267942787'
 	const formatted = getMessage({
 		data: {
@@ -74,7 +74,20 @@ ava('getMessage() should prefix Front images embedded in img tags', (test) => {
 	test.is(formatted, `<img src="https://app.frontapp.com${url}">`)
 })
 
-ava('getMessage() should prefix Front images embedded in square brackets', (test) => {
+ava('getMessage() should prefix multitple Front images embedded in img tags', (test) => {
+	const url = '/api/1/companies/resin_io/attachments/8381633c052e15b96c3a25581f7869b5332c032b?resource_link_id=14267942787'
+	const formatted = getMessage({
+		data: {
+			payload: {
+				message: `<img src="${url}"><img src="${url}"><img src="${url}"><img src="${url}">`
+			}
+		}
+	})
+
+	test.is(formatted, `<img src="https://app.frontapp.com${url}"><img src="https://app.frontapp.com${url}"><img src="https://app.frontapp.com${url}"><img src="https://app.frontapp.com${url}">`)
+})
+
+ava('getMessage() should prefix Front image embedded in square brackets', (test) => {
 	const url = '/api/1/companies/resin_io/attachments/8381633c052e15b96c3a25581f7869b5332c032b?resource_link_id=14267942787'
 	const formatted = getMessage({
 		data: {
@@ -85,6 +98,19 @@ ava('getMessage() should prefix Front images embedded in square brackets', (test
 	})
 
 	test.is(formatted, `![Attached image](https://app.frontapp.com${url})`)
+})
+
+ava('getMessage() should prefix multiple Front images embedded in square brackets', (test) => {
+	const url = '/api/1/companies/resin_io/attachments/8381633c052e15b96c3a25581f7869b5332c032b?resource_link_id=14267942787'
+	const formatted = getMessage({
+		data: {
+			payload: {
+				message: `[${url}] [${url}] [${url}]`
+			}
+		}
+	})
+
+	test.is(formatted, `![Attached image](https://app.frontapp.com${url}) ![Attached image](https://app.frontapp.com${url}) ![Attached image](https://app.frontapp.com${url})`)
 })
 
 ava('getMessage() should hide "#jellyfish-hidden" messages', (test) => {


### PR DESCRIPTION
Instead of pre-fixing only the first URL in a message, this change will match and pre-fix all Front URLs in a message.

Fixes: #3012
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
