### PR TITLE
Add support for skipping, limiting, and sorting linked cards in a query

### DIFF
--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -1204,11 +1204,15 @@ COALESCE(${table}.version_patch, '0')::text
 	buildQueryFromUncorrelatedSchema (linkType, schema, suffix) {
 		this.options.parentJsonPath.push(...suffix)
 		this.options.parentLinkTypes.push(linkType)
-		const table = pgFormat.ident(`join.${this.options.parentLinkTypes.join('.')}`)
-		const query = SqlQuery.fromSchema(table, schema, {
+
+		const options = Object.assign({
 			parentJsonPath: _.concat(this.options.parentJsonPath, _.castArray(suffix)),
 			parentLinkTypes: this.options.parentLinkTypes
-		})
+		}, _.get(this.options, [ 'links', linkType ]))
+
+		const table = pgFormat.ident(`join.${this.options.parentLinkTypes.join('.')}`)
+		const query = SqlQuery.fromSchema(table, schema, options)
+
 		this.options.parentLinkTypes.pop()
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()
@@ -1248,27 +1252,10 @@ COALESCE(${table}.version_patch, '0')::text
 		}
 
 		const filter = this.filter.toSql()
-
-		let orderBy = ''
-		let orderByField = `${this.table}.id`
-		if (this.options.sortBy) {
-			const path = _.clone(_.castArray(this.options.sortBy))
-			const dir = this.options.sortDir === 'desc' ? 'DESC' : 'ASC'
-			if (path.length === 1 && path[0] === 'version') {
-				const versionComponents = [ 'version_major', 'version_minor', 'version_patch' ]
-				orderByField = versionComponents.map((component) => {
-					return `${this.table}.${component}`
-				}).join(', ')
-				const contents = versionComponents.map((component) => {
-					return `${this.table}.${component} ${dir} NULLS LAST`
-				}).join(', ')
-				orderBy = `\nORDER BY ${contents}`
-			} else {
-				path.unshift(this.table)
-				orderByField = SqlQuery.toSqlField(path)
-				orderBy = `\nORDER BY ${orderByField} ${dir}`
-			}
-		}
+		const {
+			orderBy,
+			orderByField
+		} = this.getSqlOrderBy()
 
 		let skip = ''
 		if (this.options.skip) {
@@ -1404,11 +1391,42 @@ ON ${fragments.lateralAlias}.source = linked.id`)
 			linkedJoins = `\n${linkedData.joins.join('\n')}`
 		}
 
+		let windowFilter = ''
+		if ('skip' in this.options || 'limit' in this.options) {
+			const filter = []
+			let lowestSeq = 1
+			if ('skip' in this.options) {
+				lowestSeq = this.options.skip + 1
+				filter.push(`edges.seq >= ${lowestSeq}`)
+			}
+			if ('limit' in this.options) {
+				const highestSeq = lowestSeq + this.options.limit - 1
+				filter.push(`edges.seq <= ${highestSeq}`)
+			}
+
+			windowFilter = ` AND ${filter.join(' AND ')}`
+		}
+
+		const {
+			orderBy
+		} = this.getSqlOrderBy('linked')
+
 		const lateral = `LATERAL (
-	SELECT edges.source, array_agg(to_jsonb(linked)${linkedLinks}) AS linkedCards
-	FROM ${cardsTable} AS linked
-	JOIN unnest(main.linkEdges) AS edges
-	ON edges.idx = ${idx} AND edges.sink = linked.id${linkedJoins}
+	SELECT
+		edges.source,
+		array_agg(to_jsonb(linked)${linkedLinks}${orderBy}) AS linkedCards
+	FROM (
+		SELECT
+		    row_number() OVER (PARTITION BY edges.source${orderBy}) AS seq,
+		    edges.source,
+		    edges.sink
+		FROM unnest(main.linkEdges) AS edges
+		JOIN ${cardsTable} AS linked
+		ON linked.id = edges.sink
+		WHERE edges.idx = ${idx}
+	) AS edges
+	JOIN ${cardsTable} AS linked
+	ON linked.id = edges.sink${windowFilter}${linkedJoins}
 	GROUP BY edges.source
 ) AS ${lateralAlias}`
 
@@ -1419,6 +1437,39 @@ ON ${fragments.lateralAlias}.source = linked.id`)
 			lateral,
 			lateralAlias,
 			nextIdx
+		}
+	}
+
+	getSqlOrderBy (tableOverride) {
+		let table = this.table
+		if (tableOverride) {
+			table = tableOverride
+		}
+
+		let orderBy = ''
+		let orderByField = `${table}.id`
+		if (this.options.sortBy) {
+			const path = _.clone(_.castArray(this.options.sortBy))
+			const dir = this.options.sortDir === 'desc' ? 'DESC' : 'ASC'
+			if (path.length === 1 && path[0] === 'version') {
+				const versionComponents = [ 'version_major', 'version_minor', 'version_patch' ]
+				orderByField = versionComponents.map((component) => {
+					return `${table}.${component}`
+				}).join(', ')
+				const contents = versionComponents.map((component) => {
+					return `${table}.${component} ${dir} NULLS LAST`
+				}).join(', ')
+				orderBy = `\nORDER BY ${contents}`
+			} else {
+				path.unshift(table)
+				orderByField = SqlQuery.toSqlField(path)
+				orderBy = `\nORDER BY ${orderByField} ${dir}`
+			}
+		}
+
+		return {
+			orderBy,
+			orderByField
 		}
 	}
 }

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -517,7 +517,8 @@ module.exports = class Kernel {
 			skip: options.skip,
 			sortBy: options.sortBy,
 			sortDir: options.sortDir,
-			profile: options.profile
+			profile: options.profile,
+			links: options.links
 
 		// For debugging purposes
 		}).catch((error) => {

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -2286,6 +2286,420 @@ ava('.query() should be able to limit and skip the results', async (test) => {
 	test.deepEqual(results, [ result2 ])
 })
 
+ava('.query() should be able to sort linked cards', async (test) => {
+	const parent = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0'
+		})
+
+	const child1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 1
+			}
+		})
+
+	const child2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 0
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child1.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child1.id,
+					type: child1.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child2.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child2.id,
+					type: child2.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context, context.kernel.sessions.admin, {
+			type: 'object',
+			$$links: {
+				'has child': true
+			},
+			properties: {
+				id: {
+					const: parent.id
+				}
+			}
+		}, {
+			links: {
+				'has child': {
+					sortBy: [ 'data', 'sequence' ]
+				}
+			}
+		})
+
+	test.deepEqual(
+		results.map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: parent.id
+		} ]
+	)
+	test.deepEqual(
+		results[0].links['has child'].map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: child2.id
+		}, {
+			id: child1.id
+		} ]
+	)
+})
+
+ava('.query() should be able to skip linked cards', async (test) => {
+	const parent = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0'
+		})
+
+	const child1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 1
+			}
+		})
+
+	const child2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 0
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child1.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child1.id,
+					type: child1.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child2.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child2.id,
+					type: child2.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context, context.kernel.sessions.admin, {
+			type: 'object',
+			$$links: {
+				'has child': true
+			},
+			properties: {
+				id: {
+					const: parent.id
+				}
+			}
+		}, {
+			links: {
+				'has child': {
+					skip: 1,
+					sortBy: [ 'data', 'sequence' ]
+				}
+			}
+		})
+
+	test.deepEqual(
+		results.map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: parent.id
+		} ]
+	)
+	test.deepEqual(
+		results[0].links['has child'].map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: child1.id
+		} ]
+	)
+})
+
+ava('.query() should be able to limit linked cards', async (test) => {
+	const parent = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0'
+		})
+
+	const child1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 1
+			}
+		})
+
+	const child2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 0
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child1.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child1.id,
+					type: child1.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child2.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child2.id,
+					type: child2.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context, context.kernel.sessions.admin, {
+			type: 'object',
+			$$links: {
+				'has child': true
+			},
+			properties: {
+				id: {
+					const: parent.id
+				}
+			}
+		}, {
+			links: {
+				'has child': {
+					limit: 1,
+					sortBy: [ 'data', 'sequence' ]
+				}
+			}
+		})
+
+	test.deepEqual(
+		results.map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: parent.id
+		} ]
+	)
+	test.deepEqual(
+		results[0].links['has child'].map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: child2.id
+		} ]
+	)
+})
+
+ava('.query() should be able to skip and limit linked cards', async (test) => {
+	const parent = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0'
+		})
+
+	const child1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 1
+			}
+		})
+
+	const child2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			data: {
+				sequence: 0
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child1.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child1.id,
+					type: child1.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${child2.slug}-is-child-of-${parent.slug}`,
+			type: 'link@1.0.0',
+			name: 'is child of',
+			data: {
+				inverseName: 'has child',
+				from: {
+					id: child2.id,
+					type: child2.type
+				},
+				to: {
+					id: parent.id,
+					type: parent.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context, context.kernel.sessions.admin, {
+			type: 'object',
+			$$links: {
+				'has child': true
+			},
+			properties: {
+				id: {
+					const: parent.id
+				}
+			}
+		}, {
+			links: {
+				'has child': {
+					skip: 1,
+					limit: 1,
+					sortBy: [ 'data', 'sequence' ]
+				}
+			}
+		})
+
+	test.deepEqual(
+		results.map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: parent.id
+		} ]
+	)
+	test.deepEqual(
+		results[0].links['has child'].map((card) => {
+			return {
+				id: card.id
+			}
+		}),
+		[ {
+			id: child1.id
+		} ]
+	)
+})
+
 ava('.query() should return the cards that match a schema', async (test) => {
 	const result1 = await context.kernel.insertCard(
 		context.context, context.kernel.sessions.admin, {


### PR DESCRIPTION
This commit adds support for an additional key `links` in the `options` argument for `Kernel.query()` and `jsonschema2sql`. `links` is a map from link type to an `options` object for that link type. For example, passing the following as `options`:

```
{
  skip: 20,
  limit: 10,
  sortBy: 'updated_at',
  sortDir: 'desc',
  links: {
    'has attachment': {
        skip: 100,
        limit: 500,
        sortBy: 'created_at',
        sortDir: 'desc',
    }
  }
}
```

Root `skip`, `limit`, `sortBy`, and `sortDir` are the usual accepted keys for `options`, while the same keys inside `links['has attachment']` will only apply to the `has attachment` linked cards.

This is implemented through windowing functions over a list of linked card IDs, so overhead should not be significant.

Closes #3949

Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
