### PR TITLE
Auto-emojify messages

### DIFF
--- a/lib/chat-widget/store/action-creators.js
+++ b/lib/chat-widget/store/action-creators.js
@@ -66,7 +66,7 @@ export const initiateThread = (ctx) => {
 			payload: {
 				mentionsUser: mentions,
 				alertsUser: alerts,
-				message: text.replace(messageSymbolRE, '')
+				message: helpers.replaceEmoji(text.replace(messageSymbolRE, ''))
 			}
 		}
 

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -364,7 +364,7 @@ class Timeline extends React.Component {
 			payload: {
 				mentionsUser: mentions,
 				alertsUser: alerts,
-				message: newMessage.replace(messageSymbolRE, '')
+				message: helpers.replaceEmoji(newMessage.replace(messageSymbolRE, ''))
 			}
 		}
 

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -5,6 +5,7 @@
  */
 
 import ColorHash from 'color-hash'
+import emoji from 'node-emoji'
 import clone from 'deep-copy'
 import * as jsonpatch from 'fast-json-patch'
 import jsone from 'json-e'
@@ -255,6 +256,12 @@ export const getLocalSchema = (card) => {
 		type: 'object',
 		properties: {}
 	}
+}
+
+export const replaceEmoji = (messageText) => {
+	return emoji.emojify(messageText, (missing) => {
+		return `:${missing}:`
+	})
 }
 
 export const createPrefixRegExp = (prefix) => {

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -119,6 +119,10 @@ ava('.isCustomView returns false if user is not the only marker', (test) => {
 	test.false(helpers.isCustomView(view, user))
 })
 
+ava('.replaceEmoji replaces colon-encoded emoji but leaves unknown ones untouched', (test) => {
+	test.is(helpers.replaceEmoji('Test :+1: :unknown:'), 'Test 👍 :unknown:')
+})
+
 ava('.createPrefixRegExp() match underscore characters', (test) => {
 	const matchRE = helpers.createPrefixRegExp('@')
 	const match = matchRE.exec('Lorem ipsum @user_name dolor sit amet')


### PR DESCRIPTION
Typing `:+1:` will now result in the message being sent with a 👍  emoji rather than the plain text `:+1:`.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3830 
