### PR TITLE
Allow clients to specify a context id for logging purposes

### DIFF
--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -10,6 +10,7 @@ const uuid = require('uuid/v4')
 const _ = require('lodash')
 const helpers = require('../sdk/helpers')
 const environment = require('../../../lib/environment')
+const packageJson = require('../../../package.json')
 
 ava.serial.before(helpers.before)
 ava.serial.after(helpers.after)
@@ -969,4 +970,19 @@ ava.serial('/view/:slug endpoint should return the list of all views', async (te
 	test.deepEqual(_.uniq(_.map(result.response.data, (card) => {
 		return _.first(card.type.split('@'))
 	})), [ 'view' ])
+})
+
+ava.serial('Using the request-id header should be reflected in the X-Request-Id header', async (test) => {
+	const requestId = 'my-request'
+	const result = await test.context.http(
+		'GET',
+		'/api/v2/whoami',
+		{},
+		{
+			Authorization: `Bearer ${test.context.token}`,
+			'request-id': requestId
+		}
+	)
+
+	test.is(result.headers['x-request-id'], `REQUEST-${packageJson.version}-${requestId}`)
 })


### PR DESCRIPTION
If a client sends the 'request-id' header, this will be used for the
logging context in the API. This change allows us to trace queries
through the request lifecycle.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
