### PR TITLE
dev/ci: Disable Redis save to disk for compose

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -107,6 +107,7 @@ services:
       - internal
   redis:
     image: balena/balena-redis:0.0.3
+    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
     restart: always
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - internal
   redis:
     image: balena/balena-redis:0.0.3
+    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
     restart: always
     networks:
       - internal


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Issue: https://github.com/product-os/jellyfish/issues/3740

This change disables Redis' default save to disk behavior when running in Docker Compose by overriding the following default `save` directive found in `/usr/local/etc/redis/redis.conf` by passing `--save ''` as a command option. (The Redis config path is also being passed as an argument because that is what is being done in the `balena-io/balena-redis` image start script [here](https://github.com/balena-io/balena-redis/blob/master/start.sh).)

```
################################ SNAPSHOTTING  ################################
#                                                                   
# Save the DB on disk:                                                
#
#   save <seconds> <changes>      
#                                    
#   Will save the DB if both the given number of seconds and the given
#   number of write operations against the DB occurred.                         
#
#   In the example below the behaviour will be to save:                       
#   after 900 sec (15 min) if at least 1 key changed                      
#   after 300 sec (5 min) if at least 10 keys changed                       
#   after 60 sec if at least 10000 keys changed                            
#
#   Note: you can disable saving completely by commenting out all "save" lines.
#
#   It is also possible to remove all the previously configured save
#   points by adding a save directive with a single empty string argument
#   like in the following example:
#                                                                         
#   save ""                                                               
                                                                       
save 900 1                                                           
save 300 10                                                            
save 60 10000
```

The following output can be found several times when running Docker Compose tests. There is no reason for Redis to save to disk during these tests and doing so is causing unnecessary log output and disk I/O.
```
redis_1                  | 7:M 15 May 2020 19:57:42.562 * DB saved on disk
```

Ran the Compose tests locally with and without this change and didn't notice any speed gain. This change will at least make test output less noisy.