### PR TITLE
Allow users to have multi-threaded conversation about a repository

### DIFF
--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -362,6 +362,28 @@ export default class HomeChannel extends React.Component {
 		return !circularDeepEqual(nextState, this.state) || !circularDeepEqual(nextProps, this.props)
 	}
 
+	componentDidMount () {
+		// TODO: Replace this with parsing loop cards to define the chat room
+		// structure
+		this.props.actions.queryAPI({
+			type: 'object',
+			required: [ 'type', 'name' ],
+			properties: {
+				type: {
+					const: 'repository@1.0.0'
+				},
+				name: {
+					pattern: '^product-os'
+				}
+			}
+		})
+			.then((results) => {
+				this.setState({
+					productOS: results
+				})
+			})
+	}
+
 	componentDidUpdate (prevProps) {
 		if (!prevProps.channel.data.head && this.props.channel.data.head) {
 			this.props.actions.loadViewResults(this.props.channel.data.head)
@@ -445,6 +467,23 @@ export default class HomeChannel extends React.Component {
 			onSwipedRight: this.showDrawer,
 			onSwipedLeft: this.hideDrawer
 		}
+
+		// Add the productOS comms rooms to the top of the sidebar
+		// TODO: Replace this with a fully fledged loop mapping once the loop
+		// structure becomes concrete.
+		groups.children.unshift({
+			name: 'productOS',
+			key: 'product-os',
+			children: (this.state.productOS || []).map((item) => {
+				return {
+					name: item.name,
+					key: item.slug,
+					card: item,
+					isStarred: false,
+					children: []
+				}
+			})
+		})
 
 		return (
 			<HomeChannelWrapper

--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -269,6 +269,23 @@ export default class HomeChannel extends React.Component {
 			groups.main.children.push(starredViewsTree)
 		}
 
+		// Add the productOS comms rooms to the top of the sidebar
+		// TODO: Replace this with a fully fledged loop mapping once the loop
+		// structure becomes concrete.
+		groups.main.children.push({
+			name: 'productOS',
+			key: 'product-os',
+			children: (this.state.productOS || []).map((item) => {
+				return {
+					name: item.name,
+					key: item.slug,
+					card: item,
+					isStarred: false,
+					children: []
+				}
+			})
+		})
+
 		const [ myViews, otherViews ] = _.partition(nonDefaults, (view) => {
 			return _.startsWith(view.slug, 'view-121') || _.includes(view.markers, this.props.user.slug)
 		})
@@ -467,23 +484,6 @@ export default class HomeChannel extends React.Component {
 			onSwipedRight: this.showDrawer,
 			onSwipedLeft: this.hideDrawer
 		}
-
-		// Add the productOS comms rooms to the top of the sidebar
-		// TODO: Replace this with a fully fledged loop mapping once the loop
-		// structure becomes concrete.
-		groups.children.unshift({
-			name: 'productOS',
-			key: 'product-os',
-			children: (this.state.productOS || []).map((item) => {
-				return {
-					name: item.name,
-					key: item.slug,
-					card: item,
-					isStarred: false,
-					children: []
-				}
-			})
-		})
 
 		return (
 			<HomeChannelWrapper

--- a/apps/ui/components/HomeChannel/index.js
+++ b/apps/ui/components/HomeChannel/index.js
@@ -48,6 +48,7 @@ const mapDispatchToProps = (dispatch) => {
 				'logout',
 				'removeViewNotice',
 				'updateUser',
+				'queryAPI',
 				'removeView',
 				'setChatWidgetOpen',
 				'setDefault',

--- a/apps/ui/components/HomeChannel/tests/HomeChannel.spec.jsx
+++ b/apps/ui/components/HomeChannel/tests/HomeChannel.spec.jsx
@@ -34,6 +34,7 @@ const actions = _.reduce([
 	'addChannel',
 	'loadViewResults',
 	'logout',
+	'queryAPI',
 	'removeView',
 	'removeViewNotice',
 	'setChantWidgetOpen',
@@ -43,7 +44,7 @@ const actions = _.reduce([
 	'streamView',
 	'updateUser'
 ], (acc, action) => {
-	acc[action] = sandbox.fake()
+	acc[action] = sandbox.stub()
 	return acc
 }, {})
 
@@ -62,6 +63,7 @@ const Wrapper = ({
 }
 
 ava('Starred views appear in their own menu section', async (test) => {
+	actions.queryAPI.resolves([])
 	const homeChannel = await mount((
 		<HomeChannel
 			{...homeChannelProps}

--- a/apps/ui/core/store/actioncreators/index.js
+++ b/apps/ui/core/store/actioncreators/index.js
@@ -106,7 +106,7 @@ const loadSchema = async (sdk, query, user) => {
 	if (query.type === 'view' || query.type === 'view@1.0.0') {
 		return helpers.getViewSchema(query, user)
 	}
-	return query
+	return clone(query)
 }
 
 const getViewId = (query) => {

--- a/apps/ui/lens/full/Repository/Repository.jsx
+++ b/apps/ui/lens/full/Repository/Repository.jsx
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	circularDeepEqual
+} from 'fast-equals'
+import _ from 'lodash'
+import React from 'react'
+import {
+	Box,
+	Button,
+	Divider,
+	Flex,
+	Heading,
+	Tab,
+	Tabs,
+	Txt
+} from 'rendition'
+import styled from 'styled-components'
+import Segment from '../SingleCard/Segment'
+import CardFields from '../../../../../lib/ui-components/CardFields'
+import Icon from '../../../../../lib/ui-components/shame/Icon'
+import CardLayout from '../../../layouts/CardLayout'
+import {
+	getContextualThreadsQuery,
+	getLensBySlug
+} from '../../'
+import {
+	colorHash
+} from '../../../../../lib/ui-components/services/helpers'
+
+const SingleCardTabs = styled(Tabs) `
+	flex: 1
+
+	> [role="tabpanel"] {
+		flex: 1
+	}
+`
+
+const LIMIT = 10
+
+export default class RepositoryFull extends React.Component {
+	constructor (props) {
+		super(props)
+
+		const tail = _.get(this.props.card.links, [ 'has attached element' ], [])
+
+		const comms = _.filter(tail, (item) => {
+			const typeBase = item.type.split('@')[0]
+			return typeBase === 'message' || typeBase === 'whisper'
+		})
+
+		this.state = {
+			activeIndex: comms.length ? 1 : 0,
+			expanded: false,
+			options: {
+				page: 0,
+				totalPages: Infinity
+			},
+			relationship: {
+				target: this.props.card,
+				name: 'is of'
+			}
+		}
+
+		this.setActiveIndex = this.setActiveIndex.bind(this)
+		this.setPage = this.setPage.bind(this)
+	}
+
+	getQueryOptions () {
+		return {
+			page: this.state.options.page,
+			limit: LIMIT,
+			sortBy: 'created_at',
+			sortDir: 'desc'
+		}
+	}
+
+	loadThreadData () {
+		const query = getContextualThreadsQuery(this.props.card.id)
+		const options = this.getQueryOptions()
+		this.props.actions.loadViewResults(query, options)
+			.then((results) => {
+				if (results.length < LIMIT * (this.state.options.page + 1)) {
+					this.setState((state) => {
+						return {
+							options: {
+								...state.options,
+								totalPages: state.options.page + 1
+							}
+						}
+					})
+				}
+			})
+	}
+
+	shouldComponentUpdate (nextProps, nextState) {
+		return	!circularDeepEqual(nextState, this.state) || !circularDeepEqual(nextProps, this.props)
+	}
+
+	componentDidMount () {
+		// Trigger a query and stream for this cards contextual threads. They will
+		// be attached using redux as the `threads` prop
+		const query = getContextualThreadsQuery(this.props.card.id)
+		const options = this.getQueryOptions()
+		this.loadThreadData()
+		this.props.actions.streamView(query, options)
+	}
+
+	setActiveIndex (activeIndex) {
+		this.setState({
+			activeIndex
+		})
+	}
+
+	setPage (page) {
+		if (page + 1 >= this.state.options.totalPages) {
+			return null
+		}
+		const options = Object.assign({}, this.state.options, {
+			page
+		})
+		this.setState({
+			options
+		}, () => this.loadThreadData())
+
+		return options
+	}
+
+	componentWillUnmount () {
+		// Clean up store data on unmount
+		const query = getContextualThreadsQuery(this.props.card.id)
+		this.props.actions.clearViewData(query)
+	}
+
+	render () {
+		const {
+			actions,
+			card,
+			channel,
+			fieldOrder,
+			types,
+			threads
+		} = this.props
+		const {
+			expanded
+		} = this.state
+		const type = _.find(types, {
+			slug: card.type.split('@')[0]
+		})
+
+		const relationships = _.get(type, [ 'data', 'meta', 'relationships' ])
+
+		// TODO: This is an abomination and relies on the deprecated `linked_at` field
+		// being modified to trigger updates.
+		// Once we support queries that can traverse multiple relationships, this can
+		// be cleaned up.
+		const messages = _.flatMap(threads, 'links[has attached element]')
+
+		const Interleaved = getLensBySlug('lens-interleaved').data.renderer
+
+		return (
+			<CardLayout
+				overflowY
+				card={card}
+				channel={channel}
+				title={
+					<Flex>
+						<Button
+							plain
+							mr={3}
+							icon={<Icon name={`chevron-${expanded ? 'up' : 'down'}`} />}
+							onClick={() => this.setState({
+								expanded: !expanded
+							})}
+						/>
+						<Box>
+							<Heading.h4>
+								{card.name || card.slug || card.type}
+							</Heading.h4>
+
+							<Txt color="text.light" fontSize="0">Repository</Txt>
+						</Box>
+					</Flex>
+				}
+			>
+				<Divider mb={0} width="100%" color={colorHash(card.type)} />
+
+				{expanded && (
+					<SingleCardTabs
+						activeIndex={this.state.activeIndex}
+						onActive={this.setActiveIndex}
+					>
+						<Tab title="Info">
+							<Box p={3}>
+								<CardFields
+									card={card}
+									fieldOrder={fieldOrder}
+									type={type}
+								/>
+							</Box>
+						</Tab>
+
+						{_.map(relationships, (segment) => {
+							return (
+								<Tab title={segment.title} key={segment.title}>
+									<Segment
+										card={card}
+										segment={segment}
+										types={types}
+										actions={actions}
+									/>
+								</Tab>
+							)
+						})}
+					</SingleCardTabs>
+				)}
+
+				<Box
+					style={{
+						overflow: 'auto'
+					}}
+					flex={1}
+				>
+					<Interleaved
+						channel={channel}
+						tail={messages}
+						relationship={this.state.relationship}
+						setPage={this.setPage}
+						page={this.state.options.page}
+						totalPages={this.state.options.totalPages}
+					/>
+				</Box>
+			</CardLayout>
+		)
+	}
+}

--- a/apps/ui/lens/full/Repository/index.jsx
+++ b/apps/ui/lens/full/Repository/index.jsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as _ from 'lodash'
+import {
+	connect
+} from 'react-redux'
+import {
+	bindActionCreators
+} from 'redux'
+import {
+	actionCreators,
+	selectors
+} from '../../../core'
+import {
+	getContextualThreadsQuery
+} from '../../'
+import Repository from './Repository'
+
+const mapStateToProps = (state, ownProps) => {
+	const query = getContextualThreadsQuery(ownProps.card.id)
+
+	return {
+		types: selectors.getTypes(state),
+		threads: selectors.getViewData(state, query)
+	}
+}
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, [
+				'addChannel',
+				'addNotification',
+				'clearViewData',
+				'createLink',
+				'getLinks',
+				'loadViewResults',
+				'queryAPI',
+				'streamView'
+			]), dispatch)
+	}
+}
+
+const lens = {
+	slug: 'lens-full-repository',
+	type: 'lens',
+	version: '1.0.0',
+	name: 'Repository lens',
+	data: {
+		format: 'full',
+		icon: 'address-card',
+		renderer: connect(mapStateToProps, mapDispatchToProps)(Repository),
+		filter: {
+			type: 'object',
+			required: [ 'type' ],
+			properties: {
+				type: {
+					type: 'string',
+					const: 'repository@1.0.0'
+				}
+			}
+		}
+	}
+}
+
+export default lens

--- a/apps/ui/lens/full/index.js
+++ b/apps/ui/lens/full/index.js
@@ -5,6 +5,7 @@
  */
 
 import MyUser from './MyUser'
+import Repository from './Repository'
 import SingleCard from './SingleCard'
 import SupportThread from './SupportThread'
 import Thread from './Thread'
@@ -12,6 +13,7 @@ import View from './View'
 
 export default [
 	MyUser,
+	Repository,
 	SingleCard,
 	SupportThread,
 	Thread,

--- a/apps/ui/lens/index.js
+++ b/apps/ui/lens/index.js
@@ -92,3 +92,43 @@ export const getLensBySlug = (slug) => {
 		slug
 	}) || null
 }
+
+// Generate a query that will get all the contextual threads and their attached
+// messages and whispers
+export const getContextualThreadsQuery = (id) => {
+	return {
+		$$links: {
+			'has attached element': {
+				type: 'object',
+				required: [ 'type' ],
+				properties: {
+					type: {
+						type: 'string',
+						enum: [ 'message@1.0.0', 'whisper@1.0.0' ]
+					}
+				},
+				additionalProperties: true
+			},
+			'is of': {
+				type: 'object',
+				required: [ 'id' ],
+				properties: {
+					id: {
+						type: 'string',
+						const: id
+					}
+				},
+				additionalProperties: false
+			}
+		},
+		type: 'object',
+		required: [ 'type' ],
+		properties: {
+			type: {
+				type: 'string',
+				const: 'thread@1.0.0'
+			}
+		},
+		additionalProperties: true
+	}
+}

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -42,7 +42,8 @@ const NONE_MESSAGE_TIMELINE_TYPES = [
 	'update',
 	'create@1.0.0',
 	'event@1.0.0',
-	'update@1.0.0'
+	'update@1.0.0',
+	'thread@1.0.0'
 ]
 
 const isHiddenEventType = (type) => {

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -20,8 +20,7 @@ import {
 import {
 	Box,
 	Button,
-	Flex,
-	Theme
+	Flex
 } from 'rendition'
 import {
 	v4 as uuid
@@ -94,7 +93,15 @@ export class Interleaved extends BaseLens {
 					if (thread) {
 						this.openChannel(thread.slug || thread.id)
 					}
-					return null
+					return thread
+				})
+				.then((thread) => {
+					// If a relationship is defined, link this thread using the
+					// relationship
+					const relationship = this.props.relationship
+					if (thread && relationship) {
+						sdk.card.link(thread, relationship.target, relationship.name)
+					}
 				})
 				.then(() => {
 					analytics.track('element.create', {
@@ -226,22 +233,6 @@ export class Interleaved extends BaseLens {
 				}}
 			>
 				<ReactResizeObserver onResize={this.scrollToBottom}/>
-				<Flex my={2} mr={2} justifyContent="flex-end">
-					<Button
-						plain
-						tooltip={{
-							placement: 'left',
-							text: `${messagesOnly ? 'Show' : 'Hide'} create and update events`
-						}}
-						className="timeline__checkbox--additional-info"
-						color={messagesOnly ? Theme.colors.text.light : false}
-						ml={2}
-						onClick={this.handleEventToggle}
-					>
-						<Icon name="stream"/>
-					</Button>
-				</Flex>
-
 				<div
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1775,9 +1775,9 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.3.0.tgz",
-      "integrity": "sha512-/0HE1p0NhdhzeTiGbprv7ItQ6p/hCYb+TCch8FJ+h2B2/o64olag+VKPkFj1cm59stTPRobwmkVGSy6YIONo2A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.4.0.tgz",
+      "integrity": "sha512-UBn1gA3t8Uavxl2XJXC9AwLG3VGl8RpJ1EYibdAnz42b+HZGhKblI4uP2P2uXw4o55SiNrBP3CwRypvkN6LTWg==",
       "requires": {
         "axios": "^0.19.2",
         "bluebird": "^3.7.2",
@@ -17039,7 +17039,7 @@
       "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "smooth-dnd": {
-      "version": "git+https://github.com/rcdexta/smooth-dnd.git#f13924c67bf6ffe4613d97bb1ee83f11d364eb1e",
+      "version": "git+https://github.com/rcdexta/smooth-dnd.git#223f4672bea94f65b98af4fd28ab0db2c3b9c8a2",
       "from": "git+https://github.com/rcdexta/smooth-dnd.git"
     },
     "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
-    "@balena/jellyfish-client-sdk": "^0.3.0",
+    "@balena/jellyfish-client-sdk": "^0.4.0",
     "@balena/node-metrics-gatherer": "^5.6.0",
     "@octokit/auth-app": "^2.4.4",
     "@octokit/plugin-retry": "^2.2.0",


### PR DESCRIPTION
This change allows `repository` type cards to have multiple threads attached to them, these threads are then rendered using the interleaved lens. This behaviour lets repos behave like "chatrooms" in Jellyfish, allowing us to organise our work discussion around the code we write and repos we work on.

![image](https://user-images.githubusercontent.com/15064535/81691934-8dc74800-9455-11ea-9a5c-ed2f91493de6.png)

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
