### PR TITLE
Small UI fixes

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -254,14 +254,13 @@ const MessageIcon = ({
 	firstInThread,
 	threadColor
 }) => {
-	const transform = firstInThread ? null : 'scale(1, -1)'
 	return (
 		<Icon
 			style={{
 				marginLeft: 6,
 				marginTop: 16,
 				fontSize: '18px',
-				transform,
+				transform: 'scale(1, -1)',
 				color: threadColor
 			}}
 			name= {firstInThread ? 'comment-alt' : 'share'}

--- a/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
@@ -34,8 +34,12 @@ const QuickSearchPanel = styled(Card) `
 	overflow: auto;
 `
 
+const LoaderSpan = styled.span `
+	background-color: ${(props) => { return props.theme.colors.background }};
+`
+
 const Loader = () => {
-	return <span>Loading</span>
+	return <LoaderSpan>Loading</LoaderSpan>
 }
 
 const SubAuto = (props) => {

--- a/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
@@ -37,7 +37,10 @@ const getUsers = async (user, sdk, value) => {
 				const: 'user@1.0.0'
 			},
 			slug: {
-				pattern: `^user-${value}`
+				regexp: {
+					pattern: `^user-${value}`,
+					flags: 'i'
+				}
 			}
 		},
 		required: [ 'type', 'slug' ],


### PR DESCRIPTION
Make auto-complete user lookup in messages case-insensitive
For example, searching for '@Jelly' will return '@jellyfish'.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
Ensure auto-complete loading placeholder has solid background

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***
Flip thread-start icon so it comes from the user's avatar
This just looks a bit more logical

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Small PR to do three little fixes:
1. change the query of users that match the token typed after the `@` symbol when composing a message to be case-insensitive. This is particularly useful as some people's GitHub usernames have uppercase letters that have been converted to lowercase letters for their Jellyfish usernames - so it's easy to search for an actual GitHub username (with uppercase letters) and get no results back 😢 
1. Ensure the background of the 'Loading' auto-complete placeholder component has a solid background and isn't transparent.
1. Flip the thread start icon so that the speech bubble comes from the user's avatar. See before/after screenshots below:

| Before | After |
|---------|-------|
| ![Icon flip before](https://user-images.githubusercontent.com/2925657/82770608-5bf5ae80-9e63-11ea-8d89-c864fd8a35ad.jpg) | ![Icon flip after](https://user-images.githubusercontent.com/2925657/82770634-62842600-9e63-11ea-9cd9-cf22ff44f548.jpg)
 | 
