### PR TITLE
Revert "Temporarily reduce the amount of e2e testing"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,43 @@ jobs:
           paths:
             - dump-server.gz
 
+  e2e_tests_server_previous_dump: &e2e_tests_server_previous_dump
+    <<: *job_defaults
+
+    resource_class: xlarge
+
+    steps:
+      - checkout
+
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - run:
+          name: Install scripts-template dependencies
+          command: cd scripts/template && npm install
+      - run:
+          name: Compose Build
+          command: make compose-build
+      - run:
+          name: Docker Compose Up
+          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
+      - run:
+          name: Fetch Old Postgres Dump
+          command: ./scripts/ci/postgres-get-previous-dump.sh server && ls -l && gunzip dump.gz
+      - run:
+          name: Import Postgres Dump
+          command: docker cp dump jellyfish_sidecar_1:/usr/src/jellyfish/dump && make compose-exec-sidecar COMMAND="./scripts/ci/postgres-import-snapshot.sh" ARGS="/usr/src/jellyfish/dump"
+      - run:
+          name: End To End Tests (Server)
+          command: make compose-exec-sidecar COMMAND="make" ARGS="test-e2e-server SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
+      - run:
+          name: Docker Compose Down
+          command: make compose-stop
+
   results:
     <<: *job_defaults
 
@@ -311,6 +348,11 @@ workflows:
                   - build
                 <<: *workflow_filter
 
+            - e2e_tests_server_previous_dump:
+                requires:
+                  - build
+                <<: *workflow_filter
+
             - sync_tests_front_mirror:
                 requires:
                   - build
@@ -339,6 +381,7 @@ workflows:
             - results:
                 requires:
                   - e2e_tests_server
+                  - e2e_tests_server_previous_dump
                   - sync_tests_front_translate
                   - sync_tests_discourse_translate
                   - sync_tests_front_mirror

--- a/Makefile
+++ b/Makefile
@@ -370,10 +370,6 @@ test-integration-%:
 test-e2e-%:
 	FILES="'./test/e2e/$(subst test-e2e-,,$@)/**/*.spec.{js,jsx}'" make test
 
-# Temporarily run fewer e2e tests while we resolve instability
-test-e2e-ui:
-	FILES="'./test/e2e/ui/index.spec.js'" make test
-
 clean-front:
 	FRONT_INBOX_1=$(TEST_INTEGRATION_FRONT_INBOX_1) \
 	FRONT_INBOX_2=$(TEST_INTEGRATION_FRONT_INBOX_2) \

--- a/apps/ui/components/Inbox/index.jsx
+++ b/apps/ui/components/Inbox/index.jsx
@@ -76,7 +76,10 @@ const getBasePingQuery = (user, searchTerm) => {
 							mentionsUser: {
 								type: 'array',
 								contains: {
-									const: user.slug
+									regexp: {
+										pattern: user.slug,
+										flags: 'i'
+									}
 								}
 							}
 						},

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -267,7 +267,7 @@ ava('Only messages that ping a user should appear in their inbox', async (test) 
 	test.pass()
 })
 
-ava.serial('When having two chats side-by-side both should update with new messages', async (test) => {
+ava.serial.skip('When having two chats side-by-side both should update with new messages', async (test) => {
 	const {
 		user1,
 		page

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -84,8 +84,7 @@ ava.serial.after(async () => {
 // Core
 // ============================================================================
 
-// Temporarily run fewer e2e tests while we resolve instability
-ava.only('core: should let users login', async (test) => {
+ava.serial('core: should let users login', async (test) => {
 	const {
 		page
 	} = context

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -524,7 +524,7 @@ ava.serial('user profile: The send command should default to "shift+enter"', asy
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
 
 	await macros.waitForThenClickSelector(page, '[data-test="lens-my-user__send-command-select"]')
-	await macros.waitForThenClickSelector(page, '[role="menubar"] > div:nth-of-type(1) > button[role="menuitem"]')
+	await macros.waitForThenClickSelector(page, '[role="menubar"] > button[role="menuitem"]:nth-of-type(1)')
 
 	await page.waitForSelector('[data-test="lens-my-user__send-command-select"][value="shift+enter"]')
 
@@ -565,7 +565,7 @@ ava.serial('user profile: You should be able to change the send command to "ente
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
 
 	await macros.waitForThenClickSelector(page, '[data-test="lens-my-user__send-command-select"]')
-	await macros.waitForThenClickSelector(page, '[role="menubar"] > div:nth-of-type(3) > button[role="menuitem"]')
+	await macros.waitForThenClickSelector(page, '[role="menubar"] > button[role="menuitem"]:nth-of-type(3)')
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
@@ -607,7 +607,7 @@ ava.serial('user profile: You should be able to change the send command to "ctrl
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
 
 	await macros.waitForThenClickSelector(page, '[data-test="lens-my-user__send-command-select"]')
-	await macros.waitForThenClickSelector(page, '[role="menubar"] > div:nth-of-type(2) > button[role="menuitem"]')
+	await macros.waitForThenClickSelector(page, '[role="menubar"] > button[role="menuitem"]:nth-of-type(2)')
 
 	await page.waitForSelector('[data-test="lens-my-user__send-command-select"][value="ctrl+enter"]')
 
@@ -637,7 +637,7 @@ ava.serial('user profile: You should be able to change the send command to "ctrl
 // Views
 // =============================================================================
 
-ava.serial('views: Should be able to save a new view', async (test) => {
+ava.serial.skip('views: Should be able to save a new view', async (test) => {
 	const {
 		page
 	} = context

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -376,38 +376,6 @@ ava.serial('Support thread timeline should revert to "whisper" mode after sendin
 	test.is(rand, messageText.trim())
 })
 
-ava.serial('Users should be able to close a support thread', async (test) => {
-	const {
-		page
-	} = context
-
-	const supportThread = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'support-thread@1.0.0',
-			data: {
-				inbox: 'S/Paid_Support',
-				status: 'open'
-			}
-		})
-	})
-
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
-
-	await page.waitForSelector('.column--support-thread')
-
-	await macros.waitForThenClickSelector(page, '[data-test="support-thread__close-thread"]')
-
-	// Wait for the success alert as a heuristic for the action completing
-	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
-
-	const thread = await page.evaluate((id) => {
-		return window.sdk.card.get(id)
-	}, supportThread.id)
-
-	test.is(thread.data.status, 'closed')
-})
-
 ava.serial('Users should be able to close a support thread by sending a message with #summary', async (test) => {
 	const {
 		page


### PR DESCRIPTION
This reverts commit 94683cabe0f8f569efcf82e9fe814657457c39a8.
The platform stability is now dramatically improved (We originally
reduced e2e testing to improve velocity whilst we addressed the
outages), so its time to turn the testing back on.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
