### PR TITLE
Set blank Redis password for Compose services

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -29,7 +29,7 @@ services:
       - UI_PORT=80
       - INTEGRATION_BALENA_API_OAUTH_BASE_URL=https://api.balena-cloud.com
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT=6379
       - INTEGRATION_DISCOURSE_SIGNATURE_KEY=foobar
       - INTEGRATION_DISCOURSE_TOKEN=foobar

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -31,7 +31,7 @@ services:
       - POSTGRES_PORT={{POSTGRES_PORT}}
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT={{REDIS_PORT}}
       - SENTRY_DSN_SERVER
       - SERVER_DATABASE={{SERVER_DATABASE}}
@@ -168,7 +168,7 @@ services:
       - POSTGRES_PORT={{POSTGRES_PORT}}
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT={{REDIS_PORT}}
       - LOGLEVEL=crit
       - SENTRY_DSN_SERVER
@@ -242,7 +242,7 @@ services:
       - POSTGRES_PORT={{POSTGRES_PORT}}
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT={{REDIS_PORT}}
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - SERVER_DATABASE=jellyfish
@@ -168,7 +168,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT=6379
       - LOGLEVEL=crit
       - SENTRY_DSN_SERVER
@@ -241,7 +241,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN
@@ -299,7 +299,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN
@@ -357,7 +357,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=redis
+      - REDIS_PASSWORD=
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR removes the Redis password set in our Docker Compose configs as our Redis instance in Compose doesn't require a password. This will remove this harmless, but noisy, warning message that is output during CI/dev:
```
node_redis: Warning: Redis server does not require a password, but a password was supplied.
```

Closes: #3868 
