### PR TITLE
ui: Use location rather than channels to drive default view redirect

### DIFF
--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -382,11 +382,11 @@ export default class HomeChannel extends React.Component {
 	componentDidMount () {
 		const {
 			actions,
-			channels,
+			location,
 			history,
 			homeView
 		} = this.props
-		if (channels.length === 1) {
+		if (location.pathname === '/') {
 			if (homeView) {
 				history.push(homeView)
 			}

--- a/apps/ui/components/HomeChannel/tests/HomeChannel.spec.jsx
+++ b/apps/ui/components/HomeChannel/tests/HomeChannel.spec.jsx
@@ -63,6 +63,9 @@ ava('Starred views appear in their own menu section', async (test) => {
 			subscriptions={{}}
 			orgs={[]}
 			history={context.history}
+			location={{
+				pathname: '/some-view'
+			}}
 		/>
 	), {
 		wrappingComponent: wrapper
@@ -92,6 +95,9 @@ ava('The home view is loaded on mount if set', async (test) => {
 			orgs={[]}
 			homeView={homeView}
 			history={context.history}
+			location={{
+				pathname: '/'
+			}}
 		/>
 	), {
 		wrappingComponent: wrapper


### PR DESCRIPTION
Due to a race condition, the number of channels can still be 1 at the point when HomeChannel is mounted even when other channels are being loaded. Therefore we need to rely on the location instead (which is simpler and should have been used in the first place!).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3788

You are now not incorrectly redirected to your default/home view when loading an absolute Jellyfish link or refreshing the page. 

![huge-tiny-](https://user-images.githubusercontent.com/2925657/82165940-268c1680-98e1-11ea-8b9f-5af4f480c72f.gif)
