### PR TITLE
Refactor inbox to use materialized field instead of regexp

### DIFF
--- a/apps/server/default-cards/contrib/view-my-inbox.json
+++ b/apps/server/default-cards/contrib/view-my-inbox.json
@@ -10,7 +10,7 @@
   "data": {
     "allOf": [
       {
-        "name": "message or whisper",
+        "name": "My unread pings",
         "schema": {
           "type": "object",
           "properties": {
@@ -20,23 +20,31 @@
                 "message@1.0.0",
                 "whisper@1.0.0"
               ]
-            }
-          },
-          "additionalProperties": true
-        }
-      },
-      {
-        "name": "Unread",
-        "schema": {
-          "type": "object",
-          "properties": {
+            },
             "data": {
               "type": "object",
               "properties": {
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "mentionsUser": {
+                      "type": "array",
+                      "contains": {
+                        "const": {
+                          "$eval": "user.slug"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "mentionsUser"
+                  ],
+                  "additionalProperties": true
+                },
                 "readBy": {
                   "type": "array",
-                  "items": {
-                    "not": {
+                  "not": {
+                    "contains": {
                       "const": {
                         "$eval": "user.slug"
                       }
@@ -50,81 +58,6 @@
           "additionalProperties": true
         }
       }
-    ],
-    "anyOf": [
-      {
-        "name": "My mentions",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "payload": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "regexp": {
-                        "pattern": {
-                          "$eval": "'@' + user.slug[5:]"
-                        },
-                        "flags": "i"
-                      }
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ],
-                  "additionalProperties": true
-                }
-              },
-              "required": [
-                "payload"
-              ],
-              "additionalProperties": true
-            }
-          },
-          "additionalProperties": true
-        }
-      },
-      {
-        "name": "My alerts",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "payload": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "regexp": {
-                        "pattern": {
-                          "$eval": "'!' + user.slug[5:]"
-                        },
-                        "flags": "i"
-                      }
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ],
-                  "additionalProperties": true
-                }
-              },
-              "required": [
-                "payload"
-              ],
-              "additionalProperties": true
-            }
-          },
-          "additionalProperties": true
-        }
-      },
-    ],
-    "lenses": [
-      "lens-inbox"
     ]
   },
   "requires": [],

--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -35,6 +35,7 @@ import Login from './components/HOC/Login'
 import RequestPasswordReset from './components/HOC/RequestPasswordReset'
 import CompletePasswordReset from './components/HOC/CompletePasswordReset'
 import CompleteFirstTimeLogin from './components/HOC/CompleteFirstTimeLogin'
+import Inbox from './components/Inbox'
 import MermaidEditor from '../../lib/ui-components/shame/MermaidEditor'
 import Splash from '../../lib/ui-components/Splash'
 import AuthContainer from '../../lib/ui-components/Auth'
@@ -132,6 +133,7 @@ class JellyfishUI extends React.Component {
 
 					<Switch>
 						<Route path="/oauth/:integration" component={Oauth} />
+						<Route path="/inbox" component={Inbox} />
 						<Route path="/*" component={RouteHandler} />
 					</Switch>
 				</Flex>

--- a/apps/ui/components/HOC/HomeChannel.jsx
+++ b/apps/ui/components/HOC/HomeChannel.jsx
@@ -28,6 +28,7 @@ const mapStateToProps = (state, ownProps) => {
 		orgs: selectors.getOrgs(state),
 		tail: target ? selectors.getViewData(state, target) : null,
 		types: selectors.getTypes(state),
+		mentions: selectors.getViewData(state, 'view-my-inbox'),
 		subscriptions: selectors.getSubscriptions(state),
 		uiState: selectors.getUIState(state),
 		user,

--- a/apps/ui/core/store/actioncreators/add-user.spec.js
+++ b/apps/ui/core/store/actioncreators/add-user.spec.js
@@ -6,6 +6,12 @@
 
 import ava from 'ava'
 import sinon from 'sinon'
+
+// Hack fix for a circular dependency until we refactor the notifications code
+import {
+	// eslint-disable-next-line no-unused-vars
+	store
+} from '../../'
 import ActionCreator from './'
 
 const sandbox = sinon.createSandbox()

--- a/lib/ui-components/HomeChannel/HomeChannel.jsx
+++ b/lib/ui-components/HomeChannel/HomeChannel.jsx
@@ -495,7 +495,8 @@ export default class HomeChannel extends React.Component {
 								onClick={this.showMenu}
 								style={{
 									display: 'flex',
-									maxWidth: '100%'
+									maxWidth: '100%',
+									position: 'relative'
 								}}>
 								<Avatar
 									name={username}
@@ -516,7 +517,11 @@ export default class HomeChannel extends React.Component {
 										position: 'absolute',
 										left: '30px',
 										bottom: '10px'
-									}}>{(mentions.length >= 100) ? '99+' : mentions.length}</MentionsCount>
+									}}
+									tooltip={`${mentions.length} notifications`}
+									>
+										{(mentions.length >= 100) ? '99+' : mentions.length}
+									</MentionsCount>
 								)}
 							</Button>
 						</Flex>
@@ -540,6 +545,22 @@ export default class HomeChannel extends React.Component {
 											</RouterLink>
 										</div>
 									)}
+
+									<RouterLink
+										mb={2}
+										to="/inbox"
+										style={{
+											display: 'block'
+										}}
+									>
+										<Flex justifyContent="space-between">
+											Inbox
+
+											{(mentions && mentions.length > 0) && (
+												<MentionsCount mr={2}>{mentions.length}</MentionsCount>
+											)}
+										</Flex>
+									</RouterLink>
 
 									{_.map(defaultViews, (card) => {
 										const isActive = card.slug === activeChannelTarget ||

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -151,7 +151,7 @@ ava.serial('Messages typed but not sent should be preserved when navigating away
 	test.pass()
 })
 
-ava.skip('Messages that ping a user should appear in their inbox', async (test) => {
+ava('Messages that ping a user should appear in their inbox', async (test) => {
 	const {
 		user2,
 		page,
@@ -186,7 +186,7 @@ ava.skip('Messages that ping a user should appear in their inbox', async (test) 
 	test.pass()
 })
 
-ava.skip('Only messages that ping a user should appear in their inbox', async (test) => {
+ava('Only messages that ping a user should appear in their inbox', async (test) => {
 	const {
 		user2,
 		page,
@@ -298,7 +298,7 @@ ava.serial('When having two chats side-by-side both should update with new messa
 	test.pass()
 })
 
-ava.skip('Username pings should be case insensitive', async (test) => {
+ava('Username pings should be case insensitive', async (test) => {
 	const {
 		user2,
 		page,
@@ -333,7 +333,7 @@ ava.skip('Username pings should be case insensitive', async (test) => {
 	test.pass()
 })
 
-ava.skip('Users should be able to mark all messages as read from their inbox', async (test) => {
+ava('Users should be able to mark all messages as read from their inbox', async (test) => {
 	const {
 		user2,
 		page,


### PR DESCRIPTION
Previously the inbox had been disabled due to performance and stability
concerns. A chunk of this PR is simply re-enabling the inbox
functionality that as turned off in this PR https://github.com/product-os/jellyfish/pull/3568

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
