### PR TITLE
Refactor link traversal to use main table

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -125,6 +125,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 
 	const queryGenStart = performance.now()
 	const query = jsonschema2sql(table, schema, config)
+
 	const queryGenEnd = performance.now()
 
 	const testNewCompiler = Math.random() < environment.experimental.newCompilerTestChance
@@ -278,8 +279,6 @@ const upsertObject = async (context, backend, object, options) => {
 	const baseType = insertedObject.type.split('@')[0]
 
 	if (baseType === 'link') {
-		await links.upsert(context, backend.connection, insertedObject)
-
 		// TODO: We only "materialize" links in this way because we haven't
 		// come up with a better way to traverse links while streaming.
 		// Ideally we should leverage the database, using joins, rather
@@ -505,13 +504,8 @@ module.exports = class PostgresBackend {
 
 		await cards.setup(context, this.connection, this.database)
 
-		await links.setup(context, this.connection, this.database, {
-			cards: cards.TABLE
-		})
-
 		await markers.setup(context, this.connection, {
-			source: cards.TABLE,
-			links: links.TABLE
+			source: cards.TABLE
 		})
 
 		this.streamClient = await streams.setup(
@@ -554,7 +548,7 @@ module.exports = class PostgresBackend {
 			database: this.database
 		})
 
-		await this.connection.any(`DROP TABLE ${cards.TABLE}, ${links.TABLE} CASCADE`)
+		await this.connection.any(`DROP TABLE ${cards.TABLE} CASCADE`)
 	}
 
 	/*
@@ -566,7 +560,6 @@ module.exports = class PostgresBackend {
 		})
 
 		await this.connection.any(`
-			DELETE FROM ${links.TABLE};
 			DELETE FROM ${cards.TABLE};
 		`)
 	}

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -81,11 +81,13 @@ const getLinks = (schema) => {
 
 const generateLinkSubquery = (linkType, fromColumn, toColumn) => {
 	return [
-		`SELECT ${toColumn} FROM links`,
-		`WHERE links.name = ${builder.valueToPostgres(linkType)} AND fromId = cards.id`,
+		`SELECT ${toColumn} FROM cards c1`,
+		`WHERE c1.type = 'link@1.0.0' AND c1.name = ${builder.valueToPostgres(linkType)} AND`,
+		'c1.data->\'from\'->>\'id\' = cards.id::text',
 		'UNION',
-		`SELECT ${fromColumn} FROM links`,
-		`WHERE links.inversename = ${builder.valueToPostgres(linkType)} AND toId = cards.id`
+		`SELECT ${fromColumn} FROM cards c1`,
+		`WHERE c1.type = 'link@1.0.0' AND c1.data->>'inverseName' = ${builder.valueToPostgres(linkType)} AND`,
+		'c1.data->\'to\'->>\'id\' = cards.id::text'
 	]
 }
 
@@ -99,8 +101,8 @@ const generateQuery = (table, schema, options) => {
 			'SELECT to_jsonb(linked)',
 			`FROM ${table} linked`,
 			'WHERE (',
-			'    linked.id IN (',
-			...generateLinkSubquery(link.type, 'fromId', 'toId'),
+			'    linked.id::text IN (',
+			...generateLinkSubquery(link.type, 'data->\'from\'->>\'id\'', 'data->\'to\'->>\'id\''),
 			'    )'
 		])
 		if (link.schema) {
@@ -803,7 +805,7 @@ COALESCE(${table}.version_patch, '0')::text
 				return `key for '${this.formatJsonPath([ '$$links', linkType ])}' must be a string`
 			})
 
-			this.links[linkType] = this.buildQueryFromUncorrelatedSchema(
+			this.links[linkType] = this.buildQueryFromCorrelatedSchema(
 				pgFormat.ident(linkType), linkSchema, [ '$$links', linkType ])
 
 			assert.INTERNAL(null, _.isEmpty(this.links[linkType].links), Error,
@@ -1298,22 +1300,6 @@ COALESCE(${table}.version_patch, '0')::text
 		return query
 	}
 
-	// Uncorrelated schemas are completely independent schemas. Their only link
-	// with `this` is the current JSON path so that it can emit sane error
-	// messages, but nothing else
-	buildQueryFromUncorrelatedSchema (table, schema, suffix) {
-		this.options.parentJsonPath.push(...suffix)
-		const query = SqlQuery.fromSchema(table, schema, {
-			errors: this.options.errors,
-			parentJsonPath: _.concat(this.options.parentJsonPath, _.castArray(suffix))
-		})
-		for (let idx = 0; idx < suffix.length; ++idx) {
-			this.options.parentJsonPath.pop()
-		}
-
-		return query
-	}
-
 	toSqlSelect () {
 		let columns = null
 		if (this.additionalProperties) {
@@ -1415,17 +1401,20 @@ WHERE ${filter}${orderBy}${skip}${limit}`
 			// Assume all linked cards come from the same table as this query
 			const linkName = pgFormat.literal(linkType)
 			const linksAlias = pgFormat.ident(`linksJoin.${linkType}`)
-			joins.push(`JOIN links AS ${linksAlias}
+			joins.push(`JOIN cards AS ${linksAlias}
 ON
-\t(${linksAlias}.name = ${linkName} AND ${linksAlias}.fromId = ${this.table}.id) OR
-\t(${linksAlias}.inversename = ${linkName} AND ${linksAlias}.toId = ${this.table}.id)
+\t${linksAlias}.type = 'link@1.0.0' AND
+\t(
+\t\t(${linksAlias}.name = ${linkName} AND ${linksAlias}.data->'from'->>'id' = ${this.table}.id::text) OR
+\t\t(${linksAlias}.data->>'inverseName' = ${linkName} AND ${linksAlias}.data->'to'->>'id' = ${this.table}.id::text)
+\t)
 JOIN ${this.table} AS ${linkQuery.table}
 ON
+\t${linksAlias}.type = 'link@1.0.0' AND
 \t(
-\t\t(${linksAlias}.name = ${linkName} AND ${linksAlias}.toId = ${linkQuery.table}.id) OR
-\t\t(${linksAlias}.inversename = ${linkName} AND ${linksAlias}.fromId = ${linkQuery.table}.id)
-\t) AND
-\t(${linkQuery.filter.toSql()})`)
+\t\t(${linksAlias}.name = ${linkName} AND ${linksAlias}.data->'to'->>'id' = ${linkQuery.table}.id::text) OR
+\t\t(${linksAlias}.data->>'inverseName' = ${linkName} AND ${linksAlias}.data->'from'->>'id' = ${linkQuery.table}.id::text)
+\t)`)
 		}
 
 		// We can't use `OFFSET` in the innermost query, so limit to the least

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -5,140 +5,10 @@
  */
 
 const _ = require('lodash')
-const logger = require('../../../logger').getLogger(__filename)
 
-const LINK_ORIGIN_PROPERTY = '$link'
 const LINK_TABLE = 'links'
 
 exports.TABLE = LINK_TABLE
-
-exports.setup = async (context, connection, database, options) => {
-	logger.debug(context, 'Creating links table', {
-		table: LINK_TABLE,
-		database
-	})
-
-	await connection.any(`
-		DO $$
-		BEGIN
-			IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'linkref') THEN
-				CREATE TYPE linkRef AS (idx INT, id UUID);
-				CREATE TYPE cardAndLinkIds AS (cardId UUID, linkIds linkRef[]);
-			END IF;
-		END$$`)
-
-	await connection.any(`
-		CREATE TABLE IF NOT EXISTS ${LINK_TABLE} (
-			id UUID PRIMARY KEY NOT NULL,
-			slug VARCHAR (255) NOT NULL,
-			version_major INTEGER,
- 			version_minor INTEGER,
- 			version_patch INTEGER,
-			name TEXT NOT NULL,
-			inverseName TEXT NOT NULL,
-			fromId UUID REFERENCES ${options.cards} (id) NOT NULL,
-			toId UUID REFERENCES ${options.cards} (id) NOT NULL,
-			UNIQUE (slug, version_major, version_minor, version_patch))`)
-
-	await connection.any(`
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_major INTEGER;
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_minor INTEGER;
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_patch INTEGER;`)
-
-	const indexes = _.map(await connection.any(`
-		SELECT * FROM pg_indexes WHERE tablename = '${LINK_TABLE}'`),
-	'indexname')
-
-	const slugVersionIndex =
-		`${LINK_TABLE}_slug_version_major_version_minor_version_patch_key`
-	if (!indexes.includes(slugVersionIndex)) {
-		await connection.task(async (task) => {
-			await task.any('SET statement_timeout = 0')
-			await task.any(`CREATE UNIQUE INDEX CONCURRENTLY ${slugVersionIndex}
-				ON ${LINK_TABLE} USING btree (slug, version_major, version_minor, version_patch)`)
-		})
-	}
-
-	await connection.any(`
-		SET statement_timeout = 0;
-		ALTER TABLE ${LINK_TABLE}
-		DROP CONSTRAINT IF EXISTS ${LINK_TABLE}_slug_key;`)
-
-	for (const [ name, column ] of [
-		[ 'idx_link_from', 'fromId' ],
-		[ 'idx_link_to', 'toId' ],
-		[ 'idx_links_fromid_name', 'fromid, name' ],
-		[ 'idx_links_toid_inversename', 'toid, inversename' ]
-	]) {
-		if (indexes.includes(name)) {
-			return
-		}
-
-		logger.debug(context, 'Attempting to create table index', {
-			table: LINK_TABLE,
-			database,
-			index: name
-		})
-
-		await connection.any(`
-			CREATE INDEX IF NOT EXISTS ${name} ON ${LINK_TABLE}
-			USING BTREE (${column})`)
-	}
-}
-
-exports.upsert = async (context, connection, link) => {
-	if (link.active) {
-		const sql = `
-			INSERT INTO ${LINK_TABLE} (
-				id,
-				slug,
-				version_major,
-				version_minor,
-				version_patch,
-				name,
-				inverseName,
-				fromId,
-				toId
-			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-			ON CONFLICT (id) DO UPDATE SET
-				slug = $2,
-				version_major = $3,
-				version_minor = $4,
-				version_patch = $5,
-				name = $6,
-				inverseName = $7,
-				fromId = $8,
-				toId = $9
-		`
-
-		const [ major, minor, patch ] = link.version.split('.')
-
-		await connection.any({
-			name: `links-upsert-insert-${LINK_TABLE}`,
-			text: sql,
-			values: [
-				link.id,
-				link.slug,
-				major,
-				minor,
-				patch,
-				link.name,
-				link.data.inverseName,
-				link.data.from.id,
-				link.data.to.id
-			]
-		})
-	} else {
-		const sql = `
-			DELETE FROM ${LINK_TABLE} WHERE id = $1`
-		await connection.any({
-			name: `links-upsert-delete-${LINK_TABLE}`,
-			text: sql,
-			values: [ link.id ]
-		})
-	}
-}
 
 /**
  * @summary Parse a card link given a link card
@@ -261,7 +131,6 @@ exports.removeLink = (linkCard, card) => {
 	}
 
 	card.links[result.name] = _.reject(card.links[result.name], [
-		LINK_ORIGIN_PROPERTY,
 		linkCard.id
 	])
 

--- a/lib/core/cards/link.js
+++ b/lib/core/cards/link.js
@@ -82,7 +82,8 @@ module.exports = {
 			]
 		},
 		indexed_fields: [
-			[ 'data.from.id', 'name', 'data.to.id' ]
+			[ 'data.from.id', 'name', 'data.to.id' ],
+			[ 'data.inverseName', 'data.to.id' ]
 		]
 	},
 	requires: [],


### PR DESCRIPTION
This change refactors link traversal to use the main table, taking advantage of partial indexes that have been created. Previously whenever a link was created, modified or deleted, a row on the `links` table was updated. The `links` table was then used to traverse relationships when querying with `$$links`. This was a performance optimization that I don't think is needed now that we have partial indexes on the main table.
This PR needs to be tested in our staging system to make sure we don't have huge performance regressions! 