### PR TITLE
core: Default unset version fragments to 0.0.0

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -33,7 +33,7 @@ const CARDS_SELECT = [
 	'slug',
 	'type',
 	'active',
-	'CONCAT_WS(\'.\', COALESCE(version_major, \'1\'), COALESCE(version_minor, \'0\'), COALESCE(version_patch, \'0\')) AS version',
+	'CONCAT_WS(\'.\', COALESCE(version_major, \'0\'), COALESCE(version_minor, \'0\'), COALESCE(version_patch, \'0\')) AS version',
 	'name',
 	'tags',
 	'markers',

--- a/lib/core/backend/postgres/jsonschema2sql/builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder.js
@@ -98,7 +98,7 @@ exports.getProperty = (property, options = {}) => {
 	if (property.length === 2) {
 		if (property[1] === 'version') {
 			const fragments = [
-				`COALESCE(${property[0]}.version_major, '1')::text`,
+				`COALESCE(${property[0]}.version_major, '0')::text`,
 				`COALESCE(${property[0]}.version_minor, '0')::text`,
 				`COALESCE(${property[0]}.version_patch, '0')::text`
 			].join(',\n  ')

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -624,7 +624,7 @@ class SqlQuery {
 
 	static getVersionComputedField (table) {
 		return `CONCAT_WS('.',
-COALESCE(${table}.version_major, '1')::text,
+COALESCE(${table}.version_major, '0')::text,
 COALESCE(${table}.version_minor, '0')::text,
 COALESCE(${table}.version_patch, '0')::text
 )`


### PR DESCRIPTION
Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!