### PR TITLE
Avoid recalculating `SqlQuery.isProcessing*()`

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -379,11 +379,11 @@ class SqlFilter {
 			}
 		}
 
-		const textCast = query.isProcessingJsonProperty() ? '::text' : ''
+		const textCast = query.isProcessingJsonProperty ? '::text' : ''
 		const filter = new SqlFilter(false)
 		if (hasNull) {
 			let nullFilter = null
-			if (query.isProcessingJsonProperty()) {
+			if (query.isProcessingJsonProperty) {
 				nullFilter = new SqlFilter(`${query.pathToSqlField()} = 'null'`)
 			} else {
 				nullFilter = SqlFilter.isNull(query)
@@ -433,7 +433,7 @@ class SqlFilter {
 	}
 
 	static arrayContains (query, filter, alias) {
-		const unnest = query.isProcessingJsonProperty() ? 'jsonb_array_elements' : 'unnest'
+		const unnest = query.isProcessingJsonProperty ? 'jsonb_array_elements' : 'unnest'
 
 		return new SqlFilter(`EXISTS (
 	SELECT 1
@@ -464,7 +464,7 @@ class SqlFilter {
 	}
 
 	static arrayLengthIs (query, op, value) {
-		const cardinality = query.isProcessingJsonProperty() ? 'jsonb_array_length' : 'cardinality'
+		const cardinality = query.isProcessingJsonProperty ? 'jsonb_array_length' : 'cardinality'
 
 		return new SqlFilter(`${cardinality}(${query.pathToSqlField()}) ${op} ${value}`)
 	}
@@ -486,7 +486,7 @@ class SqlFilter {
 	}
 
 	static maybeJsonLiteral (query, value) {
-		const literal = query.isProcessingJsonProperty() ? JSON.stringify(value) : value
+		const literal = query.isProcessingJsonProperty ? JSON.stringify(value) : value
 
 		return pgFormat.literal(literal)
 	}
@@ -707,6 +707,12 @@ COALESCE(${table}.version_patch, '0')::text
 			this.columns = tableOrParent.columns
 			this.path = tableOrParent.path
 		}
+
+		this.isProcessingTable = false
+		this.isProcessingColumn = false
+		this.isProcessingSubColumn = false
+		this.isProcessingJsonProperty = false
+		this.updateisProcessingState()
 	}
 
 	addRequired (required) {
@@ -718,24 +724,26 @@ COALESCE(${table}.version_patch, '0')::text
 		this.path.push(null)
 		for (const key of required) {
 			this.path[this.path.length - 1] = key
-			const isProcessingColumn = this.isProcessingColumn()
+			this.updateisProcessingState()
 
 			// TODO: as an optimization, this is not necessary if the field is
 			// also constrained by some keywords (`const`, `enum`)
-			if (isProcessingColumn) {
+			if (this.isProcessingColumn) {
 				if (_.get(CARD_FIELDS, [ key, 'nullable' ]) === true) {
 					requiredFilter.and(SqlFilter.isNotNull(this))
 				}
-			} else if (this.isProcessingJsonProperty()) {
+			} else if (this.isProcessingJsonProperty) {
 				requiredFilter.and(SqlFilter.jsonPropertyExists(this))
 			}
 
 			this.required.add(key)
-			if (isProcessingColumn) {
+			if (this.isProcessingColumn) {
 				this.columns.add(key)
 			}
 		}
 		this.path.pop()
+		this.updateisProcessingState()
+
 		this.filter.and(this.ifTypeThen('object', requiredFilter))
 	}
 
@@ -774,7 +782,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	$$linksVisitor (linkMap) {
-		assert.INTERNAL(null, this.isProcessingTable(), Error,
+		assert.INTERNAL(null, this.isProcessingTable, Error,
 			'a \'$$links\' key is only valid at the toplevel for the moment')
 		assert.INTERNAL(null, _.isPlainObject(linkMap), Error, () => {
 			return `value for '${this.formatJsonPath('$$links')}' must be a map`
@@ -849,7 +857,7 @@ COALESCE(${table}.version_patch, '0')::text
 	// containing only the `const` keyword (and maybe a compatible `type`)
 	tryJsonContainsOptimization (schema) {
 		let filter = null
-		if (_.isPlainObject(schema) && 'const' in schema && this.isProcessingJsonProperty()) {
+		if (_.isPlainObject(schema) && 'const' in schema && this.isProcessingJsonProperty) {
 			const value = schema.const
 			const keyCount = Object.keys(schema).length
 			if (keyCount === 1) {
@@ -1069,7 +1077,8 @@ COALESCE(${table}.version_patch, '0')::text
 		this.path.push(null)
 		for (const [ propertyName, propertySchema ] of Object.entries(propertiesMap)) {
 			this.path[this.path.length - 1] = propertyName
-			if (this.isProcessingColumn()) {
+			this.updateisProcessingState()
+			if (this.isProcessingColumn) {
 				this.columns.add(propertyName)
 			}
 
@@ -1085,11 +1094,11 @@ COALESCE(${table}.version_patch, '0')::text
 				// the property filter in a material conditional to make sure
 				// that it is indeed treated as optional.
 				let existsFilter = null
-				if (this.isProcessingColumn()) {
+				if (this.isProcessingColumn) {
 					if (_.get(CARD_FIELDS, [ propertyName, 'nullable' ])) {
 						existsFilter = SqlFilter.isNotNull(this)
 					}
-				} else if (this.isProcessingJsonProperty()) {
+				} else if (this.isProcessingJsonProperty) {
 					existsFilter = SqlFilter.jsonPropertyExists(this)
 				}
 				if (existsFilter !== null) {
@@ -1099,6 +1108,7 @@ COALESCE(${table}.version_patch, '0')::text
 			this.filter.and(filter)
 		}
 		this.path.pop()
+		this.updateisProcessingState()
 	}
 
 	regexpVisitor (value) {
@@ -1158,13 +1168,13 @@ COALESCE(${table}.version_patch, '0')::text
 	// - A filter testing for the type otherwise
 	// TODO: actually this needs some review/rethink
 	getIsTypesFilter (types) {
-		if (this.isProcessingTable()) {
+		if (this.isProcessingTable) {
 			// The root type must always be 'object'
 			if (types.includes('object')) {
 				return null
 			}
 			return false
-		} else if (this.isProcessingColumn()) {
+		} else if (this.isProcessingColumn) {
 			// Toplevel properties are also fixed, except for `data`'s contents
 			const column = this.getPathTip()
 			if (column === 'data') {
@@ -1176,7 +1186,7 @@ COALESCE(${table}.version_patch, '0')::text
 				return null
 			}
 			return false
-		} else if (this.isProcessingSubColumn()) {
+		} else if (this.isProcessingSubColumn) {
 			// TODO
 			return null
 		} else if (types.includes('integer')) {
@@ -1197,16 +1207,12 @@ COALESCE(${table}.version_patch, '0')::text
 		return SqlFilter.isOfJsonTypes(this, types)
 	}
 
-	isProcessingTable () {
-		return this.getPathDepth() === 1
-	}
+	updateisProcessingState () {
+		const pathDepth = this.getPathDepth()
+		this.isProcessingTable = pathDepth === 1
+		this.isProcessingColumn = this.options.parentPath.length === 0 && this.path.length === 2
 
-	isProcessingColumn () {
-		return _.isEmpty(this.options.parentPath) && this.path.length === 2
-	}
-
-	isProcessingSubColumn () {
-		if (this.getPathDepth() === 3) {
+		if (pathDepth === 3) {
 			let column = null
 			if (this.path.length === 3) {
 				column = this.path[this.path.length - 2]
@@ -1216,17 +1222,14 @@ COALESCE(${table}.version_patch, '0')::text
 				column = this.options.parentPath[this.options.parentPath.length - 2]
 			}
 
-			return column !== 'data'
+			this.isProcessingSubColumn = column !== 'data'
+		} else {
+			this.isProcessingSubColumn = false
 		}
 
-		return false
-	}
-
-	isProcessingJsonProperty () {
-		const depth = this.getPathDepth()
-		const isData = depth === 2 && this.getPathTip() === 'data'
-
-		return isData || (depth === 3 && !this.isProcessingSubColumn()) || depth > 3
+		const isData = pathDepth === 2 && this.getPathTip() === 'data'
+		const isDataProperty = pathDepth === 3 && !this.isProcessingSubColumn
+		this.isProcessingJsonProperty = isData || isDataProperty || pathDepth > 3
 	}
 
 	getPathDepth () {
@@ -1241,7 +1244,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	pathToSqlField (options = {}) {
-		const isRootJson = this.path.length === 1 && this.isProcessingJsonProperty()
+		const isRootJson = this.path.length === 1 && this.isProcessingJsonProperty
 
 		return SqlQuery.toSqlField(this.path, isRootJson, options)
 	}


### PR DESCRIPTION
This results in a minor performance boost and unlocks a nicer
implementation of PR #3716.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
