### PR TITLE
dev: Bake Prometheus/Grafana configs in images

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -303,9 +303,9 @@ services:
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   prometheus:
-    image: 'prom/prometheus:v2.17.2'
-    volumes:
-      - './prometheus:/etc/prometheus'
+    build:
+      context: ./prometheus
+      dockerfile: Dockerfile
     command: "--config.file=/etc/prometheus/prometheus.yaml"
     ports:
       - '9090:9090'
@@ -313,9 +313,9 @@ services:
     networks:
       - internal
   grafana:
-    image: 'grafana/grafana:6.7.3'
-    volumes:
-      - './grafana:/etc/grafana'
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
     ports:
       - '3000:3000'
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -419,9 +419,9 @@ services:
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   prometheus:
-    image: 'prom/prometheus:v2.17.2'
-    volumes:
-      - './prometheus:/etc/prometheus'
+    build:
+      context: ./prometheus
+      dockerfile: Dockerfile
     command: "--config.file=/etc/prometheus/prometheus.yaml"
     ports:
       - '9090:9090'
@@ -429,9 +429,9 @@ services:
     networks:
       - internal
   grafana:
-    image: 'grafana/grafana:6.7.3'
-    volumes:
-      - './grafana:/etc/grafana'
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
     ports:
       - '3000:3000'
     restart: always

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,4 @@
+FROM grafana/grafana:6.7.3
+COPY ./grafana.ini /etc/grafana/
+COPY ./dashboards /etc/grafana/dashboards
+COPY ./provisioning /etc/grafana/provisioning

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:v2.17.2
+COPY prometheus.yaml /etc/prometheus/


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Closes https://github.com/product-os/jellyfish/issues/3776

All this change does is bake the Prometheus and Grafana configuration files into images based on official Prometheus and Grafana images. See [this forum post](https://forums.balena.io/t/bind-mounts-are-not-allowed-how-to-define-volumes-and-pass-templates-via-docker-compose/14450/2) as to why this is necessary.