### PR TITLE
server: Add file field to message and whisper card types

### DIFF
--- a/apps/server/default-cards/contrib/message.json
+++ b/apps/server/default-cards/contrib/message.json
@@ -43,6 +43,23 @@
                     "type": "string"
                   }
                 },
+                "file": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "mime": {
+                      "type": "string"
+                    },
+                    "bytesize": {
+                      "type": "number"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  }
+                },
                 "attachments": {
                   "type": "array",
                   "items": {

--- a/apps/server/default-cards/contrib/whisper.json
+++ b/apps/server/default-cards/contrib/whisper.json
@@ -47,6 +47,23 @@
                     "type": "string"
                   }
                 },
+                "file": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "mime": {
+                      "type": "string"
+                    },
+                    "bytesize": {
+                      "type": "number"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  }
+                },
                 "message": {
                   "type": "string",
                   "format": "markdown"


### PR DESCRIPTION
The file.name field will eventually be searchable so it needs to be explicitly included in the type schema.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to PR #3616 - which adds the `searchable` property to various schema fields.