### PR TITLE
core: Ensure we can handle invalid enums in $$links

### DIFF
--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -2060,6 +2060,35 @@ ava('.query() should throw an error given an invalid regex', async (test) => {
 	})
 })
 
+ava('.query() should throw an error given an invalid enum in links', async (test) => {
+	await test.throwsAsync(context.kernel.query(
+		context.context, context.kernel.sessions.admin, {
+			$$links: {
+				'is member of': {
+					type: 'object',
+					properties: {
+						slug: {
+							enum: []
+						}
+					}
+				}
+			},
+			type: 'object',
+			properties: {
+				type: {
+					const: 'user@1.0.0'
+				},
+				slug: {
+					pattern: '^user-admin'
+				}
+			},
+			required: [ 'type', 'slug' ],
+			additionalProperties: true
+		}), {
+		instanceOf: errors.JellyfishInvalidSchema
+	})
+})
+
 ava('.query() should throw an error given an invalid enum', async (test) => {
 	await test.throwsAsync(context.kernel.query(
 		context.context, context.kernel.sessions.admin, {


### PR DESCRIPTION
A further test case to ensure that the linked Sentry issues won't happen
again.

See: https://sentry.io/share/issue/d4f739f814004f158287dd1774880042/
See: https://sentry.io/share/issue/cb99ffacd6804f6e835c5abe4a4d7820/
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!