### PR TITLE
ui: Make tab headers horizontally scrollable on small screens

### DIFF
--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -74,6 +74,23 @@ const customTheme = {
 		},
 		background: '#fff',
 		border: '#eee'
+	},
+	tabs: {
+		header: {
+			extend: (props) => {
+				return `
+					@media only screen and (max-width: ${props.theme.breakpoints[1]}px) {
+						flex-wrap: nowrap;
+						overflow-x: auto;
+						button > div > span {
+							white-space: nowrap;
+							overflow: hidden;
+							text-overflow: ellipsis;
+						}
+					}
+				`
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
And force the tab header text to stick to a single line.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This is a proposed change to how we render tab headers on small screens. Let me know what you think. There's pros and cons but it definitely takes up less vertical screen space on small screens which is a big plus!

Note - the behaviour of tab headers on larger screens is unchanged.

Before:
![Tabs - wrapped](https://user-images.githubusercontent.com/2925657/81633722-96a92100-9437-11ea-9b87-88dcac8390ca.jpg)

After:
![Tabs - single line](https://user-images.githubusercontent.com/2925657/81633729-9a3ca800-9437-11ea-83f7-96018450a47c.gif)
