### PR TITLE
Use route params to add username to password reset form

### DIFF
--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -110,8 +110,8 @@ class JellyfishUI extends React.Component {
 				<AuthContainer>
 					<Switch>
 						<Route path='/request_password_reset' component={RequestPasswordReset} />
-						<Route path='/password_reset/:resetToken' component={CompletePasswordReset} />
-						<Route path='/first_time_login/:firstTimeLoginToken' component={CompleteFirstTimeLogin} />
+						<Route path='/password_reset/:resetToken/:username?' component={CompletePasswordReset} />
+						<Route path='/first_time_login/:firstTimeLoginToken/:username?' component={CompleteFirstTimeLogin} />
 						<Route path="/*" component={Login} />
 					</Switch>
 					<Notifications />

--- a/lib/action-library/handlers/action-request-password-reset.js
+++ b/lib/action-library/handlers/action-request-password-reset.js
@@ -190,7 +190,8 @@ const sendEmail = async ({
 		userEmail = userEmail[0]
 	}
 
-	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${resetToken}`
+	const username = user.slug.replace(/^user-/g, '')
+	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${resetToken}/${username}`
 
 	const request = {
 		arguments: {

--- a/lib/action-library/handlers/action-send-first-time-login-link.js
+++ b/lib/action-library/handlers/action-send-first-time-login-link.js
@@ -163,9 +163,8 @@ const sendEmail = async ({
 		userEmail = userEmail[0]
 	}
 
-	const firstTimeLoginUrl = `https://jel.ly.fish/first_time_login/${firstTimeLoginToken}`
-
 	const username = userCard.slug.replace(/^user-/g, '')
+	const firstTimeLoginUrl = `https://jel.ly.fish/first_time_login/${firstTimeLoginToken}/${username}`
 
 	const request = {
 		arguments: {

--- a/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
+++ b/lib/ui-components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react'
+import * as _ from 'lodash'
 import {
 	Box,
 	Button,
@@ -66,6 +67,8 @@ class CompleteFirstTimeLogin extends React.Component {
 			completingFirstTimeLogin
 		} = this.state
 
+		const username = _.get(this.props, [ 'match', 'params', 'username' ], '')
+
 		return (
 			<React.Fragment>
 				<Txt align="center" mb={4}>
@@ -78,6 +81,8 @@ class CompleteFirstTimeLogin extends React.Component {
 				<form
 					data-test="completeFirstTimeLogin-page__form"
 					onSubmit={this.completeFirstTimeLogin}>
+
+					<Input display="none" name="username" autoComplete="username" value={username} />
 
 					<Txt fontSize={1} mb={1}>Password</Txt>
 					<Input

--- a/lib/ui-components/Auth/CompletePasswordReset/CompletePasswordReset.jsx
+++ b/lib/ui-components/Auth/CompletePasswordReset/CompletePasswordReset.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react'
+import * as _ from 'lodash'
 import {
 	Box,
 	Button,
@@ -66,6 +67,8 @@ class CompletePasswordReset extends React.Component {
 			completingPasswordReset
 		} = this.state
 
+		const username = _.get(this.props, [ 'match', 'params', 'username' ], '')
+
 		return (
 			<React.Fragment>
 				<Txt align="center" mb={4}>
@@ -78,6 +81,8 @@ class CompletePasswordReset extends React.Component {
 				<form
 					data-test="completePasswordReset-page__form"
 					onSubmit={this.completePasswordReset}>
+
+					<Input display="none" name="username" autoComplete="username" value={username} />
 
 					<Txt fontSize={1} mb={1}>Password</Txt>
 					<Input

--- a/test/integration/worker/actions/request-password-reset.spec.js
+++ b/test/integration/worker/actions/request-password-reset.spec.js
@@ -185,7 +185,7 @@ ava('should send a password-reset email when the username in the argument matche
 		limit: 1
 	})
 
-	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${passwordReset.data.resetToken}`
+	const resetPasswordUrl = `https://jel.ly.fish/password_reset/${passwordReset.data.resetToken}/${username}`
 
 	const expectedEmailBody = `<p>Hello,</p><p>We have received a password reset request for the Jellyfish account attached to this email.</p><p>Please use the link below to reset your password:</p><a href="${resetPasswordUrl}">${resetPasswordUrl}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`
 

--- a/test/integration/worker/actions/send-first-time-login-link.spec.js
+++ b/test/integration/worker/actions/send-first-time-login-link.spec.js
@@ -253,7 +253,7 @@ ava('should send a first-time-login email to a user', async (test) => {
 		limit: 1
 	})
 
-	const firstTimeLoginUrl = `https://jel.ly.fish/first_time_login/${firstTimeLogin.data.firstTimeLoginToken}`
+	const firstTimeLoginUrl = `https://jel.ly.fish/first_time_login/${firstTimeLogin.data.firstTimeLoginToken}/${username}`
 
 	const expectedEmailBody = `<p>Hello,</p><p>Here is a link to login to your new Jellyfish account ${username}.</p><p>Please use the link below to set your password and login:</p><a href="${firstTimeLoginUrl}">${firstTimeLoginUrl}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`
 


### PR DESCRIPTION
For better password manager support we should include the username in the password reset form.

If the username is not present in the password reset in the form a new account entry will be created with only a password. With the username present, the existing entry will be updated with a new password.

This PR adds the username to the link sent to the user. Another option might be to save the username in local storage/redux when submitting the password reset request and loading the data while the user is on the `CompletePasswordReset` form.

Depends-on: #3610
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>