### PR TITLE
ui: Use react router for internal links

### DIFF
--- a/apps/ui/lens/full/MyUser/MyUser.jsx
+++ b/apps/ui/lens/full/MyUser/MyUser.jsx
@@ -17,8 +17,7 @@ import {
 	Txt,
 	Tab,
 	Tabs,
-	Divider,
-	Link
+	Divider
 } from 'rendition'
 import {
 	Form
@@ -28,6 +27,7 @@ import * as helpers from '../../../../../lib/ui-components/services/helpers'
 import CardLayout from '../../../layouts/CardLayout'
 import Avatar from '../../../../../lib/ui-components/shame/Avatar'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
+import RouterLink from '../../../../../lib/ui-components/Link'
 
 const SLUG = 'lens-my-user'
 
@@ -262,9 +262,9 @@ export default class MyUser extends React.Component {
 							<Divider color="#eee" />
 
 							<Flex justifyContent="space-between" alignItems="center">
-								<Link href="https://www.outreach.io/" blank>
+								<RouterLink to="https://www.outreach.io/" blank>
 									<Txt bold>Outreach</Txt>
-								</Link>
+								</RouterLink>
 
 								{_.get(user, [ 'data', 'oauth', 'outreach' ]) ? (
 									<Txt>Authorized</Txt>

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -18,7 +18,6 @@ import {
 	Box,
 	Button,
 	Flex,
-	Link,
 	Theme,
 	Txt
 } from 'rendition'
@@ -400,14 +399,14 @@ class SupportThreadBase extends React.Component {
 							return (
 								<Tag key={entry.id} mr={2} mb={1} tooltip={entry.name}>
 									<Icon name="github" brands />
-									<Link
+									<RouterLink
 										ml={1}
-										href={`/${entry.slug || entry.id}`}
+										to={`/${entry.slug || entry.id}`}
 										key={entry.id}
 										data-test="support-thread__linked-issue"
 									>
 										{entry.name}
-									</Link>
+									</RouterLink>
 								</Tag>
 							)
 						})}
@@ -416,14 +415,14 @@ class SupportThreadBase extends React.Component {
 							return (
 								<Tag key={entry.id} mr={2} mb={1} tooltip={entry.name}>
 									<JellyIcon />
-									<Link
+									<RouterLink
 										ml={1}
-										href={`/${entry.slug || entry.id}`}
+										to={`/${entry.slug || entry.id}`}
 										key={entry.id}
 										data-test="support-thread__linked-support-issue"
 									>
 										{entry.name}
-									</Link>
+									</RouterLink>
 								</Tag>
 							)
 						})}
@@ -432,14 +431,14 @@ class SupportThreadBase extends React.Component {
 							return (
 								<Tag key={entry.id} mr={2} mb={1} tooltip={entry.name}>
 									<JellyIcon />
-									<Link
+									<RouterLink
 										ml={1}
-										href={`/${entry.slug || entry.id}`}
+										to={`/${entry.slug || entry.id}`}
 										key={entry.id}
 										data-test="support-thread__linked-support-issue"
 									>
 										{entry.name}
-									</Link>
+									</RouterLink>
 								</Tag>
 							)
 						})}
@@ -469,13 +468,13 @@ class SupportThreadBase extends React.Component {
 					</Flex>
 
 					{!this.state.expanded && (
-						<Link
+						<RouterLink
 							onClick={this.handleExpandToggle}
 							mt={2}
 							data-test="support-thread__expand"
 						>
 							More
-						</Link>
+						</RouterLink>
 					)}
 
 					{this.state.expanded && (
@@ -483,13 +482,13 @@ class SupportThreadBase extends React.Component {
 							{highlights.length > 0 && (
 								<div>
 									<strong>
-										<Link
+										<RouterLink
 											mt={1}
 											onClick={this.toggleHighlights}
 										>
 														Highlights{' '}
 											<Icon name={`caret-${this.state.showHighlights ? 'down' : 'right'}`}/>
-										</Link>
+										</RouterLink>
 									</strong>
 								</div>
 							)}
@@ -528,9 +527,9 @@ class SupportThreadBase extends React.Component {
 							/>
 
 							<Box>
-								<Link mt={3} onClick={this.handleExpandToggle}>
+								<RouterLink mt={3} onClick={this.handleExpandToggle}>
 									Less
-								</Link>
+								</RouterLink>
 							</Box>
 						</React.Fragment>
 					)}

--- a/lib/ui-components/Auth/Login/Login.jsx
+++ b/lib/ui-components/Auth/Login/Login.jsx
@@ -12,12 +12,12 @@ import {
 	Divider,
 	Heading,
 	Input,
-	Link,
 	Txt
 } from 'rendition'
 import Icon from '../../shame/Icon'
+import RouterLink from '../../Link'
 
-const StyledLink = styled(Link) `
+const StyledLink = styled(RouterLink) `
 	float: right;
 `
 
@@ -125,7 +125,7 @@ export default class Login extends React.Component {
 				</form>
 				<StyledLink
 					mt={3}
-					href="/request_password_reset"
+					to="/request_password_reset"
 				>
 					Forgot Password?
 				</StyledLink>

--- a/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
+++ b/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
@@ -12,12 +12,12 @@ import {
 	Divider,
 	Heading,
 	Input,
-	Link,
 	Txt
 } from 'rendition'
 import Icon from '../../shame/Icon'
+import RouterLink from '../../Link'
 
-const StyledLink = styled(Link) `
+const StyledLink = styled(RouterLink) `
 	float: right;
 `
 
@@ -112,7 +112,7 @@ export default class RequestPasswordReset extends React.Component {
 				</form>
 				<StyledLink
 					mt={3}
-					href="/"
+					to="/"
 				>
 					Return to login?
 				</StyledLink>

--- a/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.spec.jsx
+++ b/lib/ui-components/Auth/RequestPasswordReset/RequestPasswordReset.spec.jsx
@@ -19,10 +19,22 @@ import RequestPasswordReset from './RequestPasswordReset.jsx'
 
 import Adapter from 'enzyme-adapter-react-16'
 
+const Router = require('react-router-dom').MemoryRouter
+
 const DATA_TEST_PREFIX = 'requestPasswordReset-page'
 
 const browserEnv = require('browser-env')
 browserEnv([ 'window', 'document', 'navigator' ])
+
+const Wrapper = ({
+	children
+}) => {
+	return (
+		<Router>
+			<Provider>{children}</Provider>
+		</Router>
+	)
+}
 
 configure({
 	adapter: new Adapter()
@@ -46,7 +58,7 @@ ava('Submit button is disabled if the username input is empty', async (test) => 
 
 	const requestPasswordReset = mount(
 		<RequestPasswordReset/>, {
-			wrappingComponent: Provider
+			wrappingComponent: Wrapper
 		})
 
 	await flushPromises()
@@ -78,7 +90,7 @@ ava('Fires the requirePasswordReset action followed by a success notification wh
 				addNotification
 			}}
 		/>, {
-			wrappingComponent: Provider
+			wrappingComponent: Wrapper
 		})
 
 	await flushPromises()
@@ -123,7 +135,7 @@ ava('Sends a danger notification if the action throws an error', async (test) =>
 				addNotification
 			}}
 		/>, {
-			wrappingComponent: Provider
+			wrappingComponent: Wrapper
 		})
 
 	await flushPromises()

--- a/lib/ui-components/CardField.jsx
+++ b/lib/ui-components/CardField.jsx
@@ -7,9 +7,9 @@
 import * as _ from 'lodash'
 import React from 'react'
 import {
-	Link,
 	Txt
 } from 'rendition'
+import RouterLink from './Link'
 import {
 	Markdown
 } from 'rendition/dist/extra/Markdown'
@@ -41,7 +41,7 @@ const CardField = ({
 				<Label my={3}>{field}</Label>
 				{_.map(value, (mirror) => {
 					const url = transformMirror(mirror)
-					return <div><Link blank href={url} key={mirror}>{url}</Link></div>
+					return <div><RouterLink blank to={url} key={mirror}>{url}</RouterLink></div>
 				})}
 			</React.Fragment>
 		)

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -307,6 +307,7 @@ export default class Event extends React.Component {
 
 		this.handleVisibilityChange = this.handleVisibilityChange.bind(this)
 		this.downloadAttachment = this.downloadAttachment.bind(this)
+		this.customMarkdownRenderer = this.customMarkdownRenderer.bind(this)
 	}
 
 	shouldComponentUpdate (nextProps, nextState) {
@@ -365,6 +366,21 @@ export default class Event extends React.Component {
 				}
 			}
 		})
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	customMarkdownRenderer (marked, renderer) {
+		renderer.link = function (_href, _title, _text, args) {
+			const link = Reflect.apply(marked.Renderer.prototype.link, this, ...args)
+
+			if (helpers.isExternalUrl(link.href)) {
+				return link.replace('<a', '<a target="_blank" rel="noopener noreferrer"')
+			}
+
+			return helpers.toRelativeUrl(link)
+		}
+
+		return renderer
 	}
 
 	handleVisibilityChange (isVisible) {
@@ -629,6 +645,8 @@ export default class Event extends React.Component {
 											? MESSAGE_COLLAPSED_HEIGHT
 											: 'none'
 									}}
+
+									renderer={this.customMarkdownRenderer}
 									data-test={card.pending ? '' : 'event-card__message'}
 									flex={0}
 								>

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -336,11 +336,6 @@ export default class Event extends React.Component {
 			return
 		}
 
-		// Modify all links in the message to open in a new tab
-		// TODO: Make this an option in the rendition <Markdown /> component.
-		Array.from(this.messageElement.querySelectorAll('a')).forEach((node) => {
-			node.setAttribute('target', '_blank')
-		})
 		const instance = new Mark(this.messageElement)
 
 		const readBy = this.props.card.data.readBy || []

--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -17,7 +17,6 @@ import {
 	Divider,
 	Fixed,
 	Flex,
-	Link,
 	Txt
 } from 'rendition'
 import {
@@ -640,16 +639,16 @@ export default class HomeChannel extends React.Component {
 							/>
 						</Box>
 
-						<Link
+						<RouterLink
 							p={2}
 							fontSize={1}
-							href='https://github.com/balena-io/jellyfish/blob/master/CHANGELOG.md'
+							to='https://github.com/balena-io/jellyfish/blob/master/CHANGELOG.md'
 							blank
 						>
 							<Txt monospace>
 								v{this.props.version} {this.props.codename}
 							</Txt>
-						</Link>
+						</RouterLink>
 					</HomeChannelContent>
 				</HomeChannelDrawer>
 			</HomeChannelWrapper>

--- a/lib/ui-components/Link/Link.jsx
+++ b/lib/ui-components/Link/Link.jsx
@@ -11,7 +11,8 @@ import {
 	Link
 } from 'rendition'
 import {
-	isExternalLink
+	isExternalLink,
+	toRelativeLink
 } from '../services/helpers'
 
 export default class RouterLink extends React.Component {
@@ -29,7 +30,7 @@ export default class RouterLink extends React.Component {
 		} = this.props
 
 		if (to) {
-			return to
+			return toRelativeLink(to)
 		}
 
 		if (append) {

--- a/lib/ui-components/Link/Link.jsx
+++ b/lib/ui-components/Link/Link.jsx
@@ -11,8 +11,8 @@ import {
 	Link
 } from 'rendition'
 import {
-	isExternalLink,
-	toRelativeLink
+	isExternalUrl,
+	toRelativeUrl
 } from '../services/helpers'
 
 export default class RouterLink extends React.Component {
@@ -30,7 +30,7 @@ export default class RouterLink extends React.Component {
 		} = this.props
 
 		if (to) {
-			return toRelativeLink(to)
+			return toRelativeUrl(to)
 		}
 
 		if (append) {
@@ -52,7 +52,7 @@ export default class RouterLink extends React.Component {
 		}
 
 		// If the link is external use default browser behaviour
-		if (blank || isExternalLink(to)) {
+		if (blank || isExternalUrl(to)) {
 			return true
 		}
 

--- a/lib/ui-components/Link/Link.jsx
+++ b/lib/ui-components/Link/Link.jsx
@@ -8,13 +8,13 @@ import _ from 'lodash'
 import path from 'path'
 import React from 'react'
 import {
-	withRouter
-} from 'react-router-dom'
-import {
 	Link
 } from 'rendition'
+import {
+	isExternalLink
+} from '../services/helpers'
 
-class RouterLink extends React.Component {
+export default class RouterLink extends React.Component {
 	constructor (props) {
 		super(props)
 
@@ -36,13 +36,23 @@ class RouterLink extends React.Component {
 			return path.join(location.pathname, append)
 		}
 
-		return ''
+		return null
 	}
 
 	navigate (event) {
-		// If control or meta keys are pressed, then use default browser behaviour
+		const {
+			blank,
+			to
+		} = this.props
+
+		// If control or meta keys are pressed use default browser behaviour
 		if (event.ctrlKey || event.metaKey) {
-			return
+			return true
+		}
+
+		// If the link is external use default browser behaviour
+		if (blank || isExternalLink(to)) {
+			return true
 		}
 
 		event.preventDefault()
@@ -53,6 +63,7 @@ class RouterLink extends React.Component {
 		const url = this.makeUrl()
 
 		history.push(url)
+		return false
 	}
 
 	render () {
@@ -70,10 +81,10 @@ class RouterLink extends React.Component {
 			<Link
 				{...props}
 				href={url}
-				onClick={this.navigate}
+
+				// We should only navigate when `url` is defined
+				onClick={url ? this.navigate : props.onClick}
 			/>
 		)
 	}
 }
-
-export default withRouter(RouterLink)

--- a/lib/ui-components/Link/index.js
+++ b/lib/ui-components/Link/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	withRouter
+} from 'react-router-dom'
+import RouterLink from './Link'
+
+export default withRouter(RouterLink)

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -18,6 +18,7 @@ import skhema from 'skhema'
 import {
 	DetectUA
 } from 'detect-ua'
+import isUrl from 'is-url-superb'
 
 export const createPermaLink = (card) => {
 	return `${window.location.origin}/${card.id}`
@@ -565,4 +566,9 @@ export const isiOS = () => {
 		return false
 	}
 	return new DetectUA().isiOS
+}
+
+export const isExternalLink = (to = null) => {
+	// It's external if it's absolute and isn't the same host
+	return isUrl(to) && !to.startsWith(window.location.origin)
 }

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -568,13 +568,37 @@ export const isiOS = () => {
 	return new DetectUA().isiOS
 }
 
-export const isExternalLink = (to = null) => {
+/**
+ *
+ * @param {String} url - The url to check
+ * @description checks if url is External from the window.location
+ * @example
+ * // window.location.origin = 'https://jel.ly.fish'
+ * // returns true
+ * isExternalUrl('https://google.com/maps')
+ * @example
+ * // window.location.origin = 'https://jel.ly.fish'
+ * // returns false
+ * isExternalUrl('https://jel.ly.fish/inbox')
+ *
+ * @returns {Boolean}
+ */
+export const isExternalUrl = (url = null) => {
 	// It's external if it's absolute and isn't the same host
-	return isUrl(to) && !to.startsWith(window.location.origin)
+	return isUrl(url) && !url.startsWith(window.location.origin)
 }
 
-export const toRelativeLink = (to = null) => {
-	// Transform absolute link into a relative link
-	// based on the current window location
-	return to.replace(window.location.origin, '')
+/**
+ *
+ * @param {String} url - The url to be converted
+ * @description Converts an absolute url of the current window.location.origin to an relative url.
+ * @example
+ * // window.location.origin = 'https://google.com/maps'
+ * // returns '/maps'
+ * toRelativeUrl('https://google.com/maps')
+ *
+ * @returns {String} Return relative url without window.location.origin
+ */
+export const toRelativeUrl = (url = null) => {
+	return url.replace(window.location.origin, '')
 }

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -572,3 +572,9 @@ export const isExternalLink = (to = null) => {
 	// It's external if it's absolute and isn't the same host
 	return isUrl(to) && !to.startsWith(window.location.origin)
 }
+
+export const toRelativeLink = (to = null) => {
+	// Transform absolute link into a relative link
+	// based on the current window location
+	return to.replace(window.location.origin, '')
+}

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -436,59 +436,59 @@ ava('BrowserEnv window can be set to \'http://localhost:9000/\'', (test) => {
 	test.is(window.location.href, 'http://localhost:9000/')
 })
 
-ava('.isExternalLink() should return false for relative url', (test) => {
+ava('.isExternalUrl() should return false for relative url', (test) => {
 	mockBrowserHost()
 
-	test.false(helpers.isExternalLink('/view-all-jellyfish-support-threads'))
+	test.false(helpers.isExternalUrl('/view-all-jellyfish-support-threads'))
 })
 
-ava('.isExternalLink() should return false for localhost', (test) => {
+ava('.isExternalUrl() should return false for localhost', (test) => {
 	mockBrowserHost()
 
-	test.false(helpers.isExternalLink('http://localhost:9000'))
+	test.false(helpers.isExternalUrl('http://localhost:9000'))
 })
 
-ava('.isExternalLink() should return false for localhost with trailing /', (test) => {
+ava('.isExternalUrl() should return false for localhost with trailing /', (test) => {
 	mockBrowserHost()
 
-	test.false(helpers.isExternalLink('http://localhost:9000/'))
+	test.false(helpers.isExternalUrl('http://localhost:9000/'))
 })
 
-ava('.isExternalLink() should return true for localhost api route', (test) => {
+ava('.isExternalUrl() should return true for localhost api route', (test) => {
 	mockBrowserHost()
 
-	test.true(helpers.isExternalLink('http://localhost:8000/api/v2/action'))
+	test.true(helpers.isExternalUrl('http://localhost:8000/api/v2/action'))
 })
 
-ava('.isExternalLink() should return false localhost UI route', (test) => {
+ava('.isExternalUrl() should return false localhost UI route', (test) => {
 	mockBrowserHost()
 
 	test.false(
-		helpers.isExternalLink('http://localhost:9000/view-all-jellyfish-support-threads/support-thread-my-first-support-da5831b1-6a7e-4d8e-a024-d0e9dac14f6a')
+		helpers.isExternalUrl('http://localhost:9000/view-all-jellyfish-support-threads/support-thread-my-first-support-da5831b1-6a7e-4d8e-a024-d0e9dac14f6a')
 	)
 })
 
-ava('.isExternalLink() should return false for route on current window', (test) => {
+ava('.isExternalUrl() should return false for route on current window', (test) => {
 	mockBrowserHost('https://jel.ly.fish')
 
-	test.false(helpers.isExternalLink('https://jel.ly.fish/inbox'))
+	test.false(helpers.isExternalUrl('https://jel.ly.fish/inbox'))
 })
 
-ava('.isExternalLink() should return true for \'https://github.com\'', (test) => {
+ava('.isExternalUrl() should return true for \'https://github.com\'', (test) => {
 	mockBrowserHost()
 
-	test.true(helpers.isExternalLink('https://github.com'))
+	test.true(helpers.isExternalUrl('https://github.com'))
 })
 
-ava('.toRelativeLink() should remove the current window.location.origin from a absolute link', (test) => {
+ava('.toRelativeUrl() should remove the current window.location.origin from a absolute link', (test) => {
 	mockBrowserHost()
 
-	test.is(helpers.toRelativeLink('http://localhost:9000/view-all-jellyfish-support-threads/'), '/view-all-jellyfish-support-threads/')
+	test.is(helpers.toRelativeUrl('http://localhost:9000/view-all-jellyfish-support-threads/'), '/view-all-jellyfish-support-threads/')
 })
 
-ava('.toRelativeLink() when window.location.origin isn\'t part of the url, the url should stay intact', (test) => {
+ava('.toRelativeUrl() when window.location.origin isn\'t part of the url, the url should stay intact', (test) => {
 	mockBrowserHost()
 
 	const url = 'https://jel.ly.fish/view-all-jellyfish-support-threads/'
-	test.is(helpers.toRelativeLink(url), url)
+	test.is(helpers.toRelativeUrl(url), url)
 })

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -7,6 +7,7 @@
 const ava = require('ava')
 const _ = require('lodash')
 const helpers = require('./helpers')
+const browserEnv = require('browser-env')
 
 const user = {
 	slug: 'user',
@@ -81,6 +82,12 @@ const user = {
 			}
 		}
 	}
+}
+
+const mockBrowserHost = (url = 'http://localhost:9000') => {
+	browserEnv([ 'window' ], {
+		url
+	})
 }
 
 ava('.slugify replaces non text with hyphens', (test) => {
@@ -421,4 +428,54 @@ ava('.stringToNumber() should convert string to number while not exeeding the ma
 	})
 
 	test.deepEqual(result, expectedResult)
+})
+
+ava('BrowserEnv window can be set to \'http://localhost:9000/\'', (test) => {
+	mockBrowserHost()
+
+	test.is(window.location.href, 'http://localhost:9000/')
+})
+
+ava('.isExternalLink() should return false for relative url', (test) => {
+	mockBrowserHost()
+
+	test.false(helpers.isExternalLink('/view-all-jellyfish-support-threads'))
+})
+
+ava('.isExternalLink() should return false for localhost', (test) => {
+	mockBrowserHost()
+
+	test.false(helpers.isExternalLink('http://localhost:9000'))
+})
+
+ava('.isExternalLink() should return false for localhost with trailing /', (test) => {
+	mockBrowserHost()
+
+	test.false(helpers.isExternalLink('http://localhost:9000/'))
+})
+
+ava('.isExternalLink() should return true for localhost api route', (test) => {
+	mockBrowserHost()
+
+	test.true(helpers.isExternalLink('http://localhost:8000/api/v2/action'))
+})
+
+ava('.isExternalLink() should return false localhost UI route', (test) => {
+	mockBrowserHost()
+
+	test.false(
+		helpers.isExternalLink('http://localhost:9000/view-all-jellyfish-support-threads/support-thread-my-first-support-da5831b1-6a7e-4d8e-a024-d0e9dac14f6a')
+	)
+})
+
+ava('.isExternalLink() should return false for route on current window', (test) => {
+	mockBrowserHost('https://jel.ly.fish')
+
+	test.false(helpers.isExternalLink('https://jel.ly.fish/inbox'))
+})
+
+ava('.isExternalLink() should return true for \'https://github.com\'', (test) => {
+	mockBrowserHost()
+
+	test.true(helpers.isExternalLink('https://github.com'))
 })

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -479,3 +479,16 @@ ava('.isExternalLink() should return true for \'https://github.com\'', (test) =>
 
 	test.true(helpers.isExternalLink('https://github.com'))
 })
+
+ava('.toRelativeLink() should remove the current window.location.origin from a absolute link', (test) => {
+	mockBrowserHost()
+
+	test.is(helpers.toRelativeLink('http://localhost:9000/view-all-jellyfish-support-threads/'), '/view-all-jellyfish-support-threads/')
+})
+
+ava('.toRelativeLink() when window.location.origin isn\'t part of the url, the url should stay intact', (test) => {
+	mockBrowserHost()
+
+	const url = 'https://jel.ly.fish/view-all-jellyfish-support-threads/'
+	test.is(helpers.toRelativeLink(url), url)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -11987,6 +11987,14 @@
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
+    "is-url-superb": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
+      "requires": {
+        "url-regex": "^5.0.0"
+      }
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -18291,6 +18299,11 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "tlds": {
+      "version": "1.207.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.207.0.tgz",
+      "integrity": "sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -18885,6 +18898,22 @@
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
+      }
+    },
+    "url-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
+      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
+      "requires": {
+        "ip-regex": "^4.1.0",
+        "tlds": "^1.203.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+          "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+        }
       }
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "howler": "^2.1.3",
     "immutability-helper": "^3.0.1",
     "intercom-client": "^2.10.4",
+    "is-url-superb": "^3.0.0",
     "json-e": "^2.6.0",
     "json-schema-ref-parser": "^6.0.2",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
Fixes: https://github.com/product-os/jellyfish/issues/2290

This PR replaces the use of the rendition `Link` component in Jellyfish with the `RouterLink`component. RouterLink wraps the rendition component with the following behavior:

- Relative links use react-router for navigation.
- External links use default browser behavior.
- Links that navigate to the current `window.location` are treated as relative links.