### PR TITLE
Quote all the things (in k8s templates)

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
@@ -1,4 +1,4 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: {{{KATAPULT_KUBE_NAMESPACE}}}
+  name: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: action-server
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   replicas: 12
   selector:
@@ -23,29 +23,29 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: DATABASE
-          value: postgres
+          value: 'postgres'
         - name: POSTGRES_DATABASE
-          value: {{POSTGRES_DATABASE}}
+          value: '{{{POSTGRES_DATABASE}}}'
         - name: POSTGRES_USER
-          value: {{POSTGRES_USER}}
+          value: '{{{POSTGRES_USER}}}'
         - name: POSTGRES_PASSWORD
-          value: {{POSTGRES_PASSWORD}}
+          value: '{{{POSTGRES_PASSWORD}}}'
         - name: POSTGRES_PORT
-          value: '{{POSTGRES_PORT}}'
+          value: '{{{POSTGRES_PORT}}}'
         - name: POSTGRES_HOST
-          value: {{POSTGRES_HOST}}
+          value: '{{{POSTGRES_HOST}}}'
         - name: REDIS_HOST
-          value: {{REDIS_HOST}}
+          value: '{{{REDIS_HOST}}}'
         - name: REDIS_PASSWORD
-          value: {{{REDIS_PASSWORD}}}
+          value: '{{{REDIS_PASSWORD}}}'
         - name: NODE_ENV
-          value: {{{NODE_ENV}}}
+          value: '{{{NODE_ENV}}}'
         - name: SENTRY_DSN_SERVER
-          value: {{{SENTRY_DSN_SERVER}}}
+          value: '{{{SENTRY_DSN_SERVER}}}'
         - name: LOGENTRIES_TOKEN
-          value: {{{LOGENTRIES_TOKEN}}}
+          value: '{{{LOGENTRIES_TOKEN}}}'
         - name: LOGLEVEL
-          value: {{{LOGLEVEL}}}
+          value: '{{{LOGLEVEL}}}'
         - name: WORKER_PORT
           value: '{{{WORKER_PORT}}}'
         - name: METRICS_PORT
@@ -57,17 +57,17 @@ spec:
         - name: INTEGRATION_BALENA_API_OAUTH_BASE_URL
           value: '{{{INTEGRATION_BALENA_API_OAUTH_BASE_URL}}}'
         - name: INTEGRATION_BALENA_API_PRIVATE_KEY
-          value: {{{INTEGRATION_BALENA_API_PRIVATE_KEY}}}
+          value: '{{{INTEGRATION_BALENA_API_PRIVATE_KEY}}}'
         - name: INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
-          value: {{{INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION}}}
+          value: '{{{INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION}}}'
         - name: INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
-          value: {{{INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING}}}
+          value: '{{{INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING}}}'
         - name: INTEGRATION_DEFAULT_USER
-          value: {{{INTEGRATION_DEFAULT_USER}}}
+          value: '{{{INTEGRATION_DEFAULT_USER}}}'
         - name: INTEGRATION_INTERCOM_TOKEN
-          value: {{{INTEGRATION_INTERCOM_TOKEN}}}
+          value: '{{{INTEGRATION_INTERCOM_TOKEN}}}'
         - name: INTEGRATION_FRONT_TOKEN
-          value: {{{INTEGRATION_FRONT_TOKEN}}}
+          value: '{{{INTEGRATION_FRONT_TOKEN}}}'
         - name: INTEGRATION_GITHUB_TOKEN
           value: '{{{INTEGRATION_GITHUB_TOKEN}}}'
         - name: INTEGRATION_GITHUB_SIGNATURE_KEY
@@ -77,31 +77,31 @@ spec:
         - name: INTEGRATION_GITHUB_APP_ID
           value: '{{{INTEGRATION_GITHUB_APP_ID}}}'
         - name: INTEGRATION_FLOWDOCK_SIGNATURE_KEY
-          value: {{{INTEGRATION_FLOWDOCK_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_FLOWDOCK_SIGNATURE_KEY}}}'
         - name: INTEGRATION_DISCOURSE_TOKEN
-          value: {{{INTEGRATION_DISCOURSE_TOKEN}}}
+          value: '{{{INTEGRATION_DISCOURSE_TOKEN}}}'
         - name: INTEGRATION_DISCOURSE_USERNAME
-          value: {{{INTEGRATION_DISCOURSE_USERNAME}}}
+          value: '{{{INTEGRATION_DISCOURSE_USERNAME}}}'
         - name: INTEGRATION_DISCOURSE_SIGNATURE_KEY
-          value: {{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}'
         - name: INTEGRATION_OUTREACH_APP_ID
-          value: {{{INTEGRATION_OUTREACH_APP_ID}}}
+          value: '{{{INTEGRATION_OUTREACH_APP_ID}}}'
         - name: INTEGRATION_OUTREACH_APP_SECRET
-          value: {{{INTEGRATION_OUTREACH_APP_SECRET}}}
+          value: '{{{INTEGRATION_OUTREACH_APP_SECRET}}}'
         - name: INTEGRATION_OUTREACH_SIGNATURE_KEY
-          value: {{{INTEGRATION_OUTREACH_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_OUTREACH_SIGNATURE_KEY}}}'
         - name: MAILGUN_TOKEN
-          value: {{{MAILGUN_TOKEN}}}
+          value: '{{{MAILGUN_TOKEN}}}'
         - name: MAILGUN_DOMAIN
-          value: {{{MAILGUN_DOMAIN}}}
+          value: '{{{MAILGUN_DOMAIN}}}'
         - name: MAILGUN_BASE_URL
-          value: {{{MAILGUN_BASE_URL}}}
+          value: '{{{MAILGUN_BASE_URL}}}'
         - name: RESET_PASSWORD_SECRET_TOKEN
-          value: {{{RESET_PASSWORD_SECRET_TOKEN}}}
+          value: '{{{RESET_PASSWORD_SECRET_TOKEN}}}'
         - name: MONITOR_SECRET_TOKEN
-          value: {{{MONITOR_SECRET_TOKEN}}}
+          value: '{{{MONITOR_SECRET_TOKEN}}}'
         - name: NEW_COMPILER_TEST_CHANCE
-          value: {{{NEW_COMPILER_TEST_CHANCE}}}
+          value: '{{{NEW_COMPILER_TEST_CHANCE}}}'
         ports:
           - containerPort: {{{METRICS_PORT}}}
             name: prometheus-a

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: jellyfish
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
     matchLabels:
@@ -49,19 +49,19 @@ spec:
         - name: PORT
           value: '8000'
         - name: DATABASE
-          value: postgres
+          value: 'postgres'
         - name: POSTGRES_DATABASE
-          value: {{POSTGRES_DATABASE}}
+          value: '{{{POSTGRES_DATABASE}}}'
         - name: POSTGRES_USER
-          value: {{POSTGRES_USER}}
+          value: '{{{POSTGRES_USER}}}'
         - name: POSTGRES_PASSWORD
-          value: {{POSTGRES_PASSWORD}}
+          value: '{{{POSTGRES_PASSWORD}}}'
         - name: POSTGRES_PORT
-          value: '{{POSTGRES_PORT}}'
+          value: '{{{POSTGRES_PORT}}}'
         - name: POSTGRES_HOST
-          value: {{POSTGRES_HOST}}
+          value: '{{{POSTGRES_HOST}}}'
         - name: REDIS_HOST
-          value: {{REDIS_HOST}}
+          value: '{{{REDIS_HOST}}}'
         - name: REDIS_PASSWORD
           value: '{{{REDIS_PASSWORD}}}'
         - name: NODE_ENV
@@ -111,19 +111,19 @@ spec:
         - name: INTEGRATION_OUTREACH_APP_SECRET
           value: '{{{INTEGRATION_OUTREACH_APP_SECRET}}}'
         - name: INTEGRATION_OUTREACH_SIGNATURE_KEY
-          value: {{{INTEGRATION_OUTREACH_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_OUTREACH_SIGNATURE_KEY}}}'
         - name: MAILGUN_TOKEN
-          value: {{{MAILGUN_TOKEN}}}
+          value: '{{{MAILGUN_TOKEN}}}'
         - name: MAILGUN_DOMAIN
-          value: {{{MAILGUN_DOMAIN}}}
+          value: '{{{MAILGUN_DOMAIN}}}'
         - name: MAILGUN_BASE_URL
-          value: {{{MAILGUN_BASE_URL}}}
+          value: '{{{MAILGUN_BASE_URL}}}'
         - name: RESET_PASSWORD_SECRET_TOKEN
-          value: {{{RESET_PASSWORD_SECRET_TOKEN}}}
+          value: '{{{RESET_PASSWORD_SECRET_TOKEN}}}'
         - name: TEST_USER_USERNAME
-          value: jellyfish
+          value: 'jellyfish'
         - name: TEST_USER_ROLE
-          value: user-community
+          value: 'user-community'
         - name: SERVER_PORT
           value: '8000'
         - name: METRICS_PORT
@@ -131,9 +131,9 @@ spec:
         - name: SOCKET_METRICS_PORT
           value: '{{{SOCKET_METRICS_PORT}}}'
         - name: MONITOR_SECRET_TOKEN
-          value: {{{MONITOR_SECRET_TOKEN}}}
+          value: '{{{MONITOR_SECRET_TOKEN}}}'
         - name: NEW_COMPILER_TEST_CHANCE
-          value: {{{NEW_COMPILER_TEST_CHANCE}}}
+          value: '{{{NEW_COMPILER_TEST_CHANCE}}}'
         ports:
         - containerPort: 8000
         - containerPort: 9229

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   labels:
     name: jellyfish-api
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver
   annotations:
@@ -20,11 +20,11 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-path: /health
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "10"
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "8"
-    external-dns.alpha.kubernetes.io/hostname: {{{JELLYFISH_API_HOST}}}
+    external-dns.alpha.kubernetes.io/hostname: '{{{JELLYFISH_API_HOST}}}'
     external-dns.alpha.kubernetes.io/ttl: "120"
 spec:
   rules:
-    - host: {{{JELLYFISH_API_HOST}}}
+    - host: '{{{JELLYFISH_API_HOST}}}'
       http:
         paths:
           - path: /*

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     name: jellyfish-api
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
 spec:
   selector:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: jellyfish-livechat
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
     matchLabels:
@@ -40,7 +40,7 @@ spec:
         - name: NGINX_PORT
           value: '80'
         - name: NODE_ENV
-          value: {{{NODE_ENV}}}
+          value: '{{{NODE_ENV}}}'
         ports:
         - containerPort: 80
       imagePullSecrets:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     name: jellyfish-livechat
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-livechat
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
@@ -14,7 +14,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "60"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    external-dns.alpha.kubernetes.io/hostname: {{{JELLYFISH_LIVECHAT_HOST}}}
+    external-dns.alpha.kubernetes.io/hostname: '{{{JELLYFISH_LIVECHAT_HOST}}}'
     external-dns.alpha.kubernetes.io/ttl: "120"
 spec:
   type: LoadBalancer

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: jellyfish-ui
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
     matchLabels:
@@ -40,7 +40,7 @@ spec:
         - name: NGINX_PORT
           value: '80'
         - name: NODE_ENV
-          value: {{{NODE_ENV}}}
+          value: '{{{NODE_ENV}}}'
         ports:
         - containerPort: 80
       imagePullSecrets:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     name: jellyfish-ui
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-ui
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
@@ -14,7 +14,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "60"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    external-dns.alpha.kubernetes.io/hostname: {{{JELLYFISH_HOST}}}
+    external-dns.alpha.kubernetes.io/hostname: '{{{JELLYFISH_HOST}}}'
     external-dns.alpha.kubernetes.io/ttl: "120"
 spec:
   type: LoadBalancer

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: redis
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
           name: redis
           env:
             - name: REDIS_PASSWORD
-              value: {{{REDIS_PASSWORD}}}
+              value: '{{{REDIS_PASSWORD}}}'
           ports:
             - containerPort: 6379
       imagePullSecrets:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-service.tpl.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     name: redis
   name: redis
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
     app: redis

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: tick-server
-  namespace: {{{KATAPULT_KUBE_NAMESPACE}}}
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
     matchLabels:
@@ -17,41 +17,41 @@ spec:
         name: tick-server
         env:
         - name: DATABASE
-          value: postgres
+          value: 'postgres'
         - name: POSTGRES_DATABASE
-          value: {{POSTGRES_DATABASE}}
+          value: '{{{POSTGRES_DATABASE}}}'
         - name: POSTGRES_USER
-          value: {{POSTGRES_USER}}
+          value: '{{{POSTGRES_USER}}}'
         - name: POSTGRES_PASSWORD
-          value: {{POSTGRES_PASSWORD}}
+          value: '{{{POSTGRES_PASSWORD}}}'
         - name: POSTGRES_PORT
-          value: '{{POSTGRES_PORT}}'
+          value: '{{{POSTGRES_PORT}}}'
         - name: POSTGRES_HOST
-          value: {{POSTGRES_HOST}}
+          value: '{{{POSTGRES_HOST}}}'
         - name: REDIS_HOST
-          value: {{REDIS_HOST}}
+          value: '{{{REDIS_HOST}}}'
         - name: REDIS_PASSWORD
-          value: {{{REDIS_PASSWORD}}}
+          value: '{{{REDIS_PASSWORD}}}'
         - name: NODE_ENV
-          value: {{{NODE_ENV}}}
+          value: '{{{NODE_ENV}}}'
         - name: SENTRY_DSN_SERVER
-          value: {{{SENTRY_DSN_SERVER}}}
+          value: '{{{SENTRY_DSN_SERVER}}}'
         - name: LOGENTRIES_TOKEN
-          value: {{{LOGENTRIES_TOKEN}}}
+          value: '{{{LOGENTRIES_TOKEN}}}'
         - name: LOGLEVEL
-          value: {{{LOGLEVEL}}}
+          value: '{{{LOGLEVEL}}}'
         - name: INTEGRATION_BALENA_API_PRIVATE_KEY
-          value: {{{INTEGRATION_BALENA_API_PRIVATE_KEY}}}
+          value: '{{{INTEGRATION_BALENA_API_PRIVATE_KEY}}}'
         - name: INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
-          value: {{{INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION}}}
+          value: '{{{INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION}}}'
         - name: INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
-          value: {{{INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING}}}
+          value: '{{{INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING}}}'
         - name: INTEGRATION_DEFAULT_USER
-          value: {{{INTEGRATION_DEFAULT_USER}}}
+          value: '{{{INTEGRATION_DEFAULT_USER}}}'
         - name: INTEGRATION_INTERCOM_TOKEN
-          value: {{{INTEGRATION_INTERCOM_TOKEN}}}
+          value: '{{{INTEGRATION_INTERCOM_TOKEN}}}'
         - name: INTEGRATION_FRONT_TOKEN
-          value: {{{INTEGRATION_FRONT_TOKEN}}}
+          value: '{{{INTEGRATION_FRONT_TOKEN}}}'
         - name: INTEGRATION_GITHUB_TOKEN
           value: '{{{INTEGRATION_GITHUB_TOKEN}}}'
         - name: INTEGRATION_GITHUB_SIGNATURE_KEY
@@ -61,29 +61,29 @@ spec:
         - name: INTEGRATION_GITHUB_APP_ID
           value: '{{{INTEGRATION_GITHUB_APP_ID}}}'
         - name: INTEGRATION_FLOWDOCK_SIGNATURE_KEY
-          value: {{{INTEGRATION_FLOWDOCK_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_FLOWDOCK_SIGNATURE_KEY}}}'
         - name: INTEGRATION_DISCOURSE_TOKEN
-          value: {{{INTEGRATION_DISCOURSE_TOKEN}}}
+          value: '{{{INTEGRATION_DISCOURSE_TOKEN}}}'
         - name: INTEGRATION_DISCOURSE_USERNAME
-          value: {{{INTEGRATION_DISCOURSE_USERNAME}}}
+          value: '{{{INTEGRATION_DISCOURSE_USERNAME}}}'
         - name: INTEGRATION_DISCOURSE_SIGNATURE_KEY
-          value: {{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_DISCOURSE_SIGNATURE_KEY}}}'
         - name: INTEGRATION_OUTREACH_APP_ID
-          value: {{{INTEGRATION_OUTREACH_APP_ID}}}
+          value: '{{{INTEGRATION_OUTREACH_APP_ID}}}'
         - name: INTEGRATION_OUTREACH_APP_SECRET
-          value: {{{INTEGRATION_OUTREACH_APP_SECRET}}}
+          value: '{{{INTEGRATION_OUTREACH_APP_SECRET}}}'
         - name: INTEGRATION_OUTREACH_SIGNATURE_KEY
-          value: {{{INTEGRATION_OUTREACH_SIGNATURE_KEY}}}
+          value: '{{{INTEGRATION_OUTREACH_SIGNATURE_KEY}}}'
         - name: MAILGUN_TOKEN
-          value: {{{MAILGUN_TOKEN}}}
+          value: '{{{MAILGUN_TOKEN}}}'
         - name: MAILGUN_DOMAIN
-          value: {{{MAILGUN_DOMAIN}}}
+          value: '{{{MAILGUN_DOMAIN}}}'
         - name: MAILGUN_BASE_URL
-          value: {{{MAILGUN_BASE_URL}}}
+          value: '{{{MAILGUN_BASE_URL}}}'
         - name: RESET_PASSWORD_SECRET_TOKEN
-          value: {{{RESET_PASSWORD_SECRET_TOKEN}}}
+          value: '{{{RESET_PASSWORD_SECRET_TOKEN}}}'
         - name: NEW_COMPILER_TEST_CHANCE
-          value: {{{NEW_COMPILER_TEST_CHANCE}}}
+          value: '{{{NEW_COMPILER_TEST_CHANCE}}}'
 
       imagePullSecrets:
         - name: com.docker.hub.travisciresin


### PR DESCRIPTION
Previously we were relying on the value to look like a string, which led
to spurious quoting for variables that could have a number-like value
like a port.

Also templeting was used inconsistently by using double brackets
({{...}}) which HTML escapes instead of triple ones that put the value
as-is.

Both issued are fixed by universally quoting all values and converting
everything to triple brackets.