### PR TITLE
measure json2schema generation duration metric as histogram

### DIFF
--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -57,14 +57,20 @@ const metricNames = {
 
 const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 29).map(Math.round)
 
-metrics.describe.histogram('jf_mirror_duration_ms',
+metrics.describe.histogram(metricNames.MIRROR_DURATION,
 	'histogram of durations taken to make mirror calls in ms',
 	{
 		buckets: latencyBuckets
 	})
 
-metrics.describe.histogram('jf_worker_job_duration_ms',
+metrics.describe.histogram(metricNames.WORKER_JOB_DURATION,
 	'histogram of durations taken to complete worker jobs in ms',
+	{
+		buckets: latencyBuckets
+	})
+
+metrics.describe.histogram(metricNames.SQL_GEN_DURATION,
+	'histogram of durations taken to generate sql in json2schema',
 	{
 		buckets: latencyBuckets
 	})
@@ -372,13 +378,13 @@ exports.measureHttpAction = getAsyncMeasureFn('HTTP_ACTION')
 exports.measureHttpWhoami = getAsyncMeasureFn('HTTP_WHOAMI')
 
 exports.markSqlGenTime = (ms, isNew) => {
-	metrics.inc(metricNames.SQL_GEN_DURATION, ms, {
+	metrics.histogram(metricNames.SQL_GEN_DURATION, ms, {
 		type: isNew ? 'new' : 'old'
 	})
 }
 
 exports.markQueryTime = (ms, isNew) => {
-	metrics.inc(metricNames.QUERY_DURATION, ms, {
+	metrics.histogram(metricNames.QUERY_DURATION, ms, {
 		type: isNew ? 'new' : 'old'
 	})
 }

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -46,8 +46,8 @@ const metricNames = {
 	HTTP_ACTION_FAILURE_TOTAl: 'jf_http_api_action_failure_total',
 	HTTP_WHOAMI_FAILURE_TOTAl: 'jf_http_whoami_query_failure_total',
 
-	SQL_GEN_DURATION: 'jf_sql_gen_ms',
-	QUERY_DURATION: 'jf_query_ms',
+	SQL_GEN_DURATION: 'jf_sql_gen_duration_ms',
+	QUERY_DURATION: 'jf_query_duration_ms',
 	COMPILER_MISMATCH_TOTAL: 'jf_compiler_mismatch_total',
 
 	STREAMS_SATURATION: 'jf_streams_saturation',
@@ -56,6 +56,7 @@ const metricNames = {
 }
 
 const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 29).map(Math.round)
+const queryLatencyBuckets = metrics.client.exponentialBuckets(1.1, Math.SQRT2, 30)
 
 metrics.describe.histogram(metricNames.MIRROR_DURATION,
 	'histogram of durations taken to make mirror calls in ms',
@@ -70,9 +71,15 @@ metrics.describe.histogram(metricNames.WORKER_JOB_DURATION,
 	})
 
 metrics.describe.histogram(metricNames.SQL_GEN_DURATION,
-	'histogram of durations taken to generate sql in json2schema',
+	'histogram of durations taken to generate sql with jsonschema2sql',
 	{
-		buckets: latencyBuckets
+		buckets: queryLatencyBuckets
+	})
+
+metrics.describe.histogram(metricNames.QUERY_DURATION,
+	'histogram of durations taken to query the database',
+	{
+		buckets: queryLatencyBuckets
 	})
 
 /**


### PR DESCRIPTION
We can then observe how distributions change between different iterations of the json2schema code

we can also observe averages over time windows via:

```
increase(jf_sql_gen_duration_ms_sum[$__interval])
/ 
increase(jf_sql_gen_duration_ms_count[$__interval])
```

Change-type: patch
Signed-off-by: dt-rush <nickp@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
