### PR TITLE
Bump jellyfish-client-sdk to v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,9 +1791,9 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.4.0.tgz",
-      "integrity": "sha512-UBn1gA3t8Uavxl2XJXC9AwLG3VGl8RpJ1EYibdAnz42b+HZGhKblI4uP2P2uXw4o55SiNrBP3CwRypvkN6LTWg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.5.0.tgz",
+      "integrity": "sha512-p8Ufc1qZeVXHD+d5k4d6eaIiA8KnDN+oRerhlXEEv3zzl+ux31DMpSogDZI8FaTwP09yBsvnfjRQ7nqcpZInSg==",
       "requires": {
         "axios": "^0.19.2",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
-    "@balena/jellyfish-client-sdk": "^0.4.0",
+    "@balena/jellyfish-client-sdk": "^0.5.0",
     "@balena/node-metrics-gatherer": "^5.6.0",
     "@octokit/auth-app": "^2.4.4",
     "@octokit/plugin-retry": "^2.2.0",


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This version adds support for linking users to groups.
