### PR TITLE
backend: Add initial full text search support

### DIFF
--- a/apps/server/default-cards/contrib/message.json
+++ b/apps/server/default-cards/contrib/message.json
@@ -21,7 +21,8 @@
           "properties": {
             "timestamp": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "fullTextSearch": true
             },
             "actor": {
               "type": "string",
@@ -47,7 +48,8 @@
                   "type": "object",
                   "properties": {
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "fullTextSearch": true
                     },
                     "mime": {
                       "type": "string"
@@ -83,7 +85,8 @@
                 },
                 "message": {
                   "type": "string",
-                  "format": "markdown"
+                  "format": "markdown",
+                  "fullTextSearch": true
                 }
               }
             },

--- a/apps/server/default-cards/contrib/sales-thread.json
+++ b/apps/server/default-cards/contrib/sales-thread.json
@@ -12,13 +12,15 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": [ "string", "null" ]
+          "type": [ "string", "null" ],
+          "fullTextSearch": true
         },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "fullTextSearch": true
         },
         "data": {
           "type": "object",
@@ -27,7 +29,8 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "fullTextSearch": true
             },
             "mirrors": {
               "type": "array",
@@ -36,11 +39,13 @@
               }
             },
             "inbox": {
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             },
             "statusDescription": {
               "title": "Current Status",
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             },
             "status": {
               "title": "Status",
@@ -50,7 +55,8 @@
                 "open",
                 "closed",
                 "archived"
-              ]
+              ],
+              "fullTextSearch": true
             }
           }
         }

--- a/apps/server/default-cards/contrib/support-thread.json
+++ b/apps/server/default-cards/contrib/support-thread.json
@@ -12,14 +12,16 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": [ "string", "null" ]
+          "type": [ "string", "null" ],
+          "fullTextSearch": true
         },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "$$formula": "AGGREGATE($events, 'tags')"
+          "$$formula": "AGGREGATE($events, 'tags')",
+          "fullTextSearch": true
         },
         "data": {
           "type": "object",
@@ -33,13 +35,15 @@
                 "devices",
                 "fleetops",
                 "security"
-              ]
+              ],
+              "fullTextSearch": true
             },
             "tags": {
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "fullTextSearch": true
             },
             "mirrors": {
               "type": "array",
@@ -51,7 +55,8 @@
               "type": "string",
               "enum": [
                 "production"
-              ]
+              ],
+              "fullTextSearch": true
             },
             "participants": {
               "type": "array",
@@ -67,14 +72,17 @@
             },
             "description": {
               "type": "string",
-              "format": "markdown"
+              "format": "markdown",
+              "fullTextSearch": true
             },
             "inbox": {
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             },
             "statusDescription": {
               "title": "Current Status",
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             },
             "status": {
               "title": "Status",

--- a/apps/server/default-cards/contrib/thread.json
+++ b/apps/server/default-cards/contrib/thread.json
@@ -16,7 +16,8 @@
           "items": {
             "type": "string"
           },
-          "$$formula": "AGGREGATE($events, 'tags')"
+          "$$formula": "AGGREGATE($events, 'tags')",
+          "fullTextSearch": true
         },
         "data": {
           "type": "object",
@@ -30,7 +31,8 @@
               "$$formula": "AGGREGATE($events, 'data.payload.alertsUser')"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             }
           }
         }

--- a/apps/server/default-cards/contrib/whisper.json
+++ b/apps/server/default-cards/contrib/whisper.json
@@ -21,7 +21,8 @@
           "properties": {
             "timestamp": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "fullTextSearch": true
             },
             "target": {
               "type": "string",
@@ -51,7 +52,8 @@
                   "type": "object",
                   "properties": {
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "fullTextSearch": true
                     },
                     "mime": {
                       "type": "string"
@@ -66,7 +68,8 @@
                 },
                 "message": {
                   "type": "string",
-                  "format": "markdown"
+                  "format": "markdown",
+                  "fullTextSearch": true
                 }
               }
             },

--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -12,6 +12,9 @@ const uuid = require('../../../uuid')
 const assert = require('../../../assert')
 const metrics = require('../../../metrics')
 const utils = require('./utils')
+const traverse = require('traverse')
+const textSearch = require('./jsonschema2sql/text-search')
+
 const CARDS_TABLE = 'cards'
 const CARDS_TRIGGER_COLUMNS = [
 	'active',
@@ -170,6 +173,14 @@ exports.setup = async (context, connection, database, options = {}) => {
 	}, {
 		concurrency: 4
 	})
+
+	/*
+	 * Create function that allows us to create tsvector indexes from text[] fields.
+	 */
+	await connection.any(`
+		CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text) RETURNS text AS $$
+			SELECT array_to_string(arr, sep);
+		$$ LANGUAGE SQL IMMUTABLE`)
 }
 
 exports.getById = async (context, connection, id, options = {}) => {
@@ -443,7 +454,7 @@ exports.materializeLink = async (context, errors, connection, card, options = {}
 }
 
 /**
- * @param {Object} context - Session contect
+ * @param {Object} context - Session context
  * @param {Object} connection - Database connection
  * @param {String[]} fields - Fields to use as an index
  * @param {String} type - The card type to constrain the index by
@@ -505,4 +516,137 @@ exports.createTypeIndex = async (context, connection, fields, type) => {
 		await task.any(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "${fullyQualifiedIndexName}" ON ${CARDS_TABLE}
 		(${columns.join(',')}) WHERE type=${pgFormat.literal(versionedType)}`)
 	})
+}
+
+/**
+ * @param {Object} context - session context
+ * @param {Object} connection - database connection
+ * @param {String} type - card type name
+ * @param {Array} fields - fields to build indexes for
+ *
+ * @example
+ * const type = 'message'
+ * const fields = [
+ *   {
+ *     path: [ 'data', 'payload', 'message' ],
+ *     type: 'string'
+ *   }
+ * ]
+ * await cards.createFullTextSearchIndex(context, connection, type, fields)
+ */
+exports.createFullTextSearchIndex = async (context, connection, type, fields) => {
+	// Leave early if fields is empty
+	if (_.isEmpty(fields)) {
+		return
+	}
+
+	// Create all necessary search indexes for the given type
+	const typeBase = type.split('@')[0]
+	const versionedType = `${typeBase}@1.0.0`
+	await connection.task(async (task) => {
+		const tasks = []
+		fields.forEach((field) => {
+			const name = `${typeBase}__${field.path.join('_')}__search_idx`
+			tasks.push(task.any(`CREATE INDEX IF NOT EXISTS "${name}" ON ${CARDS_TABLE}
+				USING GIN(${textSearch.toTSVector(CARDS_TABLE, field.path, field.isRootArray)})
+				WHERE type=${pgFormat.literal(versionedType)}`))
+
+			logger.info(context, 'Creating search index', {
+				typeBase,
+				name
+			})
+		})
+
+		// Prevent large index creation timeouts and then create all indexes
+		await task.any('SET statement_timeout=0')
+		await Bluebird.all(tasks).catch((error) => {
+			throw error
+		})
+	})
+}
+
+/* @summary Parse field paths denoted as being targets for full-text search
+ * @function
+ *
+ * @param {Object} context - session context
+ * @param {Object} schema - type card schema to traverse
+ * @param {Object} errors - a set of rich error classes
+ * @returns {Array} list of objects containing field path information
+ *
+ * @example
+ * const paths = parseFullTextSearchFields(context, schema, errors)
+ */
+exports.parseFullTextSearchFields = (context, schema, errors) => {
+	const fields = []
+	const combinators = [ 'anyOf', 'allOf', 'oneOf' ]
+	traverse(schema).forEach(function (node) {
+		if (this.key === 'fullTextSearch' && this.node === true && !_.isNil(this.parent.node.type)) {
+			// Throw an error if item doesn't have "string" as a possible type.
+			const hasStringType = Boolean(_.includes(this.parent.node.type, 'string') ||
+				(_.has(this.parent.node, [ 'items', 'type' ]) && this.parent.node.items.type.includes('string')))
+			assert.INTERNAL(context, hasStringType,
+				errors.JellyfishInvalidSchema, 'Full-text search fields must contain "string" as a possible type')
+
+			if (_.intersection(this.path, combinators).length > 0) {
+				// Handle combinators by creating an index for its parent node.
+				for (let idx = 0; idx < this.path.length; idx++) {
+					if (/^anyOf|allOf|oneOf$/.test(this.path[idx])) {
+						const path = exports.fromTypePath(_.slice(this.path, 0, idx))
+						if (!_.find(fields, (field) => {
+							return _.isEqual(field.path, path)
+						})) {
+							fields.push({
+								path,
+								isRootArray: false
+							})
+						}
+					}
+				}
+			} else {
+				fields.push({
+					path: exports.fromTypePath(_.dropRight(this.path)),
+					isRootArray: exports.isRootArray(this.parent.node.type, this.parent.path)
+				})
+			}
+		}
+	})
+	return fields
+}
+
+/**
+ * @summary Convert field path in type card to path used inside of cards of that type
+ * @function
+ *
+ * @param {Array} from - full path to field as defined in the type card
+ * @returns {Array} path to same field but in the context of non-type card
+ *
+ * @example
+ * const from = [ 'data', 'schema', 'properties', 'data', 'properties', 'tags' ]
+ * const path = cards.fromTypePath(from)
+ */
+exports.fromTypePath = (from) => {
+	const path = from.join('.').replace(/^data\.schema\.properties\./, '').split('.')
+	const target = path.pop()
+	_.remove(path, (element) => {
+		return element === 'properties'
+	})
+	path.push(target)
+	return path
+}
+
+/**
+ * @summary Check if an item is a root-level array
+ * @function
+ *
+ * @param {String} type - item type
+ * @param {Array} path - path to item in array format
+ * @returns {Boolean} boolean denoting if is root-level array
+ *
+ * @example
+ * const type = 'array'
+ * const path = [ 'data', 'schema', 'properties', 'tags' ]
+ * const result = exports.isRootArray(type, path)
+ */
+exports.isRootArray = (type, path) => {
+	return Boolean(type === 'array' && _.isEqual(_.dropRight(path), [ 'data', 'schema', 'properties' ]))
 }

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -246,6 +246,12 @@ const upsertObject = async (context, backend, object, options) => {
 				await backend.createTypeIndex(context, fields, insertedObject.slug)
 			}
 		}
+
+		// Find full-text search fields for type cards and create search indexes
+		const fullTextSearchFields = cards.parseFullTextSearchFields(context, insertedObject, backend.errors)
+		if (fullTextSearchFields.length) {
+			await backend.createFullTextSearchIndex(context, insertedObject.slug, fullTextSearchFields)
+		}
 	}
 
 	return insertedObject
@@ -824,5 +830,12 @@ module.exports = class PostgresBackend {
 	 */
 	async createTypeIndex (context, fields, type) {
 		await cards.createTypeIndex(context, this.connection, fields, type)
+	}
+
+	/*
+	 * Creates a partial index on fields denoted as being targets for full-text searches
+	 */
+	async createFullTextSearchIndex (context, type, fields) {
+		await cards.createFullTextSearchIndex(context, this.connection, type, fields)
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -11,6 +11,7 @@ const assert = require('../../../../assert')
 const {
 	InvalidSchema
 } = require('./errors')
+const textSearch = require('./text-search')
 
 // Some string constants so that we get errors on typos instead of silent bugs
 const AND = 'AND'
@@ -201,6 +202,19 @@ class SqlFilter {
 		const operator = flags.ignoreCase ? '~*' : '~'
 
 		return new SqlFilter(`(${field})::text ${operator} ${pgFormat.literal(pattern)}`)
+	}
+
+	static stringFullTextSearch (query, term) {
+		const tsVector = textSearch.toTSVector(_.head(query.path), _.drop(query.path), false)
+		const tsQuery = textSearch.toTSQuery(term)
+		return new SqlFilter(`${tsVector} @@ ${tsQuery}`)
+	}
+
+	static stringArrayFullTextSearch (query, term) {
+		const isRootArray = Boolean(query.options.parentPath.length === 0 && query.path.length === 2)
+		const tsVector = textSearch.toTSVector(_.head(query.path), _.drop(query.path), isRootArray)
+		const tsQuery = textSearch.toTSQuery(term)
+		return new SqlFilter(`${tsVector} @@ ${tsQuery}`)
 	}
 
 	static isMultipleOf (query, multiple) {
@@ -430,7 +444,7 @@ COALESCE(${table}.version_patch, '0')::text
 	 *        parsing a sub schema.
 	 * @param {Object} options - An optional map with taking anything accepted
 	 *        by {@link SqlQuery#fromSchema}, plus the following (for internal
-     *        use only):
+	 *        use only):
 	 *        - parentJsonPath: an array denoting the current path in the JSON
 	 *          schema. Used to produce useful error messages when nesting
 	 *          SqlQuery instances.
@@ -1023,6 +1037,18 @@ COALESCE(${table}.version_patch, '0')::text
 		}
 
 		this.filter.and(this.ifTypeThen('string', filter))
+	}
+
+	fullTextSearchVisitor (value) {
+		assert.INTERNAL(null, _.isPlainObject(value), Error, () => {
+			return `value for '${this.formatJsonPath('fullTextSearch')}' must be a map`
+		})
+		assert.INTERNAL(null, _.isString(value.term), Error, () => {
+			return `value for '${this.formatJsonPath('fullTextSearch')}.term' must be a string`
+		})
+
+		this.filter.and(this.ifTypeThen('string', SqlFilter.stringFullTextSearch(this, value.term)))
+		this.filter.and(this.ifTypeThen('array', SqlFilter.stringArrayFullTextSearch(this, value.term)))
 	}
 
 	ifTypeThen (type, filter) {

--- a/lib/core/backend/postgres/jsonschema2sql/text-search.js
+++ b/lib/core/backend/postgres/jsonschema2sql/text-search.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const pgFormat = require('pg-format')
+
+/**
+ * @summary Prepare a Postgres to_tsvector function call for full-text search
+ * @function
+ *
+ * @param {String} table - table name
+ * @param {Array} path - path to field
+ * @param {Boolean} isRootArray - denotes if Postgres text[] column
+ * @returns {String} to_tsvector function call
+ *
+ * @example
+ * const table = 'cards'
+ * const path = [ 'data', 'payload', 'message' ]
+ * const isRootTextArray = false
+ * const result = exports.toTSVector(table, path, isRootTextArray)
+ */
+exports.toTSVector = (table, path, isRootArray) => {
+	const keys = _.clone(path)
+
+	// Non-JSONB arrays need to be joined into a string before tokenization
+	if (keys.length === 1) {
+		const selector = `${table}.${keys.shift()}`
+		if (isRootArray) {
+			return `to_tsvector('english', immutable_array_to_string(${selector}, ' '))`
+		}
+		return `to_tsvector('english', ${selector})`
+	}
+
+	// Anything under data can be handled with jsonb_to_tsvector
+	return `jsonb_to_tsvector('english', ${table}.${keys.shift()}#>'{${keys.join(',')}}', '["string"]')`
+}
+
+/**
+ * @summary Prepare a Postgres tsquery function call for full-text search
+ * @function
+ *
+ * @param {String} term - term to search for
+ * @returns {String} tsquery function call
+ *
+ * @example
+ * const term = 'test'
+ * const result = exports.toTSQuery(term)
+ */
+exports.toTSQuery = (term) => {
+	return `plainto_tsquery('english', ${pgFormat.literal(term)})`
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19729,6 +19729,11 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "trim-off-newlines": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "socket.io-redis": "^5.2.0",
     "static-eval": "^2.0.2",
     "styled-components": "^5.0.1",
+    "traverse": "^0.6.6",
     "turndown": "^5.0.3",
     "typed-errors": "^1.1.0",
     "use-debounce": "^3.1.0",

--- a/test/e2e/server/full-text-search.spec.js
+++ b/test/e2e/server/full-text-search.spec.js
@@ -1,0 +1,460 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const _ = require('lodash')
+const helpers = require('../sdk/helpers')
+const uuid = require('uuid/v4')
+
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
+
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
+
+ava.serial.before(async (test) => {
+	// Create support-thread card to execute full-text search tests against.
+	test.context.supportThread = await test.context.sdk.card.create({
+		slug: `support-thread-test-${uuid()}`,
+		type: 'support-thread',
+		version: '1.0.0',
+		name: 'Who controls the past controls the future.',
+		tags: [
+			'foo',
+			'bar'
+		],
+		data: {
+			status: 'open',
+			category: 'security',
+			description: 'Perhaps a lunatic was simply a minority of one.',
+			environment: 'production',
+			statusDescription: 'in-progress',
+			inbox: 'my-inbox',
+			tags: [
+				'baz',
+				'buz'
+			]
+		}
+	})
+
+	// Create message card to execute full-text search tests against.
+	test.context.message = await test.context.sdk.action({
+		card: test.context.supportThread.id,
+		type: test.context.supportThread.type,
+		action: 'action-create-event@1.0.0',
+		arguments: {
+			type: 'message',
+			slug: `message-test-${uuid()}`,
+			payload: {
+				message: 'Who controls the past controls the future.'
+			}
+		}
+	})
+})
+
+const executeSearch = (test, type, anyOf) => {
+	return test.context.http(
+		'POST',
+		'/api/v2/query',
+		{
+			query: {
+				type: 'object',
+				additionalProperties: true,
+				required: [
+					'active',
+					'type'
+				],
+				anyOf,
+				properties: {
+					type: {
+						type: 'string',
+						const: `${type}@1.0.0`
+					},
+					active: {
+						type: 'boolean',
+						const: true
+					}
+				}
+			},
+			options: {
+				limit: 100
+			}
+		},
+		{
+			Authorization: `Bearer ${test.context.token}`
+		}
+	)
+}
+
+ava.serial('full-text search should match queries for card root-level string fields', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					name: {
+						type: 'string',
+						fullTextSearch: {
+							term: 'control past'
+						}
+					}
+				},
+				required: [
+					'name'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should match queries for card root-level array fields', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					tags: {
+						type: 'array',
+						fullTextSearch: {
+							term: 'foo'
+						}
+					}
+				},
+				required: [
+					'tags'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should match queries for card data->string fields', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					data: {
+						type: 'object',
+						required: [
+							'category'
+						],
+						properties: {
+							category: {
+								type: 'string',
+								fullTextSearch: {
+									term: 'security'
+								}
+							}
+						}
+					}
+				},
+				required: [
+					'data'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should match queries for card data->array fields', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					data: {
+						type: 'object',
+						required: [
+							'tags'
+						],
+						properties: {
+							tags: {
+								type: 'array',
+								fullTextSearch: {
+									term: 'buz'
+								}
+							}
+						}
+					}
+				},
+				required: [
+					'data'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should match queries for card data->object->string fields', async (test) => {
+	const result = await executeSearch(test, 'message',
+		[
+			{
+				properties: {
+					data: {
+						type: 'object',
+						required: [
+							'payload'
+						],
+						properties: {
+							type: 'object',
+							required: [
+								'message'
+							],
+							payload: {
+								properties: {
+									message: {
+										type: 'string',
+										fullTextSearch: {
+											term: 'control past'
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				required: [
+					'data'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(_.find(result.response.data, {
+		id: test.context.message.id
+	}))
+})
+
+ava.serial('full-text search should not match on root-level string fields for mismatching queries', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					name: {
+						type: 'string',
+						fullTextSearch: {
+							term: 'coffee'
+						}
+					}
+				},
+				required: [
+					'name'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(!_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should not match on root-level array fields for mismatching queries', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					tags: {
+						type: 'array',
+						fullTextSearch: {
+							term: 'mismatch'
+						}
+					}
+				},
+				required: [
+					'tags'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(!_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should not match on card data->string fields for mismatching queries', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					data: {
+						type: 'object',
+						required: [
+							'category'
+						],
+						properties: {
+							category: {
+								type: 'string',
+								fullTextSearch: {
+									term: 'coffee'
+								}
+							}
+						}
+					}
+				},
+				required: [
+					'data'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(!_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should not match on card data->array fields for mismatching queries', async (test) => {
+	const result = await executeSearch(test, 'support-thread',
+		[
+			{
+				properties: {
+					data: {
+						type: 'object',
+						required: [
+							'tags'
+						],
+						properties: {
+							tags: {
+								type: 'array',
+								fullTextSearch: {
+									term: 'coffee'
+								}
+							}
+						}
+					}
+				},
+				required: [
+					'data'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(!_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})
+
+ava.serial('full-text search should not match on card data->object->string fields for mismatching queries', async (test) => {
+	const result = await executeSearch(test, 'message',
+		[
+			{
+				properties: {
+					data: {
+						type: 'object',
+						required: [
+							'payload'
+						],
+						properties: {
+							type: 'object',
+							required: [
+								'message'
+							],
+							payload: {
+								properties: {
+									message: {
+										type: 'string',
+										fullTextSearch: {
+											term: 'coffee'
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				required: [
+					'data'
+				]
+			}
+		])
+
+	test.is(result.code, 200)
+	test.truthy(!_.find(result.response.data, {
+		id: test.context.message.id
+	}))
+})
+
+ava.serial('full-text search should match queries that also require "has attached element"', async (test) => {
+	const result = await test.context.http(
+		'POST',
+		'/api/v2/query',
+		{
+			query: {
+				type: 'object',
+				additionalProperties: true,
+				$$links: {
+					'has attached element': {
+						type: 'object',
+						properties: {
+							type: {
+								enum: [
+									'message@1.0.0'
+								]
+							}
+						},
+						additionalProperties: true
+					}
+				},
+				required: [
+					'active',
+					'type'
+				],
+				anyOf: [
+					{
+						properties: {
+							name: {
+								type: 'string',
+								fullTextSearch: {
+									term: 'control past'
+								}
+							}
+						},
+						required: [
+							'name'
+						]
+					}
+				],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'support-thread@1.0.0'
+					},
+					active: {
+						type: 'boolean',
+						const: true
+					}
+				}
+			},
+			options: {
+				limit: 100
+			}
+		},
+		{
+			Authorization: `Bearer ${test.context.token}`
+		}
+	)
+
+	test.is(result.code, 200)
+	test.truthy(_.find(result.response.data, {
+		id: test.context.supportThread.id
+	}))
+})

--- a/test/integration/core/backend/index.spec.js
+++ b/test/integration/core/backend/index.spec.js
@@ -36,7 +36,8 @@ ava('should only expose the required methods', (test) => {
 		'query',
 		'stream',
 		'getStatus',
-		'createTypeIndex'
+		'createTypeIndex',
+		'createFullTextSearchIndex'
 	])
 })
 

--- a/test/unit/core/backend/postgres/cards.spec.js
+++ b/test/unit/core/backend/postgres/cards.spec.js
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const errors = require('../../../../../lib/core/errors')
+const cards = require('../../../../../lib/core/backend/postgres/cards')
+const uuid = require('uuid/v4')
+
+ava.before((test) => {
+	test.context.context = {
+		id: `UNIT-TEST-${uuid()}`
+	}
+})
+
+ava('Should be able to convert a type card field path to that of a normal card (depth=1)', (test) => {
+	const from = [ 'data', 'schema', 'properties', 'name' ]
+	const result = cards.fromTypePath(from)
+
+	const expected = [ 'name' ]
+
+	test.deepEqual(result, expected)
+})
+
+ava('Should be able to convert a type card field path to that of a normal card (depth=2)', (test) => {
+	const from = [ 'data', 'schema', 'properties', 'data', 'properties', 'actor' ]
+	const result = cards.fromTypePath(from)
+
+	const expected = [ 'data', 'actor' ]
+
+	test.deepEqual(result, expected)
+})
+
+ava('Should be able to convert a type card field path to that of a normal card (depth=3)', (test) => {
+	const from = [ 'data', 'schema', 'properties', 'data', 'properties', 'payload', 'properties', 'message' ]
+	const result = cards.fromTypePath(from)
+
+	const expected = [ 'data', 'payload', 'message' ]
+
+	test.deepEqual(result, expected)
+})
+
+ava('Should be able to find multiple full-text search fields at various depths from a schema', (test) => {
+	const schema = {
+		slug: 'test',
+		type: 'test@1.0.0',
+		version: '1.0.0',
+		name: 'Test type',
+		markers: [],
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			schema: {
+				type: 'object',
+				required: [ 'version', 'data' ],
+				properties: {
+					version: {
+						type: 'string',
+						const: '1.0.0'
+					},
+					name: {
+						type: 'string',
+						fullTextSearch: true
+					},
+					tags: {
+						type: 'array',
+						items: {
+							type: 'string'
+						},
+						fullTextSearch: true
+					},
+					data: {
+						type: 'object',
+						properties: {
+							approvals: {
+								type: 'array',
+								items: {
+									type: [ 'boolean', 'string' ]
+								},
+								fullTextSearch: true
+							},
+							observations: {
+								anyOf: [
+									{
+										type: 'string',
+										fullTextSearch: true
+									},
+									{
+										type: 'array',
+										items: {
+											type: 'string'
+										},
+										fullTextSearch: true
+									}
+								]
+							},
+							category: {
+								type: 'string',
+								fullTextSearch: true
+							},
+							title: {
+								type: 'string'
+							},
+							payload: {
+								type: 'object',
+								required: [ 'message' ],
+								properties: {
+									description: {
+										type: 'string'
+									},
+									message: {
+										type: 'string',
+										format: 'markdown',
+										fullTextSearch: true
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	const result = cards.parseFullTextSearchFields(test.context.context, schema, errors)
+
+	const expected = [
+		{
+			path: [ 'name' ],
+			isRootArray: false
+		},
+		{
+			path: [ 'tags' ],
+			isRootArray: true
+		},
+		{
+			path: [ 'data', 'approvals' ],
+			isRootArray: false
+		},
+		{
+			path: [ 'data', 'observations' ],
+			isRootArray: false
+		},
+		{
+			path: [ 'data', 'category' ],
+			isRootArray: false
+		},
+		{
+			path: [ 'data', 'payload', 'message' ],
+			isRootArray: false
+		}
+	]
+
+	test.deepEqual(result, expected)
+})
+
+ava('Should error when an item does not have "string" as a type', (test) => {
+	const schema = {
+		slug: 'test',
+		type: 'test@1.0.0',
+		version: '1.0.0',
+		name: 'Test type',
+		markers: [],
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			schema: {
+				type: 'object',
+				required: [ 'version', 'data' ],
+				properties: {
+					version: {
+						type: 'string',
+						const: '1.0.0'
+					},
+					data: {
+						type: 'object',
+						properties: {
+							approved: {
+								type: [ 'boolean', 'null' ],
+								fullTextSearch: true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	try {
+		cards.parseFullTextSearchFields(test.context.context, schema, errors)
+		test.fail('This code should not run')
+	} catch (err) {
+		test.pass()
+	}
+})
+
+ava('Should error when an array does not have "string" as a type', (test) => {
+	const schema = {
+		slug: 'test',
+		type: 'test@1.0.0',
+		version: '1.0.0',
+		name: 'Test type',
+		markers: [],
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			schema: {
+				type: 'object',
+				required: [ 'version', 'data' ],
+				properties: {
+					version: {
+						type: 'string',
+						const: '1.0.0'
+					},
+					data: {
+						type: 'object',
+						properties: {
+							approved: {
+								type: 'array',
+								items: {
+									type: [ 'boolean', 'null' ]
+								},
+								fullTextSearch: true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	try {
+		cards.parseFullTextSearchFields(test.context.context, schema, errors)
+		test.fail('This code should not run')
+	} catch (err) {
+		test.pass()
+	}
+})
+
+ava('Should error when a combinator non-array child does not have "string" as a type', (test) => {
+	const schema = {
+		slug: 'test',
+		type: 'test@1.0.0',
+		version: '1.0.0',
+		name: 'Test type',
+		markers: [],
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			schema: {
+				type: 'object',
+				required: [ 'version', 'data' ],
+				properties: {
+					version: {
+						type: 'string',
+						const: '1.0.0'
+					},
+					data: {
+						type: 'object',
+						properties: {
+							observations: {
+								anyOf: [
+									{
+										type: [ 'boolean', 'null' ],
+										fullTextSearch: true
+									}
+								]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	try {
+		cards.parseFullTextSearchFields(test.context.context, schema, errors)
+		test.fail('This code should not run')
+	} catch (err) {
+		test.pass()
+	}
+})
+
+ava('Should error when a combinator array child does not have "string" as a type', (test) => {
+	const schema = {
+		slug: 'test',
+		type: 'test@1.0.0',
+		version: '1.0.0',
+		name: 'Test type',
+		markers: [],
+		tags: [],
+		links: {},
+		active: true,
+		data: {
+			schema: {
+				type: 'object',
+				required: [ 'version', 'data' ],
+				properties: {
+					version: {
+						type: 'string',
+						const: '1.0.0'
+					},
+					data: {
+						type: 'object',
+						properties: {
+							observations: {
+								anyOf: [
+									{
+										type: 'array',
+										items: {
+											type: [ 'boolean', 'null' ]
+										},
+										fullTextSearch: true
+									}
+								]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	try {
+		cards.parseFullTextSearchFields(test.context.context, schema, errors)
+		test.fail('This code should not run')
+	} catch (err) {
+		test.pass()
+	}
+})

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const jsonschema2sql = require('../../../../../../lib/core/backend/postgres/jsonschema2sql')
+
+ava('when performing full-text searches we use to_tsvector and to_tsquery functions', (test) => {
+	const payload = {
+		query: {
+			type: 'object',
+			additionalProperties: true,
+			required: [
+				'active',
+				'type'
+			],
+			anyOf: [
+				{
+					properties: {
+						name: {
+							type: 'string',
+							fullTextSearch: {
+								term: 'test'
+							}
+						}
+					},
+					required: [
+						'name'
+					]
+				}
+			]
+		},
+		options: {
+			limit: 1
+		}
+	}
+
+	const query = jsonschema2sql('cards', payload.query, payload.options)
+	test.truthy(query.includes('to_tsvector'))
+	test.truthy(query.includes('to_tsquery'))
+})

--- a/test/unit/core/backend/postgres/jsonschema2sql/text-search.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/text-search.spec.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const ava = require('ava')
+const textSearch = require('../../../../../../lib/core/backend/postgres/jsonschema2sql/text-search')
+
+ava('toTSVector should prepare a correct to_tsvector function call for Postgres text fields', (test) => {
+	const table = 'cards'
+	const path = [ 'name' ]
+	const isRootArray = false
+	const result = textSearch.toTSVector(table, path, isRootArray)
+
+	const expected = `to_tsvector('english', ${table}.${_.head(path)})`
+
+	test.is(result, expected)
+})
+
+ava('toTSVector should prepare a correct to_tsvector function call for Postgres text[] fields', (test) => {
+	const table = 'cards'
+	const path = [ 'tags' ]
+	const isRootArray = true
+	const result = textSearch.toTSVector(table, path, isRootArray)
+
+	const expected = `to_tsvector('english', immutable_array_to_string(${table}.${_.head(path)}, ' '))`
+
+	test.is(result, expected)
+})
+
+ava('toTSVector should prepare a correct to_tsvector function call for keys inside of data', (test) => {
+	const table = 'cards'
+	const path = [ 'data', 'payload', 'message' ]
+	const isRootArray = false
+	const result = textSearch.toTSVector(table, path, isRootArray)
+
+	const expected = `jsonb_to_tsvector('english', ${table}.${path.shift()}#>'{${path.join(',')}}', '["string"]')`
+
+	test.is(result, expected)
+})
+
+ava('toTSQuery should prepare a correct plainto_tsquery function call', (test) => {
+	const term = 'test'
+	const result = textSearch.toTSQuery(term)
+
+	const expected = `plainto_tsquery('english', '${term}')`
+
+	test.is(result, expected)
+})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- builds `tsvector` partial indexes on init for each card field that has `fullTextSearch: true`
  - Indexes for `text[]` columns are created using a new custom function `immutable_array_to_string()` in order to achieve the same `tsvector` results
  - Indexes for values that exist under `data` are created using `jsonb_to_tsvector()`
  - Indexes for `text` columns are created using `to_tsvector()`
- adds `fullTextSearch` keyword handlers to the `jsonschema2sql` compiler
- adds full text search functionality, initially for these cards:
  - `support-thread`
    - `name`, `tags`, `data.category`, `data.tags`, `data.environment`, `data.description`, `data.inbox`, `data.statusDescription`
  - `sales-thread`
    - `name`, `tags`, `data.tags`, `data.inbox`, `data.statusDescription`, `data.status`
  - `thread`
    - `data.tags`, `data.description`
  - `message`
    - `data.timestamp`, `data.payload.file.name`, `data.payload.message`
  - `whisper`
    - `data.timestamp`, `data.payload.file.name`, `data.payload.message`

***

Full-text search using `tsvector`s will allow to perform searches more efficiently by reducing terms to their stems (e.g. `cats` => `cat`) and removing "noise" that will not help in search (e.g. a, and, the).

Here are a couple examples of what some text looks like after being transformed into `tsvector`s using [`to_tsvector`](https://www.postgresql.org/docs/9.1/textsearch-controls.html):
```
# SELECT to_tsvector('english', 'cats and dogs');
   to_tsvector
-----------------
 'cat':1 'dog':3

# SELECT to_tsvector('english', 'Add full-text search support for strings nested inside of complex structures');
                                                       to_tsvector
--------------------------------------------------------------------------------------------------------------------------
 'add':1 'complex':12 'full':3 'full-text':2 'insid':10 'nest':9 'search':5 'string':8 'structur':13 'support':6 'text':4
```

These `tsvector`s are stored in partial indexes, one index per field per card type. For example, a partial index for the `data.payload.message` field on the `message` card will be created as `message__data_payload_message__search_idx`.

Search queries are prepared to be ran against these indexes using [`plainto_tsquery`](https://www.postgresql.org/docs/9.1/textsearch-controls.html): 
```
SELECT slug FROM cards WHERE to_tsvector('english', cards.data#>'{description}') @@ plainto_tsquery('english', 'job explore') AND type='support-thread@1.0.0';
```

***

Things to be done in subsequent PRs:
- Add full-text search support for strings nested inside of complex structures (object->array->object->string) such as `data.payload.attachments.name` in `message` cards

Closes https://github.com/product-os/jellyfish/issues/386