### PR TITLE
SRE: Increase API liveness threshold to 10.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -25,6 +25,7 @@ spec:
           initialDelaySeconds: 20
           periodSeconds: 10
           timeoutSeconds: 8
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /readiness


### PR DESCRIPTION
The liveness commonly fails around 6 times during boot up
of the service. Increasing the threshold instead of the
initial delay allows the service to identify it as alive
sooner.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

