### PR TITLE
ui: Improve layout of cards on small screens

### DIFF
--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -10,7 +10,6 @@ import {
 	connect
 } from 'react-redux'
 import {
-	Box,
 	Flex,
 	Heading,
 	Txt
@@ -59,8 +58,12 @@ const CardLayout = (props) => {
 				overflowY={overflowY}
 				data-test={props['data-test']}
 			>
-				<Box p={3} pb={0}>
-					<Flex justifyContent="space-between" alignItems="center">
+				<Flex
+					p={3} pb={0}
+					flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
+					justifyContent="space-between"
+					alignItems="center">
+					<Flex alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
 						{title}
 
 						{!title && (
@@ -74,22 +77,20 @@ const CardLayout = (props) => {
 								)}
 							</div>
 						)}
-
-						<Flex align="baseline">
-							{!noActions && (
-								<CardActions card={card}>
-									{actionItems}
-								</CardActions>
-							)}
-
-							<CloseButton
-								onClick={props.onClose}
-								ml={3}
-								channel={channel}
-							/>
-						</Flex>
 					</Flex>
-				</Box>
+					<Flex alignSelf={[ 'flex-end', 'flex-end', 'inherit' ]}>
+						{!noActions && (
+							<CardActions card={card}>
+								{actionItems}
+							</CardActions>
+						)}
+						<CloseButton
+							flex={0}
+							onClick={props.onClose}
+							channel={channel}
+						/>
+					</Flex>
+				</Flex>
 
 				{children}
 				<SlideInFlowPanel

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -394,11 +394,7 @@ class SupportThreadBase extends React.Component {
 					</React.Fragment>
 				)}
 			>
-
-				<Box
-					px={3}
-					pt={2}
-				>
+				<Box px={3}>
 					<Flex alignItems="center" mb={1} flexWrap="wrap">
 						{Boolean(linkedGitHubIssues && linkedGitHubIssues.length) && _.map(linkedGitHubIssues, (entry) => {
 							return (

--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -610,7 +610,7 @@ class ViewRenderer extends React.Component {
 
 								{sliceOptions && sliceOptions.length && (
 									<Select
-										mx={3}
+										ml={3}
 										mb={3}
 										options={sliceOptions}
 										value={this.state.activeSlice}
@@ -620,7 +620,7 @@ class ViewRenderer extends React.Component {
 								)}
 
 								{this.lenses.length > 1 && Boolean(lens) && (
-									<ButtonGroup>
+									<ButtonGroup ml={3}>
 										{_.map(this.lenses, (item) => {
 											return (
 												<Button
@@ -641,7 +641,7 @@ class ViewRenderer extends React.Component {
 							<CloseButton
 								flex={0}
 								p={3}
-								mt="-4px"
+								mt="-8px"
 								mr={-3}
 								channel={this.props.channel}
 							/>

--- a/lib/ui-components/CardOwner/CardOwner.jsx
+++ b/lib/ui-components/CardOwner/CardOwner.jsx
@@ -11,6 +11,7 @@ import {
 	DropDownButton
 } from 'rendition'
 import _ from 'lodash'
+import styled from 'styled-components'
 import {
 	userDisplayName,
 	getType
@@ -22,6 +23,13 @@ import {
 	FLOW_IDS
 } from '../Flows'
 import * as handoverUtils from '../Flows/HandoverFlowPanel/handover-utils'
+
+const OwnerTxt = styled(Txt.span) `
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 120px;
+`
 
 export default class CardOwner extends React.Component {
 	constructor (props) {
@@ -122,7 +130,7 @@ export default class CardOwner extends React.Component {
 					tertiary={cardOwner && (cardOwner.id === user.id)}
 					quartenary={cardOwner && (cardOwner.id !== user.id)}
 					label={cardOwner ? (
-						<Txt.span
+						<OwnerTxt
 							bold
 							data-test="card-owner-dropdown__label--assigned"
 							onClick={this.openOwnerChannel}
@@ -132,9 +140,9 @@ export default class CardOwner extends React.Component {
 							}}
 						>
 							{userDisplayName(cardOwner)}
-						</Txt.span>
+						</OwnerTxt>
 					) : (
-						<Txt.span
+						<OwnerTxt
 							bold
 							italic
 							data-test="card-owner-dropdown__label--unassigned"
@@ -144,7 +152,7 @@ export default class CardOwner extends React.Component {
 							}}
 						>
 						Unassigned
-						</Txt.span>
+						</OwnerTxt>
 					)}
 				>
 					<ActionLink

--- a/lib/ui-components/shame/CloseButton.jsx
+++ b/lib/ui-components/shame/CloseButton.jsx
@@ -8,6 +8,7 @@ import React from 'react'
 import {
 	withRouter
 } from 'react-router-dom'
+import styled from 'styled-components'
 import {
 	pathWithoutChannel
 } from '../services/helpers'
@@ -15,6 +16,12 @@ import {
 	Button
 } from 'rendition'
 import Icon from './Icon'
+
+const CloseRenditionButton = styled(Button) `
+	i {
+		line-height: 1.5;
+	}
+`
 
 class CloseButtonBase extends React.Component {
 	constructor (props) {
@@ -39,7 +46,8 @@ class CloseButtonBase extends React.Component {
 
 	render () {
 		return (
-			<Button
+			<CloseRenditionButton
+				pl={3}
 				{...this.props}
 				plain
 				icon={<Icon name="times"/>}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Just some fairly minor CSS tweaks to improve the layout of cards on mobile/small screens. Its still far from ideal but at least the close button on support threads doesn't get hidden off-screen now!

### Before
![image](https://user-images.githubusercontent.com/2925657/80803606-ffdd9880-8bdc-11ea-84a5-0176b0897ff6.png)

### After
![image](https://user-images.githubusercontent.com/2925657/80803660-37e4db80-8bdd-11ea-8afd-70a809491dfb.png)
