### PR TITLE
Improve support for password managers

### DIFF
--- a/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
+++ b/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
@@ -88,6 +88,7 @@ class CompleteFirstTimeLogin extends React.Component {
 						name="password"
 						placeholder="New Password"
 						type="password"
+						autoComplete="new-password"
 						value={password}
 						onChange={this.handleInputChange}
 					/>
@@ -100,6 +101,7 @@ class CompleteFirstTimeLogin extends React.Component {
 						name="passwordConfirmation"
 						placeholder="Password Confirmation"
 						type="password"
+						autoComplete="new-password"
 						value={passwordConfirmation}
 						onChange={this.handleInputChange}
 					/>

--- a/lib/ui-components/Auth/CompletePasswordReset/CompletePasswordReset.jsx
+++ b/lib/ui-components/Auth/CompletePasswordReset/CompletePasswordReset.jsx
@@ -88,6 +88,7 @@ class CompletePasswordReset extends React.Component {
 						name="password"
 						placeholder="New Password"
 						type="password"
+						autoComplete="new-password"
 						value={password}
 						onChange={this.handleInputChange}
 					/>
@@ -100,6 +101,7 @@ class CompletePasswordReset extends React.Component {
 						name="passwordConfirmation"
 						placeholder="Password Confirmation"
 						type="password"
+						autoComplete="new-password"
 						value={passwordConfirmation}
 						onChange={this.handleInputChange}
 					/>

--- a/lib/ui-components/Auth/Login/Login.jsx
+++ b/lib/ui-components/Auth/Login/Login.jsx
@@ -92,6 +92,7 @@ export default class Login extends React.Component {
 						width="100%"
 						emphasized={true}
 						placeholder="Username"
+						autoComplete="username"
 						value={username}
 						onChange={this.handleUsernameChange}
 					/>
@@ -104,6 +105,7 @@ export default class Login extends React.Component {
 						emphasized={true}
 						placeholder="Password"
 						type="password"
+						autoComplete="current-password"
 						value={password}
 						onChange={this.handlePasswordChange}
 					/>

--- a/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
+++ b/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
@@ -93,6 +93,7 @@ export default class RequestPasswordReset extends React.Component {
 						width="100%"
 						emphasized={true}
 						placeholder="Username"
+						autoComplete="username"
 						value={username}
 						onChange={this.handleUsernameChange}
 					/>

--- a/lib/ui-components/Auth/index.js
+++ b/lib/ui-components/Auth/index.js
@@ -34,12 +34,14 @@ const AuthContainer = (props) => {
 				justifyContent="space-between"
 				align="center"
 			>
-				<Icon
-					width={70}
-					pl={2}
-					p={10}
-					src="/icons/jellyfish-icon.svg"
-				/>
+				<Box>
+					<Icon
+						width={70}
+						pl={2}
+						p={10}
+						src="/icons/jellyfish-icon.svg"
+					/>
+				</Box>
 			</ShadowBox>
 			<Container mt={4}>
 				<AuthBox mx="auto">


### PR DESCRIPTION
Based on the following resources:

- https://hiddedevries.nl/en/blog/2018-01-13-making-password-managers-play-ball-with-your-login-form
- https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands

I formatted and tested our account management forms. With this change Jellyfish supports the following password managers:

All routes:
- Chrome
- 1Password

Route specific:
- Firefox
- LastPass

1Password and Lastpass extensions work consistently on Safari, Chrome and Firefox.

**Note:** Safari only triggers the keychain on actual page navigation. For now, the choice is made to not support Safari/iOS for this.

Issue #1008 has been investigated and labeld won't fix

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>