### PR TITLE
dev: don't inject SW manifest when debugging

### DIFF
--- a/apps/ui/environment.js
+++ b/apps/ui/environment.js
@@ -33,6 +33,6 @@ export const version = (typeof env === 'undefined') ? 'v1.0.0' : (env.VERSION ||
 
 export const pwa = {
 	debugSW: () => {
-		return env.JF_DEBUG_SW === 'true' || env.JF_DEBUG_SW === '1'
+		return (typeof env === 'undefined') ? false : (env.JF_DEBUG_SW === '1')
 	}
 }

--- a/apps/ui/service-worker.js
+++ b/apps/ui/service-worker.js
@@ -39,9 +39,8 @@ self.addEventListener('message', (event) => {
 // dev logs while in development mode.
 // 2. __WB_DISABLE_DEV_LOGS defaults to true (disable logging).
 // 3. __WB_DISABLE_DEV_LOGS is ignored if NODE_ENV === 'production'
-const jfDebugSW = (env.JF_DEBUG_SW || '').toLowerCase()
 // eslint-disable-next-line no-underscore-dangle
-self.__WB_DISABLE_DEV_LOGS = jfDebugSW !== 'true' && jfDebugSW !== '1'
+self.__WB_DISABLE_DEV_LOGS = env.JF_DEBUG_SW !== '1'
 
 // Cache google font files
 registerRoute(

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -114,8 +114,7 @@ const config = mergeConfig(baseConfig, {
 })
 
 if (process.env.NODE_ENV === 'production' ||
-		process.env.JF_DEBUG_SW === '1' ||
-		(process.env.JF_DEBUG_SW || '').toLowerCase() === 'true') {
+		process.env.JF_DEBUG_SW === '1') {
 	config.plugins.push(
 		new WorkboxPlugin.InjectManifest({
 			mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -90,14 +90,6 @@ const config = mergeConfig(baseConfig, {
 			template: indexFilePath
 		}),
 
-		new WorkboxPlugin.InjectManifest({
-			mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
-
-			// The vendors.js file is BIG - set this to a safe value of 40MB
-			maximumFileSizeToCacheInBytes: 40000000,
-			swSrc: './apps/ui/service-worker.js'
-		}),
-
 		new DefinePlugin({
 			env: {
 				API_URL: JSON.stringify(process.env.API_URL),
@@ -120,6 +112,20 @@ const config = mergeConfig(baseConfig, {
 		new MonacoWebpackPlugin()
 	]
 })
+
+if (process.env.NODE_ENV === 'production' ||
+		process.env.JF_DEBUG_SW === '1' ||
+		(process.env.JF_DEBUG_SW || '').toLowerCase() === 'true') {
+	config.plugins.push(
+		new WorkboxPlugin.InjectManifest({
+			mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+
+			// The vendors.js file is BIG - set this to a safe value of 40MB
+			maximumFileSizeToCacheInBytes: 40000000,
+			swSrc: './apps/ui/service-worker.js'
+		})
+	)
+}
 
 if (process.env.NODE_ENV !== 'production') {
 	config.plugins.push(

--- a/docs/developing/frontend.markdown
+++ b/docs/developing/frontend.markdown
@@ -32,8 +32,8 @@ The environment variables `NODE_ENV` and `JF_DEBUG_SW` determine whether the ser
 
 |                                       | `NODE_ENV === 'production'` | `NODE_ENV !== 'production'` |
 |---------------------------|----------------------------------|---------------------------------|
-| `JF_DEBUG_SW` is set    | Service worker is registered<br>Workbox logs are disabled | Service worker is registered<br>Workbox logs are enabled |
-| `JF_DEBUG_SW` not set |  Service worker is registered<br>Workbox logs are disabled | Service worker is not registered<br>Workbox logs are disabled |
+| `JF_DEBUG_SW === '1'`    | Service worker is registered<br>Workbox logs are disabled | Service worker is registered<br>Workbox logs are enabled |
+| `JF_DEBUG_SW !== '1'` |  Service worker is registered<br>Workbox logs are disabled | Service worker is not registered<br>Workbox logs are disabled |
 
 In summary: if you are debugging, first clear your application cache and then ensure the `JF_DEBUG_SW` environment variable is unset. Run `make dev-ui` and the service worker will not be used.
 


### PR DESCRIPTION
Small change to the webpack config which ensures we don't inject the precache manifest into the service worker unless we're in production mode or we've explicitly said we're debugging the SW (via the JF_DEBUG_SW env var). This change speeds up the build time when debugging and also removes the 'InjectManifest has been called multiple times' warning when running `make dev-ui`.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
