### PR TITLE
backend: Add IF NOT EXISTS to CREATE INDEX statements

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -161,14 +161,14 @@ exports.setup = async (context, connection, database, options = {}) => {
 			return
 		}
 
-		logger.debug(context, 'Creating table index', {
+		logger.debug(context, 'Attempting to create table index', {
 			table,
 			database,
 			index: secondaryIndex.column
 		})
 
 		await connection.any(`
-			CREATE INDEX ${fullyQualifiedIndexName} ON ${table}
+			CREATE INDEX IF NOT EXISTS ${fullyQualifiedIndexName} ON ${table}
 			USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
 	}, {
 		concurrency: 4
@@ -482,7 +482,7 @@ exports.createTypeIndex = async (context, connection, fields, type) => {
 		return
 	}
 
-	logger.debug(context, 'Creating cards table type index', {
+	logger.debug(context, 'Attempting to create cards table type index', {
 		index: fields,
 		type
 	})
@@ -508,7 +508,7 @@ exports.createTypeIndex = async (context, connection, fields, type) => {
 	// Statement timeout is set to 0 to prevent large index creations from timing out
 	await connection.task(async (task) => {
 		await task.any('SET statement_timeout=0')
-		await task.any(`CREATE INDEX CONCURRENTLY "${fullyQualifiedIndexName}" ON ${CARDS_TABLE}
+		await task.any(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "${fullyQualifiedIndexName}" ON ${CARDS_TABLE}
 		(${columns.join(',')}) WHERE type=${pgFormat.literal(versionedType)}`)
 	})
 }

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -41,8 +41,14 @@ exports.setup = async (context, connection, database, options) => {
 			return
 		}
 
+		logger.debug(context, 'Attempting to create table index', {
+			table: LINK_TABLE,
+			database,
+			index: name
+		})
+
 		await connection.any(`
-			CREATE INDEX ${name} ON ${LINK_TABLE}
+			CREATE INDEX IF NOT EXISTS ${name} ON ${LINK_TABLE}
 			USING BTREE (${column})`)
 	}
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

When we create indexes we check if they already exist with JavaScript, but should also include `IF NOT EXISTS` in the `CREATE INDEX` statement as well just in case.

Noticed this while looking into what could be causing the following errors we sometimes run into during balenaCI compose tests. Not convinced that this change will solve the problem, but will leave this here for context:
```
postgres_1               | 2020-05-02 15:27:16.877 UTC [94] ERROR:  duplicate key value violates unique constraint "pg_class_relname_nsp_index"
postgres_1               | 2020-05-02 15:27:16.877 UTC [94] DETAIL:  Key (relname, relnamespace)=(updated_at_cards_idx, 2200) already exists.
postgres_1               | 2020-05-02 15:27:16.877 UTC [94] STATEMENT:  
postgres_1               | 				CREATE INDEX updated_at_cards_idx ON cards
postgres_1               | 				USING BTREE (updated_at )
...
postgres_1               | 2020-05-02 15:27:16.878 UTC [96] ERROR:  duplicate key value violates unique constraint "pg_class_relname_nsp_index"
postgres_1               | 2020-05-02 15:27:16.878 UTC [96] DETAIL:  Key (relname, relnamespace)=(data_mirrors_cards_idx, 2200) already exists.
postgres_1               | 2020-05-02 15:27:16.878 UTC [96] STATEMENT:  
postgres_1               | 				CREATE INDEX data_mirrors_cards_idx ON cards
postgres_1               | 				USING GIN ((data->'mirrors') jsonb_path_ops)
```