### PR TITLE
test: Drop SQL tables after running integration tests

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -487,6 +487,21 @@ module.exports = class PostgresBackend {
 	}
 
 	/*
+	 * Drop the database tables.
+	 */
+	async drop (context) {
+		if (!this.connection) {
+			return
+		}
+
+		logger.debug(context, 'Dropping database tables', {
+			database: this.database
+		})
+
+		await this.connection.any(`DROP TABLE ${cards.TABLE}, ${links.TABLE} CASCADE`)
+	}
+
+	/*
 	 * Reset the database state.
 	 */
 	async reset (context) {

--- a/test/integration/core/backend/index.spec.js
+++ b/test/integration/core/backend/index.spec.js
@@ -26,6 +26,7 @@ ava('should only expose the required methods', (test) => {
 		'constructor',
 		'connect',
 		'disconnect',
+		'drop',
 		'reset',
 		'insertElement',
 		'upsertElement',

--- a/test/integration/core/helpers.js
+++ b/test/integration/core/helpers.js
@@ -34,6 +34,7 @@ exports.beforeEach = async (test, options = {}) => {
 }
 
 exports.afterEach = async (test) => {
+	await test.context.backend.drop(test.context.context)
 	await test.context.kernel.disconnect(test.context.context)
 	await helpers.afterEach(test)
 }


### PR DESCRIPTION
Introducing a unique composite constraint on the slug and version
properties for some reason slows down PostgreSQL a lot (>6x) when we
have a lot of databases, which we do when running integration test (we
create a separate database for each test case).

This commit makes sure we drop the tables from the databases after
running each integration test case, which seems to solve the issue.

Change-type: minor
See: https://github.com/product-os/jellyfish/pull/3621


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!