### PR TITLE
ci: Restore CircleCI Postgres server dump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,16 @@ jobs:
           name: End To End Tests (Server)
           command: make compose-exec-sidecar COMMAND="make" ARGS="test-e2e-server SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
       - run:
+          name: Postgres Dump
+          command: docker exec jellyfish_postgres_1 bash -c 'PGPASSWORD="${POSTGRES_PASSWORD}" pg_dump --username="${POSTGRES_USER}" jellyfish' | gzip -9 > dump-server.gz
+      - run:
           name: Docker Compose Down
           command: make compose-stop
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dump-server.gz
 
   results:
     <<: *job_defaults
@@ -260,6 +268,9 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm i
+      - run:
+          name: Postgres Dump
+          command: mkdir -p /tmp/test-results && cp dump-*.gz /tmp/test-results/
 
       # Store artifacts for debugging purposes
       - store_test_results:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

We are seeing consistent failures on https://github.com/product-os/jellyfish/pull/3699 when attempting to execute the `e2e_tests_server_previous_dump` job. After doing a bit of debugging I was able to confirm that the `curl` call to the CircleCI API to retrieve previous run artifact information resulted in an empty array. I believe this is caused by the fact that we have not been storing Postgres dumps as artifacts since https://github.com/product-os/jellyfish/commit/94683cabe0f8f569efcf82e9fe814657457c39a8

This PR will begin storing Postgres dumps as artifacts again allowing subsequent `e2e_tests_server_previous_dump` jobs to download previous dumps and run properly.