### PR TITLE
test: Ensure community users can't spoof sessions

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -105,7 +105,19 @@ const preUpsert = async (instance, context, session, card) => {
 		throw error
 	}
 
-	jsonSchema.validate(filter, card)
+	try {
+		jsonSchema.validate(filter, card)
+	} catch (error) {
+		// Failing to match the filter schema is a permissions error
+		if (error instanceof errors.JellyfishSchemaMismatch) {
+			const newError = new errors.JellyfishPermissionsError(error.message)
+			newError.expected = true
+			throw newError
+		}
+
+		throw error
+	}
+
 	return filter
 }
 

--- a/test/e2e/server/external-support-user-security.spec.js
+++ b/test/e2e/server/external-support-user-security.spec.js
@@ -173,7 +173,7 @@ ava.serial(
 			}
 		}))
 
-		test.is(error.name, 'JellyfishSchemaMismatch')
+		test.is(error.name, 'JellyfishPermissionsError')
 
 		// Create thread on behalf of external support user without markers
 		error = await test.throwsAsync(test.context.sdk.card.create({
@@ -186,7 +186,7 @@ ava.serial(
 			}
 		}))
 
-		test.is(error.name, 'JellyfishSchemaMismatch')
+		test.is(error.name, 'JellyfishPermissionsError')
 	}
 )
 

--- a/test/e2e/server/security/index.spec.js
+++ b/test/e2e/server/security/index.spec.js
@@ -727,7 +727,7 @@ ava.serial('Users should not be able to create sessions as other users', async (
 		})
 	})
 
-	test.is(error.name, 'JellyfishSchemaMismatch')
+	test.is(error.name, 'JellyfishPermissionsError')
 })
 
 ava.serial('Users should not be able to create action requests', async (test) => {
@@ -776,7 +776,7 @@ ava.serial('Users should not be able to create action requests', async (test) =>
 		await sdk.card.create(actionRequest)
 	})
 
-	test.is(error.name, 'JellyfishSchemaMismatch')
+	test.is(error.name, 'JellyfishPermissionsError')
 })
 
 ava.serial('Users should not be able to view create cards that create users', async (test) => {

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -1817,7 +1817,7 @@ ava('.insertCard() read access on a property should not allow to write other pro
 			roles: []
 		}
 	}), {
-		instanceOf: errors.JellyfishSchemaMismatch
+		instanceOf: errors.JellyfishPermissionsError
 	})
 })
 


### PR DESCRIPTION
Fixes: https://sentry.io/share/issue/2597b632d0fb48d3a767f1023331dee3/
Change-type: patch

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!