### PR TITLE
core: Remove slug UNIQUE constraint on links table

### DIFF
--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -30,7 +30,7 @@ exports.setup = async (context, connection, database, options) => {
 	await connection.any(`
 		CREATE TABLE IF NOT EXISTS ${LINK_TABLE} (
 			id UUID PRIMARY KEY NOT NULL,
-			slug VARCHAR (255) UNIQUE NOT NULL,
+			slug VARCHAR (255) NOT NULL,
 			version_major INTEGER,
  			version_minor INTEGER,
  			version_patch INTEGER,
@@ -58,6 +58,11 @@ exports.setup = async (context, connection, database, options) => {
 				ON ${LINK_TABLE} USING btree (slug, version_major, version_minor, version_patch)`)
 		})
 	}
+
+	await connection.any(`
+		SET statement_timeout = 0;
+		ALTER TABLE ${LINK_TABLE}
+		DROP CONSTRAINT IF EXISTS ${LINK_TABLE}_slug_key;`)
 
 	for (const [ name, column ] of [
 		[ 'idx_link_from', 'fromId' ],


### PR DESCRIPTION
We will rely on the existing slug + version composite UNIQUE constraint
instead.

Change-type: minor 
See: https://github.com/product-os/jellyfish/pull/3655
Signed-off-by: Juan Cruz Viotti <juan@balena.io>