### PR TITLE
Display timeline images inside MessageContainer component

### DIFF
--- a/lib/ui-components/AuthenticatedImage/index.jsx
+++ b/lib/ui-components/AuthenticatedImage/index.jsx
@@ -13,6 +13,9 @@ import {
 const ResponsiveImg = styled.img `
 	height: auto;
 	max-width: 100%;
+	border-radius: 6px;
+	border-top-left-radius: 0;
+	display: block;
 `
 
 class AuthenticatedImage extends React.Component {

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -563,25 +563,33 @@ export default class Event extends React.Component {
 							)}
 						</Flex>
 
-						{Boolean(attachments) && _.map(attachments, (attachment) => {
+						{Boolean(attachments.length) && _.map(attachments, (attachment, index) => {
 							// If the mime type is of an image, display the file as an image
 							// Additionally, if there are many attachments, skip trying to
 							// render them
 							if (attachments.length < 3 && attachment.mime && attachment.mime.match(/image\//)) {
 								return (
-									<AuthenticatedImage
-										data-test="event-card__image"
-										key={attachment.slug}
-										cardId={card.id}
-										fileName={attachment.slug}
-										addNotification={addNotification}
-									/>
+									<MessageContainer
+										key={`${attachment.slug}-${index}`}
+										card={card}
+										actor={actor}
+										py={2}
+										px={3}
+										mr={1}
+									>
+										<AuthenticatedImage
+											data-test="event-card__image"
+											cardId={card.id}
+											fileName={attachment.slug}
+											addNotification={addNotification}
+										/>
+									</MessageContainer>
 								)
 							}
 
 							return (
 								<Button
-									key={attachment.url}
+									key={`${attachment.url}-${index}`}
 									data-attachmentslug={attachment.slug}
 									onClick={this.downloadAttachment}
 									secondary={card.type.split('@')[0] === 'whisper'}
@@ -593,7 +601,8 @@ export default class Event extends React.Component {
 									<Txt monospace ml={2}>{attachment.name}</Txt>
 								</Button>
 							)
-						})}
+						}
+						)}
 
 						{isMessage && Boolean(message) && (
 							<MessageContainer

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -45,6 +45,18 @@ import {
 	HIDDEN_ANCHOR
 } from '../Timeline'
 
+const OverflowButton = styled(Button) `
+	color: inherit;
+
+	&:hover {
+		color: inherit !important;
+	}
+
+	${(expanded) => {
+		return expanded ? {} : 'boxShadow: \'0 -5px 5px -5px rgba(0,0,0,0.5)\''
+	}}
+`
+
 const ActorPlaceholder = styled.span `
 	width: 80px;
 	line-height: inherit;
@@ -629,19 +641,16 @@ export default class Event extends React.Component {
 								</Markdown>
 
 								{messageOverflows && (
-									<Button
+									<OverflowButton
 										className="event-card__expand"
 										plain
 										width="100%"
 										py={1}
 										onClick={this.expand}
-										style={this.state.expanded ? {} : {
-											boxShadow: '0 -5px 5px -5px rgba(0,0,0,0.5)',
-											color: 'inherit'
-										}}
+										expanded={this.state.expanded}
 									>
 										<Icon name={`chevron-${this.state.expanded ? 'up' : 'down'}`} />
-									</Button>
+									</OverflowButton>
 								)}
 							</MessageContainer>
 						)}

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -550,7 +550,7 @@ class Timeline extends React.Component {
 
 						if (_.includes(this.state.uploadingFiles, card.slug)) {
 							return (
-								<Box p={3}>
+								<Box key={card.slug} p={3}>
 									<Icon name="cog" spin /><em>{' '}Uploading file...</em>
 								</Box>
 							)


### PR DESCRIPTION
With this PR uploaded images show what type of message they are.

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>


![Screenshot 2020-04-30 at 12 35 57](https://user-images.githubusercontent.com/11800807/80701150-3b923880-8adf-11ea-80f7-469318a7da78.png)

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
