### PR TITLE
Display multiple email addresses correctly in own user card

### DIFF
--- a/apps/ui/lens/full/MyUser/MyUser.jsx
+++ b/apps/ui/lens/full/MyUser/MyUser.jsx
@@ -163,6 +163,8 @@ export default class MyUser extends React.Component {
 			}
 		}
 
+		const emails = Array.isArray(user.data.email) ? user.data.email.join(', ') : user.data.email
+
 		return (
 			<CardLayout
 				data-test={`lens--${SLUG}`}
@@ -193,7 +195,7 @@ export default class MyUser extends React.Component {
 									<strong>{user.slug.replace('user-', '')}</strong>
 
 									<br />
-									<strong>{user.data.email}</strong>
+									<strong>{emails}</strong>
 								</Box>
 							</Flex>
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: JuanFRidano <juanfridano@gmail.com>

***
**Before**
![image](https://user-images.githubusercontent.com/7922689/81663724-31592e00-943f-11ea-8dbd-8b62cb1b1166.png)

**After**
![image](https://user-images.githubusercontent.com/7922689/81663858-4df56600-943f-11ea-86fb-a460d2d8a0ca.png)

**only one** email address (string, not Array)
![image](https://user-images.githubusercontent.com/7922689/81664088-7b421400-943f-11ea-845d-5b0db377bbf4.png)
