### PR TITLE
ui: Make links step optional in support thread teardown flow

### DIFF
--- a/apps/ui/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
+++ b/apps/ui/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react'
 import Bluebird from 'bluebird'
-import _ from 'lodash'
 import {
 	stepStatus
 } from '../flow-utils'
@@ -80,8 +79,7 @@ export default function TeardownFlowPanel ({
 
 	const {
 		problem,
-		solution,
-		links
+		solution
 	} = flowState
 
 	const cardTypeName = helpers.getType(card.type, types).name
@@ -89,7 +87,7 @@ export default function TeardownFlowPanel ({
 	const completed = {
 		problem: Boolean(problem),
 		solution: Boolean(solution),
-		persist: _.some(links, (link) => { return link.results && link.results.length })
+		persist: true
 	}
 
 	return (


### PR DESCRIPTION
Mark step 3 as complete by default - meaning it can be skipped if the user doesn't want to create any links.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This change is in response to support agents complaining that they can't close a support thread without linking to a GitHub issue, Support issue or Product improvement. This step is now hard-coded as 'complete'. It is still shown to the user and they can still add links etc but they can also click 'Next' or click on the 'Finish!' step label without adding any links. 

See [Flowdock thread](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/cmJSrYoYqS8kkttQRswUa0Ssr6X)
