### PR TITLE
SRE: Parse the Google Meet JWT from env var string.

### DIFF
--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -141,7 +141,7 @@ exports.integration = {
 		signature: (process.env.INTEGRATION_TYPEFORM_SIGNATURE_KEY || '')
 	},
 	'google-meet': {
-		credentials: process.env.INTEGRATION_GOOGLE_MEET_CREDENTIALS
+		credentials: JSON.parse(process.env.INTEGRATION_GOOGLE_MEET_CREDENTIALS)
 	}
 }
 


### PR DESCRIPTION
The env var is considered as a string so we need to parse it into a JSON object.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
