### PR TITLE
Correctly deal with arrays containing objects in the new compiler

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -581,7 +581,7 @@ class SqlFilter {
  * SqlQuery#toSqlSelect} to generate a text query for the parsed JSON schema.
  */
 class SqlQuery {
-	static toSqlField (path, rootIsJson = false, options = {}) {
+	static toSqlField (path, tableIsJson = false, options = {}) {
 		// TODO: in theory this fails to emit the computed field with the
 		// following valid even if unusual schema:
 		//
@@ -592,14 +592,17 @@ class SqlQuery {
 		//     }
 		//   }
 		// }
-		if (!rootIsJson && path.length === 2 && path[1] === 'version') {
+		if (!tableIsJson && path.length === 2 && path[1] === 'version') {
 			return SqlQuery.getVersionComputedField(path[0])
 		}
 
 		const field = [ path[0] ]
 		if (path.length > 1) {
-			const accessor = rootIsJson ? '->' : '.'
-			field.push(accessor, pgFormat.ident(path[1]))
+			if (tableIsJson) {
+				field.push('->', pgFormat.literal(path[1]))
+			} else {
+				field.push('.', pgFormat.ident(path[1]))
+			}
 		}
 		for (let selector of path.slice(2)) {
 			if (!_.isNumber(selector)) {
@@ -611,7 +614,7 @@ class SqlQuery {
 		if (options.asText) {
 			if (field.length > 2 && field[field.length - 2] === '->') {
 				field[field.length - 2] = '->>'
-			} else if (rootIsJson && field.length === 1) {
+			} else if (tableIsJson && field.length === 1) {
 				field.push('#>>\'{}\'')
 			}
 		}
@@ -666,6 +669,8 @@ COALESCE(${table}.version_patch, '0')::text
 	 *          is used when creating a child SqlQuery that refers to a
 	 *          different table. See {@link
 	 *          SqlQuery#buildQueryFromCorrelatedSchema}.
+	 *        - tableIsJson: whether the table for this SqlQuery is actually a
+	 *          JSON value
 	 */
 	constructor (tableOrParent, options = {}) {
 		// Set of properties that must exist
@@ -713,6 +718,11 @@ COALESCE(${table}.version_patch, '0')::text
 		this.isProcessingSubColumn = false
 		this.isProcessingJsonProperty = false
 		this.updateisProcessingState()
+
+		// See the constructor's docs
+		if (!('tableIsJson' in this.options)) {
+			this.options.tableIsJson = this.isProcessingJsonProperty
+		}
 	}
 
 	addRequired (required) {
@@ -1244,9 +1254,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	pathToSqlField (options = {}) {
-		const isRootJson = this.path.length === 1 && this.isProcessingJsonProperty
-
-		return SqlQuery.toSqlField(this.path, isRootJson, options)
+		return SqlQuery.toSqlField(this.path, this.options.tableIsJson, options)
 	}
 
 	formatJsonPath (suffix) {

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -1241,3 +1241,66 @@ avaTest('const matches against strings nested in contains should work against to
 	test.is(results.length, 1)
 	test.deepEqual(results[0].slug, elements[0].slug)
 })
+
+// TODO: enable this test when the new compiler becomes the default
+ava.skip('contains - items of type object should be handled correctly', async (test) => {
+	const table = 'contains_object'
+
+	const schema = {
+		type: 'object',
+		required: [ 'data' ],
+		properties: {
+			data: {
+				type: 'object',
+				required: [ 'array' ],
+				properties: {
+					array: {
+						type: 'array',
+						contains: {
+							type: 'object',
+							required: [ 'name' ],
+							properties: {
+								name: {
+									type: 'string',
+									pattern: 'abc'
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	const elements = [
+		{
+			slug: 'test-1',
+			type: 'card',
+			data: {
+				array: [ {
+					name: 'abc'
+				} ]
+			}
+		},
+		{
+			slug: 'test-2',
+			type: 'card',
+			data: {
+				array: [ {
+					name: 'cba'
+				} ]
+			}
+		}
+	]
+
+	const results = await runner({
+		connection: test.context.connection,
+		database: test.context.database,
+		table,
+		elements,
+		schema
+	})
+
+	test.is(results.length, 1)
+	test.deepEqual(results[0].slug, elements[0].slug)
+})


### PR DESCRIPTION
The `contains` and `items` keywords are implemented as subqueries in the general case. The `SqlQuery` instance handling this subquery has to know whether it is checking the contents of a PG array, or a JSON array so it can generate the correct field access. Handling of this flag was faulty and an incorrect field access was being generated.

This commit also includes a test case that is skipped by default and should be enabled when the new compiler becomes the default.

Chage-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>