### PR TITLE
SRE: Enables debug port 9229 for the API servers.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish
-  replicas: 3
+  replicas: 6
   template:
     metadata:
       labels:
@@ -134,6 +134,8 @@ spec:
           value: {{{MONITOR_SECRET_TOKEN}}}
         ports:
         - containerPort: 8000
+        - containerPort: 9229
+          name: debug
         - containerPort: {{{METRICS_PORT}}}
           name: prometheus-a
         - containerPort: {{{SOCKET_METRICS_PORT}}}


### PR DESCRIPTION
This is to allow debugging using K8s port forwarding.
It also increases the number of pods from 3 to 6 for better concurrency.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>


