### PR TITLE
ui: Improve view filter layout on small screens

### DIFF
--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -599,27 +599,16 @@ class ViewRenderer extends React.Component {
 			>
 				{Boolean(head) && (
 					<React.Fragment>
-						<Flex mt={3} mx={3} alignItems='flex-start'>
-							<Flex flex={1} flexWrap='wrap'>
-								<Box flex="1">
-									{useFilters && (
-										<Box mt={0} flex="1 0 auto">
-											<Filters
-												schema={schemaForFilters}
-												filters={this.state.filters}
-												onFiltersUpdate={this.updateFilters}
-												onViewsUpdate={this.saveView}
-												compact={FiltersBreakpointSettings}
-												renderMode={[ 'add', 'search' ]}
-											/>
-										</Box>
-									)}
-								</Box>
-
+						<Flex
+							mt={3} mx={3}
+							flexWrap={[ 'wrap', 'wrap', 'nowrap' ]}
+							flexDirection="row-reverse"
+							alignItems={[ 'flex-start', 'flex-start', 'center' ]}
+						>
+							<Flex mb={3} alignItems="center" justifyContent="flex-end" minWidth={[ '100%', '100%', 'auto' ]}>
 								{sliceOptions && sliceOptions.length && (
 									<Select
 										ml={3}
-										mb={3}
 										options={sliceOptions}
 										value={this.state.activeSlice}
 										labelKey='title'
@@ -644,19 +633,33 @@ class ViewRenderer extends React.Component {
 										})}
 									</ButtonGroup>
 								)}
-							</Flex>
 
-							<CloseButton
-								flex={0}
-								p={3}
-								mt="-8px"
-								mr={-3}
-								channel={this.props.channel}
-							/>
+								<CloseButton
+									flex={0}
+									p={3}
+									py={2}
+									mr={-3}
+									channel={this.props.channel}
+								/>
+							</Flex>
+							<Box flex="1">
+								{useFilters && (
+									<Box mt={0} flex="1 0 auto">
+										<Filters
+											schema={schemaForFilters}
+											filters={this.state.filters}
+											onFiltersUpdate={this.updateFilters}
+											onViewsUpdate={this.saveView}
+											compact={FiltersBreakpointSettings}
+											renderMode={[ 'add', 'search' ]}
+										/>
+									</Box>
+								)}
+							</Box>
 						</Flex>
 
 						{useFilters && this.state.filters.length > 0 && (
-							<Box flex="1 0 auto" mx={3}>
+							<Box flex="1 0 auto" mx={3} mt={-3}>
 								<Filters
 									schema={schemaForFilters}
 									filters={this.state.filters}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Small refactor of the components at the top of the `ViewRenderer` component to improve the layout when viewing on a small screen.

_Note: further work should add some ability to collapse all this content or slide it out of view so the user can concentrate on the list instead._

|  | Large Screen | Small Screen |
|--|----------------|--------------|
| Before | <img src="https://user-images.githubusercontent.com/2925657/81691226-adc32f80-9486-11ea-9ea3-c351f6e12371.png" width="300" >  | <img src="https://user-images.githubusercontent.com/2925657/81691167-98e69c00-9486-11ea-8d81-025417bef37e.png" width="200" >   |
| After | <img src="https://user-images.githubusercontent.com/2925657/81691006-53c26a00-9486-11ea-918d-13790e74bd99.png" width="300" >  |  <img src="https://user-images.githubusercontent.com/2925657/81691108-7f455480-9486-11ea-9be8-86bdf58aa438.png" width="200" >   | 
