### PR TITLE
core: Small optimization for filtering stream subscriptions

### DIFF
--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -12,22 +12,22 @@ const logger = require('../../../logger').getLogger(__filename)
 const uuid = require('../../../uuid')
 const utils = require('./utils')
 
+const getConstValue = (name, value) => {
+	return name === 'type' ? value.split('@')[0] : value
+}
+
 const filter = (schema, element) => {
 	if (schema.required && schema.required.length > 0) {
 		if (_.isEmpty(element)) {
 			return null
 		}
 
-		if (_.includes(schema.required, 'slug') &&
-			_.has(schema, [ 'properties', 'slug', 'const' ]) &&
-			element.slug !== schema.properties.slug.const) {
-			return null
-		}
-
-		if (_.includes(schema.required, 'type') &&
-			_.has(schema, [ 'properties', 'type', 'const' ]) &&
-			element.type.split('@')[0] !== schema.properties.type.const.split('@')[0]) {
-			return null
+		for (const requiredField in schema.required) {
+			if (_.has(schema, [ 'properties', requiredField, 'const' ]) &&
+				getConstValue(requiredField, element[requiredField]) !==
+				getConstValue(requiredField, schema.properties[requiredField].const)) {
+				return null
+			}
 		}
 	}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Shortcut - return null from the `filter` function if any of the top-level required schema fields have a const value that does not match the corresponding field in the element.