### PR TITLE
Don't modify `options.sortBy` when using the new `jsonschema2sql`

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -1289,7 +1289,7 @@ COALESCE(${table}.version_patch, '0')::text
 		let orderBy = ''
 		let orderByField = `${this.table}.id`
 		if (this.options.sortBy) {
-			const path = _.castArray(this.options.sortBy)
+			const path = _.clone(_.castArray(this.options.sortBy))
 			const dir = this.options.sortDir === 'desc' ? 'DESC' : 'ASC'
 			if (path.length === 1 && path[0] === 'version') {
 				const versionComponents = [ 'version_major', 'version_minor', 'version_patch' ]


### PR DESCRIPTION
`options.sortBy` could be modified in some cases. While this is innocuous most of the time, it will lead to an invalid query if reusing the same `options` object.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
