### PR TITLE
Fix navigation from desktop notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ lint:
 	./scripts/lint/check-deployable-lib.sh
 	shellcheck ./scripts/*.sh ./scripts/*/*.sh ./deploy-templates/*.sh
 	./node_modules/.bin/deplint
-	./node_modules/.bin/depcheck --ignore-bin-package --ignores='@babel/*,@jellyfish/*,scripts-template,assignment,@ava/babel,canvas'
+	./node_modules/.bin/depcheck --ignore-bin-package --ignores='@babel/*,@jellyfish/*,scripts-template,assignment,@ava/babel,canvas,history'
 
 scrub:
 	$(SCRUB_COMMAND)

--- a/apps/ui/core/store/actioncreators/add-user.spec.js
+++ b/apps/ui/core/store/actioncreators/add-user.spec.js
@@ -6,12 +6,6 @@
 
 import ava from 'ava'
 import sinon from 'sinon'
-
-// Hack fix for a circular dependency until we refactor the notifications code
-import {
-	// eslint-disable-next-line no-unused-vars
-	store
-} from '../../'
 import ActionCreator from './'
 
 const sandbox = sinon.createSandbox()

--- a/apps/ui/core/store/actioncreators/index.spec.js
+++ b/apps/ui/core/store/actioncreators/index.spec.js
@@ -8,12 +8,6 @@ import ava from 'ava'
 import sinon from 'sinon'
 import _ from 'lodash'
 import Bluebird from 'bluebird'
-
-// HACK: We need to import this first to avoid a cyclical dependency issue
-import {
-	// eslint-disable-next-line no-unused-vars
-	store
-} from '../../index'
 import actions from '../actions'
 import ActionCreator from './'
 

--- a/apps/ui/core/store/index.js
+++ b/apps/ui/core/store/index.js
@@ -7,6 +7,9 @@
 import localForage from 'localforage'
 import * as redux from 'redux'
 import reduxThunk from 'redux-thunk'
+import {
+	routerMiddleware
+} from 'connected-react-router'
 import _ from 'lodash'
 import {
 	isProduction
@@ -18,6 +21,7 @@ import actions from './actions'
 import ActionCreator, {
 	selectors
 } from './actioncreators'
+import history from '../../services/history'
 
 // Set localStorage as the backend driver, as it is a little easier to work
 // with.
@@ -57,8 +61,13 @@ export const setupStore = ({
 		window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
 	) || redux.compose
 
+	const middleware = [
+		routerMiddleware(history),
+		reduxThunk
+	]
+
 	return {
-		store: redux.createStore(reducerWrapper, composeEnhancers(redux.applyMiddleware(reduxThunk))),
+		store: redux.createStore(reducerWrapper, composeEnhancers(redux.applyMiddleware(...middleware))),
 		actions,
 		actionCreators: new ActionCreator({
 			sdk,

--- a/apps/ui/core/store/reducer.js
+++ b/apps/ui/core/store/reducer.js
@@ -6,12 +6,16 @@
 
 import clone from 'deep-copy'
 import update from 'immutability-helper'
+import {
+	connectRouter
+} from 'connected-react-router'
 import * as _ from 'lodash'
 import * as redux from 'redux'
 import {
 	v4 as uuid
 } from 'uuid'
 import actions from './actions'
+import history from '../../services/history'
 
 const getDefaultState = () => {
 	return {
@@ -423,6 +427,7 @@ const coreReducer = (state, action) => {
 }
 
 export const reducer = redux.combineReducers({
+	router: connectRouter(history),
 	core: coreReducer,
 	views: viewsReducer
 })

--- a/apps/ui/core/store/reducer.spec.js
+++ b/apps/ui/core/store/reducer.spec.js
@@ -32,51 +32,49 @@ ava('SET_VIEW_DATA action updates the specified view data', (test) => {
 ava('reducer should create a default state if one is not provided', (test) => {
 	const initialState = reducer()
 
-	test.deepEqual(initialState, {
-		core: {
-			status: 'initializing',
-			channels: [
-				{
-					id: initialState.core.channels[0].id,
-					created_at: initialState.core.channels[0].created_at,
-					slug: initialState.core.channels[0].slug,
-					type: 'channel',
-					version: '1.0.0',
-					tags: [],
-					markers: [],
-					links: {},
-					requires: [],
-					capabilities: [],
-					active: true,
-					data: {
-						target: 'view-all-views',
-						cardType: 'view'
-					}
-				}
-			],
-			types: [],
-			session: null,
-			notifications: [],
-			viewNotices: {},
-			cards: {},
-			orgs: [],
-			config: {},
-			ui: {
-				flows: {},
-				sidebar: {
-					expanded: []
-				},
-				timelines: {},
-				chatWidget: {
-					open: false
+	test.deepEqual(initialState.core, {
+		status: 'initializing',
+		channels: [
+			{
+				id: initialState.core.channels[0].id,
+				created_at: initialState.core.channels[0].created_at,
+				slug: initialState.core.channels[0].slug,
+				type: 'channel',
+				version: '1.0.0',
+				tags: [],
+				markers: [],
+				links: {},
+				requires: [],
+				capabilities: [],
+				active: true,
+				data: {
+					target: 'view-all-views',
+					cardType: 'view'
 				}
 			}
-		},
-		views: {
-			activeView: null,
-			viewData: {},
-			subscriptions: {}
+		],
+		types: [],
+		session: null,
+		notifications: [],
+		viewNotices: {},
+		cards: {},
+		orgs: [],
+		config: {},
+		ui: {
+			flows: {},
+			sidebar: {
+				expanded: []
+			},
+			timelines: {},
+			chatWidget: {
+				open: false
+			}
 		}
+	})
+	test.deepEqual(initialState.views, {
+		activeView: null,
+		viewData: {},
+		subscriptions: {}
 	})
 })
 

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -24,14 +24,15 @@ import {
 	sdk,
 	store
 } from './core'
+import history from './services/history'
 import JellyfishUI from './JellyfishUI'
 import ErrorBoundary from '../../lib/ui-components/shame/ErrorBoundary'
 import {
 	ResponsiveProvider
 } from '../../lib/ui-components/hooks/ResponsiveProvider'
 import {
-	BrowserRouter as Router
-} from 'react-router-dom'
+	ConnectedRouter
+} from 'connected-react-router'
 import {
 	SetupProvider
 } from '../../lib/ui-components/SetupProvider'
@@ -79,29 +80,27 @@ const customTheme = {
 
 ReactDOM.render(
 	(
-		<Router>
-			<RProvider
-				theme={customTheme}
-				style={{
-					height: '100%',
-					fontSize: 14
-				}}
-			>
-				<ResponsiveProvider>
-					<SetupProvider sdk={sdk} analytics={analytics} errorReporter={errorReporter}>
-						<Provider store={store}>
-							<React.Fragment>
-								<GlobalStyle />
+		<RProvider
+			theme={customTheme}
+			style={{
+				height: '100%',
+				fontSize: 14
+			}}
+		>
+			<ResponsiveProvider>
+				<SetupProvider sdk={sdk} analytics={analytics} errorReporter={errorReporter}>
+					<Provider store={store}>
+						<ConnectedRouter history={history}>
+							<GlobalStyle />
 
-								<ErrorBoundary>
-									<JellyfishUI />
-								</ErrorBoundary>
-							</React.Fragment>
-						</Provider>
-					</SetupProvider>
-				</ResponsiveProvider>
-			</RProvider>
-		</Router>
+							<ErrorBoundary>
+								<JellyfishUI />
+							</ErrorBoundary>
+						</ConnectedRouter>
+					</Provider>
+				</SetupProvider>
+			</ResponsiveProvider>
+		</RProvider>
 	),
 	document.getElementById('app')
 )

--- a/apps/ui/services/history.js
+++ b/apps/ui/services/history.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	createBrowserHistory,
+	createMemoryHistory
+} from 'history'
+import {
+	isProduction
+} from '../environment'
+
+// Because we use connected-react-router we need to explicitly create
+// our history instance
+const getHistory = () => {
+	try {
+		// Default to browser history - if available
+		// Note: due to Ava's precompilation it's not always possible to determine
+		// at this stage whether we can/should use browser history or not.
+		return createBrowserHistory()
+	} catch (error) {
+		// If we're in production mode we need to be using browser history
+		// so this is a problem.
+		if (isProduction()) {
+			console.log('Browser History is required in production')
+			throw error
+		}
+
+		// We're in a test environment with no DOM support so we use a
+		// memory history instance instead.
+		return createMemoryHistory()
+	}
+}
+
+export default getHistory()

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -7,12 +7,10 @@
 import {
 	Howl
 } from 'howler'
-import * as _ from 'lodash'
+import path from 'path'
 import {
-	actionCreators,
-	selectors,
-	store
-} from '../core'
+	pathWithoutTarget
+} from '../../../lib/ui-components/services/helpers'
 
 const TIMEOUT = 10 * 1000
 
@@ -33,17 +31,12 @@ if (typeof window !== 'undefined') {
 }
 
 export const createNotification = ({
+	historyPush,
 	title,
 	body,
 	target
 }) => {
 	if (!canUseNotifications) {
-		return
-	}
-
-	// Skip notifications if the user's status is set to 'Do Not Disturb'
-	const userStatus = selectors.getCurrentUserStatus(store.getState())
-	if (_.get(userStatus, [ 'value' ]) === 'DoNotDisturb') {
 		return
 	}
 
@@ -67,10 +60,14 @@ export const createNotification = ({
 			console.error()
 		}
 
-		store.dispatch(actionCreators.addChannel({
-			target,
-			parentChannel: _.get(store.getState(), [ 'channels', '0', 'id' ])
-		}))
+		const newPath = path.join(pathWithoutTarget(target), target)
+
+		// Don't bother pushing if the location won't actually change
+		// (avoid a 'null' history entry)
+		if (newPath !== window.location.pathname) {
+			historyPush(newPath)
+		}
+
 		clearTimeout(timeout)
 		notice.close()
 	}

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -35,13 +35,17 @@ export const isCustomView = (view, user) => {
 	return view.slug.startsWith('view-user-created-view') && view.markers.length === 1 && view.markers[0] === user.slug
 }
 
-export const pathWithoutChannel = (channel) => {
+export const pathWithoutTarget = (target) => {
 	const filtered = Reflect.apply(path.join, null, window.location.pathname.split('/').filter((part) => {
 		const identifier = part.split('...')[0]
-		return identifier !== channel.data.target
+		return identifier !== target
 	}))
 
 	return `/${filtered}`
+}
+
+export const pathWithoutChannel = (channel) => {
+	return pathWithoutTarget(channel.data.target)
 }
 
 export const appendToChannelPath = (channel, card) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6146,6 +6146,14 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
     },
+    "connected-react-router": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.8.0.tgz",
+      "integrity": "sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "classnames": "^2.2.6",
     "color-hash": "^1.0.3",
     "common-tags": "^1.8.0",
+    "connected-react-router": "^6.8.0",
     "copy-to-clipboard": "^3.0.8",
     "css-loader": "^2.1.1",
     "d3": "^5.9.2",


### PR DESCRIPTION
Integrate react-router with redux store
We use connected-react-router to hook up the react-router to the redux store. This will allow us to do things like call history.push from a redux action. 

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
ui: Fix navigation from desktop notification

We now use react-router to navigate to the appropriate channel when a desktop notification is clicked on. If the channel is already open, it is moved to the end of the list of channels.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes #3745

Ok - this looks like a big ol' change for what seems like a simple problem. So here's the rationale... 

1. In `notifications.js` we want to 'focus' on the channel that corresponds to the subject (target) of the notification. So we use `history.push`. But with react-router v4/5 this is only available by using `withRouter` - i.e. within a component*. So we introduce [`connected-react-router`](https://github.com/supasate/connected-react-router) so that `history.push` is available from a redux action (and the history is the _same_ history used by `react-router` - so it actually causes the route to change!). This is the [first commit](https://github.com/product-os/jellyfish/commit/a6ee336200d3a229e82ec89e2f45310da07040b6).

2. Then it's a relatively simple change to include a `historyPush` function in the `createNotification` options so we can call this in the Notification `onclick` callback. This is the [second commit](https://github.com/product-os/jellyfish/commit/4b345989557c9ff4e48364b24e7d15780b019080).

Note the behaviour:
* If the target channel is not currently in the url, it will be appended to the path
* If the target channel is currently in the url, it will be moved to the end of the path
* If the new path is the same as the current path, `history.push` is not called. This avoids us pushing a 'null' change to the history stack.

\* FWIW I tried just passing our own `history` object as a prop to the `Router` component. But it looks like in the newer versions of react-router [this is ignored](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/BrowserRouter.js#L10-L16). Hence the use of a more heavy-weight third-party component!
