### PR TITLE
Add simple constant folding to `SqlFilter` in `jsonschema2sql`

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -275,6 +275,25 @@ const generateQuery = (table, schema, options) => {
 const AND = 'AND'
 const OR = 'OR'
 
+const boolConstFold = {
+	AND: {
+		true: (other) => {
+			return other
+		},
+		false: () => {
+			return [ false ]
+		}
+	},
+	OR: {
+		true: () => {
+			return [ true ]
+		},
+		false: (other) => {
+			return other
+		}
+	}
+}
+
 // Columns of the `cards` table
 // TODO: probably worth taking this as an argument and remove the implicit
 // assumptions on the table structure from the `SqlQuery` class
@@ -506,8 +525,9 @@ class SqlFilter {
 	}
 
 	applyBinaryOperator (op, other) {
-		// TODO: might be worth doing simple constant propagation as we emit a
-		// lot of `true` and `false` constants
+		if (this.tryConstantFolding(op, other)) {
+			return
+		}
 
 		if (this.op !== op && this.expr.length > 1) {
 			this.expr.unshift('(')
@@ -524,6 +544,22 @@ class SqlFilter {
 			this.expr.push(...other.expr)
 			this.expr.push(')')
 		}
+	}
+
+	// If applicable, fold constants to simplify the resulting SQL
+	tryConstantFolding (op, other) {
+		if (this.expr.length === 1 && _.isBoolean(this.expr[0])) {
+			this.op = other.op
+			this.expr = boolConstFold[op][this.expr[0]](other.expr)
+
+			return true
+		} else if (other.expr.length === 1 && _.isBoolean(other.expr[0])) {
+			this.expr = boolConstFold[op][other.expr[0]](this.expr)
+
+			return true
+		}
+
+		return false
 	}
 
 	makeUnsatisfiable () {


### PR DESCRIPTION
This will simplify the generated SQL and make debugging easier

Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
