### PR TITLE
Add auto-completion of groups when writing messages.

### DIFF
--- a/apps/server/default-cards/contrib/group.json
+++ b/apps/server/default-cards/contrib/group.json
@@ -25,6 +25,9 @@
         "name"
       ]
     },
+    "indexed_fields": [
+      [ "data.name" ]
+    ],
     "meta": {
       "relationships": [
         {

--- a/apps/server/default-cards/contrib/group.json
+++ b/apps/server/default-cards/contrib/group.json
@@ -14,11 +14,16 @@
         "name": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
-        "namespace": {
-          "type": "string"
+        "data": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          }
         }
       },
       "required": [
@@ -26,7 +31,7 @@
       ]
     },
     "indexed_fields": [
-      [ "data.name" ]
+      [ "name" ]
     ],
     "meta": {
       "relationships": [

--- a/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
@@ -53,6 +53,35 @@ const getUsers = async (user, sdk, value) => {
 	return results
 }
 
+const getGroups = async (sdk, value) => {
+	// Return all matching user groups
+	// TODO: limit this by organisation
+	const results = await sdk.query({
+		type: 'object',
+		properties: {
+			type: {
+				const: 'group@1.0.0'
+			},
+			data: {
+				properties: {
+					name: {
+						pattern: `^${value}`
+					}
+				},
+				required: [ 'name' ],
+				additionalProperties: true
+			}
+		},
+		required: [ 'type' ],
+		additionalProperties: true
+	}, {
+		limit: 10,
+		sortBy: 'slug'
+	})
+
+	return results
+}
+
 const EmojiItem = ({
 	entity
 }) => {
@@ -117,6 +146,44 @@ export const getTrigger = _.memoize((allTypes, sdk, user) => {
 				entity
 			}) => { return <div>{entity}</div> },
 			output: (item) => { return item }
+		},
+		'@@': {
+			dataProvider: debounce(async (token) => {
+				if (!token) {
+					return []
+				}
+				const groups = await getGroups(sdk, token.replace(/^@+/, ''))
+				return groups.map((group) => {
+					return `@@${group.data.name}`
+				})
+			}, AUTOCOMPLETE_DEBOUNCE),
+			component: ({
+				entity
+			}) => {
+				return <div>{entity}</div>
+			},
+			output: (item) => {
+				return item
+			}
+		},
+		'!!': {
+			dataProvider: debounce(async (token) => {
+				if (!token) {
+					return []
+				}
+				const groups = await getGroups(sdk, token.replace(/^!+/, ''))
+				return groups.map((group) => {
+					return `!!${group.data.name}`
+				})
+			}, AUTOCOMPLETE_DEBOUNCE),
+			component: ({
+				entity
+			}) => {
+				return <div>{entity}</div>
+			},
+			output: (item) => {
+				return item
+			}
 		},
 		'?': {
 			dataProvider: (token) => {

--- a/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/triggers.jsx
@@ -62,17 +62,11 @@ const getGroups = async (sdk, value) => {
 			type: {
 				const: 'group@1.0.0'
 			},
-			data: {
-				properties: {
-					name: {
-						pattern: `^${value}`
-					}
-				},
-				required: [ 'name' ],
-				additionalProperties: true
+			name: {
+				pattern: `^${value}`
 			}
 		},
-		required: [ 'type' ],
+		required: [ 'type', 'name' ],
 		additionalProperties: true
 	}, {
 		limit: 10,
@@ -154,7 +148,7 @@ export const getTrigger = _.memoize((allTypes, sdk, user) => {
 				}
 				const groups = await getGroups(sdk, token.replace(/^@+/, ''))
 				return groups.map((group) => {
-					return `@@${group.data.name}`
+					return `@@${group.name}`
 				})
 			}, AUTOCOMPLETE_DEBOUNCE),
 			component: ({
@@ -173,7 +167,7 @@ export const getTrigger = _.memoize((allTypes, sdk, user) => {
 				}
 				const groups = await getGroups(sdk, token.replace(/^!+/, ''))
 				return groups.map((group) => {
-					return `!!${group.data.name}`
+					return `!!${group.name}`
 				})
 			}, AUTOCOMPLETE_DEBOUNCE),
 			component: ({

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -731,3 +731,74 @@ ava.serial('A user can edit their own message', async (test) => {
 	const newMessageText = await macros.getElementText(page, `${eventSelector} [data-test="event-card__message"]`)
 	test.is(newMessageText.trim(), messageTextAfter)
 })
+
+ava.serial('You can select a user and a group from the auto-complete options', async (test) => {
+	const {
+		page
+	} = context
+
+	const uuid1 = uuid()
+	const username = `${uuid1}-test-user`
+	const uuid2 = uuid()
+	const groupName = `${uuid2}-test-group`
+
+	const testUser = await context.createUser({
+		username,
+		email: `test-user-${uuid()}@example.com`,
+		password: 'password'
+	})
+
+	await context.addUserToBalenaOrg(testUser.id)
+
+	await page.evaluate((name) => {
+		return window.sdk.card.create({
+			type: 'group@1.0.0',
+			name: 'test-1',
+			data: {
+				name
+			}
+		})
+	}, groupName)
+
+	const supportThread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'support-thread@1.0.0',
+			data: {
+				inbox: 'S/Paid_Support',
+				status: 'open'
+			}
+		})
+	})
+
+	// Navigate to the thread and wait for the thread to be displayed
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	const threadSelector = '.column--support-thread'
+	await page.waitForSelector(threadSelector)
+
+	await page.waitForSelector('.new-message-input', macros.WAIT_OPTS)
+
+	// Use auto-complete to find a user
+	await page.type('textarea', `@${uuid1}`)
+	await page.waitForSelector('.rta__autocomplete .rta__item')
+	const userMatches = await page.$$('.rta__autocomplete .rta__item')
+	test.is(userMatches.length, 1)
+	const userMatch = await macros.getElementText(page, '.rta__autocomplete .rta__item:first-child')
+	test.is(userMatch.trim().substr(1), username)
+
+	// Select the first item from the auto-complete suggestions (note: this also appends a space to the message)
+	await page.keyboard.press('Enter')
+
+	// Now user auto-complete to find a group
+	await page.type('textarea', `@@${uuid2}`)
+	await page.waitForSelector('.rta__autocomplete .rta__item')
+	const groupMatches = await page.$$('.rta__autocomplete .rta__item')
+	test.is(groupMatches.length, 1)
+	const groupMatch = await macros.getElementText(page, '.rta__autocomplete .rta__item:first-child')
+	test.is(groupMatch.trim().substr(2), groupName)
+
+	// Select the first item from the auto-complete suggestions
+	await page.keyboard.press('Enter')
+
+	const textareaText = await macros.getElementText(page, 'textarea')
+	test.is(textareaText.trim(), `@${username} @@${groupName}`)
+})

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -753,10 +753,7 @@ ava.serial('You can select a user and a group from the auto-complete options', a
 	await page.evaluate((name) => {
 		return window.sdk.card.create({
 			type: 'group@1.0.0',
-			name: 'test-1',
-			data: {
-				name
-			}
+			name
 		})
 	}, groupName)
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #2883 

Adds support for typing `@@` to prompt an auto-completion search for groups. 

Note: I've added an e2e test to test auto-completion functionality as the `react-textarea-autosize` component doesn't play well with the DOM-less unit-test environment.