### PR TITLE
ui-components: Log exceptions caught by the ErrorBoundary to Sentry

### DIFF
--- a/apps/ui/core/index.js
+++ b/apps/ui/core/index.js
@@ -7,6 +7,7 @@
 import localForage from 'localforage'
 import * as _ from 'lodash'
 import Analytics from '../../../lib/ui-components/services/analytics'
+import ErrorReporter from '../../../lib/ui-components/services/error-reporter'
 import * as environment from '../environment'
 import {
 	sdk as SDK
@@ -27,8 +28,15 @@ export const analytics = new Analytics({
 	token: environment.analytics.mixpanel.token
 })
 
+export const errorReporter = new ErrorReporter({
+	isProduction: environment.isProduction(),
+	dsn: environment.sentry.dsn,
+	version: environment.version
+})
+
 const bundle = setupStore({
 	analytics,
+	errorReporter,
 	sdk,
 	storageKey: STORAGE_KEY
 })

--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -159,6 +159,7 @@ let commsStream = null
 export default class ActionCreator {
 	constructor (context) {
 		this.sdk = context.sdk
+		this.errorReporter = context.errorReporter
 		this.analytics = context.analytics
 		this.tokenRefreshInterval = null
 
@@ -688,6 +689,12 @@ export default class ActionCreator {
 						})
 					}
 
+					this.errorReporter.setUser({
+						id: user.id,
+						slug: user.slug,
+						email: _.get(user, [ 'data', 'email' ])
+					})
+
 					this.tokenRefreshInterval = setInterval(async () => {
 						const newToken = await this.sdk.auth.refreshToken()
 						dispatch(this.setAuthToken(newToken))
@@ -837,6 +844,7 @@ export default class ActionCreator {
 
 		this.analytics.track('ui.logout')
 		this.analytics.identify()
+		this.errorReporter.setUser(null)
 		if (commsStream) {
 			commsStream.close()
 			commsStream = null

--- a/apps/ui/core/store/actioncreators.spec.js
+++ b/apps/ui/core/store/actioncreators.spec.js
@@ -63,8 +63,13 @@ ava.beforeEach((test) => {
 		track: sandbox.fake(),
 		identify: sandbox.fake()
 	}
+	test.context.errorReporter = {
+		reportException: sandbox.fake(),
+		setUser: sandbox.fake()
+	}
 	test.context.actionCreator = new ActionCreator({
 		sdk: test.context.sdk,
+		errorReporter: test.context.errorReporter,
 		analytics: test.context.analytics
 	})
 	test.context.getCardAction = test.context.actionCreator.getCard(cardId, 'user', [ 'is member of' ])

--- a/apps/ui/core/store/index.js
+++ b/apps/ui/core/store/index.js
@@ -29,6 +29,7 @@ localForage.setDriver(localForage.LOCALSTORAGE)
 export const setupStore = ({
 	sdk,
 	analytics,
+	errorReporter,
 	storageKey
 }) => {
 	const save = (state) => {
@@ -62,6 +63,7 @@ export const setupStore = ({
 		actionCreators: new ActionCreator({
 			sdk,
 			analytics,
+			errorReporter,
 			selectors
 		}),
 		selectors

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import '@babel/polyfill'
-import * as Sentry from '@sentry/browser'
 import 'circular-std'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -21,6 +20,7 @@ import {
 } from 'styled-components'
 import {
 	analytics,
+	errorReporter,
 	sdk,
 	store
 } from './core'
@@ -29,21 +29,12 @@ import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
 import {
 	ResponsiveProvider
 } from '../../lib/ui-components/hooks/ResponsiveProvider'
-import * as environment from './environment'
 import {
 	BrowserRouter as Router
 } from 'react-router-dom'
 import {
 	SetupProvider
 } from '../../lib/ui-components/SetupProvider'
-
-if (environment.isProduction() && environment.sentry.dsn !== '0') {
-	Sentry.init({
-		dsn: environment.sentry.dsn,
-		release: environment.version,
-		environment: 'ui'
-	})
-}
 
 const GlobalStyle = createGlobalStyle `
   * {
@@ -93,7 +84,7 @@ ReactDOM.render(
 				}}
 			>
 				<ResponsiveProvider>
-					<SetupProvider sdk={sdk} analytics={analytics}>
+					<SetupProvider sdk={sdk} analytics={analytics} errorReporter={errorReporter}>
 						<Provider store={store}>
 							<React.Fragment>
 								<GlobalStyle />

--- a/lib/ui-components/SetupProvider.jsx
+++ b/lib/ui-components/SetupProvider.jsx
@@ -9,15 +9,16 @@ import React from 'react'
 const setupContext = React.createContext(null)
 
 export const SetupProvider = ({
-	analytics, sdk, actions, children
+	analytics, errorReporter, sdk, actions, children
 }) => {
 	const setup = React.useMemo(() => {
 		return {
 			sdk,
 			analytics,
+			errorReporter,
 			actions
 		}
-	}, [ sdk, analytics, actions ])
+	}, [ sdk, analytics, errorReporter, actions ])
 
 	return (
 		<setupContext.Provider value={setup}>{children}</setupContext.Provider>

--- a/lib/ui-components/services/error-reporter.js
+++ b/lib/ui-components/services/error-reporter.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as Sentry from '@sentry/browser'
+
+export default class Reporter {
+	constructor ({
+		version,
+		dsn,
+		isProduction
+	}) {
+		this.config = {
+			version,
+			dsn,
+			isProduction
+		}
+		this.initialized = false
+		this.reportException = this.reportException.bind(this)
+		if (this.config.isProduction && this.config.dsn !== '0') {
+			Sentry.init({
+				dsn: this.config.dsn,
+				release: this.config.version,
+				environment: 'ui'
+			})
+			this.initialized = true
+		}
+	}
+
+	setUser (user) {
+		if (this.initialized) {
+			Sentry.configureScope((scope) => {
+				scope.setUser(user)
+			})
+		}
+	}
+
+	reportException (error, errorInfo) {
+		if (this.initialized) {
+			Sentry.withScope((scope) => {
+				scope.setExtra(errorInfo)
+				Sentry.captureException(error)
+			})
+		}
+	}
+}

--- a/lib/ui-components/shame/ErrorBoundary/ErrorBoundary.jsx
+++ b/lib/ui-components/shame/ErrorBoundary/ErrorBoundary.jsx
@@ -66,6 +66,7 @@ export default class ErrorBoundary extends React.Component {
 			info,
 			error
 		})
+		this.props.errorReporter.reportException(error, info)
 		this.setState({
 			hasError: true
 		})

--- a/lib/ui-components/shame/ErrorBoundary/index.js
+++ b/lib/ui-components/shame/ErrorBoundary/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ErrorBoundary from './ErrorBoundary'
+import {
+	withSetup
+} from '../../SetupProvider'
+
+export default withSetup(ErrorBoundary)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2040,6 +2040,78 @@
         "@types/node": ">= 8"
       }
     },
+    "@sentry/apm": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.5.tgz",
+      "integrity": "sha512-2PyifsiQdvFEQhbL7tQnCKGLOO1JtZeqso3bc6ARJBvKxM77mtyMo/D0C2Uzt9sXCYiALhQ1rbB1aY8iYyglpg==",
+      "requires": {
+        "@sentry/browser": "5.15.5",
+        "@sentry/hub": "5.15.5",
+        "@sentry/minimal": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/browser": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
+          "integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+          "requires": {
+            "@sentry/core": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/core": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+          "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/minimal": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+        },
+        "@sentry/utils": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@sentry/browser": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-4.6.6.tgz",
@@ -2084,73 +2156,65 @@
       }
     },
     "@sentry/node": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.9.0.tgz",
-      "integrity": "sha512-1CWwSGhRfMr4Bvt1i0vIms+BBZd4dBzlDyWpyCboodCXF1rTJRci9roQ+Wh9XWwFEWvgDD2PzuKzfvu638v2Wg==",
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.5.tgz",
+      "integrity": "sha512-BK0iTOiiIM0UnydLeT/uUBY1o1Sp85aqwaQRMfZbjMCsgXERLNGvzzV68FDH1cyC1nR6dREK3Gs8bxS4S54aLQ==",
       "requires": {
-        "@sentry/core": "5.8.0",
-        "@sentry/hub": "5.8.0",
-        "@sentry/types": "5.7.1",
-        "@sentry/utils": "5.8.0",
+        "@sentry/apm": "5.15.5",
+        "@sentry/core": "5.15.5",
+        "@sentry/hub": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
         "cookie": "^0.3.1",
-        "https-proxy-agent": "^3.0.0",
+        "https-proxy-agent": "^4.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.8.0.tgz",
-          "integrity": "sha512-aAh2KLidIXJVGrxmHSVq2eVKbu7tZiYn5ylW6yzJXFetS5z4MA+JYaSBaG2inVYDEEqqMIkb17TyWxxziUDieg==",
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+          "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
           "requires": {
-            "@sentry/hub": "5.8.0",
-            "@sentry/minimal": "5.8.0",
-            "@sentry/types": "5.7.1",
-            "@sentry/utils": "5.8.0",
+            "@sentry/hub": "5.15.5",
+            "@sentry/minimal": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/hub": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.8.0.tgz",
-          "integrity": "sha512-VdApn1ZCNwH1wwQwoO6pu53PM/qgHG+DQege0hbByluImpLBhAj9w50nXnF/8KzV4UoMIVbzCb6jXzMRmqqp9A==",
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
           "requires": {
-            "@sentry/types": "5.7.1",
-            "@sentry/utils": "5.8.0",
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/minimal": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.8.0.tgz",
-          "integrity": "sha512-MIlFOgd+JvAUrBBmq7vr9ovRH1HvckhnwzHdoUPpKRBN+rQgTyZy1o6+kA2fASCbrRqFCP+Zk7EHMACKg8DpIw==",
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
           "requires": {
-            "@sentry/hub": "5.8.0",
-            "@sentry/types": "5.7.1",
+            "@sentry/hub": "5.15.5",
+            "@sentry/types": "5.15.5",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
-          "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
         },
         "@sentry/utils": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.8.0.tgz",
-          "integrity": "sha512-KDxUvBSYi0/dHMdunbxAxD3389pcQioLtcO6CI6zt/nJXeVFolix66cRraeQvqupdLhvOk/el649W4fCPayTHw==",
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
           "requires": {
-            "@sentry/types": "5.7.1",
+            "@sentry/types": "5.15.5",
             "tslib": "^1.9.3"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
           }
         }
       }
@@ -2889,6 +2953,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -7743,6 +7808,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -10949,7 +11015,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
       "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
       "requires": {
         "agent-base": "5",
         "debug": "4"
@@ -10958,14 +11023,12 @@
         "agent-base": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
         },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -16411,7 +16474,7 @@
       "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "smooth-dnd": {
-      "version": "git+https://github.com/rcdexta/smooth-dnd.git#223f4672bea94f65b98af4fd28ab0db2c3b9c8a2",
+      "version": "git+https://github.com/rcdexta/smooth-dnd.git#f13924c67bf6ffe4613d97bb1ee83f11d364eb1e",
       "from": "git+https://github.com/rcdexta/smooth-dnd.git"
     },
     "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@octokit/plugin-throttling": "^2.6.0",
     "@octokit/rest": "^17.1.4",
     "@sentry/browser": "^4.4.2",
-    "@sentry/node": "^5.9.0",
+    "@sentry/node": "^5.15.5",
     "@webscopeio/react-textarea-autocomplete": "^4.5.0",
     "aws-sdk": "^2.289.0",
     "bcrypt": "^3.0.6",

--- a/test/register.js
+++ b/test/register.js
@@ -37,3 +37,5 @@ require('@babel/register')({
 		/apps\/chat-widget/
 	]
 })
+
+global.env = {}


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

We were already initializing Sentry on the front-end so any uncaught exceptions would be logged to Sentry. However, as we have a top level `ErrorBoundary` component that catches exceptions (and console logs them) not all of our errors are logged to Sentry! In fact, just the ones that are thrown and not caught in async methods are logged to Sentry.

This PR tidies up the integration with Sentry on the front-end and ensures we report exceptions caught by the `ErrorBoundary` to Sentry.

We also set user context info (id, slug, email) when the app is bootstrapped and clear it when the user logs out.

Finally, I've updated @sentry/browser to v5.15.5 which closes #3429.

