### PR TITLE
ui: Fix reference to guided handover flow panel

### DIFF
--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -23,9 +23,7 @@ import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
 import {
 	FLOW_IDS
 } from '../../components/Flows/flow-utils'
-import {
-	HandoverFlowPanel
-} from '../../components/Flows/HandoverFlowPanel'
+import HandoverFlowPanel from '../../components/Flows/HandoverFlowPanel'
 import {
 	LinksProvider
 } from '../../../../lib/ui-components/LinksProvider'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes a bug where attempting to transfer ownership of a thread results in a `Oh no, Something went wrong!` - because of a faulty import statement.

To resolve: why do build warnings not cause one of the CI tasks to fail?