### PR TITLE
Add support for `format{Maximum,Minimum}` in the new compiler

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -151,10 +151,21 @@ class SqlFilter {
 		return filter
 	}
 
-	static valueIs (query, operator, value) {
-		const literal = SqlFilter.maybeJsonLiteral(query, value)
+	static valueIs (query, operator, value, cast) {
+		let field = null
+		let literal = null
+		if (cast) {
+			field = query.pathToSqlField({
+				asText: true
+			})
+			field = `(${field})::${cast}`
+			literal = `(${pgFormat.literal(value)})::${cast}`
+		} else {
+			field = query.pathToSqlField()
+			literal = SqlFilter.maybeJsonLiteral(query, value)
+		}
 
-		return new SqlFilter(`${query.pathToSqlField()} ${operator} ${literal}`)
+		return new SqlFilter(`${field} ${operator} ${literal}`)
 	}
 
 	static isOfJsonTypes (query, types) {
@@ -394,6 +405,11 @@ COALESCE(${table}.version_patch, '0')::text
 				// We need to know all required properties before processing
 				query.setRequired(schema.required)
 			}
+			if ('format' in schema) {
+				// Visitors for `format{Maximum,Minimum}` need to know this
+				// ahead of time
+				query.setFormat(schema.format)
+			}
 
 			for (const [ key, value ] of Object.entries(schema)) {
 				query.visit(key, value)
@@ -448,6 +464,9 @@ COALESCE(${table}.version_patch, '0')::text
 		// Filter for keyword `properties`. We need to keep this separate until
 		// `finalize()` is called to apply some optimizations
 		this.propertiesFilter = null
+
+		// Format as specified by the `format` keyword
+		this.format = null
 
 		// See the constructor's docs
 		this.options = options
@@ -535,7 +554,7 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	setRequired (required) {
-		assert.INTERNAL(null, Array.isArray(required), Error, () => {
+		assert.INTERNAL(null, Array.isArray(required), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('required')}' must be an array`
 		})
 
@@ -545,6 +564,21 @@ COALESCE(${table}.version_patch, '0')::text
 				this.columns.add(key)
 			}
 		}
+	}
+
+	setFormat (format) {
+		assert.INTERNAL(null, _.isString(format), InvalidSchema, () => {
+			return `value for '${this.formatJsonPath('format')}' must be a string`
+		})
+
+		assert.INTERNAL(null, format in REGEXES.format, InvalidSchema, () => {
+			return `value for '${this.formatJsonPath('format')}' is invalid`
+		})
+
+		this.format = format
+		const regex = REGEXES.format[format]
+		const filter = SqlFilter.matchesPattern(this, regex)
+		this.filter.and(this.ifTypeThen('string', filter))
 	}
 
 	finalize () {
@@ -577,6 +611,7 @@ COALESCE(${table}.version_patch, '0')::text
 			'additionalProperties',
 			'description',
 			'examples',
+			'format',
 			'required',
 			'title',
 			'type'
@@ -713,21 +748,6 @@ COALESCE(${table}.version_patch, '0')::text
 		this.filter.and(SqlFilter.isEqual(this, values))
 	}
 
-	formatVisitor (format) {
-		assert.INTERNAL(null, _.isString(format), InvalidSchema, () => {
-			return `value for '${this.formatJsonPath('format')}' must be a string`
-		})
-
-		const regex = REGEXES.format[format]
-		if (regex) {
-			const filter = SqlFilter.matchesPattern(this, regex)
-			this.filter.and(this.ifTypeThen('string', filter))
-		} else {
-			// TODO: maybe an informative error instead
-			this.filter.makeUnsatisfiable()
-		}
-	}
-
 	exclusiveMaximumVisitor (limit) {
 		assert.INTERNAL(null, _.isNumber(limit), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('exclusiveMaximum')}' must be a number`
@@ -744,6 +764,32 @@ COALESCE(${table}.version_patch, '0')::text
 
 		const filter = SqlFilter.valueIs(this, '>', limit)
 		this.filter.and(this.ifTypeThen('number', filter))
+	}
+
+	formatMaximumVisitor (limit) {
+		assert.INTERNAL(null, _.isString(limit), InvalidSchema, () => {
+			return `value for '${this.formatJsonPath('formatMaximum')}' must be a string`
+		})
+
+		assert.INTERNAL(null, this.format !== null, InvalidSchema, () => {
+			return `missing '${this.formatJsonPath('format')}' for formatMaximum`
+		})
+
+		const filter = SqlFilter.valueIs(this, '<=', limit, 'timestamp')
+		this.filter.and(this.ifTypeThen('string', filter))
+	}
+
+	formatMinimumVisitor (limit) {
+		assert.INTERNAL(null, _.isString(limit), InvalidSchema, () => {
+			return `value for '${this.formatJsonPath('formatMinimum')}' must be a string`
+		})
+
+		assert.INTERNAL(null, this.format !== null, InvalidSchema, () => {
+			return `missing '${this.formatJsonPath('format')}' for formatMinimum`
+		})
+
+		const filter = SqlFilter.valueIs(this, '>=', limit, 'timestamp')
+		this.filter.and(this.ifTypeThen('string', filter))
 	}
 
 	itemsVisitor (schema) {

--- a/test/integration/core/backend/postgres/jsonschema2sql/format-max-min.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/format-max-min.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/*
+ * This is a test suite for the non-standard key words "formatMaximum" and
+ * "formatMinimum" that are used by the client for query against dates
+ * see: https://github.com/epoberezkin/ajv-keywords#formatmaximum--formatminimum-and-formatexclusivemaximum--formatexclusiveminimum
+ */
+module.exports = {
+	name: 'formatMaximum|formatMinimum',
+	schemas: [
+		{
+			description: 'formatMaximum can filter date-time correctly',
+			schema: {
+				format: 'date-time',
+				formatMaximum: '2019-08-08T00:00:00.000Z'
+			},
+			tests: [
+				{
+					description: 'data that is < is valid',
+					data: '2018-08-08T00:00:00.000Z',
+					valid: true
+				},
+				{
+					description: 'data that is <= is valid',
+					data: '2019-08-08T00:00:00.000Z',
+					valid: true
+				},
+				{
+					description: 'data that is > is invalid',
+					data: '2020-08-08T00:00:00.000Z',
+					valid: false
+				}
+			]
+		},
+		{
+			description: 'formatMinimum can filter date-time correctly',
+			schema: {
+				format: 'date-time',
+				formatMinimum: '2019-08-08T00:00:00.000Z'
+			},
+			tests: [
+				{
+					description: 'data that is > is valid',
+					data: '2020-08-08T00:00:00.000Z',
+					valid: true
+				},
+				{
+					description: 'data that is >= is valid',
+					data: '2019-08-08T00:00:00.000Z',
+					valid: true
+				},
+				{
+					description: 'data that is < is invalid',
+					data: '2018-08-08T00:00:00.000Z',
+					valid: false
+				}
+			]
+		}
+	]
+}

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -15,6 +15,7 @@ const cards = require('../../../../../../lib/core/backend/postgres/cards')
 const links = require('../../../../../../lib/core/backend/postgres/links')
 const errors = require('../../../../../../lib/core/errors')
 const regexpTestSuite = require('./regexp')
+const formatMaxMinTestSuite = require('./format-max-min')
 
 const IS_POSTGRES = environment.database.type === 'postgres'
 
@@ -67,8 +68,8 @@ const SUPPORTED_SUITES = [
 	'type',
 	// uniqueItems
 
-	'regexp'
-	// 'formatMaximum|formatMinimum'
+	'regexp',
+	'formatMaximum|formatMinimum'
 ]
 /* eslint-enable capitalized-comments, lines-around-comment */
 
@@ -179,6 +180,13 @@ const testSuites = jsonSchemaTestSuite.draft6()
  * see: https://github.com/epoberezkin/ajv-keywords#regexp
  */
 testSuites.push(regexpTestSuite)
+
+/*
+ * Add a test suite for the non-standard key words "formatMaximum" and
+ * "formatMinimum" that are used by the client for query against dates
+ * see: https://github.com/epoberezkin/ajv-keywords#formatmaximum--formatminimum-and-formatexclusivemaximum--formatexclusiveminimum
+ */
+testSuites.push(formatMaxMinTestSuite)
 
 /*
  * The JSON Schema tests are divided in suites, where


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>