### PR TITLE
Use speech-bubble icon for the first thread message in the repo channel

### DIFF
--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -50,6 +50,17 @@ const isHiddenEventType = (type) => {
 	return _.includes(NONE_MESSAGE_TIMELINE_TYPES, type)
 }
 
+// TODO: remove once we can retrieve this data during query
+const isFirstInThread = (card, firstMessagesByThreads) => {
+	const target = _.get(card, [ 'data', 'target' ])
+	const firstInThread = firstMessagesByThreads[target]
+	if (!firstInThread) {
+		firstMessagesByThreads[target] = card
+		return true
+	}
+	return false
+}
+
 export class Interleaved extends BaseLens {
 	constructor (props) {
 		super(props)
@@ -158,6 +169,7 @@ export class Interleaved extends BaseLens {
 		this.handleCardVisible = this.handleCardVisible.bind(this)
 		this.bindScrollArea = this.bindScrollArea.bind(this)
 	}
+
 	componentWillUpdate () {
 		if (!this.scrollArea) {
 			return
@@ -166,6 +178,7 @@ export class Interleaved extends BaseLens {
 		// Only set the scroll flag if the scroll area is already at the bottom
 		this.shouldScroll = this.scrollArea.scrollTop >= this.scrollArea.scrollHeight - this.scrollArea.offsetHeight
 	}
+
 	componentDidUpdate (nextProps) {
 		// Scroll to bottom if the component has been updated with new items
 		this.scrollToBottom()
@@ -203,6 +216,7 @@ export class Interleaved extends BaseLens {
 		} = this.state
 
 		let tail = this.props.tail ? this.props.tail.slice() : null
+		const firstMessagesByThreads = {}
 
 		// If tail has expanded links, interleave them in with the head cards
 		_.forEach(tail, (card) => {
@@ -263,6 +277,7 @@ export class Interleaved extends BaseLens {
 									openChannel={this.openChannel}
 									user={this.props.user}
 									card={card}
+									firstInThread={isFirstInThread(card, firstMessagesByThreads)}
 									selectCard={selectors.getCard}
 									getCard={this.props.actions.getCard}
 									addNotification={this.props.actions.addNotification}

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -251,6 +251,25 @@ const MessageContainer = styled(Box) `
 	}}
 `
 
+const MessageIcon = ({
+	firstInThread,
+	threadColor
+}) => {
+	const transform = firstInThread ? null : 'scale(1, -1)'
+	return (
+		<Icon
+			style={{
+				marginLeft: 6,
+				marginTop: 16,
+				fontSize: '18px',
+				transform,
+				color: threadColor
+			}}
+			name= {firstInThread ? 'comment-alt' : 'share'}
+		/>
+	)
+}
+
 export default class Event extends React.Component {
 	constructor (props) {
 		super(props)
@@ -418,6 +437,7 @@ export default class Event extends React.Component {
 		const {
 			card,
 			actor,
+			firstInThread,
 			addNotification,
 			threadIsMirrored
 		} = this.props
@@ -456,23 +476,16 @@ export default class Event extends React.Component {
 						/>
 
 						{this.props.openChannel &&
-							<Box
-								tooltip={{
-									placement: 'bottom',
-									text: `Open ${card.type.split('@')[0]}`
-								}}
-							>
-								<Icon
-									style={{
-										marginLeft: 6,
-										marginTop: 16,
-										fontSize: '18px',
-										transform: 'scale(1, -1)',
-										color: threadColor
-									}}
-									name="share"
-								/>
-							</Box>
+						<Box
+							tooltip={{
+								placement: 'bottom',
+								text: `Open ${card.type.split('@')[0]}`
+							}}
+						>
+							<MessageIcon
+								threadColor={threadColor}
+								firstInThread={firstInThread} />
+						</Box>
 						}
 
 					</EventButton>


### PR DESCRIPTION
At the moment, all messages in a repository have the same icon next to them, making it hard to differentiate where one thread ends and another starts.

This PR introduces a temporary solution to replace the usual icon with a speech bubble icon when the message is the first in a thread. This makes our channel look a little more like Flowdock.

Before:

<img width="1091" alt="Screen Shot 2020-05-18 at 1 27 15 PM" src="https://user-images.githubusercontent.com/6325359/82166031-4d5f4280-990b-11ea-95ef-87e577204a88.png">

After: 

<img width="1084" alt="Screen Shot 2020-05-18 at 1 21 24 PM" src="https://user-images.githubusercontent.com/6325359/82166073-6e279800-990b-11ea-9b9d-e7fddae39ed8.png">


- [x] Ensure messages are date-sorted
- [x] Move first-message testing to Interleave component
- [x] Ensure other types of linked card are ignored (e.g events)
- [x] fix bug with view-all-messages loading animation
- [x] test various situations in which interleave is used
