### PR TITLE
ui: Only create a notification for 'insert' stream updates

### DIFF
--- a/apps/ui/core/store/actioncreators/index.js
+++ b/apps/ui/core/store/actioncreators/index.js
@@ -778,6 +778,7 @@ export default class ActionCreator {
 
 							// Create a desktop notification if an unread message ping appears
 							if (
+								update.type === 'insert' &&
 								(baseType === 'message' || baseType === 'whisper') &&
 								_.includes(_.get(card, [ 'data', 'payload', 'mentionsUser' ]), user.slug) &&
 								!_.includes(_.get(card, [ 'data', 'readBy' ]), user.slug)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #3789 (note: this PR doesn't fix the issue - but does reduce the problem!)

Previously we were calling the 'create notification' code on every type of update to a message/whisper card. When a message is sent, the stream listener is notified about an `insert`  event and then at least one `update` event. We only care about the initial `insert` event.
