### PR TITLE
ui-components: Use same color for the event left border and thread icon

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -438,6 +438,7 @@ export default class Event extends React.Component {
 
 		const timestamp = _.get(card, [ 'data', 'timestamp' ]) || card.created_at
 		const messageOverflows = this.state.messageHeight >= MESSAGE_COLLAPSED_HEIGHT
+		const threadColor = helpers.colorHash(getTargetId(card))
 
 		return (
 			<VisibilitySensor
@@ -445,7 +446,7 @@ export default class Event extends React.Component {
 			>
 				<EventWrapper {...props} className={`event-card--${typeBase}`}>
 					<EventButton onClick={this.openChannel} style={{
-						borderLeftColor: helpers.colorHash(getTargetId(card))
+						borderLeftColor: threadColor
 					}}>
 						<Avatar
 							small
@@ -467,7 +468,7 @@ export default class Event extends React.Component {
 										marginTop: 16,
 										fontSize: '18px',
 										transform: 'scale(1, -1)',
-										color: '#2e587a'
+										color: threadColor
 									}}
 									name="share"
 								/>


### PR DESCRIPTION
This change will help to identify which thread a message belongs to.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #3781 

Before:
![Thread icon color - before](https://user-images.githubusercontent.com/2925657/82172075-64923600-98f3-11ea-8549-0470cf752d42.jpg)

After:
![Thread icon color - after](https://user-images.githubusercontent.com/2925657/82172080-6825bd00-98f3-11ea-8001-c8c4ba5b3546.jpg)

