### PR TITLE
ui: Fix logic when subscribing to card updates

### DIFF
--- a/apps/ui/core/store/actioncreators.js
+++ b/apps/ui/core/store/actioncreators.js
@@ -14,6 +14,9 @@ import * as skhema from 'skhema'
 import {
 	v4 as uuid
 } from 'uuid'
+import {
+	isUUID
+} from '../../../../lib/uuid'
 import actions from './actions'
 import * as helpers from '../../../../lib/ui-components/services/helpers'
 import {
@@ -516,6 +519,7 @@ export default class ActionCreator {
 					})
 				})
 				.then(async () => {
+					const identifier = isUUID(target) ? 'id' : 'slug'
 					const stream = await this.sdk.stream({
 						$$links: {
 							'has attached element': {
@@ -524,12 +528,12 @@ export default class ActionCreator {
 						},
 						type: 'object',
 						properties: {
-							slug: {
+							[identifier]: {
 								type: 'string',
 								const: target
 							}
 						},
-						required: [ 'slug' ]
+						required: [ identifier ]
 					})
 
 					const hash = hashCode(target)


### PR DESCRIPTION
Target can now be an ID or a slug.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3667

Ironically this fixes some e2e tests that are currently not being run on CI - so hard to verify via CI! 😆 
