### PR TITLE
ci: Restore S3 file upload tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,37 @@ jobs:
           name: Docker Compose Down
           command: make compose-stop
 
+  s3_file_upload: &s3_file_upload
+    <<: *job_defaults
+
+    resource_class: xlarge
+
+    steps:
+      - checkout
+
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - run:
+          name: Install scripts-template dependencies
+          command: cd scripts/template && npm install
+      - run:
+          name: Compose Build
+          command: make compose-build
+      - run:
+          name: Docker Compose Up
+          command: make compose-up DETACH=1 FS_DRIVER=s3FS
+      - run:
+          name: S3 File Upload Tests
+          command: make compose-exec-sidecar COMMAND="/bin/bash -c '. /root/.bashrc && make test FILES="./test/e2e/ui/file-upload.spec.js"'"
+      - run:
+          name: Docker Compose Down
+          command: make compose-stop
+
   results:
     <<: *job_defaults
 
@@ -353,6 +384,11 @@ workflows:
                   - build
                 <<: *workflow_filter
 
+            - s3_file_upload:
+                requires:
+                  - build
+                <<: *workflow_filter
+
             - sync_tests_front_mirror:
                 requires:
                   - build
@@ -382,6 +418,7 @@ workflows:
                 requires:
                   - e2e_tests_server
                   - e2e_tests_server_previous_dump
+                  - s3_file_upload
                   - sync_tests_front_translate
                   - sync_tests_discourse_translate
                   - sync_tests_front_mirror

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-test:latest
+FROM resinci/jellyfish-test:v1.3.7
 
 WORKDIR /usr/src/jellyfish
 
@@ -13,11 +13,6 @@ ARG NPM_TOKEN
 RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
 RUN rm -f ~/.npmrc
-
-RUN apt-get update && apt-get install -y \
-	libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 \
-	libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
-	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0
 
 COPY ./apps ./apps
 COPY ./lib ./lib

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-sidecar
+FROM resinci/jellyfish-sidecar:v1.3.8
 
 WORKDIR /usr/src/jellyfish
 

--- a/test/e2e/ui/file-upload.spec.js
+++ b/test/e2e/ui/file-upload.spec.js
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const path = require('path')
+const uuid = require('uuid/v4')
+const environment = require('../../../lib/environment')
+const helpers = require('./helpers')
+const macros = require('./macros')
+
+const context = {
+	context: {
+		id: `UI-INTEGRATION-TEST-${uuid()}`
+	}
+}
+
+const users = {
+	community: {
+		username: `johndoe-${uuid()}`,
+		email: `johndoe-${uuid()}@example.com`,
+		password: 'password'
+	}
+}
+
+// If the current user is not the community user, logout, then login as the
+// community user.
+const ensureCommunityLogin = async (page) => {
+	const baseURL = `${environment.ui.host}:${environment.ui.port}`
+
+	if (!page.url().includes(baseURL)) {
+		await page.goto(baseURL)
+	}
+
+	const currentUser = await page.evaluate(() => {
+		return window.sdk.auth.whoami()
+	})
+
+	if (currentUser.slug !== `user-${users.community.username}`) {
+		await macros.logout(page)
+		await macros.loginUser(page, users.community)
+
+		return page.evaluate(() => {
+			return window.sdk.auth.whoami()
+		})
+	}
+
+	return currentUser
+}
+
+ava.serial.before(async () => {
+	await helpers.browser.beforeEach({
+		context
+	})
+
+	const user = await context.createUser(users.community)
+	await context.addUserToBalenaOrg(user.id)
+})
+
+ava.serial.after(async () => {
+	await helpers.browser.afterEach({
+		context
+	})
+})
+
+ava.serial('files upload: Users should be able to upload an image', async (test) => {
+	const {
+		page
+	} = context
+
+	await ensureCommunityLogin(page)
+
+	// Create a new thread
+	const thread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'thread@1.0.0'
+		})
+	})
+
+	// Navigate to the user profile page
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+
+	await page.waitForSelector(`.column--slug-${thread.slug}`)
+
+	await page.waitForSelector('input[type="file"]')
+	const input = await page.$('input[type="file"]')
+	await input.uploadFile(path.join(__dirname, 'assets', 'test.png'))
+
+	await page.waitForSelector('.column--thread [data-test="event-card__image"]')
+
+	test.pass()
+})
+
+ava.serial('file upload: Users should be able to upload an image to a support thread', async (test) => {
+	const {
+		page
+	} = context
+
+	await ensureCommunityLogin(page)
+
+	// Create a new thread
+	const thread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'support-thread@1.0.0'
+		})
+	})
+
+	// Navigate to the user profile page
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+
+	const selector = '.column--support-thread'
+
+	await page.waitForSelector(selector)
+	await page.waitForSelector('input[type="file"]')
+	const input = await page.$('input[type="file"]')
+	await input.uploadFile(path.join(__dirname, 'assets', 'test.png'))
+
+	await page.waitForSelector(`${selector} [data-test="event-card__image"]`)
+
+	test.pass()
+})
+
+ava.serial('file upload: Users should be able to upload a text file', async (test) => {
+	const {
+		page
+	} = context
+
+	await ensureCommunityLogin(page)
+
+	// Create a new thread
+	const thread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'thread@1.0.0'
+		})
+	})
+
+	// Navigate to the user profile page
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+
+	await page.waitForSelector(`.column--slug-${thread.slug}`)
+
+	await page.waitForSelector('input[type="file"]')
+	const input = await page.$('input[type="file"]')
+	await input.uploadFile(path.join(__dirname, 'assets', 'test.txt'))
+
+	await page.waitForSelector('.column--thread [data-test="event-card__file"]')
+
+	test.pass()
+})
+
+ava.serial('file upload: Users should be able to upload a text file to a support thread', async (test) => {
+	const {
+		page
+	} = context
+
+	await ensureCommunityLogin(page)
+
+	// Create a new thread
+	const thread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'support-thread@1.0.0'
+		})
+	})
+
+	// Navigate to the user profile page
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+
+	const selector = '.column--support-thread'
+
+	await page.waitForSelector(selector)
+	await page.waitForSelector('input[type="file"]')
+	const input = await page.$('input[type="file"]')
+	await input.uploadFile(path.join(__dirname, 'assets', 'test.txt'))
+
+	await page.waitForSelector(`${selector} [data-test="event-card__file"]`)
+
+	test.pass()
+})

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -7,7 +7,6 @@
 const ava = require('ava')
 const bluebird = require('bluebird')
 const _ = require('lodash')
-const path = require('path')
 const uuid = require('uuid/v4')
 const environment = require('../../../lib/environment')
 const helpers = require('./helpers')
@@ -307,123 +306,6 @@ ava.serial('card actions: should let users add a custom field to a card', async 
 	const updatedCard = await context.sdk.card.get(card.id)
 
 	test.is(updatedCard.data[fieldName], fieldValue)
-})
-
-// File upload
-// =============================================================================
-
-ava.serial('files upload: Users should be able to upload an image', async (test) => {
-	const {
-		page
-	} = context
-
-	await ensureCommunityLogin(page)
-
-	// Create a new thread
-	const thread = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'thread@1.0.0'
-		})
-	})
-
-	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
-
-	await page.waitForSelector(`.column--slug-${thread.slug}`)
-
-	await page.waitForSelector('input[type="file"]')
-	const input = await page.$('input[type="file"]')
-	await input.uploadFile(path.join(__dirname, 'assets', 'test.png'))
-
-	await page.waitForSelector('.column--thread [data-test="event-card__image"]')
-
-	test.pass()
-})
-
-ava.serial('file upload: Users should be able to upload an image to a support thread', async (test) => {
-	const {
-		page
-	} = context
-
-	await ensureCommunityLogin(page)
-
-	// Create a new thread
-	const thread = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'support-thread@1.0.0'
-		})
-	})
-
-	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
-
-	const selector = '.column--support-thread'
-
-	await page.waitForSelector(selector)
-	await page.waitForSelector('input[type="file"]')
-	const input = await page.$('input[type="file"]')
-	await input.uploadFile(path.join(__dirname, 'assets', 'test.png'))
-
-	await page.waitForSelector(`${selector} [data-test="event-card__image"]`)
-
-	test.pass()
-})
-
-ava.serial('file upload: Users should be able to upload a text file', async (test) => {
-	const {
-		page
-	} = context
-
-	await ensureCommunityLogin(page)
-
-	// Create a new thread
-	const thread = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'thread@1.0.0'
-		})
-	})
-
-	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
-
-	await page.waitForSelector(`.column--slug-${thread.slug}`)
-
-	await page.waitForSelector('input[type="file"]')
-	const input = await page.$('input[type="file"]')
-	await input.uploadFile(path.join(__dirname, 'assets', 'test.txt'))
-
-	await page.waitForSelector('.column--thread [data-test="event-card__file"]')
-
-	test.pass()
-})
-
-ava.serial('file upload: Users should be able to upload a text file to a support thread', async (test) => {
-	const {
-		page
-	} = context
-
-	await ensureCommunityLogin(page)
-
-	// Create a new thread
-	const thread = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'support-thread@1.0.0'
-		})
-	})
-
-	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
-
-	const selector = '.column--support-thread'
-
-	await page.waitForSelector(selector)
-	await page.waitForSelector('input[type="file"]')
-	const input = await page.$('input[type="file"]')
-	await input.uploadFile(path.join(__dirname, 'assets', 'test.txt'))
-
-	await page.waitForSelector(`${selector} [data-test="event-card__file"]`)
-
-	test.pass()
 })
 
 // Lenses


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Depends on: https://github.com/product-os/jellyfish-base-images/pull/15

This PR:
- moves e2e ui file upload tests into their own file: `test/e2e/ui/file-upload.spec.js`
- adds a new job to the CircleCI config that runs the file upload tests against our test S3 bucket

This means we will run file upload tests against S3 on CircleCI and against local FS on balenaCI. Once secrets are available on balenaCI everything needs to be moved to run on balenaCI.

Here is confirmation that the new `s3_file_upload` job in the CircleCI config does indeed run upload tests against S3 ([Job Output](https://circleci.com/gh/product-os/jellyfish/109205)):
```
...
(30.23.3) 2020-05-19T02:21:31.152Z [server/http/facades/action] [info] [REQUEST-30.23.3-0c48738a-cbf0-4a24-9715-b5e09389a9a7]: Uploading attachment {"card":"2dce0527-6892-40cf-be6f-56da1e3baf09","key":"d637827e-110e-41d0-bf18-3dd12be82365.test.txt"}
(30.23.3) 2020-05-19T02:21:31.152Z [server/http/file-storage/index] [info] [REQUEST-30.23.3-0c48738a-cbf0-4a24-9715-b5e09389a9a7]: Storing file {"scope":"2dce0527-6892-40cf-be6f-56da1e3baf09","name":"d637827e-110e-41d0-bf18-3dd12be82365.test.txt"}
(30.23.3) 2020-05-19T02:21:31.152Z [server/http/file-storage/s3-fs] [info] [REQUEST-30.23.3-0c48738a-cbf0-4a24-9715-b5e09389a9a7]: Storing S3 object {"key":"2dce0527-6892-40cf-be6f-56da1e3baf09/d637827e-110e-41d0-bf18-3dd12be82365.test.txt","bucket":"**************************"}
...
```

Closes https://github.com/product-os/jellyfish/issues/3753