### PR TITLE
Fix edge case where a subschema of type object could produce invalid SQL

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -533,8 +533,11 @@ class SqlQuery {
 
 		const field = [ path[0] ]
 		if (path.length > 1) {
-			const accessor = rootIsJson ? '->' : '.'
-			field.push(accessor, pgFormat.ident(path[1]))
+			if (rootIsJson) {
+				field.push('->', pgFormat.literal(path[1]))
+			} else {
+				field.push('.', pgFormat.ident(path[1]))
+			}
 		}
 		for (let selector of path.slice(2)) {
 			if (!_.isNumber(selector)) {
@@ -601,6 +604,9 @@ COALESCE(${table}.version_patch, '0')::text
 	 *          is used when creating a child SqlQuery that refers to a
 	 *          different table. See {@link
 	 *          SqlQuery#buildQueryFromCorrelatedSchema}.
+	 *        - isRootJson: whether the table is actually a JSONB value. This
+	 *          is only relevant for correlated queries. See {@link
+	 *          SqlQuery#buildQueryFromCorrelatedSchema}.
 	 */
 	constructor (tableOrParent, options = {}) {
 		// Set of properties that must exist
@@ -621,7 +627,8 @@ COALESCE(${table}.version_patch, '0')::text
 		this.options = options
 		_.defaults(this.options, {
 			parentJsonPath: [],
-			parentPath: []
+			parentPath: [],
+			isRootJson: false
 		})
 
 		this.errors = options.errors
@@ -1192,9 +1199,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	pathToSqlField (options = {}) {
-		const isRootJson = this.path.length === 1 && this.isProcessingJsonProperty()
-
-		return SqlQuery.toSqlField(this.path, isRootJson, options)
+		return SqlQuery.toSqlField(this.path, this.options.isRootJson, options)
 	}
 
 	formatJsonPath (suffix) {
@@ -1229,7 +1234,8 @@ COALESCE(${table}.version_patch, '0')::text
 		const query = SqlQuery.fromSchema(table, schema, {
 			parentJsonPath: this.options.parentJsonPath,
 			errors: this.options.errors,
-			parentPath
+			parentPath,
+			isRootJson: this.isProcessingJsonProperty()
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -1242,3 +1242,66 @@ avaTest('const matches against strings nested in contains should work against to
 	test.is(results.length, 1)
 	test.deepEqual(results[0].slug, elements[0].slug)
 })
+
+// TODO: enable this when the new compiler becomes the default
+ava.skip('contains - pattern of an object property should be handled correctly', async (test) => {
+	const table = 'contains_object_property_pattern'
+
+	const schema = {
+		type: 'object',
+		required: [ 'data' ],
+		properties: {
+			data: {
+				type: 'object',
+				required: [ 'array' ],
+				properties: {
+					array: {
+						type: 'array',
+						contains: {
+							type: 'object',
+							required: [ 'name' ],
+							properties: {
+								name: {
+									type: 'string',
+									pattern: 'abc'
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	const elements = [
+		{
+			slug: 'test-1',
+			type: 'card',
+			data: {
+				array: [ {
+					name: 'abc'
+				} ]
+			}
+		},
+		{
+			slug: 'test-2',
+			type: 'card',
+			data: {
+				array: [ {
+					name: 'cba'
+				} ]
+			}
+		}
+	]
+
+	const results = await runner({
+		connection: test.context.connection,
+		database: test.context.database,
+		table,
+		elements,
+		schema
+	})
+
+	test.is(results.length, 1)
+	test.deepEqual(results[0].slug, elements[0].slug)
+})


### PR DESCRIPTION
The JSON schema keywords `contains` and `items` can be implemented as subqueries. Both old and new compilers were not handling this correctly when the `contains`/`items` schema was an object with a property restricetd by a keyword that requires JSON-specific text-extraction operators (`->>`/`#>>`). For example, the `pattern` keyword.

This commit fixes this edge case in the new compiler and adds a test for this edge case that is skipped by default. This test should be enabled when the new compiler becomes the default or if the old one is patched.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
