### PR TITLE
add app.kubernetes.io/name labels to deployments

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: action-server
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-action-server
 spec:
   replicas: 12
   selector:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: jellyfish
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-api
 spec:
   selector:
     matchLabels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: jellyfish-livechat
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-livechat
 spec:
   selector:
     matchLabels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: jellyfish-ui
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-ui
 spec:
   selector:
     matchLabels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: redis
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-redis
 spec:
   selector:
     matchLabels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: tick-server
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-tick-server
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This is needed for monitoring to provide meaningful labels on metrics
discovered from the deployed pods (if/when they expose metrics ports)

(in more detail, all pods metrics are transtioning to being discovered via the same targets section, meaning the `job` label is always going to be `kubernetes-pods-prometheus-ports`, see: https://monitor.balena-cloud.com/prometheus/targets#job-kubernetes-pods-prometheus-ports, thus we will rely on the `app_kubernetes_io_name` label to discern the nature of the target) 

Change-type: patch
Signed-off-by: dt-rush <nickp@balena.io>