### PR TITLE
Trim whitespace from AWS S3 access credentials

### DIFF
--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -16,6 +16,8 @@
  *   console.log('Production!')
  * }
  */
+const _ = require('lodash')
+
 exports.isProduction = () => {
 	return process.env.NODE_ENV === 'production'
 }
@@ -70,9 +72,9 @@ exports.fileStorage = {
 }
 
 exports.aws = {
-	accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-	secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-	s3BucketName: process.env.AWS_S3_BUCKET_NAME
+	accessKeyId: _.trim(process.env.AWS_ACCESS_KEY_ID),
+	secretAccessKey: _.trim(process.env.AWS_SECRET_ACCESS_KEY),
+	s3BucketName: _.trim(process.env.AWS_S3_BUCKET_NAME)
 }
 
 exports.redis = {
@@ -127,8 +129,8 @@ exports.integration = {
 		signature: process.env.INTEGRATION_DISCOURSE_SIGNATURE_KEY
 	},
 	outreach: {
-		appId: (process.env.INTEGRATION_OUTREACH_APP_ID || '').trim(),
-		appSecret: (process.env.INTEGRATION_OUTREACH_APP_SECRET || '').trim(),
+		appId: _.trim(process.env.INTEGRATION_OUTREACH_APP_ID),
+		appSecret: _.trim(process.env.INTEGRATION_OUTREACH_APP_SECRET),
 		signature: process.env.INTEGRATION_OUTREACH_SIGNATURE_KEY
 	},
 	flowdock: {


### PR DESCRIPTION
This change help defend against situations where env vars may have extra
whitespace in them.

Change-type: patch
Connects-to: #3706
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
