### PR TITLE
Use custom `InvalidSchema` in `jsonschema2sql`

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -115,8 +115,6 @@ const queryTable = async (context, backend, table, schema, options) => {
 
 	const preProcessingStartDate = new Date()
 	const config = _.defaults(options, {
-		errors: backend.errors,
-
 		// Exclude converting additionalProperties to SQL, as its used for field
 		// filtering rather than record selection and will typically break the
 		// generated SQL query, causing no results to be returned
@@ -160,7 +158,16 @@ const queryTable = async (context, backend, table, schema, options) => {
 			const newConfig = _.cloneDeep(config)
 			newConfig.useNewCompiler = true
 			const newQueryGenStart = performance.now()
-			const newQuery = jsonschema2sql(table, schema, newConfig)
+			let newQuery = null
+			try {
+				newQuery = jsonschema2sql(table, schema, newConfig)
+			} catch (error) {
+				if (error.name === 'InvalidSchema') {
+					throw new backend.errors.JellyfishInvalidSchema(error.message)
+				}
+
+				throw error
+			}
 			const newQueryGenEnd = performance.now()
 
 			const newQueryStart = performance.now()

--- a/lib/core/backend/postgres/jsonschema2sql/errors.js
+++ b/lib/core/backend/postgres/jsonschema2sql/errors.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const typedErrors = require('typed-errors')
+
+_.each([
+	'InvalidSchema'
+], (error) => {
+	exports[error] = typedErrors.makeTypedError(error)
+})

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -10,6 +10,9 @@ const REGEXES = require('./regexes')
 const builder = require('./builder')
 const keywords = require('./keywords')
 const assert = require('../../../../assert')
+const {
+	InvalidSchema
+} = require('./errors')
 
 /*
  * See https://www.postgresql.org/docs/9.6/functions-json.html for reference.
@@ -717,8 +720,6 @@ COALESCE(${table}.version_patch, '0')::text
 			this.options.parentPath = []
 		}
 
-		this.errors = options.errors
-
 		if (_.isString(tableOrParent)) {
 			// Set of columns we are selecting
 			this.columns = new Set()
@@ -773,7 +774,7 @@ COALESCE(${table}.version_patch, '0')::text
 
 	setAdditionalProperties (schema) {
 		// TODO: technically this can be a schema too
-		assert.INTERNAL(null, _.isBoolean(schema), Error, () => {
+		assert.INTERNAL(null, _.isBoolean(schema), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('additionalProperties')}' must be a boolean`
 		})
 
@@ -781,7 +782,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	setType (value) {
-		assert.INTERNAL(null, _.isString(value) || Array.isArray(value), Error, () => {
+		assert.INTERNAL(null, _.isString(value) || Array.isArray(value), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('type')}' must be a string or an array`
 		})
 
@@ -830,7 +831,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	visit (key, value) {
-		assert.INTERNAL(null, _.isString(key), Error, () => {
+		assert.INTERNAL(null, _.isString(key), InvalidSchema, () => {
 			return `key for '${this.formatJsonPath(key)}' must be a string`
 		})
 
@@ -848,7 +849,7 @@ COALESCE(${table}.version_patch, '0')::text
 		}
 
 		const visitor = `${key}Visitor`
-		assert.INTERNAL(null, visitor in this, Error, () => {
+		assert.INTERNAL(null, visitor in this, InvalidSchema, () => {
 			return `invalid key: ${this.formatJsonPath(key)}`
 		})
 
@@ -856,34 +857,34 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	$$linksVisitor (linkMap) {
-		assert.INTERNAL(null, this.isProcessingTable, Error,
+		assert.INTERNAL(null, this.isProcessingTable, InvalidSchema,
 			'a \'$$links\' key is only valid at the toplevel for the moment')
-		assert.INTERNAL(null, _.isPlainObject(linkMap), Error, () => {
+		assert.INTERNAL(null, _.isPlainObject(linkMap), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('$$links')}' must be a map`
 		})
 
 		for (const [ linkType, linkSchema ] of Object.entries(linkMap)) {
-			assert.INTERNAL(null, _.isString(linkType), Error, () => {
+			assert.INTERNAL(null, _.isString(linkType), InvalidSchema, () => {
 				return `key for '${this.formatJsonPath([ '$$links', linkType ])}' must be a string`
 			})
 
 			this.links[linkType] = this.buildQueryFromUncorrelatedSchema(
 				pgFormat.ident(linkType), linkSchema, [ '$$links', linkType ])
 
-			assert.INTERNAL(null, _.isEmpty(this.links[linkType].links), Error,
+			assert.INTERNAL(null, _.isEmpty(this.links[linkType].links), InvalidSchema,
 				'\'$$links\' is not supported inside another \'$$links\' declaration')
 		}
 	}
 
 	allOfVisitor (branches) {
-		assert.INTERNAL(null, Array.isArray(branches), Error, () => {
+		assert.INTERNAL(null, Array.isArray(branches), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('allOf')}' must be an array`
 		})
 
 		for (const [ idx, branchSchema ] of branches.entries()) {
 			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'allOf', idx ])
 
-			assert.INTERNAL(null, _.isEmpty(branchQuery.links), Error,
+			assert.INTERNAL(null, _.isEmpty(branchQuery.links), InvalidSchema,
 				'\'$$links\' is not supported inside an \'allOf\' declaration')
 
 			this.filterImpliesExists = this.filterImpliesExists || branchQuery.filterImpliesExists
@@ -892,7 +893,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	anyOfVisitor (branches) {
-		assert.INTERNAL(null, Array.isArray(branches), Error, () => {
+		assert.INTERNAL(null, Array.isArray(branches), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('anyOf')}' must be an array`
 		})
 
@@ -901,7 +902,7 @@ COALESCE(${table}.version_patch, '0')::text
 		for (const [ idx, branchSchema ] of branches.entries()) {
 			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'anyOf', idx ])
 
-			assert.INTERNAL(null, _.isEmpty(branchQuery.links), Error,
+			assert.INTERNAL(null, _.isEmpty(branchQuery.links), InvalidSchema,
 				'\'$$links\' is not supported inside an \'anyOf\' declaration')
 
 			allFilterImpliesExists = allFilterImpliesExists && branchQuery.filterImpliesExists
@@ -925,7 +926,7 @@ COALESCE(${table}.version_patch, '0')::text
 		const alias = 'items'
 		const containsQuery = this.buildQueryFromCorrelatedSchema(alias, schema, [ 'contains' ])
 
-		assert.INTERNAL(null, _.isEmpty(containsQuery.links), Error,
+		assert.INTERNAL(null, _.isEmpty(containsQuery.links), InvalidSchema,
 			'\'$$links\' is not supported inside a \'contains\' declaration')
 
 		const filter = SqlFilter.arrayContains(this, containsQuery.filter, alias)
@@ -962,11 +963,11 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	enumVisitor (values) {
-		assert.INTERNAL(null, Array.isArray(values), Error, () => {
+		assert.INTERNAL(null, Array.isArray(values), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('enum')}' must be an array`
 		})
 
-		assert.INTERNAL(null, values.length > 0, this.errors.JellyfishInvalidSchema, () => {
+		assert.INTERNAL(null, values.length > 0, InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('enum')}' must not be empty`
 		})
 
@@ -975,7 +976,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	formatVisitor (format) {
-		assert.INTERNAL(null, _.isString(format), Error, () => {
+		assert.INTERNAL(null, _.isString(format), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('format')}' must be a string`
 		})
 
@@ -990,7 +991,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	exclusiveMaximumVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('exclusiveMaximum')}' must be a number`
 		})
 
@@ -999,7 +1000,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	exclusiveMinimumVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('exclusiveMinimum')}' must be a number`
 		})
 
@@ -1019,7 +1020,7 @@ COALESCE(${table}.version_patch, '0')::text
 		const alias = 'items'
 		const itemsQuery = this.buildQueryFromCorrelatedSchema(alias, schema, [ 'items' ])
 
-		assert.INTERNAL(null, _.isEmpty(itemsQuery.links), Error,
+		assert.INTERNAL(null, _.isEmpty(itemsQuery.links), InvalidSchema,
 			'\'$$links\' is not supported inside an \'items\' declaration')
 
 		const filter = SqlFilter.arrayContains(this, itemsQuery.filter.negate(), alias)
@@ -1037,7 +1038,7 @@ COALESCE(${table}.version_patch, '0')::text
 			const elementQuery = this.buildQueryFromSubSchema(schema, [ 'items', idx ])
 			this.path.pop()
 
-			assert.INTERNAL(null, _.isEmpty(elementQuery.links), Error,
+			assert.INTERNAL(null, _.isEmpty(elementQuery.links), InvalidSchema,
 				'\'$$links\' is not supported inside an \'items\' declaration')
 
 			filter.and(
@@ -1051,7 +1052,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	maximumVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('maximum')}' must be a number`
 		})
 
@@ -1060,7 +1061,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	maxLengthVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('maxLength')}' must be a number`
 		})
 
@@ -1069,7 +1070,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	maxItemsVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('maxItems')}' must be a number`
 		})
 
@@ -1078,7 +1079,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	maxPropertiesVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('maxProperties')}' must be a number`
 		})
 
@@ -1087,7 +1088,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	minimumVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('minimum')}' must be a number`
 		})
 
@@ -1096,7 +1097,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	minLengthVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('minLength')}' must be a number`
 		})
 
@@ -1105,7 +1106,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	minItemsVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('minItems')}' must be a number`
 		})
 
@@ -1114,7 +1115,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	minPropertiesVisitor (limit) {
-		assert.INTERNAL(null, _.isNumber(limit), Error, () => {
+		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('minProperties')}' must be a number`
 		})
 
@@ -1123,7 +1124,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	multipleOfVisitor (multiple) {
-		assert.INTERNAL(null, _.isNumber(multiple), Error, () => {
+		assert.INTERNAL(null, _.isNumber(multiple), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('multipleOf')}' must be a number`
 		})
 
@@ -1134,7 +1135,7 @@ COALESCE(${table}.version_patch, '0')::text
 	notVisitor (schema) {
 		const subQuery = this.buildQueryFromSubSchema(schema, [ 'not' ])
 
-		assert.INTERNAL(null, _.isEmpty(subQuery.links), Error,
+		assert.INTERNAL(null, _.isEmpty(subQuery.links), InvalidSchema,
 			'\'$$links\' is not supported inside a \'not\' declaration')
 
 		this.filterImpliesExists = this.filterImpliesExists || subQuery.filterImpliesExists
@@ -1142,7 +1143,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	patternVisitor (pattern) {
-		assert.INTERNAL(null, _.isString(pattern), Error, () => {
+		assert.INTERNAL(null, _.isString(pattern), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('pattern')}' must be a string`
 		})
 
@@ -1151,7 +1152,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	propertiesVisitor (propertiesMap) {
-		assert.INTERNAL(null, _.isPlainObject(propertiesMap), Error, () => {
+		assert.INTERNAL(null, _.isPlainObject(propertiesMap), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('properties')}' must be a map`
 		})
 
@@ -1167,7 +1168,7 @@ COALESCE(${table}.version_patch, '0')::text
 			const propertyQuery = this.buildQueryFromSubSchema(
 				propertySchema, [ 'properties', propertyName ])
 
-			assert.INTERNAL(null, _.isEmpty(propertyQuery.links), Error,
+			assert.INTERNAL(null, _.isEmpty(propertyQuery.links), InvalidSchema,
 				'\'$$links\' is not supported inside a \'properties\' declaration')
 
 			const isRequired = this.required.includes(propertyName)
@@ -1206,7 +1207,7 @@ COALESCE(${table}.version_patch, '0')::text
 	regexpVisitor (value) {
 		const isString = _.isString(value)
 
-		assert.INTERNAL(null, isString || _.isPlainObject(value), Error, () => {
+		assert.INTERNAL(null, isString || _.isPlainObject(value), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('regexp')}' must be a string or a map`
 		})
 
@@ -1219,7 +1220,7 @@ COALESCE(${table}.version_patch, '0')::text
 				if (value.flags === 'i') {
 					flags.ignoreCase = true
 				} else {
-					assert.INTERNAL(null, false, Error,
+					assert.INTERNAL(null, false, InvalidSchema,
 						`value for '${this.formatJsonPath([ 'regexp', 'flags' ])}' may only be set to 'i'`)
 				}
 			}
@@ -1368,7 +1369,6 @@ COALESCE(${table}.version_patch, '0')::text
 		this.options.parentJsonPath.push(...suffix)
 		const query = SqlQuery.fromSchema(table, schema, {
 			parentJsonPath: this.options.parentJsonPath,
-			errors: this.options.errors,
 			parentPath
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {
@@ -1384,7 +1384,6 @@ COALESCE(${table}.version_patch, '0')::text
 	buildQueryFromUncorrelatedSchema (table, schema, suffix) {
 		this.options.parentJsonPath.push(...suffix)
 		const query = SqlQuery.fromSchema(table, schema, {
-			errors: this.options.errors,
 			parentJsonPath: _.concat(this.options.parentJsonPath, _.castArray(suffix))
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {


### PR DESCRIPTION
Commit `1904f273900b8a19d8b073aa8a804828eeedcfb0` added an assertion to the new `jsonschema2sql` compiler that throws an error of type `JellyfishInvalidSchema`, passed through the `options` object. This commit adds a module-specific `InvalidSchema` error, applied to all applicable cases. This commit also removes the need for `options.errors` to simplify the logic and avoid cases where `options.errors` could be undefined.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>