### PR TITLE
ci: Fix make command for S3 upload test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ jobs:
           command: make compose-up DETACH=1 FS_DRIVER=s3FS
       - run:
           name: S3 File Upload Tests
-          command: make compose-exec-sidecar COMMAND="/bin/bash -c '. /root/.bashrc && make test FILES="./test/e2e/ui/file-upload.spec.js"'"
+          command: make compose-exec-sidecar COMMAND="/bin/bash -c \". /root/.bashrc && make test FILES=./test/e2e/ui/file-upload.spec.js\""
       - run:
           name: Docker Compose Down
           command: make compose-stop


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Noticed that the `make` command defined for S3 upload tests in our CircleCI config seems to be working fine, but may not have quotes closed properly. Vim indicates that the quotes are not closed properly while vscode doesn't complain at all. Making this fix to make sure quotes are properly matched.
