### PR TITLE
ci: Improve front-delete-converstions script

### DIFF
--- a/scripts/ci/front-delete-conversations.js
+++ b/scripts/ci/front-delete-conversations.js
@@ -38,10 +38,13 @@ const deleteConversations = async (options) => {
 		console.log(`Looking through ${inbox}...`)
 		let pageToken = null
 		while (true) {
+			console.log('Getting conversations...')
 			const conversations = await front.inbox.listConversations({
 				inbox_id: inbox,
 				limit: CONVERSATION_LIMIT,
 				page_token: pageToken
+			}).catch((err) => {
+				console.error(err)
 			})
 
 			// Set next page token for subsequent search.
@@ -55,6 +58,7 @@ const deleteConversations = async (options) => {
 			// Check if conversation is old enough to delete.
 			conversations._results.forEach((conversation) => {
 				if (conversation.created_at <= BEFORE && conversation.status !== 'deleted') {
+					console.log(`Marking ${inbox}:${conversation.id} for deletion`)
 					oldConversations.push(`${inbox}:${conversation.id}`)
 				}
 			})
@@ -124,7 +128,7 @@ validate(options)
 // Delete old conversations using provided options.
 deleteConversations(options)
 	.then((total) => {
-		console.log(`Successfully deleted ${total} conversations`)
+		console.log(`Successfully deleted ${total} old conversations`)
 	})
 	.catch((err) => {
 		console.error(err)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

CircleCI kills jobs if they do not update `stdout` within 10 minutes. Since we are not able to query the Front API using `created_at`/`since` search parameters ([API docs](https://dev.frontapp.com/reference/inboxes-1#get_inboxes-inbox-id-conversations-1)), we have to list ALL conversations including those that are not yet old enough to delete. This means it may well take >10 minutes to list all conversations as we create new conversations with every CI cycle.

This PR simply adds more output to the script so Circle doesn't kill the job.