### PR TITLE
Explicitly set which links table columns that values are written to

### DIFF
--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -89,7 +89,18 @@ exports.setup = async (context, connection, database, options) => {
 exports.upsert = async (context, connection, link) => {
 	if (link.active) {
 		const sql = `
-			INSERT INTO ${LINK_TABLE} VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			INSERT INTO ${LINK_TABLE} (
+				id,
+				slug,
+				version_major,
+				version_minor,
+				version_patch,
+				name,
+				inverseName,
+				fromId,
+				toId
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 			ON CONFLICT (id) DO UPDATE SET
 				slug = $2,
 				version_major = $3,


### PR DESCRIPTION
By explicitly setting which columns alues are written to, we avoid an
error where the insert would fail if the table columns were in
a different order to the values being inserted. This can happen if
a previously created table is altered to include the new version
columns.

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
