### PR TITLE
server: Add new web-push-subscription type card

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -80,6 +80,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/view-all-pipelines.json'),
 		await loadCard('contrib/whisper.json'),
 		await loadCard('contrib/workflow.json'),
+		await loadCard('contrib/web-push-subscription.json'),
 
 		// Triggered actions
 		await loadCard('contrib/triggered-action-github-issue-link.json'),

--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -77,7 +77,7 @@
         },
         {
           "type": "object",
-          "description": "User can view their own execute, session and view cards",
+          "description": "User can view their own execute, session, web-push-subscription and view cards",
           "additionalProperties": true,
           "required": [ "data", "type" ],
           "properties": {
@@ -86,6 +86,7 @@
               "enum": [
                 "view@1.0.0",
                 "session@1.0.0",
+                "web-push-subscription@1.0.0",
                 "execute@1.0.0"
               ]
             },

--- a/apps/server/default-cards/contrib/web-push-subscription.json
+++ b/apps/server/default-cards/contrib/web-push-subscription.json
@@ -1,0 +1,39 @@
+{
+  "slug": "web-push-subscription",
+  "type": "type@1.0.0",
+  "version": "1.0.0",
+  "name": "Web Push subscription",
+  "markers": [],
+  "requires": [],
+  "capabilities": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "schema": {
+      "type": "object",
+      "required": [ "data" ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "endpoint",
+            "token",
+            "auth"
+          ],
+          "properties": {
+            "endpoint": {
+              "type": "string"
+            },
+            "token": {
+              "type": "string"
+            },
+            "auth": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Users with the user-community role can view their own web-push-subscription cards.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #3651 

Pre-requisite for implementing Service Worker Push Notifications.

**TBD**: Are we ok to store the `auth` value 'as-is' or do we need to encrypt it in some way that only the server can decrypt?
