### PR TITLE
Unify handling of nulls in `SqlFilter` and compare JSON as text when possible

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -347,19 +347,48 @@ class SqlFilter {
 	}
 
 	static isEqual (query, values) {
-		const field = query.pathToSqlField()
-		const literals = values.map((value) => {
-			return SqlFilter.maybeJsonLiteral(query, value)
-		})
-
-		let sql = null
-		if (literals.length === 1) {
-			sql = `${field} = ${literals[0]}`
-		} else {
-			sql = `${field} IN (${literals.join(', ')})`
+		let hasNull = false
+		const text = []
+		const nonText = []
+		for (const value of values) {
+			if (value === null) {
+				hasNull = true
+			} else if (_.isString(value)) {
+				text.push(pgFormat.literal(value))
+			} else {
+				nonText.push(SqlFilter.maybeJsonLiteral(query, value))
+			}
 		}
 
-		return new SqlFilter(sql)
+		const textCast = query.isProcessingJsonProperty() ? '::text' : ''
+		const filter = new SqlFilter(false)
+		if (hasNull) {
+			let nullFilter = null
+			if (query.isProcessingJsonProperty()) {
+				nullFilter = new SqlFilter(`${query.pathToSqlField()} = 'null'`)
+			} else {
+				nullFilter = SqlFilter.isNull(query)
+			}
+			filter.or(nullFilter)
+		}
+		if (text.length === 1) {
+			const field = query.pathToSqlField({
+				asText: true
+			})
+			filter.or(new SqlFilter(`(${field})${textCast} = ${text[0]}`))
+		} else if (text.length > 1) {
+			const field = query.pathToSqlField({
+				asText: true
+			})
+			filter.or(new SqlFilter(`(${field})${textCast} IN (${text.join(',')})`))
+		}
+		if (nonText.length === 1) {
+			filter.or(new SqlFilter(`${query.pathToSqlField()} = ${nonText[0]}`))
+		} else if (nonText.length > 1) {
+			filter.or(new SqlFilter(`${query.pathToSqlField()} IN (${nonText.join(',')})`))
+		}
+
+		return filter
 	}
 
 	static valueIs (query, operator, value) {
@@ -760,14 +789,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	constVisitor (value) {
-		// TODO: fold this null test into `SqlFilter.isEqual()`
-		let filter = null
-		if (value === null && !this.isProcessingJsonProperty()) {
-			filter = SqlFilter.isNull(this)
-		} else {
-			filter = SqlFilter.isEqual(this, [ value ])
-		}
-		this.filter.and(filter)
+		this.filter.and(SqlFilter.isEqual(this, [ value ]))
 	}
 
 	containsVisitor (schema) {
@@ -823,18 +845,7 @@ COALESCE(${table}.version_patch, '0')::text
 			return `value for '${this.formatJsonPath('enum')}' must not be empty`
 		})
 
-		// TODO: fold this null test into `SqlFilter.isEqual()`
-		let filter = null
-		if (values.includes(null) && !this.isProcessingJsonProperty()) {
-			filter = SqlFilter.isNull(this)
-			const nonNullValues = _.without(values, null)
-			if (!_.isEmpty(nonNullValues)) {
-				filter.or(SqlFilter.isEqual(this, nonNullValues))
-			}
-		} else {
-			filter = SqlFilter.isEqual(this, values)
-		}
-		this.filter.and(filter)
+		this.filter.and(SqlFilter.isEqual(this, values))
 	}
 
 	formatVisitor (format) {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
