### PR TITLE
Reduce the number of inserted cards in an e2e test to reduce the chance of timeouts

### DIFF
--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -591,7 +591,7 @@ ava.serial('should fail with a user error given no input card', async (test) => 
 })
 
 ava.serial('should limit the amount of get elements by type endpoint', async (test) => {
-	for (const time of _.range(0, 200)) {
+	for (const time of _.range(0, 101)) {
 		await test.context.sdk.card.create({
 			type: 'card',
 			slug: test.context.generateRandomSlug({


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
