### PR TITLE
ci: Change LOGLEVEL for sut

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,6 +15,7 @@ services:
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres
+      - LOGLEVEL=crit
       - LIVECHAT_HOST=http://livechat
       - LIVECHAT_PORT=80
       - NODE_ENV=test


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Change the `LOGLEVEL` for the `sut` service to `crit` to reduce output noise during balenaCI compose tests. By default it was being set to `warning` which is the default for tests in the `Makefile`.