### PR TITLE
Update import of @oktokit/plugin-throttling as per breaking change introduced in 3.0.0

### DIFF
--- a/lib/sync/integrations/github.js
+++ b/lib/sync/integrations/github.js
@@ -6,9 +6,12 @@
 
 const _ = require('lodash')
 const crypto = require('crypto')
+const {
+	throttling
+} = require('@octokit/plugin-throttling')
 const Octokit = require('@octokit/rest').Octokit.plugin(
 	require('@octokit/plugin-retry'),
-	require('@octokit/plugin-throttling')
+	throttling
 )
 
 const authApp = require('@octokit/auth-app')


### PR DESCRIPTION
As per breaking change: 

```
Instead of const throttling = require("@octokit/throttling-plugin"), do const { throttling } = require("@octokit/throttling-plugin")
```

https://github.com/octokit/plugin-throttling.js/releases/tag/v3.0.0
