### PR TITLE
Generate better SQL in the new compiler with `required`/`properties` in schemas

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -757,7 +757,7 @@ COALESCE(${table}.version_patch, '0')::text
 
 	addRequired (required) {
 		assert.INTERNAL(null, Array.isArray(required), Error, () => {
-			return `value for '${this.formatJsonPath('required')}' must be a string`
+			return `value for '${this.formatJsonPath('required')}' must be an array`
 		})
 
 		const requiredFilter = new SqlFilter(true)

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -569,6 +569,10 @@ class SqlFilter {
 		return this
 	}
 
+	isUnsatisfiable () {
+		return this.expr.length === 1 && this.expr[0] === false
+	}
+
 	toSql () {
 		return this.expr.join('')
 	}
@@ -647,11 +651,14 @@ COALESCE(${table}.version_patch, '0')::text
 			}
 			if ('required' in schema) {
 				// We need to know all required properties before processing
-				query.addRequired(schema.required)
+				query.setRequired(schema.required)
 			}
+
 			for (const [ key, value ] of Object.entries(schema)) {
 				query.visit(key, value)
 			}
+
+			query.finalize()
 		}
 
 		return query
@@ -679,7 +686,7 @@ COALESCE(${table}.version_patch, '0')::text
 	 */
 	constructor (tableOrParent, options = {}) {
 		// Set of properties that must exist
-		this.required = new Set()
+		this.required = []
 
 		// SQL filter. Defaults to `true` as an empty schema matches anything
 		this.filter = new SqlFilter(true)
@@ -691,6 +698,15 @@ COALESCE(${table}.version_patch, '0')::text
 		// Map of link types (i.e. the name of the relation between different
 		// cards) to the `SqlQuery` of the schema of that link type
 		this.links = {}
+
+		// True if, and only if `this.filter` implies that the property that
+		// this object represents must exist. This is used to elide needless
+		// `NOT NULL`/`?` checks with the `required`/`properties` keywords
+		this.filterImpliesExists = false
+
+		// Filter for keyword `properties`. We need to keep this separate until
+		// `finalize()` is called to apply some optimizations
+		this.propertiesFilter = null
 
 		// See the constructor's docs
 		this.options = options
@@ -755,38 +771,6 @@ COALESCE(${table}.version_patch, '0')::text
 		}
 	}
 
-	addRequired (required) {
-		assert.INTERNAL(null, Array.isArray(required), Error, () => {
-			return `value for '${this.formatJsonPath('required')}' must be an array`
-		})
-
-		const requiredFilter = new SqlFilter(true)
-		this.path.push(null)
-		for (const key of required) {
-			this.path[this.path.length - 1] = key
-			this.updateisProcessingState()
-
-			// TODO: as an optimization, this is not necessary if the field is
-			// also constrained by some keywords (`const`, `enum`)
-			if (this.isProcessingColumn) {
-				if (_.get(CARD_FIELDS, [ key, 'nullable' ]) === true) {
-					requiredFilter.and(SqlFilter.isNotNull(this))
-				}
-			} else if (this.isProcessingJsonProperty) {
-				requiredFilter.and(SqlFilter.jsonPropertyExists(this))
-			}
-
-			this.required.add(key)
-			if (this.isProcessingColumn) {
-				this.columns.add(key)
-			}
-		}
-		this.path.pop()
-		this.updateisProcessingState()
-
-		this.filter.and(this.ifTypeThen('object', requiredFilter))
-	}
-
 	setAdditionalProperties (schema) {
 		// TODO: technically this can be a schema too
 		assert.INTERNAL(null, _.isBoolean(schema), Error, () => {
@@ -806,8 +790,43 @@ COALESCE(${table}.version_patch, '0')::text
 		if (typeFilter === false) {
 			this.filter.makeUnsatisfiable()
 		} else if (typeFilter !== null) {
+			this.filterImpliesExists = true
 			this.filter.and(typeFilter)
 		}
+	}
+
+	setRequired (required) {
+		assert.INTERNAL(null, Array.isArray(required), Error, () => {
+			return `value for '${this.formatJsonPath('required')}' must be an array`
+		})
+
+		this.required = _.clone(required)
+		if (this.isProcessingTable) {
+			for (const key of required) {
+				this.columns.add(key)
+			}
+		}
+	}
+
+	finalize () {
+		const noPropertiesFilter = this.propertiesFilter === null
+		if (this.required.length === 0 && noPropertiesFilter) {
+			return
+		}
+
+		const filter = noPropertiesFilter ? new SqlFilter(true) : this.propertiesFilter
+		this.path.push(null)
+		for (const required of this.required) {
+			this.path[this.path.length - 1] = required
+			this.updateisProcessingState()
+			const existsFilter = this.existsFilter()
+			if (existsFilter !== null) {
+				filter.and(existsFilter)
+			}
+		}
+		this.path.pop()
+
+		this.filter.and(this.ifTypeThen('object', filter))
 	}
 
 	visit (key, value) {
@@ -867,6 +886,7 @@ COALESCE(${table}.version_patch, '0')::text
 			assert.INTERNAL(null, _.isEmpty(branchQuery.links), Error,
 				'\'$$links\' is not supported inside an \'allOf\' declaration')
 
+			this.filterImpliesExists = this.filterImpliesExists || branchQuery.filterImpliesExists
 			this.filter.and(branchQuery.filter)
 		}
 	}
@@ -876,6 +896,7 @@ COALESCE(${table}.version_patch, '0')::text
 			return `value for '${this.formatJsonPath('anyOf')}' must be an array`
 		})
 
+		let allFilterImpliesExists = true
 		const filter = new SqlFilter(false)
 		for (const [ idx, branchSchema ] of branches.entries()) {
 			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'anyOf', idx ])
@@ -883,13 +904,16 @@ COALESCE(${table}.version_patch, '0')::text
 			assert.INTERNAL(null, _.isEmpty(branchQuery.links), Error,
 				'\'$$links\' is not supported inside an \'anyOf\' declaration')
 
+			allFilterImpliesExists = allFilterImpliesExists && branchQuery.filterImpliesExists
 			filter.or(branchQuery.filter)
 		}
 
+		this.filterImpliesExists = this.filterImpliesExists || allFilterImpliesExists
 		this.filter.and(filter)
 	}
 
 	constVisitor (value) {
+		this.filterImpliesExists = true
 		this.filter.and(SqlFilter.isEqual(this, [ value ]))
 	}
 
@@ -946,6 +970,7 @@ COALESCE(${table}.version_patch, '0')::text
 			return `value for '${this.formatJsonPath('enum')}' must not be empty`
 		})
 
+		this.filterImpliesExists = true
 		this.filter.and(SqlFilter.isEqual(this, values))
 	}
 
@@ -1112,6 +1137,7 @@ COALESCE(${table}.version_patch, '0')::text
 		assert.INTERNAL(null, _.isEmpty(subQuery.links), Error,
 			'\'$$links\' is not supported inside a \'not\' declaration')
 
+		this.filterImpliesExists = this.filterImpliesExists || subQuery.filterImpliesExists
 		this.filter.and(subQuery.filter.negate())
 	}
 
@@ -1129,6 +1155,7 @@ COALESCE(${table}.version_patch, '0')::text
 			return `value for '${this.formatJsonPath('properties')}' must be a map`
 		})
 
+		this.propertiesFilter = new SqlFilter(true)
 		this.path.push(null)
 		for (const [ propertyName, propertySchema ] of Object.entries(propertiesMap)) {
 			this.path[this.path.length - 1] = propertyName
@@ -1143,24 +1170,34 @@ COALESCE(${table}.version_patch, '0')::text
 			assert.INTERNAL(null, _.isEmpty(propertyQuery.links), Error,
 				'\'$$links\' is not supported inside a \'properties\' declaration')
 
+			const isRequired = this.required.includes(propertyName)
+			if (isRequired) {
+				_.pull(this.required, propertyName)
+			}
+
 			let filter = propertyQuery.filter
-			if (!this.required.has(propertyName)) {
-				// If the property is not required nor a non-null column, wrap
-				// the property filter in a material conditional to make sure
-				// that it is indeed treated as optional.
-				let existsFilter = null
-				if (this.isProcessingColumn) {
-					if (_.get(CARD_FIELDS, [ propertyName, 'nullable' ])) {
-						existsFilter = SqlFilter.isNotNull(this)
-					}
-				} else if (this.isProcessingJsonProperty) {
-					existsFilter = SqlFilter.jsonPropertyExists(this)
-				}
+			const cantExist = filter.isUnsatisfiable()
+			const ensureExists = isRequired && !propertyQuery.filterImpliesExists
+			const allowNotExists = !isRequired
+			if (cantExist || ensureExists || allowNotExists) {
+				const existsFilter = this.existsFilter()
 				if (existsFilter !== null) {
-					filter = SqlFilter.materialConditional(existsFilter, filter)
+					if (cantExist) {
+						if (ensureExists) {
+							filter.makeUnsatisfiable()
+						} else {
+							filter = existsFilter.negate()
+						}
+					} else if (ensureExists) {
+						filter.and(existsFilter)
+					} else if (allowNotExists) {
+						filter = SqlFilter.materialConditional(existsFilter, filter)
+					}
 				}
 			}
-			this.filter.and(filter)
+
+			this.filterImpliesExists = this.filterImpliesExists || propertyQuery.filterImpliesExists
+			this.propertiesFilter.and(filter)
 		}
 		this.path.pop()
 		this.updateisProcessingState()
@@ -1242,6 +1279,18 @@ COALESCE(${table}.version_patch, '0')::text
 		}
 
 		return SqlFilter.isOfJsonTypes(this, validTypes)
+	}
+
+	existsFilter () {
+		if (this.isProcessingColumn) {
+			if (_.get(CARD_FIELDS, [ this.getPathTip(), 'nullable' ])) {
+				return SqlFilter.isNotNull(this)
+			}
+		} else if (this.isProcessingJsonProperty) {
+			return SqlFilter.jsonPropertyExists(this)
+		}
+
+		return null
 	}
 
 	updateisProcessingState () {


### PR DESCRIPTION
Some keywords (`type`, `const`, and `enum`) will only be true if the property they constrain exists, while all other keywords can be true if the property doesn't exist. We can use this to elide checks for required properties. For example:

```
{
  properties: {
    'data': {
      required: ['actor'],
      properties: {
        actor: {
          const: 'user-qwerty'
        }
      }
    }
  }
}
```

The `required: ['actor']` schema fragment would generate an SQL fragment (if querying the `cards` table):

```
cards.data ? 'actor'
```

In this case this check can be elided because `actor` is constrained by a `const` keyword. The following two fragments are functionally equal:

```
cards.data ? 'actor'
AND
const.data->>'actor' = 'user-qwerty'
```

```
const.data->>'actor' = 'user-qwerty'
```

This optimization works recursively, so a deep `const` may cause multiple `required` to be elided.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>