### PR TITLE
ci: Decrease verbosity of compose logs

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - DATABASE={{DATABASE}}
       - LOGENTRIES_TOKEN
-      - LOGLEVEL={{LOGLEVEL}}
+      - LOGLEVEL=crit
       - NODE_ENV={{NODE_ENV}}
       - POD_NAME={{POD_NAME}}
       - PORT={{PORT}}
@@ -170,7 +170,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PASSWORD=redis
       - REDIS_PORT={{REDIS_PORT}}
-      - LOGLEVEL={{LOGLEVEL}}
+      - LOGLEVEL=crit
       - SENTRY_DSN_SERVER
       - FS_DRIVER
       - AWS_ACCESS_KEY_ID
@@ -235,7 +235,7 @@ services:
       - balena-mdns-publisher
     environment:
       - DATABASE={{DATABASE}}
-      - LOGLEVEL={{LOGLEVEL}}
+      - LOGLEVEL=crit
       - NODE_ENV={{NODE_ENV}}
       - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
       - POSTGRES_HOST=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - DATABASE=postgres
       - LOGENTRIES_TOKEN
-      - LOGLEVEL=info
+      - LOGLEVEL=crit
       - NODE_ENV=test
       - POD_NAME=localhost
       - PORT=8000
@@ -170,7 +170,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PASSWORD=redis
       - REDIS_PORT=6379
-      - LOGLEVEL=info
+      - LOGLEVEL=crit
       - SENTRY_DSN_SERVER
       - FS_DRIVER
       - AWS_ACCESS_KEY_ID
@@ -234,7 +234,7 @@ services:
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres
-      - LOGLEVEL=info
+      - LOGLEVEL=crit
       - NODE_ENV=test
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres
@@ -293,7 +293,7 @@ services:
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres
-      - LOGLEVEL=info
+      - LOGLEVEL=crit
       - NODE_ENV=test
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres
@@ -352,7 +352,7 @@ services:
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres
-      - LOGLEVEL=info
+      - LOGLEVEL=crit
       - NODE_ENV=test
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Reduce log verbosity in Docker Compose to help remove "noise" from balenaCI test output.