### PR TITLE
ui: Enable message send button on small screens

### DIFF
--- a/apps/ui/lens/list/Timeline.jsx
+++ b/apps/ui/lens/list/Timeline.jsx
@@ -9,6 +9,7 @@ import {
 	connect
 } from 'react-redux'
 import {
+	compose,
 	bindActionCreators
 } from 'redux'
 import {
@@ -18,11 +19,15 @@ import {
 } from '../../core'
 import * as environment from '../../environment'
 import Timeline from '../../../../lib/ui-components/Timeline'
+import {
+	withResponsiveContext
+} from '../../../../lib/ui-components/hooks/ResponsiveProvider'
 
 const mapStateToProps = (state, ownProps) => {
 	const card = ownProps.card
 
 	return {
+		wide: !ownProps.isMobile,
 		selectCard: selectors.getCard,
 		enableAutocomplete: !environment.isTest(),
 		sdk,
@@ -54,7 +59,10 @@ const lens = {
 	data: {
 		format: 'list',
 		icon: 'address-card',
-		renderer: connect(mapStateToProps, mapDispatchToProps)(Timeline),
+		renderer: compose(
+			withResponsiveContext,
+			connect(mapStateToProps, mapDispatchToProps)
+		)(Timeline),
 
 		// This lens can display event-like objects
 		filter: {

--- a/lib/ui-components/Timeline/MessageInput.jsx
+++ b/lib/ui-components/Timeline/MessageInput.jsx
@@ -47,15 +47,30 @@ const InputWrapper = styled(Box) `
 			&::after {
 				content: ' ';
 				position: absolute;
-				top: calc(50% - 6px);
-				right: -6px;
 				width: 0;
 				height: 0;
+			}
+		` : ''
+	}}
+
+	${(props) => {
+		return props.wide ? `
+			&::after {
+				top: calc(50% - 6px);
+				right: -6px;
 				border-top: 6px solid transparent;
 				border-bottom: 6px solid transparent;
 				border-left: 6px solid ${props.borderColor};
 			}
-		` : ''
+		` : `
+			&::after {
+				left: 14px;
+				bottom: -6px;
+				border-left: 6px solid transparent;
+				border-right: 6px solid transparent;
+				border-top: 6px solid ${props.borderColor};
+			}
+		`
 	}}
 `
 
@@ -97,6 +112,7 @@ const MessageInput = React.memo(({
 			bubble={whisper}
 			py={2}
 			px={3}
+			wide={wide}
 			{...(whisper ? {
 				color: 'white',
 				bg: theme.colors.secondary.main,


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes the `MessageInput` to display a compact view with a send button when the screen size is small. 

_Note: a future improvement might be to measure the width of the component itself and use that to set the `wide` variable. But for now, this simple fix should suffice._

Large screens:
![MessageInput - large screen](https://user-images.githubusercontent.com/2925657/81547647-551c6580-93a6-11ea-82e5-073a70a97820.jpg)

Small screens:
![MessageInput - small screen](https://user-images.githubusercontent.com/2925657/81547980-c9570900-93a6-11ea-8dd1-90fe5506ff97.jpg)

