### PR TITLE
server: The /whoami endpoint should respond regardless of permissions

### DIFF
--- a/apps/server/http/facades/auth.js
+++ b/apps/server/http/facades/auth.js
@@ -8,7 +8,10 @@ const QueryFacade = require('./query')
 
 module.exports = class AuthFacade extends QueryFacade {
 	async whoami (context, sessionToken, ipAddress) {
-		const result = await this.jellyfish.getCardById(context, sessionToken, sessionToken)
+		// Use the admin session, as the user invoking this function
+		// might not have enough access to read its entire session card.
+		const result = await this.jellyfish.getCardById(
+			context, this.jellyfish.sessions.admin, sessionToken)
 
 		if (!result) {
 			throw new Error('Could not retrieve session data')


### PR DESCRIPTION
Right now the `/whoami` endpoint will raise an exception if the user
sending a request can't see their whole session card.

Fixes: https://sentry.io/share/issue/3625525a06484e928fb77bd48892f9ba/
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!