### PR TITLE
Bump jellyfish-client-sdk to v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1775,9 +1775,9 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.2.3.tgz",
-      "integrity": "sha512-zSSIg8fb2j0Td9VOoCzUmd0YdjKf3SHggzKZXB4UfH9sTvYZXq5kknAwhQrp23tSl758YuxE+HO0qez3O1dtZg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.3.0.tgz",
+      "integrity": "sha512-/0HE1p0NhdhzeTiGbprv7ItQ6p/hCYb+TCch8FJ+h2B2/o64olag+VKPkFj1cm59stTPRobwmkVGSy6YIONo2A==",
       "requires": {
         "axios": "^0.19.2",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
-    "@balena/jellyfish-client-sdk": "^0.2.3",
+    "@balena/jellyfish-client-sdk": "^0.3.0",
     "@balena/node-metrics-gatherer": "^5.6.0",
     "@octokit/auth-app": "^2.4.4",
     "@octokit/plugin-retry": "^2.2.0",


### PR DESCRIPTION
This version adds support for ownership of sales threads.

Change-type: patch/minor/major
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Sales threads now magically have the ability to assign owners!

![image](https://user-images.githubusercontent.com/2925657/81308782-674b8a80-90ac-11ea-9044-023d24514bcc.png)
