### PR TITLE
Add options for triggered actions to be sync or async

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -61,6 +61,13 @@ const transformTriggerCard = (trigger) => {
 		object.mode = trigger.data.mode
 	}
 
+	// Triggered actions default to being asynchronous
+	if (_.has(trigger.data, [ 'async' ])) {
+		object.async = trigger.data.async
+	} else {
+		object.async = true
+	}
+
 	return object
 }
 

--- a/apps/server/default-cards/contrib/triggered-action-github-issue-link.json
+++ b/apps/server/default-cards/contrib/triggered-action-github-issue-link.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": true,
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/default-cards/contrib/triggered-action-hangouts-link.json
+++ b/apps/server/default-cards/contrib/triggered-action-hangouts-link.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": true,
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/default-cards/contrib/triggered-action-increment-tag.json
+++ b/apps/server/default-cards/contrib/triggered-action-increment-tag.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": true,
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "anyOf": [

--- a/apps/server/default-cards/contrib/triggered-action-integration-front-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-front-mirror-event.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "anyOf": [

--- a/apps/server/default-cards/contrib/triggered-action-integration-github-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-github-mirror-event.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/default-cards/contrib/triggered-action-integration-import-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-import-event.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": true,
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "required": [ "type" ],

--- a/apps/server/default-cards/contrib/triggered-action-set-user-avatar.json
+++ b/apps/server/default-cards/contrib/triggered-action-set-user-avatar.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "required": [ "type" ],

--- a/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "$$links": {
         "is attached to": {

--- a/apps/server/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-reopen.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "$$links": {
         "is attached to": {

--- a/apps/server/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-summary.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "$$links": {

--- a/apps/server/default-cards/contrib/triggered-action-user-contact.json
+++ b/apps/server/default-cards/contrib/triggered-action-user-contact.json
@@ -7,6 +7,7 @@
   "links": {},
   "active": true,
   "data": {
+    "async": false,
     "filter": {
       "type": "object",
       "required": [ "type" ],

--- a/lib/jellyscript/index.js
+++ b/lib/jellyscript/index.js
@@ -166,6 +166,7 @@ exports.getTypeTriggers = (typeCard) => {
 				markers: [],
 				tags: [],
 				data: {
+					async: true,
 					action: 'action-set-add@1.0.0',
 					type: `${typeCard.slug}@${typeCard.version}`,
 					target: {

--- a/lib/worker/cards/triggered-action.js
+++ b/lib/worker/cards/triggered-action.js
@@ -24,6 +24,11 @@ module.exports = {
 				data: {
 					type: 'object',
 					properties: {
+						async: {
+							description: 'True if the triggered action should be executed asynchronously, false otherwise',
+							type: 'boolean',
+							default: true
+						},
 						mode: {
 							type: 'string',
 							enum: [ 'insert', 'update' ]

--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -5,6 +5,7 @@
  */
 
 const Bluebird = require('bluebird')
+const errio = require('errio')
 const _ = require('lodash')
 const skhema = require('skhema')
 const fastEquals = require('fast-equals')
@@ -156,7 +157,7 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 	}
 
 	if (options.triggers) {
-		await Bluebird.map(options.triggers, async (trigger) => {
+		const runTrigger = async (trigger) => {
 			// Ignore triggered actions whose start date is in the future
 			if (options.currentTime < triggers.getStartDate({
 				data: trigger
@@ -208,9 +209,40 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 						originator: options.originator || request.originator
 					})
 			}))
-		}, {
+		}
+
+		const [ syncTriggers, asyncTriggers ] = _.partition(options.triggers, {
+			async: false
+		})
+
+		// Run the synchronous, "blocking" triggers first
+		await Bluebird.map(syncTriggers, runTrigger, {
 			// Triggers can't be processed concurrently as they may modify cards, which
 			// can cause race conditions if they are not done in serial
+			concurrency: 1
+		})
+
+		// Don't await aync triggers
+		Bluebird.map(asyncTriggers, (trigger) => {
+			return runTrigger(trigger)
+				.catch((error) => {
+					const errorObject = errio.toObject(error, {
+						stack: true
+					})
+
+					const logData = {
+						error: errorObject,
+						input: insertedCard.slug,
+						trigger: trigger.slug
+					}
+
+					if (error.expected) {
+						logger.warn(context, 'Execute error in asynchronous trigger', logData)
+					} else {
+						logger.error(context, 'Execute error', logData)
+					}
+				})
+		}, {
 			concurrency: 1
 		})
 	}
@@ -232,15 +264,8 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 				})
 
 			// Also from the locally cached triggers
-			_.remove(options.triggers, (element) => {
-				return fastEquals.deepEqual(element, {
-					id: trigger.id,
-					slug: trigger.slug,
-					action: trigger.data.action,
-					target: trigger.data.target,
-					filter: trigger.data.filter,
-					arguments: trigger.data.arguments
-				})
+			_.remove(options.triggers, {
+				id: trigger.id
 			})
 		}, {
 			concurrency: INSERT_CONCURRENCY
@@ -263,6 +288,13 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 
 			if (trigger.data.mode) {
 				triggerObject.mode = trigger.data.mode
+			}
+
+			// Triggered actions default to being asynchronous
+			if (_.has(trigger.data, [ 'async' ])) {
+				triggerObject.async = trigger.data.async
+			} else {
+				triggerObject.async = true
 			}
 
 			// Registered the newly created trigger

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -71,7 +71,8 @@ const parseTrigger = (context, trigger) => {
 		slug: trigger.slug,
 		action: trigger.action,
 		target: trigger.target,
-		arguments: trigger.arguments
+		arguments: trigger.arguments,
+		async: trigger.async
 	}
 
 	if (trigger.startDate) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "ava": {
-    "timeout": "1m",
+    "timeout": "2m",
     "verbose": true,
     "serial": true,
     "failWithoutAssertions": true,

--- a/test/e2e/sdk/helpers.js
+++ b/test/e2e/sdk/helpers.js
@@ -43,6 +43,10 @@ exports.before = async (test) => {
 		await Bluebird.delay(1000)
 		return test.context.executeThenWait(null, waitQuery, times - 1)
 	}
+
+	test.context.waitForMatch = async (query) => {
+		return test.context.executeThenWait(null, query)
+	}
 }
 
 exports.after = async (test) => {

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -808,8 +808,16 @@ ava.serial.only('should merge and relink a diverging contact with a matching slu
 		}
 	})
 
-	const contact = await test.context.sdk.card.get(
-		slug.replace(/^user-/, 'contact-'))
+	const contact = await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'slug' ],
+		properties: {
+			slug: {
+				type: 'string',
+				const: slug.replace(/^user-/, 'contact-')
+			}
+		}
+	})
 
 	const contactCard = await test.context.sdk.card.update(contact.id, contact.type, [
 		{

--- a/test/e2e/server/external-support-user-security.spec.js
+++ b/test/e2e/server/external-support-user-security.spec.js
@@ -85,7 +85,7 @@ async (test) => {
 	await sdk.auth.login(externalSupportUserDetails)
 
 	// Create thread with different product
-	let error = await test.throwsAsync(test.context.sdk.card.create({
+	let error = await test.throwsAsync(sdk.card.create({
 		type: 'support-thread',
 		name: 'test subject',
 		markers: [ `${externalSupportUser.slug}+org-balena` ],

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -53,6 +53,7 @@ ava.serial('should be able to run high privilege triggers in response to common 
 		data: {
 			action: 'action-create-card@1.0.0',
 			mode: 'insert',
+			async: false,
 			filter: {
 				type: 'object',
 				properties: {
@@ -656,9 +657,11 @@ ava.serial('should fail to query with an invalid query object', async (test) => 
 })
 
 ava.serial('should get all elements by type', async (test) => {
+	const token = test.context.sdk.getAuthToken()
+
 	const result = await test.context.http(
 		'GET', '/api/v2/type/user', null, {
-			Authorization: `Bearer ${test.context.token}`
+			Authorization: `Bearer ${token}`
 		})
 
 	test.is(result.code, 200)
@@ -673,8 +676,11 @@ ava.serial('should get all elements by type', async (test) => {
 				const: 'user@1.0.0'
 			}
 		}
+	}, {
+		limit: 100
 	})
 
+	test.is(result.response.length, users.length)
 	test.deepEqual(result.response, users)
 })
 

--- a/test/e2e/server/security/community.spec.js
+++ b/test/e2e/server/security/community.spec.js
@@ -90,10 +90,9 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	const newUser = await test.context.sdk.card.get(newUserId)
 
 	test.truthy(newUser.data.hash)
-	test.deepEqual(newUser.data, {
+	test.deepEqual(_.omit(newUser.data, 'avatar'), {
 		email: newUserDetails.email,
 		hash: newUser.data.hash,
-		avatar: null,
 		roles: [ 'user-community' ]
 	})
 
@@ -129,7 +128,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	test.is(result3.response.data.name, 'WorkerAuthenticationError')
 
 	const newUserAfter = await test.context.sdk.card.get(newUser.id)
-	test.deepEqual(newUserAfter.data, newUser.data)
+	test.deepEqual(_.omit(newUserAfter.data, 'avatar'), _.omit(newUser.data, 'avatar'))
 })
 
 ava.serial('a community user should not be able to reset other user\'s passwords given an incorrect password', async (test) => {
@@ -175,10 +174,9 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 
 	const newUser = await test.context.sdk.card.get(newUserId)
 	test.truthy(newUser.data.hash)
-	test.deepEqual(newUser.data, {
+	test.deepEqual(_.omit(newUser.data, 'avatar'), {
 		email: newUserDetails.email,
 		hash: newUser.data.hash,
-		avatar: null,
 		roles: [ 'user-community' ]
 	})
 
@@ -200,7 +198,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	test.is(result3.response.data.name, 'WorkerAuthenticationError')
 
 	const newUserAfter = await test.context.sdk.card.get(newUser.id)
-	test.deepEqual(newUserAfter.data, newUser.data)
+	test.deepEqual(_.omit(newUserAfter.data, 'avatar'), _.omit(newUser.data, 'avatar'))
 })
 
 ava.serial('a community user should not be able to reset other user\'s passwords given no password', async (test) => {
@@ -246,10 +244,9 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 
 	const newUser = await test.context.sdk.card.get(newUserId)
 	test.truthy(newUser.data.hash)
-	test.deepEqual(newUser.data, {
+	test.deepEqual(_.omit(newUser.data, 'avatar'), {
 		email: newUserDetails.email,
 		hash: newUser.data.hash,
-		avatar: null,
 		roles: [ 'user-community' ]
 	})
 
@@ -271,7 +268,7 @@ ava.serial('a community user should not be able to reset other user\'s passwords
 	test.is(result3.response.data.name, 'WorkerAuthenticationError')
 
 	const newUserAfter = await test.context.sdk.card.get(newUser.id)
-	test.deepEqual(newUserAfter.data, newUser.data)
+	test.deepEqual(_.omit(newUserAfter.data, 'avatar'), _.omit(newUser.data, 'avatar'))
 })
 
 ava.serial('a community user should not be able to set a first time password to another user', async (test) => {
@@ -313,11 +310,10 @@ ava.serial('a community user should not be able to set a first time password to 
 	})
 
 	const newUserCard = await test.context.sdk.card.get(newUser.id)
-	test.deepEqual(newUserCard.data, {
+	test.deepEqual(_.omit(newUserCard.data, 'avatar'), {
 		email: newUserDetails.email,
 		hash: 'PASSWORDLESS',
-		roles: [ 'user-community' ],
-		avatar: null
+		roles: [ 'user-community' ]
 	})
 
 	const result2 = await test.context.http(
@@ -339,11 +335,10 @@ ava.serial('a community user should not be able to set a first time password to 
 
 	const newUserAfter = await test.context.sdk.card.get(newUser.id)
 
-	test.deepEqual(newUserAfter.data, {
+	test.deepEqual(_.omit(newUserAfter.data, 'avatar'), {
 		email: newUserDetails.email,
 		hash: 'PASSWORDLESS',
-		roles: [ 'user-community' ],
-		avatar: null
+		roles: [ 'user-community' ]
 	})
 })
 

--- a/test/e2e/server/security/index.spec.js
+++ b/test/e2e/server/security/index.spec.js
@@ -692,7 +692,10 @@ ava.serial('should apply permissions on resolved links', async (test) => {
 					Object.assign({}, targetUser, {
 						links: results[0].links['is attached to'][0].links,
 						linked_at: results[0].links['is attached to'][0].linked_at,
-						data: _.omit(targetUser.data, [ 'hash', 'roles', 'profile' ])
+						updated_at: results[0].links['is attached to'][0].updated_at,
+						data: Object.assign(_.omit(targetUser.data, [ 'hash', 'roles', 'profile' ]), {
+							avatar: null
+						})
 					})
 				]
 			},

--- a/test/integration/worker/insert-card.spec.js
+++ b/test/integration/worker/insert-card.spec.js
@@ -23,6 +23,7 @@ ava('.insertCard() should pass a triggered action originator', async (test) => {
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
+			async: false,
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -77,6 +78,7 @@ ava('.insertCard() should take an originator option', async (test) => {
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
+			async: false,
 			filter: {
 				type: 'object',
 				required: [ 'data' ],

--- a/test/integration/worker/trigger-updates.spec.js
+++ b/test/integration/worker/trigger-updates.spec.js
@@ -17,6 +17,7 @@ ava.after(helpers.worker.after)
 ava('.setTriggers() should be able to set a trigger with a start date', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -35,6 +36,7 @@ ava('.setTriggers() should be able to set a trigger with a start date', (test) =
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -53,6 +55,7 @@ ava('.setTriggers() should be able to set a trigger with a start date', (test) =
 ava('.setTriggers() should be able to set a trigger with an interval', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -68,6 +71,7 @@ ava('.setTriggers() should be able to set a trigger with an interval', (test) =>
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -83,6 +87,7 @@ ava('.setTriggers() should be able to set a trigger with an interval', (test) =>
 ava('.setTriggers() should be able to set triggers', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -95,6 +100,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 			}
 		},
 		{
+			async: true,
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -113,6 +119,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -125,6 +132,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 			}
 		},
 		{
+			async: true,
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -142,6 +150,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 ava('.setTriggers() should not store extra properties', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			foo: 'bar',
@@ -161,6 +170,7 @@ ava('.setTriggers() should not store extra properties', (test) => {
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -178,6 +188,7 @@ ava('.setTriggers() should not store extra properties', (test) => {
 ava('.setTriggers() should store a mode', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			mode: 'update',
@@ -196,6 +207,7 @@ ava('.setTriggers() should store a mode', (test) => {
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -215,6 +227,7 @@ ava('.setTriggers() should throw if no interval nor filter', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -234,6 +247,7 @@ ava('.setTriggers() should throw if mode is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-foo-bar@1.0.0',
@@ -256,6 +270,7 @@ ava('.setTriggers() should throw if both interval and filter', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -279,6 +294,7 @@ ava('.setTriggers() should throw if no id', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -300,6 +316,7 @@ ava('.setTriggers() should throw if no slug', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				action: 'action-create-card@1.0.0',
@@ -321,6 +338,7 @@ ava('.setTriggers() should throw if id is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 999,
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -343,6 +361,7 @@ ava('.setTriggers() should throw if interval is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -363,6 +382,7 @@ ava('.setTriggers() should throw if no action', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -383,6 +403,7 @@ ava('.setTriggers() should throw if action is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 1,
@@ -404,6 +425,7 @@ ava('.setTriggers() should throw if no target', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -425,6 +447,7 @@ ava('.setTriggers() should throw if target is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -447,6 +470,7 @@ ava('.setTriggers() should throw if no filter', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -466,6 +490,7 @@ ava('.setTriggers() should throw if filter is not an object', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -486,6 +511,7 @@ ava('.setTriggers() should throw if no arguments', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -504,6 +530,7 @@ ava('.setTriggers() should throw if arguments is not an object', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
+				async: true,
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -522,6 +549,7 @@ ava('.setTriggers() should throw if arguments is not an object', (test) => {
 ava('.upsertTrigger() should be able to add a trigger', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -536,6 +564,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 	])
 
 	test.context.worker.upsertTrigger(test.context.context, {
+		async: true,
 		id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 		slug: 'triggered-action-foo-baz',
 		action: 'action-foo-bar@1.0.0',
@@ -553,6 +582,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -565,6 +595,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 			}
 		},
 		{
+			async: true,
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -582,6 +613,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -594,6 +626,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 			}
 		},
 		{
+			async: true,
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -609,6 +642,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 	])
 
 	test.context.worker.upsertTrigger(test.context.context, {
+		async: true,
 		id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 		slug: 'triggered-action-foo-baz',
 		action: 'action-foo-bar@1.0.0',
@@ -626,6 +660,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 
 	test.deepEqual(triggers, [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -638,6 +673,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 			}
 		},
 		{
+			async: true,
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -655,6 +691,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 ava('.removeTrigger() should be able to remove an existing trigger', (test) => {
 	const cards = [
 		{
+			async: true,
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -667,6 +704,7 @@ ava('.removeTrigger() should be able to remove an existing trigger', (test) => {
 			}
 		},
 		{
+			async: true,
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',

--- a/test/unit/jellyscript/index.spec.js
+++ b/test/unit/jellyscript/index.spec.js
@@ -312,6 +312,7 @@ ava('.getTypeTriggers() should report back watchers when aggregating events', as
 			links: {},
 			markers: [],
 			data: {
+				async: true,
 				type: 'thread@1.0.0',
 				action: 'action-set-add@1.0.0',
 				target: {


### PR DESCRIPTION
This change allows for triggered-actions to be evaluated and executed
asynchronously, resulting in a big performance boost when processing
actions. Triggered action cards default to being asynchronous.

Connects-to: #3697
Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
