### PR TITLE
Don't use `_.defaults()` for better performance in `SqlQuery` constructor

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -684,10 +684,12 @@ COALESCE(${table}.version_patch, '0')::text
 
 		// See the constructor's docs
 		this.options = options
-		_.defaults(this.options, {
-			parentJsonPath: [],
-			parentPath: []
-		})
+		if (!('parentJsonPath' in this.options)) {
+			this.options.parentJsonPath = []
+		}
+		if (!('parentPath' in this.options)) {
+			this.options.parentPath = []
+		}
 
 		this.errors = options.errors
 


### PR DESCRIPTION
Profiling showed that lodash's `defaults()` was taking a not
insignificant amount of time. Benchmarking showed that using plain `in`
operators to set the default values led to a not insignificant
performance boost.

Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
