### PR TITLE
Put view and thread details within collapsible sections

### DIFF
--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -35,6 +35,7 @@ import CardLayout from '../../../layouts/CardLayout'
 import CardFields from '../../../../../lib/ui-components/CardFields'
 import Event from '../../../../../lib/ui-components/Event'
 import RouterLink from '../../../../../lib/ui-components/Link'
+import Collapsible from '../../../../../lib/ui-components/Collapsible'
 import {
 	TagList,
 	Tag
@@ -144,26 +145,12 @@ class SupportThreadBase extends React.Component {
 				})
 		}
 
-		this.handleExpandToggle = () => {
-			this.setState({
-				expanded: !this.state.expanded
-			})
-		}
-
-		this.toggleHighlights = () => {
-			this.setState({
-				showHighlights: !this.state.showHighlights
-			})
-		}
-
 		this.state = {
 			actor: null,
 			isClosing: false,
 			linkedSupportIssues: [],
 			linkedGitHubIssues: [],
-			linkedProductImprovements: [],
-			showHighlights: false,
-			expanded: false
+			linkedProductImprovements: []
 		}
 		this.loadLinks(props.card.id)
 	}
@@ -459,41 +446,17 @@ class SupportThreadBase extends React.Component {
 						</Box>
 					)}
 
-					<Flex justifyContent="space-between">
-						<Txt><em>Created {helpers.formatTimestamp(card.created_at)}</em></Txt>
+					<Collapsible title="Details" maxContentHeight='50vh' lazyLoadContent data-test="support-thread-details">
+						<Flex mt={1} justifyContent="space-between">
+							<Txt><em>Created {helpers.formatTimestamp(card.created_at)}</em></Txt>
 
-						<Txt>
-							<em>Updated {helpers.timeAgo(_.get(helpers.getLastUpdate(card), [ 'data', 'timestamp' ]))}</em>
-						</Txt>
-					</Flex>
+							<Txt>
+								<em>Updated {helpers.timeAgo(_.get(helpers.getLastUpdate(card), [ 'data', 'timestamp' ]))}</em>
+							</Txt>
+						</Flex>
 
-					{!this.state.expanded && (
-						<Link
-							onClick={this.handleExpandToggle}
-							mt={2}
-							data-test="support-thread__expand"
-						>
-							More
-						</Link>
-					)}
-
-					{this.state.expanded && (
-						<React.Fragment>
-							{highlights.length > 0 && (
-								<div>
-									<strong>
-										<Link
-											mt={1}
-											onClick={this.toggleHighlights}
-										>
-														Highlights{' '}
-											<Icon name={`caret-${this.state.showHighlights ? 'down' : 'right'}`}/>
-										</Link>
-									</strong>
-								</div>
-							)}
-
-							{this.state.showHighlights && (
+						{highlights.length > 0 && (
+							<Collapsible mt={1} title="Highlights" lazyLoadContent data-test="support-thread-highlights">
 								<Extract py={2}>
 									{_.map(highlights, (statusEvent) => {
 										return (
@@ -510,31 +473,24 @@ class SupportThreadBase extends React.Component {
 										)
 									})}
 								</Extract>
-							)}
+							</Collapsible>
+						)}
 
-							<CardFields
-								card={card}
-								fieldOrder={fieldOrder}
-								type={typeCard}
-								omit={[
-									'category',
-									'status',
-									'inbox',
-									'origin',
-									'environment',
-									'translateDate'
-								]}
-							/>
-
-							<Box>
-								<Link mt={3} onClick={this.handleExpandToggle}>
-									Less
-								</Link>
-							</Box>
-						</React.Fragment>
-					)}
+						<CardFields
+							card={card}
+							fieldOrder={fieldOrder}
+							type={typeCard}
+							omit={[
+								'category',
+								'status',
+								'inbox',
+								'origin',
+								'environment',
+								'translateDate'
+							]}
+						/>
+					</Collapsible>
 				</Box>
-
 				<Box flex="1" style={{
 					minHeight: 0
 				}}>

--- a/apps/ui/lens/full/Thread.jsx
+++ b/apps/ui/lens/full/Thread.jsx
@@ -17,6 +17,7 @@ import {
 	Txt
 } from 'rendition'
 import CardFields from '../../../../lib/ui-components/CardFields'
+import Collapsible from '../../../../lib/ui-components/Collapsible'
 import {
 	TagList
 } from '../../../../lib/ui-components/Tag'
@@ -49,17 +50,23 @@ class Thread extends React.Component {
 				card={card}
 				channel={channel}
 				title={(
-					<Txt mb={3}>
+					<Txt mb={[ 0, 0, 3 ]}>
 						<strong>
 							Thread created at {helpers.formatTimestamp(card.created_at)}
 						</strong>
 					</Txt>
 				)}
 			>
-				<Box px={3} pb={0}>
+				<Collapsible
+					title="Details"
+					px={3}
+					maxContentHeight='50vh'
+					lazyLoadContent
+					data-test="thread-details"
+				>
 					<TagList
 						tags={card.tags}
-						mb={1}
+						my={1}
 					/>
 
 					<CardFields
@@ -67,7 +74,7 @@ class Thread extends React.Component {
 						fieldOrder={fieldOrder}
 						type={typeCard}
 					/>
-				</Box>
+				</Collapsible>
 
 				<Box flex="1" style={{
 					minHeight: 0

--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -44,6 +44,10 @@ import {
 	CloseButton
 } from '../../../../lib/ui-components/shame/CloseButton'
 import Icon from '../../../../lib/ui-components/shame/Icon'
+import Collapsible from '../../../../lib/ui-components/Collapsible'
+import {
+	withResponsiveContext
+} from '../../../../lib/ui-components/hooks/ResponsiveProvider'
 
 const USER_FILTER_NAME = 'user-generated-filter'
 
@@ -598,78 +602,86 @@ class ViewRenderer extends React.Component {
 				}}
 			>
 				{Boolean(head) && (
-					<React.Fragment>
-						<Flex
-							mt={3} mx={3}
-							flexWrap={[ 'wrap', 'wrap', 'nowrap' ]}
-							flexDirection="row-reverse"
-							alignItems={[ 'flex-start', 'flex-start', 'center' ]}
+					<Flex alignItems="flex-start" mx={3} mt={3}>
+						<Collapsible
+							title="Filters and Lenses"
+							maxContentHeight="70vh"
+							flex={1}
+							collapsible={this.props.isMobile}
+							data-test="filters-and-lense"
 						>
-							<Flex mb={3} alignItems="center" justifyContent="flex-end" minWidth={[ '100%', '100%', 'auto' ]}>
-								{sliceOptions && sliceOptions.length && (
-									<Select
-										ml={3}
-										options={sliceOptions}
-										value={this.state.activeSlice}
-										labelKey='title'
-										onChange={this.setSlice}
-									/>
-								)}
-
-								{this.lenses.length > 1 && Boolean(lens) && (
-									<ButtonGroup ml={3}>
-										{_.map(this.lenses, (item) => {
-											return (
-												<Button
-													key={item.slug}
-													active={lens && lens.slug === item.slug}
-													data-test={`lens-selector--${item.slug}`}
-													data-slug={item.slug}
-													onClick={this.setLens}
-													pt={11}
-													icon={<Icon name={item.data.icon}/>}
-												/>
-											)
-										})}
-									</ButtonGroup>
-								)}
-
-								<CloseButton
-									flex={0}
-									p={3}
-									py={2}
-									mr={-3}
-									channel={this.props.channel}
-								/>
-							</Flex>
-							<Box flex="1">
-								{useFilters && (
-									<Box mt={0} flex="1 0 auto">
-										<Filters
-											schema={schemaForFilters}
-											filters={this.state.filters}
-											onFiltersUpdate={this.updateFilters}
-											onViewsUpdate={this.saveView}
-											compact={FiltersBreakpointSettings}
-											renderMode={[ 'add', 'search' ]}
+							<Flex
+								mt={[ 2, 2, 0 ]}
+								flexWrap={[ 'wrap', 'wrap', 'nowrap' ]}
+								flexDirection="row-reverse"
+								alignItems={[ 'flex-start', 'flex-start', 'center' ]}
+							>
+								<Flex mb={3} alignItems="center" justifyContent="flex-end" minWidth={[ '100%', '100%', 'auto' ]}>
+									{sliceOptions && sliceOptions.length && (
+										<Select
+											ml={3}
+											options={sliceOptions}
+											value={this.state.activeSlice}
+											labelKey='title'
+											onChange={this.setSlice}
 										/>
-									</Box>
-								)}
-							</Box>
-						</Flex>
+									)}
 
-						{useFilters && this.state.filters.length > 0 && (
-							<Box flex="1 0 auto" mx={3} mt={-3}>
-								<Filters
-									schema={schemaForFilters}
-									filters={this.state.filters}
-									onFiltersUpdate={this.updateFilters}
-									onViewsUpdate={this.saveView}
-									renderMode={[ 'summary' ]}
-								/>
-							</Box>
-						)}
-					</React.Fragment>
+									{this.lenses.length > 1 && Boolean(lens) && (
+										<ButtonGroup ml={3}>
+											{_.map(this.lenses, (item) => {
+												return (
+													<Button
+														key={item.slug}
+														active={lens && lens.slug === item.slug}
+														data-test={`lens-selector--${item.slug}`}
+														data-slug={item.slug}
+														onClick={this.setLens}
+														pt={11}
+														icon={<Icon name={item.data.icon}/>}
+													/>
+												)
+											})}
+										</ButtonGroup>
+									)}
+								</Flex>
+								<Box flex="1">
+									{useFilters && (
+										<Box mt={0} flex="1 0 auto">
+											<Filters
+												schema={schemaForFilters}
+												filters={this.state.filters}
+												onFiltersUpdate={this.updateFilters}
+												onViewsUpdate={this.saveView}
+												compact={FiltersBreakpointSettings}
+												renderMode={[ 'add', 'search' ]}
+											/>
+										</Box>
+									)}
+								</Box>
+							</Flex>
+
+							{useFilters && this.state.filters.length > 0 && (
+								<Box flex="1 0 auto" mt={-3}>
+									<Filters
+										schema={schemaForFilters}
+										filters={this.state.filters}
+										onFiltersUpdate={this.updateFilters}
+										onViewsUpdate={this.saveView}
+										renderMode={[ 'summary' ]}
+									/>
+								</Box>
+							)}
+						</Collapsible>
+						<CloseButton
+							flex={0}
+							p={3}
+							py={2}
+							mr={-3}
+							mt={[ -2, -2, 0 ]}
+							channel={this.props.channel}
+						/>
+					</Flex>
 				)}
 
 				<Flex height="100%" minHeight="0" mt={this.state.filters.length ? 0 : 3}>
@@ -719,6 +731,11 @@ const mapDispatchToProps = (dispatch) => {
 	}
 }
 
+const WrappedViewRenderer = redux.compose(
+	connect(mapStateToProps, mapDispatchToProps),
+	withResponsiveContext
+)(ViewRenderer)
+
 const lens = {
 	slug: 'lens-view',
 	type: 'lens',
@@ -728,7 +745,7 @@ const lens = {
 		type: 'view',
 		icon: 'filter',
 		format: 'full',
-		renderer: connect(mapStateToProps, mapDispatchToProps)(ViewRenderer),
+		renderer: WrappedViewRenderer,
 		filter: {
 			type: 'object',
 			properties: {

--- a/lib/ui-components/Collapsible.jsx
+++ b/lib/ui-components/Collapsible.jsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import cn from 'classnames'
+import styled from 'styled-components'
+import {
+	Box,
+	Flex,
+	Txt
+} from 'rendition'
+import Icon from './shame/Icon'
+import {
+	px
+} from './services/helpers'
+import useDebounce from './hooks/use-debounce'
+
+const DELAY = 500
+
+const CollapsibleWrapper = styled(Box) ``
+
+const CollapsibleHeader = styled(Flex) `
+	cursor: pointer;
+`
+
+const CollapsibleContent = styled(Box) `
+	max-height: ${(props) => { return px(props.maxHeight) }};
+	transition: max-height ease-in-out ${DELAY}ms;
+	overflow-y: auto;
+	&.collapsed {
+		max-height: 0;
+		overflow-y: hidden;
+	}
+`
+
+export default function Collapsible ({
+	title,
+	collapsible = true,
+	defaultCollapsed = true,
+	maxContentHeight = 1000,
+	lazyLoadContent = false,
+	children,
+	...rest
+}) {
+	const [ isCollapsed, setIsCollapsed ] = React.useState(collapsible && defaultCollapsed)
+	const isContentLoaded = useDebounce(!isCollapsed, DELAY, {
+		lagOnRisingEdge: false
+	})
+	const toggleCollapsed = () => {
+		setIsCollapsed(!isCollapsed)
+	}
+	return (
+		<CollapsibleWrapper data-test="collapsible" {...rest}>
+			{collapsible && (
+				<CollapsibleHeader
+					color="primary.main"
+					alignItems="center"
+					onClick={toggleCollapsed}
+					data-test="collapsible__header"
+				>
+					<Box mr={2}><Icon name="angle-down" rotate={isCollapsed ? 0 : 180} /></Box>
+					{typeof title === 'string' ? <Txt>{title}</Txt> : title}
+				</CollapsibleHeader>
+			)}
+			<CollapsibleContent
+				data-test="collapsible__content"
+				maxHeight={maxContentHeight}
+				className={cn({
+					collapsed: isCollapsed
+				})}
+			>
+				{(!lazyLoadContent || isContentLoaded) && children}
+			</CollapsibleContent>
+		</CollapsibleWrapper>
+	)
+}

--- a/lib/ui-components/Collapsible.jsx
+++ b/lib/ui-components/Collapsible.jsx
@@ -52,21 +52,22 @@ export default function Collapsible ({
 	const toggleCollapsed = () => {
 		setIsCollapsed(!isCollapsed)
 	}
+	const dataTest = rest['data-test'] || 'collapsible'
 	return (
-		<CollapsibleWrapper data-test="collapsible" {...rest}>
+		<CollapsibleWrapper data-test={dataTest} {...rest}>
 			{collapsible && (
 				<CollapsibleHeader
 					color="primary.main"
 					alignItems="center"
 					onClick={toggleCollapsed}
-					data-test="collapsible__header"
+					data-test={`${dataTest}__header`}
 				>
 					<Box mr={2}><Icon name="angle-down" rotate={isCollapsed ? 0 : 180} /></Box>
 					{typeof title === 'string' ? <Txt>{title}</Txt> : title}
 				</CollapsibleHeader>
 			)}
 			<CollapsibleContent
-				data-test="collapsible__content"
+				data-test={`${dataTest}__content`}
 				maxHeight={maxContentHeight}
 				className={cn({
 					collapsed: isCollapsed

--- a/lib/ui-components/Collapsible.spec.jsx
+++ b/lib/ui-components/Collapsible.spec.jsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getWrapper
+} from '../../test/ui-setup'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import {
+	Txt
+} from 'rendition'
+import React from 'react'
+import Collapsible from './Collapsible'
+
+const wrappingComponent = getWrapper().wrapper
+
+const Content = () => {
+	return <Txt data-test="test-content">Content</Txt>
+}
+
+const mountCollapsible = (props) => {
+	return mount((
+		<Collapsible title='Test' {...props}>
+			<Content />
+		</Collapsible>
+	), {
+		wrappingComponent
+	})
+}
+
+ava('Collapsible doesn\'t render content if collapsed and lazyLoadContent is set', async (test) => {
+	const component = await mountCollapsible({
+		lazyLoadContent: true
+	})
+	const content = component.find('Txt[data-test="test-content"]')
+	test.is(content.length, 0)
+})
+
+ava('Collapsible renders (hidden) content if collapsed and lazyLoadContent is false', async (test) => {
+	const component = await mountCollapsible({
+		lazyLoadContent: false
+	})
+	const content = component.find('Txt[data-test="test-content"]')
+	test.is(content.length, 1)
+})
+
+ava('Collapsible renders content if not collapsed', async (test) => {
+	const component = await mountCollapsible({
+		defaultCollapsed: false
+	})
+	const content = component.find('Txt[data-test="test-content"]')
+	test.is(content.length, 1)
+})
+
+ava('Collapsible header is not displayed if collapsible prop is false', async (test) => {
+	const component = await mountCollapsible({
+		collapsible: false
+	})
+	const header = component.find('CollapsibleHeader[data-test="collapsible__header"]')
+	test.is(header.length, 0)
+})

--- a/lib/ui-components/SlideInPanel.jsx
+++ b/lib/ui-components/SlideInPanel.jsx
@@ -14,6 +14,7 @@ import {
 	swallowEvent
 } from './services/helpers'
 import ErrorBoundary from './shame/ErrorBoundary'
+import useDebounce from './hooks/use-debounce'
 
 // Slide-in delay in seconds
 const DELAY = 0.6
@@ -101,19 +102,9 @@ export default function SlideIn ({
 	lazyLoadContent,
 	children
 }) {
-	const [ isContentLoaded, setIsContentLoaded ] = React.useState(isOpen)
-
-	React.useEffect(() => {
-		if (isOpen) {
-			// Load the panel's content as soon as we open the panel
-			setIsContentLoaded(true)
-		} else {
-			// Unload the panel's content after the panel has fully slid out of view
-			setTimeout(() => {
-				return setIsContentLoaded(false)
-			}, DELAY * 1000)
-		}
-	}, [ isOpen ])
+	const isContentLoaded = useDebounce(isOpen, DELAY * 1000, {
+		lagOnRisingEdge: false
+	})
 
 	const SlideInPanel = Panels[from]
 	if (typeof SlideInPanel === 'undefined') {

--- a/lib/ui-components/hooks/use-debounce.js
+++ b/lib/ui-components/hooks/use-debounce.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react'
+import _ from 'lodash'
 
 /**
  * React Hook to debounce a value by the specified time period.
@@ -14,23 +15,35 @@ import React from 'react'
  *
  * @param {Any} value - the value to debounce
  * @param {Number} delay - the number of milliseconds to wait before updating the debounced value
+ * @param {Object} options - debounce options:
+ *                             - lagOnFallingEdge (default: true)
+ *                             - lagOnRisingEdge (default: true)
  *
  * @returns {Any} the debounced value
  */
-export default function useDebounce (value, delay) {
+export default function useDebounce (value, delay, options = {}) {
 	const [ debouncedValue, setDebouncedValue ] = React.useState(value)
-
+	const opts = _.defaults(options, {
+		lagOnRisingEdge: true, lagOnFallingEdge: true
+	})
 	React.useEffect(
 		() => {
 			// Set debouncedValue to value (passed in) after the specified delay
-			const handler = setTimeout(() => {
+			let handler = null
+			if ((opts.lagOnRisingEdge && Boolean(value)) || (opts.lagOnFallingEdge && !value)) {
+				handler = setTimeout(() => {
+					setDebouncedValue(value)
+				}, delay)
+			} else {
 				setDebouncedValue(value)
-			}, delay)
+			}
 
 			// Prevent debouncedValue from changing if value is
 			// changed within the delay period. Timeout gets cleared and restarted.
 			return () => {
-				clearTimeout(handler)
+				if (handler) {
+					clearTimeout(handler)
+				}
 			}
 		},
 		[ value, delay ]

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -26,7 +26,7 @@ const context = {
 }
 
 const selectors = {
-	threadMoreButton: '[data-test="support-thread__expand"]',
+	threadMoreButton: '[data-test="support-thread-details__header"]',
 	rbTeam: 'label[for="rb-ghf-team"]',
 	rbUnassign: 'label[for="rb-ghf-unassign"]',
 	ddAssignToMe: '[data-test="card-owner-menu__assign-to-me"]',
@@ -336,7 +336,7 @@ ava.serial('You can reassign a thread from another user to yourself', async (tes
 	test.is(whisperText, `Reassigned from @${otherCommunityUserSlug} to @${currentUserSlug}`)
 })
 
-ava.serial('TEMP You cannot assign a thread to its existing owner', async (test) => {
+ava.serial('You cannot assign a thread to its existing owner', async (test) => {
 	const {
 		page,
 		otherCommunityUser,

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -244,7 +244,7 @@ ava.serial('You should be able to link support threads to existing support issue
 
 	await page.click('[data-test="card-linker--existing__submit"]')
 
-	await macros.waitForThenClickSelector(page, '[data-test="support-thread__expand"]')
+	await macros.waitForThenClickSelector(page, '[data-test="support-thread-details__header"]')
 
 	await page.waitForSelector('[data-test="support-thread__linked-support-issue"]')
 


### PR DESCRIPTION
ui-components: Add new Collapsible component
Note - the 'useDebounce' React hook has been extended to allow the caller to disable the lag/debounce for rising edges and/or falling edges - this applies more to boolean values but can still be used with, for example, string values where you want different behaviour when the string is empty.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***
ui-components: Use updated useDebounce hook in SlideInPanel component
A minor code clean-up

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***
ui: Move thread and view header info into collapsible sections

These collapsible sections are collapsed by default. The Views 'Filters and Lenses' collapsible section is only collapsible on smaller screens.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes #3782 

I've added a new `Collapsible` component in the ui-components lib. I've then made use of this in the `ViewRenderer`, `SupportThreadBase` and `Thread` lens components to ensure the details of these lenses don't take up too much room. See gif demos below.

We can probably tweak the styling/layout more if required but this change should be a big improvement from the current situation!

Note: expanding the `Collapsible` section is tested as part of the `support-thread.spec.js` and `guided-handover.spec.js` e2e tests.

**Thread**
![Collapsible - Thread](https://user-images.githubusercontent.com/2925657/82196905-7cce7900-9924-11ea-8f02-b91c5902ed29.gif)

**Support Thread**
![Collapsible - Support Thread](https://user-images.githubusercontent.com/2925657/82196909-7f30d300-9924-11ea-9bad-cea12e7a63b3.gif)

**View**
![Collapsible - View](https://user-images.githubusercontent.com/2925657/82196918-81932d00-9924-11ea-9cc1-b50ea3871c21.gif)
