### PR TITLE
sync: Improve OAuthUnsuccessfulResponse error logs

### DIFF
--- a/lib/sync/oauth.js
+++ b/lib/sync/oauth.js
@@ -130,8 +130,14 @@ const oauthPost = async (baseUrl, path, data) => {
 			return `POST ${baseUrl}${path} responded with ${code}: ${(JSON.stringify(body, null, 2))}`
 		})
 
-	assert.USER(null, code < 400, exports.OAuthUnsuccessfulResponse,
-		`POST ${baseUrl}${path} responded with ${body.error_description}`)
+	assert.INTERNAL(null, code < 400, exports.OAuthUnsuccessfulResponse,
+		() => {
+			return [
+				`POST ${baseUrl}${path} responded with ${code}:`,
+				JSON.stringify(body, null, 2),
+				`to payload: ${JSON.stringify(data, null, 2)}`
+			].join(' ')
+		})
 
 	assert.INTERNAL(null, code === 200, exports.OAuthRequestError,
 		() => {


### PR DESCRIPTION
I've seen some warnings in Rapid7 about Outreach OAuth. This should help
us debug the issue further:

- Log the response body
- Log the response code
- Mark it as an internal error so we get it in Sentry

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!