### PR TITLE
Livechat: Add tests for displaying message actor

### DIFF
--- a/apps/server/default-cards/contrib/role-user-external-support.json
+++ b/apps/server/default-cards/contrib/role-user-external-support.json
@@ -143,9 +143,6 @@
           "additionalProperties": true,
           "required": [ "id", "slug", "type", "data" ],
           "properties": {
-            "id": {
-              "type": "string"
-            },
             "slug": {
               "type": "string",
               "const": {
@@ -186,18 +183,9 @@
           "additionalProperties": true,
           "required": [ "id", "slug", "type", "data" ],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "slug": {
-              "type": "string"
-            },
             "type": {
               "type": "string",
               "const": "user@1.0.0"
-            },
-            "name": {
-              "type": "string"
             },
             "data": {
               "type": "object",
@@ -208,6 +196,10 @@
                 },
                 "avatar": {
                   "type": [ "string", "null" ]
+                },
+                "profile": {
+                  "type": "object",
+                  "additionalProperties": true
                 }
               }
             }

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -496,29 +496,37 @@ export const generateActorFromUserCard = (card) => {
 	if (!card) {
 		return null
 	}
-	let name = 'unknown user'
 
-	// IF proxy is true, it indicates that the actor has been created as a proxy
-	// for a real user in JF, usually as a result of syncing from an external
-	// service
-	let proxy = false
+	/* Get user name to display with priorities:
+	 * 1. profile.name
+	 * 2. card name or slug substring if user is balena org member
+	 * 3. [card name or handle]
+	 * 4. [email(s)]
+	 * 5. [card slug substring]
+	*/
+	const profileName = _.get(card, [ 'data', 'profile', 'name' ])
 	const email = _.get(card, [ 'data', 'email' ], '')
 
-	const isBalenaTeam = _.find(
+	const isBalenaOrgMember = _.find(
 		_.get(card, [ 'links', 'is member of' ], []),
 		{
 			slug: 'org-balena'
 		}
 	)
 
-	// Check if the user is part of the balena org
-	if (isBalenaTeam) {
+	let name = 'unknown user'
+	if (profileName && (profileName.first || profileName.last)) {
+		name = _.compact([ profileName.first, profileName.last ]).join(' ')
+	} else if (isBalenaOrgMember) {
 		name = card.name || card.slug.replace('user-', '')
 	} else {
-		proxy = true
 		let handle = card.name || _.get(card, [ 'data', 'handle' ])
 		if (!handle) {
-			handle = email || card.slug.replace(/^(account|user)-/, '')
+			if (email && email.length) {
+				handle = _.isArray(email) ? email.join(', ') : email
+			} else {
+				handle = card.slug.replace(/^(account|user)-/, '')
+			}
 		}
 		name = `[${handle}]`
 	}
@@ -527,7 +535,11 @@ export const generateActorFromUserCard = (card) => {
 		name,
 		email,
 		avatarUrl: _.get(card, [ 'data', 'avatar' ]),
-		proxy,
+
+		// IF proxy is true, it indicates that the actor has been created as a proxy
+		// for a real user in JF, usually as a result of syncing from an external
+		// service
+		proxy: !isBalenaOrgMember,
 		card
 	}
 }

--- a/scripts/ci/tests/e2e.spec.sh
+++ b/scripts/ci/tests/e2e.spec.sh
@@ -10,8 +10,7 @@ set -e
 source "$(dirname $0)/helpers.sh"
 
 # Run Livechat end-to-end tests.
-# Temporarily run fewer e2e tests while we resolve instability
-# run_test "Livechat End-to-End Tests" test-e2e-livechat
+run_test "Livechat End-to-End Tests" test-e2e-livechat
 
 # Run UI end-to-end tests.
 run_test "UI End-to-End Tests" test-e2e-ui INTEGRATION_OUTREACH_APP_ID=

--- a/test/e2e/livechat/macros.js
+++ b/test/e2e/livechat/macros.js
@@ -4,17 +4,26 @@
  * Proprietary and confidential.
  */
 
+const {
+	v4: uuid
+} = require('uuid')
+const {
+	getSdk
+} = require('@balena/jellyfish-client-sdk')
 const environment = require('../../../lib/environment')
 
 exports.createThreads = async (context, start, count) => {
 	const threads = []
+	const markers = [ `${context.supportUser.card.slug}+${context.supportUser.org.slug}` ]
 
 	for (let index = start; index < start + count; index++) {
-		const thread = await context.sdk.card.create({
+		const thread = await context.supportUser.sdk.card.create({
 			type: 'support-thread@1.0.0',
 			name: `Thread subject ${index}`,
+			markers,
 			data: {
-				product: 'jellyfish'
+				product: 'jellyfish',
+				status: 'open'
 			}
 		})
 
@@ -46,14 +55,96 @@ exports.createConversation = async (context) => {
 	await context.page.click('[data-test="start-conversation-button"]')
 }
 
+exports.createOrg = async (context) => {
+	const uniqueId = uuid()
+	return context.sdk.card.create({
+		type: 'org',
+		slug: `org-${uniqueId}`,
+		name: `Org ${uniqueId}`,
+		version: '1.0.0'
+	})
+}
+
+exports.prepareUser = async (context, org, role, name) => {
+	const details = {
+		username: `${uuid()}`,
+		email: `${uuid()}@example.com`,
+		password: 'foobarbaz'
+	}
+
+	const card = await context.sdk.action({
+		card: 'user@1.0.0',
+		type: 'type',
+		action: 'action-create-user@1.0.0',
+		arguments: {
+			username: `user-${details.username}`,
+			email: details.email,
+			password: details.password
+		}
+	})
+
+	await context.sdk.card.update(
+		card.id,
+		card.type,
+		[
+			{
+				op: 'add',
+				path: '/data/roles/0',
+				value: role
+			},
+			{
+				op: 'add',
+				path: '/data/profile',
+				value: {
+					name: (([ first, last ]) => {
+						return {
+							first,
+							last
+						}
+					})(name.split(' '))
+				}
+			}
+		]
+	)
+
+	await context.sdk.card.link(card, org, 'is member of')
+
+	const sdk = getSdk({
+		apiPrefix: 'api/v2',
+		apiUrl: `${environment.http.host}:${environment.http.port}`
+	})
+
+	await sdk.auth.login(details)
+
+	return {
+		sdk,
+		card,
+		org
+	}
+}
+
 exports.initChat = async (context) => {
-	await context.page.evaluate(async (token, userSlug) => {
-		window.localStorage.setItem('token', token)
+	await context.page.evaluate(async (supportUserToken, supportUserSlug) => {
+		window.localStorage.setItem('token', supportUserToken)
 
 		await window.init({
 			product: 'jellyfish',
 			productTitle: 'Jelly',
-			userSlug
+			userSlug: supportUserSlug
 		})
-	}, context.sdk.getAuthToken(), `user-${environment.test.user.username}`)
+	}, context.supportUser.sdk.getAuthToken(), context.supportUser.card.slug)
+}
+
+exports.insertAgentReply = async (context, thread, message) => {
+	return context.supportAgent.sdk.event.create({
+		target: thread,
+		type: 'message',
+		slug: `message-${uuid()}`,
+		tags: [],
+		payload: {
+			mentionsUser: [],
+			alertsUser: [],
+			message
+		}
+	})
 }

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -162,6 +162,17 @@ exports.getElementText = async (page, selector) => {
 	})
 }
 
+exports.waitForInnerText = async (page, selector, text, index = 0, options = {}) => {
+	await page.waitForFunction(
+		(sel, txt, ind) => {
+			const matches = document.querySelectorAll(sel)
+			return matches[ind] && matches[ind].innerText === txt
+		},
+		options,
+		selector, text, index
+	)
+}
+
 exports.waitForSelectorToDisappear = async (page, selector, retryCount = 30) => {
 	return exports.retry(retryCount, async () => {
 		try {


### PR DESCRIPTION
Change-type: patch

***

Improved livechat tests. Livechat is now initialized with proper user (with role `user-external-support`). Added test case to check if agent's response is displayed correctly.

~~**This now fails to read support agent's name correctly**, this happens because support user can't fetch agent's profile information despite of adding field in the role.~~ Works in test environment
