### PR TITLE
core: Add temporary DEFAULT value to the "version" column

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -62,7 +62,7 @@ exports.setup = async (context, connection, database, options = {}) => {
 				slug VARCHAR (255) UNIQUE NOT NULL,
 				type TEXT NOT NULL,
 				active BOOLEAN NOT NULL,
-				version TEXT NOT NULL,
+				version TEXT NOT NULL DEFAULT '1.0.0',
 				version_major INTEGER DEFAULT 1,
 				version_minor INTEGER,
 				version_patch INTEGER,


### PR DESCRIPTION
This is an intermediary state so we can remove this column definition
from the codebase and keep the system up and running while we delete it
from the actual production database.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!