### PR TITLE
core: Always replace card with NULL version fragments if any

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -279,6 +279,23 @@ exports.upsert = async (context, errors, connection, object, options) => {
 	const insertedObject = Object.assign({}, object)
 	insertedObject.links = {}
 
+	// Always modify the unversioned card if any
+	const unversionedCard = await connection.oneOrNone({
+		name: `cards-unversioned-id-${table}`,
+		text: `SELECT id FROM ${table}
+			WHERE
+				slug = $1 AND
+				version_major IS NULL AND
+				version_minor IS NULL AND
+				version_patch IS NULL
+			LIMIT 1`,
+		values: [ insertedObject.slug ]
+	})
+	if (unversionedCard) {
+		options.id = unversionedCard.id
+		options.replace = true
+	}
+
 	const elementId = options.id || await uuid.random()
 
 	if (options.replace) {


### PR DESCRIPTION
Right now we set a default on NULL fragments when reading them from the
database. Attempting to update one of these unversioned cards will
result in a version bump as they obtain the new version.

This change adds logic to update the unversioned card in place for such
scenarios.

Change-type: patch


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!