### PR TITLE
Improve performance of kernel integration tests

### DIFF
--- a/test/integration/core/helpers.js
+++ b/test/integration/core/helpers.js
@@ -8,7 +8,7 @@ const uuid = require('uuid/v4')
 const helpers = require('./backend/helpers')
 const Kernel = require('../../../lib/core/kernel')
 
-const generateRandomSlug = (options) => {
+const generateRandomSlug = (options = {}) => {
 	const suffix = uuid()
 	if (options.prefix) {
 		return `${options.prefix}-${suffix}`

--- a/test/integration/core/kernel.disconnect.spec.js
+++ b/test/integration/core/kernel.disconnect.spec.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const helpers = require('./helpers')
+
+/*
+ * Tests in this spec file actively disconnect the server. As such they are
+ * seperated from other kernel tests, as each test requires a new connection to
+ * be established
+ */
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach(helpers.afterEach)
+
+ava('should be able to disconnect the kernel multiple times without errors', async (test) => {
+	await test.notThrowsAsync(async () => {
+		await test.context.kernel.disconnect(test.context.context)
+		await test.context.kernel.disconnect(test.context.context)
+		await test.context.kernel.disconnect(test.context.context)
+	})
+})
+
+ava('.disconnect() should gracefully close streams', async (test) => {
+	await test.notThrowsAsync(async () => {
+		await test.context.kernel.stream(test.context.context, test.context.kernel.sessions.admin, {
+			type: 'object'
+		})
+		await test.context.kernel.disconnect(test.context.context)
+	})
+})


### PR DESCRIPTION
Previously, the kernel tests would configure new backend and kernel
instances for every test, allowing the tests to run in a pristine
environment.
This commit makes the bulk of the kernel tests share a backend and kernel
instance, which required a number of refactors to ensure that the tests
still work, even when there are many more cards in the system.
Some tests have remained as they were, as they explicitly test
disconnects, requiring them to have seperate instances.

In addition to these changes, duplicate tests for skip and limit options
have been removed.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
