### PR TITLE
docs: Add metrics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ as a cross between Slack and Excel!
 	- [**Working with the backend**](https://github.com/balena-io/jellyfish/blob/master/docs/developing/backend.markdown)
 	- [**Adding a new type**](https://github.com/balena-io/jellyfish/blob/master/docs/developing/add-new-type.markdown)
 	- [**Developing locally**](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-on-balena.markdown)
+	- [**Adding metrics**](https://github.com/product-os/jellyfish/blob/master/docs/developing/adding-metrics.markdown)
 - **Links**
 	- [**Rapid7**](https://eu.ops.insight.rapid7.com/op/8306227C3C134F65ACF1#/search?logs=%5B%225df30105-2e0a-4e5a-b76a-baa5fc997b36%22%5D&range=Last%2020%20Minutes)
 	- [**Sentry**](https://sentry.io/organizations/balena/issues/?project=1366139)
 	- [**New Relic**](https://synthetics.newrelic.com/accounts/2054842/monitors/8bf2b38d-7c2a-4d71-9629-7cbf05b6bd21)
+	- [**Metrics**](https://monitor.k8s.balena-cloud.com/d/jellyfish/jellyfish?orgId=1)
 - **Services**
 	- [**Using New Relic**](https://github.com/balena-io/jellyfish/blob/master/docs/newrelic.markdown)
 	- [**Using Balena CI**](https://github.com/balena-io/jellyfish/blob/master/docs/balenaci.markdown)

--- a/docs/developing/adding-metrics.markdown
+++ b/docs/developing/adding-metrics.markdown
@@ -1,0 +1,45 @@
+# Metrics
+
+This document briefly explains the Jellyfish metrics infrastructure and where to start when looking to add new metrics.
+
+## Production Graphs
+
+Production Jellyfish metrics are gathered and processed by [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/) instances defined in the [balena-io/balena-monitor](https://github.com/balena-io/balena-monitor) repository.
+The real-time Jellyfish graphs can be viewed [here](https://monitor.k8s.balena-cloud.com/d/jellyfish/jellyfish?orgId=1).
+
+## Adding Metrics
+
+Jellyfish uses the [balena-io-modules/node-metrics-gatherer](https://github.com/balena-io-modules/node-metrics-gatherer) library to gather and expose metrics data.
+Specifically, `lib/metrics/index.js` uses this library to define and export Jellyfish-specific logic and wrappers for the rest of the system to use.
+This setup makes it quite easy for anyone to add new metrics to Jellyfish, usually with only a couple of lines.
+
+Take a look through the following docs and past pull requests to get started:
+- [balena-io-modules/node-metrics-gatherer](https://github.com/balena-io-modules/node-metrics-gatherer)
+- [Prometheus Metric Types](https://prometheus.io/docs/concepts/metric_types/)
+- [PR Example #1](https://github.com/product-os/jellyfish/pull/3502/files)
+- [PR Example #2](https://github.com/product-os/jellyfish/pull/3619/files)
+
+## Current Metrics
+For more detailed information as to what actions each of the following metrics are tied to and how everything is wired, take a look at the `metricNames` variable at the top of `lib/metrics/index.js` and perform a few `grep`s under `apps/` and `lib/` for "metrics\.".
+
+- Card upsert total
+- Card insert total
+- Card read total
+- Mirror total
+- Mirror duration
+- Mirror failure total
+- Worker saturation
+- Worker job duration
+- Worker action request total
+- HTTP `/query` request duration
+- HTTP `/query` request total
+- HTTP get card by ID request total
+- HTTP get card by ID request duration
+- HTTP get card by slug request total
+- HTTP get card by slug request duration
+- HTTP `/query` request failure total
+- HTTP get card by ID request failure total
+- HTTP `/whoami` request total
+- HTTP `/whoami` request duration
+- System CPU/memory/disk usage
+- General API HTTP performance (bytes read/written, latency, request total)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Add a link to production Grafana Jellyfish graphs for easy access
- Add a doc describing current metrics and how developers can add new ones
