### PR TITLE
backend: Enable full-text search for message attachments

### DIFF
--- a/apps/server/default-cards/contrib/message.json
+++ b/apps/server/default-cards/contrib/message.json
@@ -93,7 +93,8 @@
                         "type": "number"
                       }
                     }
-                  }
+                  },
+                  "fullTextSearch": true
                 },
                 "message": {
                   "type": "string",

--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -577,12 +577,6 @@ exports.parseFullTextSearchFields = (context, schema, errors) => {
 	const combinators = [ 'anyOf', 'allOf', 'oneOf' ]
 	traverse(schema).forEach(function (node) {
 		if (this.key === 'fullTextSearch' && this.node === true && !_.isNil(this.parent.node.type)) {
-			// Throw an error if item doesn't have "string" as a possible type.
-			const hasStringType = Boolean(_.includes(this.parent.node.type, 'string') ||
-				(_.has(this.parent.node, [ 'items', 'type' ]) && this.parent.node.items.type.includes('string')))
-			assert.INTERNAL(context, hasStringType,
-				errors.JellyfishInvalidSchema, 'Full-text search fields must contain "string" as a possible type')
-
 			if (_.intersection(this.path, combinators).length > 0) {
 				// Handle combinators by creating an index for its parent node.
 				for (let idx = 0; idx < this.path.length; idx++) {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR may become mergeable at some point, but for now should be seen as a place to discuss the solution to the problem discussed in https://github.com/product-os/jellyfish/issues/3824. In short, we need to find a way to index and search through strings stored within somewhat complex data structures, such as the properties of files stored in objects of an array as can be seen in `message` cards' `data.payload.attachments`.

The method included implemented in this PR uses the built-in Postgres `jsonb_to_tsvector()` function to traverse and convert all string typed values stored within the objects of this array. This is a very easy way to handle this problem as Postgres does everything for us, but including *all* string data may be casting too wide a net and cause us end up indexing data that we otherwise wouldn't.

Here is some example data for `data.payload.attachments` on `message` cards:

Original data (generated randomly):
```
jellyfish=# select cards.data#>'{payload,attachments}' from cards where type='message@1.0.0';
                                                      ?column?                                                      
--------------------------------------------------------------------------------------------------------------------
 [{"url": "https://constantly.com/slide/year.jpg", "mime": "image/jpeg", "name": "year.jpg", "bytesize": 1234}]
 [{"url": "https://anywhere.com/anyway/orange.jpg", "mime": "image/jpeg", "name": "orange.jpg", "bytesize": 1234}]
 [{"url": "https://sharp.com/spin/good.jpg", "mime": "image/jpeg", "name": "good.jpg", "bytesize": 1234}]
 [{"url": "https://shells.com/know/chose.jpg", "mime": "image/jpeg", "name": "chose.jpg", "bytesize": 1234}]
 [{"url": "https://silence.com/drive/quietly.jpg", "mime": "image/jpeg", "name": "quietly.jpg", "bytesize": 1234}]
 [{"url": "https://rear.com/animal/pretty.jpg", "mime": "image/jpeg", "name": "pretty.jpg", "bytesize": 1234}]
 [{"url": "https://large.com/gas/flag.jpg", "mime": "image/jpeg", "name": "flag.jpg", "bytesize": 1234}]
 [{"url": "https://diagram.com/moment/special.jpg", "mime": "image/jpeg", "name": "special.jpg", "bytesize": 1234}]
 [{"url": "https://sang.com/magnet/tin.jpg", "mime": "image/jpeg", "name": "tin.jpg", "bytesize": 1234}]
 [{"url": "https://thou.com/tired/closer.jpg", "mime": "image/jpeg", "name": "closer.jpg", "bytesize": 1234}]
```

TSVectors indexed and used for full-text search:
```
jellyfish=# select jsonb_to_tsvector('english', cards.data#>'{payload,attachments}', '["string"]') from cards where type='message@1.0.0';
                                             jsonb_to_tsvector                                             
-----------------------------------------------------------------------------------------------------------
 '/slide/year.jpg':3 'constantly.com':2 'constantly.com/slide/year.jpg':1 'image/jpeg':5 'year.jpg':7
 '/anyway/orange.jpg':3 'anywhere.com':2 'anywhere.com/anyway/orange.jpg':1 'image/jpeg':5 'orange.jpg':7
 '/spin/good.jpg':3 'good.jpg':7 'image/jpeg':5 'sharp.com':2 'sharp.com/spin/good.jpg':1
 '/know/chose.jpg':3 'chose.jpg':7 'image/jpeg':5 'shells.com':2 'shells.com/know/chose.jpg':1
 '/drive/quietly.jpg':3 'image/jpeg':5 'quietly.jpg':7 'silence.com':2 'silence.com/drive/quietly.jpg':1
 '/animal/pretty.jpg':3 'image/jpeg':5 'pretty.jpg':7 'rear.com':2 'rear.com/animal/pretty.jpg':1
 '/gas/flag.jpg':3 'flag.jpg':7 'image/jpeg':5 'large.com':2 'large.com/gas/flag.jpg':1
 '/moment/special.jpg':3 'diagram.com':2 'diagram.com/moment/special.jpg':1 'image/jpeg':5 'special.jpg':7
 '/magnet/tin.jpg':3 'image/jpeg':5 'sang.com':2 'sang.com/magnet/tin.jpg':1 'tin.jpg':7
 '/tired/closer.jpg':3 'closer.jpg':7 'image/jpeg':5 'thou.com':2 'thou.com/tired/closer.jpg':1
```

Closes #3824 