### PR TITLE
Remove clean old test data job from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,18 +276,6 @@ jobs:
           name: Post PR Summary
           command: GITHUB_TOKEN=$GITHUB_TOKEN node scripts/ci/github-pr-summary.js $CIRCLE_PULL_REQUEST ./SUMMARY
 
-  clean_old_test_data:
-    <<: *job_defaults
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Clean up old test data
-          command: |
-            make clean-github
-            make clean-front
-
 workflows:
     version: 2
     build:
@@ -333,9 +321,4 @@ workflows:
                   - sync_tests_front_mirror
                   - sync_tests_discourse_mirror
                   - sync_tests_github_mirror
-                <<: *workflow_filter
-
-            - clean_old_test_data:
-                requires:
-                  - build
                 <<: *workflow_filter


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Removes the `clean_old_test_data` job from the CircleCI config. The scripts work, but timeout quite a bit lately when trying to clean out Front inboxes and block CI. These scripts also don't need to be ran every time and can be executed manually if necessary.