### PR TITLE
Add new group card

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -82,6 +82,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/whisper.json'),
 		await loadCard('contrib/workflow.json'),
 		await loadCard('contrib/web-push-subscription.json'),
+		await loadCard('contrib/group.json'),
 
 		// Triggered actions
 		await loadCard('contrib/triggered-action-github-issue-link.json'),

--- a/apps/server/default-cards/contrib/group.json
+++ b/apps/server/default-cards/contrib/group.json
@@ -1,0 +1,40 @@
+{
+  "slug": "group",
+  "type": "type@1.0.0",
+  "version": "1.0.0",
+  "name": "Group",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "meta": {
+      "relationships": [
+        {
+          "title": "Members",
+          "link": "has group member",
+          "type": "user"
+        }
+      ]
+    }
+  },
+  "requires": [],
+  "capabilities": []
+}


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #2883

This card simply represents a group. In subsequent PRs we will associate users with groups and add support for pinging a group in order to notify everyone in that group.