### PR TITLE
Fix flakey kernel query test

### DIFF
--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -2249,11 +2249,12 @@ ava('.query() should be able to limit and skip the results', async (test) => {
 		},
 		required: [ 'data' ]
 	}, {
+		sortBy: [ 'data', 'timestamp' ],
 		limit: 1,
 		skip: 1
 	})
 
-	test.deepEqual(_.sortBy(results, [ 'data', 'test' ]), [ result2 ])
+	test.deepEqual(results, [ result2 ])
 })
 
 ava('.query() should return the cards that match a schema', async (test) => {


### PR DESCRIPTION
The sort order of results returned from the DB was not explicitly set
and could result in a failing test.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
