### PR TITLE
Display an error notice in place of the message if an image load fails

### DIFF
--- a/lib/ui-components/AuthenticatedImage/index.jsx
+++ b/lib/ui-components/AuthenticatedImage/index.jsx
@@ -7,8 +7,13 @@
 import React from 'react'
 import styled from 'styled-components'
 import {
+	Markdown
+} from 'rendition/dist/extra/Markdown'
+import {
 	withSetup
 } from '../SetupProvider'
+import Collapsible from '../Collapsible'
+import Icon from '../shame/Icon'
 
 const ResponsiveImg = styled.img `
 	height: auto;
@@ -22,7 +27,8 @@ class AuthenticatedImage extends React.Component {
 	constructor (props) {
 		super(props)
 		this.state = {
-			imageSrc: null
+			imageSrc: null,
+			error: null
 		}
 	}
 
@@ -35,17 +41,40 @@ class AuthenticatedImage extends React.Component {
 				})
 			})
 			.catch((error) => {
-				this.props.addNotification('danger', error.message || error)
+				this.setState({
+					error: error.message || error
+				})
 			})
 	}
 
 	render () {
 		const {
-			imageSrc
+			imageSrc,
+			error
 		} = this.state
 
+		if (error) {
+			const detail = `\`\`\`\n${error}\n\`\`\``
+			return (
+				<div>
+					<span><em>An error occurred whilst loading image</em></span>
+					<Collapsible
+						title="Details"
+						maxContentHeight="70vh"
+						flex={1}
+					>
+						<Markdown>
+							{detail}
+						</Markdown>
+					</Collapsible>
+				</div>
+			)
+		}
+
 		if (!imageSrc) {
-			return null
+			return (
+				<Icon name="cog" spin />
+			)
 		}
 
 		return (


### PR DESCRIPTION
Fixes #3705

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

This PR adds a small note and details fo the load error, instead of an overlay alert

![Annotation 2020-05-19 112207](https://user-images.githubusercontent.com/15064535/82315285-ff0d7a80-99c2-11ea-8f61-f050e9c2e192.jpg)

![image](https://user-images.githubusercontent.com/15064535/82315315-0896e280-99c3-11ea-8335-30eb7716b7d3.png)


***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
