### PR TITLE
Improve performance when keeping trigger data up to date in workers

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -36,6 +36,63 @@ const runExecutor = async (fn, instance, context, session, typeCard, card, optio
 	}, card, patch)
 }
 
+const parseTrigger = (context, trigger) => {
+	assert.INTERNAL(context, trigger.slug && _.isString(trigger.slug),
+		errors.WorkerInvalidTrigger, `Invalid slug: ${trigger.slug}`)
+	assert.INTERNAL(context, trigger.id && _.isString(trigger.id),
+		errors.WorkerInvalidTrigger, `Invalid id: ${trigger.id}`)
+	assert.INTERNAL(context, trigger.action && _.isString(trigger.action),
+		errors.WorkerInvalidTrigger, `Invalid action: ${trigger.action}`)
+	assert.INTERNAL(context, !trigger.mode || _.isString(trigger.mode),
+		errors.WorkerInvalidTrigger, `Invalid mode: ${trigger.mode}`)
+	assert.INTERNAL(context,
+		trigger.target && (_.isString(trigger.target) || _.isPlainObject(trigger.target) || _.isArray(trigger.target)),
+		errors.WorkerInvalidTrigger, `Invalid target: ${trigger.target}`)
+	if (_.isArray(trigger.target)) {
+		assert.INTERNAL(context,
+			trigger.target.length === _.uniq(trigger.target).length,
+			errors.WorkerInvalidTrigger, 'Invalid target: it contains duplicates')
+	}
+	assert.INTERNAL(context,
+		(trigger.interval || trigger.filter) && !(trigger.interval && trigger.filter),
+		errors.WorkerInvalidTrigger, 'Use either a filter or an interval')
+	assert.INTERNAL(context,
+		trigger.interval || (trigger.filter && _.isPlainObject(trigger.filter)),
+		errors.WorkerInvalidTrigger, `Invalid filter: ${trigger.filter}`)
+	assert.INTERNAL(context,
+		trigger.filter || (trigger.interval && _.isString(trigger.interval)),
+		errors.WorkerInvalidTrigger, `Invalid interval: ${trigger.interval}`)
+	assert.INTERNAL(context,
+		trigger.arguments && _.isPlainObject(trigger.arguments),
+		errors.WorkerInvalidTrigger, `Invalid arguments: ${trigger.arguments}`)
+
+	const result = {
+		id: trigger.id,
+		slug: trigger.slug,
+		action: trigger.action,
+		target: trigger.target,
+		arguments: trigger.arguments
+	}
+
+	if (trigger.startDate) {
+		result.startDate = trigger.startDate
+	}
+
+	if (trigger.filter) {
+		result.filter = trigger.filter
+	}
+
+	if (trigger.interval) {
+		result.interval = trigger.interval
+	}
+
+	if (trigger.mode) {
+		result.mode = trigger.mode
+	}
+
+	return result
+}
+
 module.exports = class Worker {
 	/**
 	 * @summary The Jellyfish Actions Worker
@@ -240,60 +297,58 @@ module.exports = class Worker {
 		})
 
 		this.triggers = objects.map((trigger) => {
-			assert.INTERNAL(context, trigger.slug && _.isString(trigger.slug),
-				errors.WorkerInvalidTrigger, `Invalid slug: ${trigger.slug}`)
-			assert.INTERNAL(context, trigger.id && _.isString(trigger.id),
-				errors.WorkerInvalidTrigger, `Invalid id: ${trigger.id}`)
-			assert.INTERNAL(context, trigger.action && _.isString(trigger.action),
-				errors.WorkerInvalidTrigger, `Invalid action: ${trigger.action}`)
-			assert.INTERNAL(context, !trigger.mode || _.isString(trigger.mode),
-				errors.WorkerInvalidTrigger, `Invalid mode: ${trigger.mode}`)
-			assert.INTERNAL(context,
-				trigger.target && (_.isString(trigger.target) || _.isPlainObject(trigger.target) || _.isArray(trigger.target)),
-				errors.WorkerInvalidTrigger, `Invalid target: ${trigger.target}`)
-			if (_.isArray(trigger.target)) {
-				assert.INTERNAL(context,
-					trigger.target.length === _.uniq(trigger.target).length,
-					errors.WorkerInvalidTrigger, 'Invalid target: it contains duplicates')
-			}
-			assert.INTERNAL(context,
-				(trigger.interval || trigger.filter) && !(trigger.interval && trigger.filter),
-				errors.WorkerInvalidTrigger, 'Use either a filter or an interval')
-			assert.INTERNAL(context,
-				trigger.interval || (trigger.filter && _.isPlainObject(trigger.filter)),
-				errors.WorkerInvalidTrigger, `Invalid filter: ${trigger.filter}`)
-			assert.INTERNAL(context,
-				trigger.filter || (trigger.interval && _.isString(trigger.interval)),
-				errors.WorkerInvalidTrigger, `Invalid interval: ${trigger.interval}`)
-			assert.INTERNAL(context,
-				trigger.arguments && _.isPlainObject(trigger.arguments),
-				errors.WorkerInvalidTrigger, `Invalid arguments: ${trigger.arguments}`)
+			return parseTrigger(context, trigger)
+		})
+	}
 
-			const result = {
-				id: trigger.id,
-				slug: trigger.slug,
-				action: trigger.action,
-				target: trigger.target,
-				arguments: trigger.arguments
-			}
+	/**
+		* @summary Upsert a single registered trigger
+		* @function
+		* @public
+		* @param {Object} context - execution context
+		* @param {Object} card - trigger card
+		* @example
+		* const worker = new Worker({ ... })
+		* worker.upsertTrigger({ ... })
+		*/
+	upsertTrigger (context, card) {
+		logger.info(context, 'Upserting trigger', {
+			slug: card.slug
+		})
 
-			if (trigger.startDate) {
-				result.startDate = trigger.startDate
-			}
+		const trigger = parseTrigger(context, card)
 
-			if (trigger.filter) {
-				result.filter = trigger.filter
-			}
+		// Find the index of an existing trigger with the same id
+		const existingTriggerIndex = _.findIndex(this.triggers, {
+			id: trigger.id
+		})
 
-			if (trigger.interval) {
-				result.interval = trigger.interval
-			}
+		if (existingTriggerIndex === -1) {
+			// If an existing trigger is not found, add the trigger
+			this.triggers.push(trigger)
+		} else {
+			// If an existing trigger is found, replace it
+			this.triggers.splice(existingTriggerIndex, 1, trigger)
+		}
+	}
 
-			if (trigger.mode) {
-				result.mode = trigger.mode
-			}
+	/**
+		* @summary Remove a single registered trigger
+		* @function
+		* @public
+		* @param {Object} context - execution context
+		* @param {Object} slug - slug of trigger card
+		* @example
+		* const worker = new Worker({ ... })
+		* worker.removeTrigger('trigger-ed3c21f2-fa5e-4cdf-b862-392a2697abe4')
+		*/
+	removeTrigger (context, slug) {
+		logger.info(context, 'Removing trigger', {
+			slug
+		})
 
-			return result
+		this.triggers = _.reject(this.triggers, {
+			slug
 		})
 	}
 

--- a/test/integration/worker/trigger-updates.spec.js
+++ b/test/integration/worker/trigger-updates.spec.js
@@ -518,3 +518,176 @@ ava('.setTriggers() should throw if arguments is not an object', (test) => {
 		instanceOf: test.context.worker.errors.WorkerInvalidTrigger
 	})
 })
+
+ava('.upsertTrigger() should be able to add a trigger', (test) => {
+	test.context.worker.setTriggers(test.context.context, [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			action: 'action-foo-bar@1.0.0',
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'bar'
+			}
+		}
+	])
+
+	test.context.worker.upsertTrigger(test.context.context, {
+		id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+		slug: 'triggered-action-foo-baz',
+		action: 'action-foo-bar@1.0.0',
+		target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
+		type: 'card@1.0.0',
+		filter: {
+			type: 'object'
+		},
+		arguments: {
+			foo: 'baz'
+		}
+	})
+
+	const triggers = test.context.worker.getTriggers()
+
+	test.deepEqual(triggers, [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			action: 'action-foo-bar@1.0.0',
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'bar'
+			}
+		},
+		{
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			action: 'action-foo-bar@1.0.0',
+			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'baz'
+			}
+		}
+	])
+})
+
+ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
+	test.context.worker.setTriggers(test.context.context, [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			action: 'action-foo-bar@1.0.0',
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'bar'
+			}
+		},
+		{
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			action: 'action-foo-bar@1.0.0',
+			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
+			type: 'card@1.0.0',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'baz'
+			}
+		}
+	])
+
+	test.context.worker.upsertTrigger(test.context.context, {
+		id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+		slug: 'triggered-action-foo-baz',
+		action: 'action-foo-bar@1.0.0',
+		target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
+		type: 'card@1.0.0',
+		filter: {
+			type: 'object'
+		},
+		arguments: {
+			baz: 'buzz'
+		}
+	})
+
+	const triggers = test.context.worker.getTriggers()
+
+	test.deepEqual(triggers, [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			action: 'action-foo-bar@1.0.0',
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'bar'
+			}
+		},
+		{
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			action: 'action-foo-bar@1.0.0',
+			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				baz: 'buzz'
+			}
+		}
+	])
+})
+
+ava('.removeTrigger() should be able to remove an existing trigger', (test) => {
+	const cards = [
+		{
+			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			slug: 'triggered-action-foo-bar',
+			action: 'action-foo-bar@1.0.0',
+			target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'bar'
+			}
+		},
+		{
+			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
+			slug: 'triggered-action-foo-baz',
+			action: 'action-foo-bar@1.0.0',
+			target: 'a13474e4-7b44-453b-9f3e-aa783b8f37ea',
+			type: 'card@1.0.0',
+			filter: {
+				type: 'object'
+			},
+			arguments: {
+				foo: 'baz'
+			}
+		}
+	]
+
+	test.context.worker.setTriggers(test.context.context, cards)
+
+	test.context.worker.removeTrigger(test.context.context, cards[1].slug)
+
+	const triggers = test.context.worker.getTriggers()
+
+	test.deepEqual(triggers, [
+		cards[0]
+	])
+})


### PR DESCRIPTION
Previously, when a triggered-action was upserted into the DB, every worker would
load every triggered-action again. With this change, individual triggered-action
are extracted from the stream event payload, and updated individually,
allowing us to avoid querying the jellyfish core.

Connects-to: #3931
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
