### PR TITLE
server: Return 400 on /api/v2/whoami if the session is invalid

### DIFF
--- a/apps/server/http/facades/auth.js
+++ b/apps/server/http/facades/auth.js
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+const assert = require('../../../../lib/assert')
 const QueryFacade = require('./query')
 
 module.exports = class AuthFacade extends QueryFacade {
@@ -12,10 +13,8 @@ module.exports = class AuthFacade extends QueryFacade {
 		// might not have enough access to read its entire session card.
 		const result = await this.jellyfish.getCardById(
 			context, this.jellyfish.sessions.admin, sessionToken)
-
-		if (!result) {
-			throw new Error('Could not retrieve session data')
-		}
+		assert.USER(context, result,
+			this.jellyfish.errors.JellyfishInvalidSession, 'Session does not exist')
 
 		const schema = {
 			type: 'object',

--- a/test/e2e/server/security/index.spec.js
+++ b/test/e2e/server/security/index.spec.js
@@ -23,6 +23,22 @@ const createUserDetails = () => {
 	}
 }
 
+ava.serial('querying whoami with an invalid session should fail', async (test) => {
+	const result = await test.context.http('GET', '/api/v2/whoami', null, {
+		Authorization: `Bearer ${uuid()}`
+	})
+
+	test.is(result.code, 400)
+	test.deepEqual(result.response, {
+		error: true,
+		data: {
+			context: result.response.data.context,
+			name: 'JellyfishInvalidSession',
+			message: 'Session does not exist'
+		}
+	})
+})
+
 ava.serial('creating a user with the guest user session should fail', async (test) => {
 	const userDetails = createUserDetails()
 	const username = `user-${userDetails.username.toLowerCase()}`


### PR DESCRIPTION
This would clearly be a user error. We can throw a meaningful error such
as `JellyfishInvalidSession` and don't report it to Sentry.

Change-type: patch
Fixes: https://sentry.io/share/issue/1982e52d855e402da2d0435110d8ad0a/


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!