### PR TITLE
core: Add versions columns to link table

### DIFF
--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -31,10 +31,18 @@ exports.setup = async (context, connection, database, options) => {
 		CREATE TABLE IF NOT EXISTS ${LINK_TABLE} (
 			id UUID PRIMARY KEY NOT NULL,
 			slug VARCHAR (255) UNIQUE NOT NULL,
+			version_major INTEGER,
+ 			version_minor INTEGER,
+ 			version_patch INTEGER,
 			name TEXT NOT NULL,
 			inverseName TEXT NOT NULL,
 			fromId UUID REFERENCES ${options.cards} (id) NOT NULL,
 			toId UUID REFERENCES ${options.cards} (id) NOT NULL)`)
+
+	await connection.any(`
+		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_major INTEGER;
+		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_minor INTEGER;
+		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_patch INTEGER;`)
 
 	const indexes = _.map(await connection.any(`
 		SELECT * FROM pg_indexes WHERE tablename = '${LINK_TABLE}'`),
@@ -65,20 +73,29 @@ exports.setup = async (context, connection, database, options) => {
 exports.upsert = async (context, connection, link) => {
 	if (link.active) {
 		const sql = `
-			INSERT INTO ${LINK_TABLE} VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO ${LINK_TABLE} VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 			ON CONFLICT (id) DO UPDATE SET
 				slug = $2,
-				name = $3,
-				inverseName = $4,
-				fromId = $5,
-				toId = $6
+				version_major = $3,
+				version_minor = $4,
+				version_patch = $5,
+				name = $6,
+				inverseName = $7,
+				fromId = $8,
+				toId = $9
 		`
+
+		const [ major, minor, patch ] = link.version.split('.')
+
 		await connection.any({
 			name: `links-upsert-insert-${LINK_TABLE}`,
 			text: sql,
 			values: [
 				link.id,
 				link.slug,
+				major,
+				minor,
+				patch,
 				link.name,
 				link.data.inverseName,
 				link.data.from.id,


### PR DESCRIPTION
As a first step to then introduce a slug + version composite unique
constraint on the links table to match what we have on the cards table.

Change-type: patch
See: https://github.com/product-os/jellyfish/pull/3655


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!