### PR TITLE
test: Run all UI e2e tests serially

### DIFF
--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -151,7 +151,7 @@ ava.serial('Messages typed but not sent should be preserved when navigating away
 	test.pass()
 })
 
-ava('Messages that ping a user should appear in their inbox', async (test) => {
+ava.serial('Messages that ping a user should appear in their inbox', async (test) => {
 	const {
 		user2,
 		page,
@@ -186,7 +186,7 @@ ava('Messages that ping a user should appear in their inbox', async (test) => {
 	test.pass()
 })
 
-ava('Only messages that ping a user should appear in their inbox', async (test) => {
+ava.serial('Only messages that ping a user should appear in their inbox', async (test) => {
 	const {
 		user2,
 		page,
@@ -298,7 +298,7 @@ ava.serial.skip('When having two chats side-by-side both should update with new 
 	test.pass()
 })
 
-ava('Username pings should be case insensitive', async (test) => {
+ava.serial('Username pings should be case insensitive', async (test) => {
 	const {
 		user2,
 		page,
@@ -333,7 +333,7 @@ ava('Username pings should be case insensitive', async (test) => {
 	test.pass()
 })
 
-ava('Users should be able to mark all messages as read from their inbox', async (test) => {
+ava.serial('Users should be able to mark all messages as read from their inbox', async (test) => {
 	const {
 		user2,
 		page,

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -99,7 +99,7 @@ ava.serial.after(async () => {
 	})
 })
 
-ava('You can assign an unassigned thread to yourself', async (test) => {
+ava.serial('You can assign an unassigned thread to yourself', async (test) => {
 	const {
 		page,
 		currentUserSlug
@@ -126,7 +126,7 @@ ava('You can assign an unassigned thread to yourself', async (test) => {
 	test.is(whisperText, `Assigned to @${currentUserSlug}`)
 })
 
-ava('You can assign an unassigned thread to another user', async (test) => {
+ava.serial('You can assign an unassigned thread to another user', async (test) => {
 	const {
 		page,
 		otherCommunityUser,
@@ -173,7 +173,7 @@ ava('You can assign an unassigned thread to another user', async (test) => {
 	await verifyThreadStatus(test, page, context.context.statusDescription)
 })
 
-ava('You can unassign a thread that was assigned to you', async (test) => {
+ava.serial('You can unassign a thread that was assigned to you', async (test) => {
 	const {
 		page,
 		currentUser,
@@ -217,7 +217,7 @@ ava('You can unassign a thread that was assigned to you', async (test) => {
 	await verifyThreadStatus(test, page, context.context.statusDescription)
 })
 
-ava('You can unassign a thread that was assigned to another user', async (test) => {
+ava.serial('You can unassign a thread that was assigned to another user', async (test) => {
 	const {
 		page,
 		otherCommunityUser,
@@ -260,7 +260,7 @@ ava('You can unassign a thread that was assigned to another user', async (test) 
 	await verifyThreadStatus(test, page, context.context.statusDescription)
 })
 
-ava('You can reassign a thread from yourself to another user', async (test) => {
+ava.serial('You can reassign a thread from yourself to another user', async (test) => {
 	const {
 		page,
 		currentUser,
@@ -310,7 +310,7 @@ ava('You can reassign a thread from yourself to another user', async (test) => {
 	await verifyThreadStatus(test, page, context.context.statusDescription)
 })
 
-ava('You can reassign a thread from another user to yourself', async (test) => {
+ava.serial('You can reassign a thread from another user to yourself', async (test) => {
 	const {
 		page,
 		currentUserSlug,
@@ -336,7 +336,7 @@ ava('You can reassign a thread from another user to yourself', async (test) => {
 	test.is(whisperText, `Reassigned from @${otherCommunityUserSlug} to @${currentUserSlug}`)
 })
 
-ava('TEMP You cannot assign a thread to its existing owner', async (test) => {
+ava.serial('TEMP You cannot assign a thread to its existing owner', async (test) => {
 	const {
 		page,
 		otherCommunityUser,

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -55,7 +55,7 @@ ava.serial.after(async () => {
 	})
 })
 
-ava('You can teardown a support thread following a specific flow', async (test) => {
+ava.serial('You can teardown a support thread following a specific flow', async (test) => {
 	const {
 		page,
 		context: {


### PR DESCRIPTION
Ensure tests don't conflict with each other.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Small fix to ensure all tests in `test/e2e/ui` run serially (i.e. with `ava.serial` rather than just `ava`)
