### PR TITLE
environment: Trim Outreach client id and client secret env vars

### DIFF
--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -127,8 +127,8 @@ exports.integration = {
 		signature: process.env.INTEGRATION_DISCOURSE_SIGNATURE_KEY
 	},
 	outreach: {
-		appId: process.env.INTEGRATION_OUTREACH_APP_ID,
-		appSecret: process.env.INTEGRATION_OUTREACH_APP_SECRET,
+		appId: (process.env.INTEGRATION_OUTREACH_APP_ID || '').trim(),
+		appSecret: (process.env.INTEGRATION_OUTREACH_APP_SECRET || '').trim(),
 		signature: process.env.INTEGRATION_OUTREACH_SIGNATURE_KEY
 	},
 	flowdock: {


### PR DESCRIPTION
Looks like we have a trailing whitespace that is confusing
https://api.outreach.io/oauth/token in production.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!