### PR TITLE
Reduce emission of type-checking conditionals in the new compiler

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -1198,7 +1198,7 @@ COALESCE(${table}.version_patch, '0')::text
 		if (typeFilter === null) {
 			return filter
 		} else if (typeFilter === false) {
-			return new SqlFilter(false)
+			return new SqlFilter(true)
 		}
 
 		return SqlFilter.materialConditional(typeFilter, filter)

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -1194,6 +1194,13 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	ifTypeThen (type, filter) {
+		if (this.types.length === 1 && type === this.types[0]) {
+			// No need for a conditional since the field can only be of one
+			// type. Also PG doesn't optimize `x && (!x || y)` so we have to do
+			// that here
+			return filter
+		}
+
 		const typeFilter = this.getIsTypesFilter([ type ])
 		if (typeFilter === null) {
 			return filter

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -640,6 +640,11 @@ COALESCE(${table}.version_patch, '0')::text
 				// processing
 				query.setAdditionalProperties(schema.additionalProperties)
 			}
+			if ('type' in schema) {
+				// We need to know the accepted types before processing to be
+				// able to apply some optimizations
+				query.setType(schema.type)
+			}
 			if ('required' in schema) {
 				// We need to know all required properties before processing
 				query.addRequired(schema.required)
@@ -723,6 +728,31 @@ COALESCE(${table}.version_patch, '0')::text
 		if (!('tableIsJson' in this.options)) {
 			this.options.tableIsJson = this.isProcessingJsonProperty
 		}
+
+		// Array of types this schema can be. Defaults to all accepted types
+		this.types = [
+			'array',
+			'boolean',
+			'integer',
+			'null',
+			'number',
+			'object',
+			'string'
+		]
+
+		if (this.isProcessingTable) {
+			this.types = [ 'object' ]
+		} else if (this.isProcessingColumn && !this.isProcessingJsonProperty) {
+			const columnType = _.get(CARD_FIELDS, [ this.getPathTip(), 'type' ])
+			if (columnType) {
+				this.types = [ columnType ]
+			}
+		} else if (this.isProcessingSubColumn) {
+			const itemsType = _.get(CARD_FIELDS, [ this.getPreviousPathTip(), 'items' ])
+			if (itemsType) {
+				this.types = [ itemsType ]
+			}
+		}
 	}
 
 	addRequired (required) {
@@ -766,6 +796,20 @@ COALESCE(${table}.version_patch, '0')::text
 		this.additionalProperties = schema
 	}
 
+	setType (value) {
+		assert.INTERNAL(null, _.isString(value) || Array.isArray(value), Error, () => {
+			return `value for '${this.formatJsonPath('type')}' must be a string or an array`
+		})
+
+		this.types = _.intersection(this.types, _.castArray(value))
+		const typeFilter = this.getIsTypesFilter(this.types)
+		if (typeFilter === false) {
+			this.filter.makeUnsatisfiable()
+		} else if (typeFilter !== null) {
+			this.filter.and(typeFilter)
+		}
+	}
+
 	visit (key, value) {
 		assert.INTERNAL(null, _.isString(key), Error, () => {
 			return `key for '${this.formatJsonPath(key)}' must be a string`
@@ -776,7 +820,8 @@ COALESCE(${table}.version_patch, '0')::text
 			'description',
 			'examples',
 			'required',
-			'title'
+			'title',
+			'type'
 		]
 		if (skippedKeywords.includes(key)) {
 			// Known keywords that we do not handle (at least here)
@@ -1148,19 +1193,6 @@ COALESCE(${table}.version_patch, '0')::text
 		this.filter.and(this.ifTypeThen('string', filter))
 	}
 
-	typeVisitor (value) {
-		assert.INTERNAL(null, _.isString(value) || Array.isArray(value), Error, () => {
-			return `value for '${this.formatJsonPath('type')}' must be a string or an array`
-		})
-
-		const typeFilter = this.getIsTypesFilter(_.castArray(value))
-		if (typeFilter === false) {
-			this.filter.makeUnsatisfiable()
-		} else if (typeFilter !== null) {
-			this.filter.and(typeFilter)
-		}
-	}
-
 	ifTypeThen (type, filter) {
 		const typeFilter = this.getIsTypesFilter([ type ])
 		if (typeFilter === null) {
@@ -1174,47 +1206,35 @@ COALESCE(${table}.version_patch, '0')::text
 
 	// Returns:
 	// - `null` if an explicit check isn't necessary
-	// - `false` if the types are incompatible with the `card` table
+	// - `false` if the types are incompatible with `this.types`
 	// - A filter testing for the type otherwise
-	// TODO: actually this needs some review/rethink
 	getIsTypesFilter (types) {
-		if (this.isProcessingTable) {
-			// The root type must always be 'object'
-			if (types.includes('object')) {
-				return null
-			}
+		const validTypes = _.intersection(types, this.types)
+		if (validTypes.length === 0) {
 			return false
-		} else if (this.isProcessingColumn) {
-			// Toplevel properties are also fixed, except for `data`'s contents
-			const column = this.getPathTip()
-			if (column === 'data') {
-				return SqlFilter.isOfJsonTypes(this, types)
-			}
+		}
 
-			const knownField = CARD_FIELDS[column]
-			if (!knownField || types.includes(knownField.type)) {
-				return null
-			}
-			return false
-		} else if (this.isProcessingSubColumn) {
-			// TODO
+		if (!this.isProcessingJsonProperty) {
+			// Only JSON properties require type checks
 			return null
-		} else if (types.includes('integer')) {
+		}
+
+		if (validTypes.includes('integer')) {
 			// JSON doesn't have the concept of integers, so this requires
 			// some extra checks
 			const filter = new SqlFilter(true)
 			filter.and(SqlFilter.isOfJsonTypes(this, [ 'number' ]))
 			filter.and(SqlFilter.isMultipleOf(this, 1))
 
-			const nonIntegerTypes = _.without(types, 'integer')
-			if (!_.isEmpty(nonIntegerTypes)) {
+			const nonIntegerTypes = _.without(validTypes, 'integer')
+			if (nonIntegerTypes.length > 0) {
 				filter.or(SqlFilter.isOfJsonTypes(this, nonIntegerTypes))
 			}
 
 			return filter
 		}
 
-		return SqlFilter.isOfJsonTypes(this, types)
+		return SqlFilter.isOfJsonTypes(this, validTypes)
 	}
 
 	updateisProcessingState () {
@@ -1223,16 +1243,7 @@ COALESCE(${table}.version_patch, '0')::text
 		this.isProcessingColumn = this.options.parentPath.length === 0 && this.path.length === 2
 
 		if (pathDepth === 3) {
-			let column = null
-			if (this.path.length === 3) {
-				column = this.path[this.path.length - 2]
-			} else if (this.path.length === 2) {
-				column = this.options.parentPath[this.options.parentPath.length - 1]
-			} else {
-				column = this.options.parentPath[this.options.parentPath.length - 2]
-			}
-
-			this.isProcessingSubColumn = column !== 'data'
+			this.isProcessingSubColumn = this.getPreviousPathTip() !== 'data'
 		} else {
 			this.isProcessingSubColumn = false
 		}
@@ -1251,6 +1262,19 @@ COALESCE(${table}.version_patch, '0')::text
 			return this.options.parentPath[this.options.parentPath.length - 1]
 		}
 		return this.path[this.path.length - 1]
+	}
+
+	getPreviousPathTip () {
+		if (this.path.length > 2) {
+			return this.path[this.path.length - 2]
+		} else if (this.path.length === 2) {
+			if (_.isEmpty(this.options.parentPath)) {
+				return this.path[this.path.length - 2]
+			}
+			return this.options.parentPath[this.options.parentPath.length - 1]
+		}
+
+		return this.options.parentPath[this.options.parentPath.length - 2]
 	}
 
 	pathToSqlField (options = {}) {


### PR DESCRIPTION
Many JSON schema keywords must be implemented with a material conditional at the SQL level, equivalent to:
    
```
typeof <field> === <type> ? <condition> : true
```
    
This is implemented as a boolean expression at the SQL level:
    
```
NOT <isType> OR <condition>
```
    
where `<isType>` is the equivalent SQL for the `typeof` check. Frequently the type is specified in the schema, leading to the following SQL expression:
    
```
<isType> AND (NOT <isType> OR <condition>)
```
    
which siplifies to just `<condition>`. PG does not recognize this optimization opportunity so this commit applies it at the compiler level.
    
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>