### PR TITLE
core: Throw JellyfishInvalidSchema on invalid schemas

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -111,6 +111,8 @@ const queryTable = async (context, backend, table, schema, options) => {
 
 	const preProcessingStartDate = new Date()
 	const config = _.defaults(options, {
+		errors: backend.errors,
+
 		// Exclude converting additionalProperties to SQL, as its used for field
 		// filtering rather than record selection and will typically break the
 		// generated SQL query, causing no results to be returned
@@ -217,7 +219,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 				}
 
 				element.links[linkType] = utils
-					.filter(linkSchema, element[`links.${linkSlug}`])
+					.filter(linkSchema, element[`links.${linkSlug}`], backend.errors)
 					.map(utils.convertDatesToISOString)
 					.map(utils.removeVersionFields)
 
@@ -227,7 +229,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 			return element
 		})
 
-	utils.filter(schema, elements)
+	utils.filter(schema, elements, backend.errors)
 	const postProcessingEndDate = new Date()
 
 	logger[mode](context, 'Query database response', {

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -581,6 +581,8 @@ COALESCE(${table}.version_patch, '0')::text
 			parentPath: []
 		})
 
+		this.errors = options.errors
+
 		if (_.isString(tableOrParent)) {
 			this.columns = new Set()
 			this.path = [ tableOrParent ]
@@ -765,6 +767,10 @@ COALESCE(${table}.version_patch, '0')::text
 	enumVisitor (values) {
 		assert.INTERNAL(null, Array.isArray(values), Error, () => {
 			return `value for '${this.formatJsonPath('enum')}' must be an array`
+		})
+
+		assert.INTERNAL(null, values.length > 0, this.errors.JellyfishInvalidSchema, () => {
+			return `value for '${this.formatJsonPath('enum')}' must not be empty`
 		})
 
 		let filter = null
@@ -1163,6 +1169,7 @@ COALESCE(${table}.version_patch, '0')::text
 		this.options.parentJsonPath.push(...suffix)
 		const query = SqlQuery.fromSchema(table, schema, {
 			parentJsonPath: this.options.parentJsonPath,
+			errors: this.options.errors,
 			parentPath
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {
@@ -1175,6 +1182,7 @@ COALESCE(${table}.version_patch, '0')::text
 	buildQueryFromUncorrelatedSchema (table, schema, suffix) {
 		this.options.parentJsonPath.push(...suffix)
 		const query = SqlQuery.fromSchema(table, schema, {
+			errors: this.options.errors,
 			parentJsonPath: _.concat(this.options.parentJsonPath, _.castArray(suffix))
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -7,11 +7,21 @@
 const _ = require('lodash')
 const skhema = require('skhema')
 
-exports.filter = (schema, element) => {
+exports.filter = (schema, element, errors) => {
 	if (_.isNil(schema)) {
 		return element
 	}
-	const result = skhema.filter(schema, element)
+
+	const result = _.attempt(skhema.filter, schema, element)
+	if (_.isError(result)) {
+		if (result instanceof skhema.InvalidSchema) {
+			const error = new errors.JellyfishInvalidSchema(result.message)
+			error.expected = true
+			throw error
+		}
+
+		throw result
+	}
 
 	// If additionalProperties is false, remove properties that haven't been
 	// explicitly selected. This is done because the Skhema module will merge

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -14,6 +14,7 @@ _.each([
 	'JellyfishInvalidSlug',
 	'JellyfishInvalidId',
 	'JellyfishInvalidVersion',
+	'JellyfishInvalidSchema',
 	'JellyfishInvalidPatch',
 	'JellyfishInvalidLimit',
 	'JellyfishInvalidRegularExpression',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16415,9 +16415,9 @@
       }
     },
     "skhema": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.2.10.tgz",
-      "integrity": "sha512-ofvO6A97/m3IgXbPoK+YEMpkI2mqywdBDfA4mPV8A79hnqLdHxKdjmb/G7XZaxG2Td892y7gZLvqBHT4PJMMZw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.0.tgz",
+      "integrity": "sha512-MkQmLN1mgB98DoTVhj7Cd4FY3wRVLuJmRNI57IVU3esdrLAg7EnSXmGre0xStjz2vK9JxqAaZ9MdHXEjKzfVIQ==",
       "requires": {
         "@types/json-schema": "^6.0.1",
         "ajv": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "request-promise": "^4.2.2",
     "response-time": "^2.3.2",
     "semver": "^7.1.3",
-    "skhema": "5.2.10",
+    "skhema": "^5.3.0",
     "socket.io": "^2.1.0",
     "socket.io-prometheus-metrics": "^1.0.5",
     "socket.io-redis": "^5.2.0",

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -2060,6 +2060,23 @@ ava('.query() should throw an error given an invalid regex', async (test) => {
 	})
 })
 
+ava('.query() should throw an error given an invalid enum', async (test) => {
+	await test.throwsAsync(context.kernel.query(
+		context.context, context.kernel.sessions.admin, {
+			type: 'object',
+			additionalProperties: true,
+			required: [ 'slug' ],
+			properties: {
+				slug: {
+					type: 'string',
+					enum: []
+				}
+			}
+		}), {
+		instanceOf: errors.JellyfishInvalidSchema
+	})
+})
+
 ava('.query() should be able to limit the results', async (test) => {
 	const ref = uuid()
 	const result1 = await context.kernel.insertCard(context.context, context.kernel.sessions.admin, {


### PR DESCRIPTION
This error is marked as a user error and will not reach Sentry.

Fixes: https://sentry.io/share/issue/9c35af243677480c846683b12fa0f1cf/
Fixes: https://sentry.io/share/issue/4a739cb0d79348549b32d8f85ff2c077/
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!