### PR TITLE
Remove unique constraint from version index

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -105,7 +105,7 @@ exports.setup = async (context, connection, database, options = {}) => {
 	if (!indexes.includes(slugVersionIndex)) {
 		await connection.task(async (task) => {
 			await task.any('SET statement_timeout = 0')
-			await task.any(`CREATE UNIQUE INDEX CONCURRENTLY ${slugVersionIndex}
+			await task.any(`CREATE INDEX CONCURRENTLY ${slugVersionIndex}
 				ON ${table} USING btree (slug, version_major, version_minor, version_patch)`)
 		})
 	}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This removes the `UNIQUE` constraint from the `${table}_slug_version_major_version_minor_version_patch_key` index. This index was introduced a few days ago with https://github.com/product-os/jellyfish/pull/3637

**Feel free to close this PR if we need to keep the `UNIQUE` constraint for some reason or if there is a better way to solve the problem.** I am unaware as to why this constraint was added in the first place and in my testing found that the problem described in https://github.com/product-os/jellyfish/issues/3641 seems to be alleviated if the `UNIQUE` constraint for this index is removed.