### PR TITLE
backend: Create/drop SQL functions on server init

### DIFF
--- a/lib/core/backend/postgres/functions.js
+++ b/lib/core/backend/postgres/functions.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const Bluebird = require('bluebird')
+const QueryFile = require('./pg-promise').QueryFile
+const logger = require('../../../logger').getLogger(__filename)
+const path = require('path')
+
+/**
+ * @summary Prepare a function SQL file for execution. Using minify option to remove comments.
+ * @function
+ *
+ * @param {String} file - name of file under "functions" directory to execute
+ * @returns {Object} object containing filename and prepared SQL
+ *
+ * @example
+ * const sqlFunction = loadFunction('my-function.sql')
+ */
+const loadFunction = (file) => {
+	return {
+		file,
+		query: new QueryFile(path.join(__dirname, 'functions', file), {
+			minify: true
+		})
+	}
+}
+
+/**
+ * @summary Prepare and execute SQL files located under "./functions"
+ * @function
+ *
+ * @param {Object} context - session context
+ * @param {Object} connection - Postgres database connection
+ *
+ * @example
+ * await functions.setup(context, connection)
+ */
+exports.setup = async (context, connection) => {
+	await Bluebird.each([
+		loadFunction('immutable-array-to-string.sql')
+	], async (func) => {
+		if (!func) {
+			return
+		}
+
+		logger.info(context, 'Creating Postgres function', {
+			file: func.file
+		})
+
+		await connection.any(func.query)
+	})
+}

--- a/lib/core/backend/postgres/functions/immutable-array-to-string.sql
+++ b/lib/core/backend/postgres/functions/immutable-array-to-string.sql
@@ -1,0 +1,4 @@
+/* Create an immutable wrapper for array_to_string() for text array tsvector index creation */
+CREATE OR REPLACE FUNCTION immutable_array_to_string(arr ANYARRAY, sep TEXT) RETURNS text AS $$
+	SELECT array_to_string(arr, sep);
+$$ LANGUAGE SQL IMMUTABLE

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -19,6 +19,7 @@ const cards = require('./cards')
 const streams = require('./streams')
 const utils = require('./utils')
 const markers = require('./markers')
+const functions = require('./functions')
 const metrics = require('../../../metrics')
 
 /*
@@ -405,6 +406,8 @@ module.exports = class PostgresBackend {
 			idleTimeoutMillis: 60 * 1000,
 			database: this.database
 		}))
+
+		await functions.setup(context, this.connection)
 
 		await cards.setup(context, this.connection, this.database)
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add a standard way to create/drop custom Postgres SQL functions on server init.

Still working out the exact implementation strategy. The current logic mirrors that of `apps/server/card-loader.js`, but it may be better to employ a more robust solution like [db-migrate](https://www.npmjs.com/package/db-migrate) and its [programable API](https://db-migrate.readthedocs.io/en/latest/API/programable/).

Closes https://github.com/product-os/jellyfish/issues/3822