### PR TITLE
backend: Add stream metrics

### DIFF
--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -11,6 +11,7 @@ const PGLiveSelect = require('./pg-live-select')
 const logger = require('../../../logger').getLogger(__filename)
 const uuid = require('../../../uuid')
 const utils = require('./utils')
+const metrics = require('../../../metrics')
 
 const filter = (schema, element) => {
 	if (schema.required && schema.required.length > 0) {
@@ -81,6 +82,7 @@ exports.teardown = async (context, connection, instance) => {
 	if (instance && instance.openStreams) {
 		for (const [ id, stream ] of Object.entries(instance.openStreams)) {
 			logger.info(context, 'Disconnecting stream', id)
+			metrics.markStreamClosed(context, instance.table)
 			await stream.close()
 			Reflect.deleteProperty(instance.openStreams, id)
 		}
@@ -99,7 +101,7 @@ exports.teardown = async (context, connection, instance) => {
 exports.attach = async (context, instance, schema, options) => {
 	/*
 	 * Create a new emitter instance and register it in the
-	 * list of opens stream the instance keeps track of.
+	 * list of open streams the instance keeps track of.
 	 */
 	const emitter = new EventEmitter()
 	emitter.id = await uuid.random()
@@ -109,6 +111,8 @@ exports.attach = async (context, instance, schema, options) => {
 		table: instance.table,
 		openStreams: Object.values(instance.openStreams).length
 	})
+
+	metrics.markStreamOpened(context, instance.table)
 
 	const changeHandler = async (change) => {
 		const {
@@ -142,7 +146,7 @@ exports.attach = async (context, instance, schema, options) => {
 
 		// Resolve any links queries
 		// TODO: Refactor links in streams. This is tricky as the SQL stream
-		// implmentation can't resolve links for us, so we're forced to fetch links
+		// implementation can't resolve links for us, so we're forced to fetch links
 		// "after the fact", this means that the link data attached to "oldMatch"
 		// might not be accurate.
 		// In addition to this, the async retrieval of links here means that events
@@ -150,6 +154,8 @@ exports.attach = async (context, instance, schema, options) => {
 		// issue.
 		if (schema.$$links && (newMatch || oldMatch)) {
 			const id = afterId || beforeId
+
+			metrics.markStreamLinkQuery(context, instance.table, change)
 
 			const [ result ] = await options.query({
 				$$links: schema.$$links,
@@ -190,6 +196,7 @@ exports.attach = async (context, instance, schema, options) => {
 	}
 
 	const errorHandler = (error) => {
+		metrics.markStreamError(context, instance.table)
 		emitter.emit('error', error)
 	}
 
@@ -205,6 +212,7 @@ exports.attach = async (context, instance, schema, options) => {
 			table: instance.table,
 			openStreams: Object.values(instance.openStreams).length
 		})
+		metrics.markStreamClosed(context, instance.table)
 
 		/*
 		 * Remove all the listeners we added.

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -48,7 +48,11 @@ const metricNames = {
 
 	SQL_GEN_DURATION: 'jf_sql_gen_ms',
 	QUERY_DURATION: 'jf_query_ms',
-	COMPILER_MISMATCH_TOTAL: 'jf_compiler_mismatch_total'
+	COMPILER_MISMATCH_TOTAL: 'jf_compiler_mismatch_total',
+
+	STREAMS_SATURATION: 'jf_streams_saturation',
+	STREAMS_LINK_QUERY_TOTAL: 'jf_streams_link_query_total',
+	STREAMS_ERROR_TOTAL: 'jf_streams_error_total'
 }
 
 const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 29).map(Math.round)
@@ -104,12 +108,28 @@ const isCard = (card) => {
 }
 
 /**
+ * @summary Extract actor name from context ID
+ * @function
+ *
+ * @param {Object} context - caller context
+ * @returns {String} actor name
+ *
+ * @example
+ * const actorName = actorFromContext(context)
+ */
+const actorFromContext = (context) => {
+	if (_.has(context, [ 'id' ]) && _.isString(context.id)) {
+		return _.dropRight(context.id.split('-'), 6).join('-').toLowerCase()
+	}
+	return 'unknown'
+}
+
+/**
  * @summary Create express app using metrics and expose data on /metrics
  * @function
  *
  * @param {Object} context - execution context
  * @returns {Object} express app
- *
  * @example
  * const application = metrics.initExpress(context)
  */
@@ -365,4 +385,75 @@ exports.markQueryTime = (ms, isNew) => {
 
 exports.markCompilerMismatch = () => {
 	metrics.inc(metricNames.COMPILER_MISMATCH_TOTAL, 1)
+}
+
+/**
+ * @summary Mark that a new stream was opened
+ * @function
+ *
+ * @param {Object} context - caller context
+ * @param {String} table - table name
+ *
+ * @example
+ * metrics.markStreamOpened(context, 'cards')
+ */
+exports.markStreamOpened = (context, table) => {
+	metrics.inc(metricNames.STREAMS_SATURATION, 1, {
+		actor: actorFromContext(context),
+		table
+	})
+}
+
+/**
+ * @summary Mark that a stream was closed
+ * @function
+ *
+ * @param {Object} context - caller context
+ * @param {String} table - table name
+ *
+ * @example
+ * metrics.markStreamClosed(context, 'cards')
+ */
+exports.markStreamClosed = (context, table) => {
+	metrics.dec(metricNames.STREAMS_SATURATION, 1, {
+		actor: actorFromContext(context),
+		table
+	})
+}
+
+/**
+ * @summary Mark that a stream is querying links
+ * @function
+ *
+ * @param {Object} context - caller context
+ * @param {String} table - table name
+ * @param {Object} change - change event object
+ *
+ * @example
+ * metrics.markStreamLinkQuery(context, change)
+ */
+exports.markStreamLinkQuery = (context, table, change) => {
+	metrics.inc(metricNames.STREAMS_LINK_QUERY_TOTAL, 1, {
+		table,
+		actor: actorFromContext(context),
+		type: (_.has(change, [ 'type' ]) && _.isString(change.type)) ? change.type.toLowerCase() : 'unknown',
+		card: (_.has(change, [ 'after', 'type' ]) && _.isString(change.after.type)) ? change.after.type.split('@')[0] : 'unknown'
+	})
+}
+
+/**
+ * @summary Mark that a stream error has occurred
+ * @function
+ *
+ * @param {Object} context - caller context
+ * @param {String} table - table name
+ *
+ * @example
+ * metrics.markStreamError()
+ */
+exports.markStreamError = (context, table) => {
+	metrics.inc(metricNames.STREAMS_ERROR_TOTAL, 1, {
+		actor: actorFromContext(context),
+		table
+	})
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add metrics to our streams library to help track down excess CPU usage.
Flowdock conversation: [Link](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/HLd-X7_ztCp2bq1fhaPTy8FtmYS)

This adds:
- Postgres stream saturation by:
  - `actor`: `worker`, `request`, `socket`, etc.
  - `table`: `cards`, etc. (?)
- Postgres stream link query count by:
  - `actor`: `worker`, `request`, `socket`, etc.
  - `table`: `cards`, etc. (?)
  - `type`: `update`, `insert`, etc.
  - `card`: `support-thread`, etc.
- Postgres stream error total
  - `actor`: `worker`, `request`, `socket`, etc.
  - `table`: `cards`, etc. (?)

Grafana graphs are currently located under `volatile/Jellyfish Streams` [here](https://monitor.balena-cloud.com/d/izZ7pKgGz/jellyfish-streams?orgId=1). If these metrics and graphs end up being useful and satisfactory, they will need to be merged into [balena-io/balena-monitor](https://github.com/balena-io/balena-monitor) as well as into our local dev Grafana configs.

![image](https://user-images.githubusercontent.com/45343541/81907536-e12ac900-9602-11ea-9b0d-9b56ebc5d369.png)