### PR TITLE
ui: Ensure starred ProductOS views appear in Starred Views section

### DIFF
--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -258,9 +258,15 @@ export default class HomeChannel extends React.Component {
 		})
 		groups.defaults = defaults
 
-		const starredViews = _.filter(tail, (view) => {
-			return Boolean(userStarredViews[view.slug])
-		})
+		const starredViews = []
+		const addToStarredViewsIfStarred = (view) => {
+			if (userStarredViews[view.slug]) {
+				starredViews.push(view)
+			}
+		}
+		_.forEach(this.state.productOS, addToStarredViewsIfStarred)
+		_.forEach(tail, addToStarredViewsIfStarred)
+
 		if (starredViews.length) {
 			const starredViewsTree = viewsToTree(userStarredViews, starredViews, {
 				name: 'Starred',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes: #3797

The new ProductOS views are a special case - stored in the `HomeChannel` component's state rather than included in the `tail` prop. So we need to iterate through these ProductOS views as well as the 'tail' when looking for starred views.
