### PR TITLE
ui-components: Use text representation of inline images in chat summary

### DIFF
--- a/lib/ui-components/CardChatSummary/tests/fixtures/msg-inline-image.json
+++ b/lib/ui-components/CardChatSummary/tests/fixtures/msg-inline-image.json
@@ -1,0 +1,28 @@
+{
+  "id": "25a28dc8-2cb2-4dc4-94b1-13cdcd08e083",
+  "data": {
+    "actor": "4972802e-ae01-4939-8375-c25e231d4d10",
+    "target": "e6633dd1-b729-4a6a-9db9-e682baefafa8",
+    "payload": {
+      "message": "[<img src=\"https://via.placeholder.com/150\" alt=\"some-image.png\">](https://via.placeholder.com/150 \"image-title.png\")",
+      "alertsUser": [],
+      "mentionsUser": []
+    },
+    "timestamp": "2020-05-14T06:50:39.989Z"
+  },
+  "name": null,
+  "slug": "msg-inline-img-4",
+  "tags": [],
+  "type": "message@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "requires": [],
+  "linked_at": {
+    "is attached to": "2020-05-14T06:50:40.308Z"
+  },
+  "created_at": "2020-05-14T06:50:40.054Z",
+  "updated_at": null,
+  "capabilities": [],
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Also transform links so that they actually work!

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3043 

This PR fixes two related issues:
1. Inline images are stripped out of the 'last message summary' in the `CardChatSummary` component and replaced with a text representation, for example `[some-image.png]`.
1. Links (`<a>`) are given an extra `onclick` handler that calls `event.stopPropagation()`. This ensures that clicking on the link actually takes you to the link rather than opening the thread channel. 

See gifs below for a demo of the old and new behaviour:

Before:
![Inline Image summary - before](https://user-images.githubusercontent.com/2925657/81907589-33afb980-95f2-11ea-8504-7fc0b019e981.gif)

After:
![Inline Image summary - after](https://user-images.githubusercontent.com/2925657/81907606-3a3e3100-95f2-11ea-9524-40b2d7e3d2b4.gif)


