### PR TITLE
Use proper transaction isolation when comparing old and new compilers

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -93,6 +93,10 @@ const getStrippedCard = (card) => {
 	return result
 }
 
+const queryTransactionMode = new pgp.txMode.TransactionMode({
+	tiLevel: pgp.txMode.isolationLevel.repeatableRead
+})
+
 const queryTable = async (context, backend, table, schema, options) => {
 	const mode = options.profile ? 'info' : 'debug'
 
@@ -128,7 +132,8 @@ const queryTable = async (context, backend, table, schema, options) => {
 	let queryEndDate = null
 	let results = null
 	await backend.connection.txIf({
-		cnd: testNewCompiler
+		cnd: testNewCompiler,
+		mode: queryTransactionMode
 	}, async (tx) => {
 		queryStartDate = new Date()
 		const queryStart = performance.now()


### PR DESCRIPTION
Turns out PG's default isolation level is `read commited` which allows nonrepeatable reads, possibly leading to spurious mismatches between old and new compilers. This commit explicitly uses `repeatable reads` isolation level to avoid that problem.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>