### PR TITLE
Add support for subscribing to web push notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,12 @@ export INTEGRATION_OUTREACH_SIGNATURE_KEY
 INTEGRATION_TYPEFORM_SIGNATURE_KEY ?=
 export INTEGRATION_TYPEFORM_SIGNATURE_KEY
 
+# Service Worker
+JF_WEB_PUSH ?=
+export JF_WEB_PUSH
+VAPID_PUBLIC_KEY ?=
+export VAPID_PUBLIC_KEY
+
 # -----------------------------------------------
 # Test Runtime Configuration
 # -----------------------------------------------

--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -36,9 +36,13 @@ import {
 	swallowEvent,
 	isiOS
 } from '../../../../lib/ui-components/services/helpers'
+import pwa from '../../pwa'
 import {
 	registerForNotifications
 } from '../../services/notifications'
+import {
+	pwa as pwaEnv
+} from '../../environment'
 
 // Slide-in delay in seconds
 const DELAY = 0.6
@@ -390,6 +394,8 @@ export default class HomeChannel extends React.Component {
 
 	componentDidMount () {
 		const {
+			user,
+			sdk,
 			actions,
 			location,
 			history,
@@ -401,9 +407,15 @@ export default class HomeChannel extends React.Component {
 			}
 		}
 
-		// Register for desktop notifications now that we're safely logged in
+		// Register for notifications now that we're safely logged in
 		// (This keeps Firefox happy)
-		registerForNotifications()
+		registerForNotifications().then((canUseNotifications) => {
+			if (canUseNotifications && pwaEnv.enableWebPush) {
+				pwa.subscribeToPushNotifications(user, sdk, {
+					vapidPublicKey: pwaEnv.vapidPublicKey
+				})
+			}
+		})
 
 		// TODO: Replace this with parsing loop cards to define the chat room
 		// structure

--- a/apps/ui/components/HomeChannel/index.js
+++ b/apps/ui/components/HomeChannel/index.js
@@ -16,6 +16,7 @@ import {
 	withTheme
 } from 'styled-components'
 import {
+	sdk,
 	actionCreators,
 	selectors
 } from '../../core'
@@ -28,6 +29,7 @@ const mapStateToProps = (state, ownProps) => {
 	const target = _.get(ownProps, [ 'channel', 'data', 'head', 'id' ])
 	const user = selectors.getCurrentUser(state)
 	return {
+		sdk,
 		channels: selectors.getChannels(state),
 		codename: selectors.getAppCodename(state),
 		orgs: selectors.getOrgs(state),

--- a/apps/ui/environment.js
+++ b/apps/ui/environment.js
@@ -32,6 +32,8 @@ export const analytics = {
 export const version = (typeof env === 'undefined') ? 'v1.0.0' : (env.VERSION || 'v1.0.0')
 
 export const pwa = {
+	vapidPublicKey: (typeof env === 'undefined') ? null : env.VAPID_PUBLIC_KEY,
+	enableWebPush: (typeof env === 'undefined') ? false : (env.JF_WEB_PUSH === '1'),
 	debugSW: () => {
 		return (typeof env === 'undefined') ? false : (env.JF_DEBUG_SW === '1')
 	}

--- a/apps/ui/environment.js
+++ b/apps/ui/environment.js
@@ -34,7 +34,5 @@ export const version = (typeof env === 'undefined') ? 'v1.0.0' : (env.VERSION ||
 export const pwa = {
 	vapidPublicKey: (typeof env === 'undefined') ? null : env.VAPID_PUBLIC_KEY,
 	enableWebPush: (typeof env === 'undefined') ? false : (env.JF_WEB_PUSH === '1'),
-	debugSW: () => {
-		return (typeof env === 'undefined') ? false : (env.JF_DEBUG_SW === '1')
-	}
+	debugServiceWorker: (typeof env === 'undefined') ? false : (env.JF_DEBUG_SW === '1')
 }

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -42,10 +42,12 @@ import {
 	SetupProvider
 } from '../../lib/ui-components/SetupProvider'
 import * as environment from './environment'
-import PWA from './pwa'
+import pwa from './pwa'
 
-export const pwa = new PWA()
-pwa.init()
+pwa.init({
+	debugServiceWorker: environment.pwa.debugSW(),
+	enableWebPush: environment.pwa.enableWebPush
+})
 
 const GlobalStyle = createGlobalStyle `
   * {

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -45,7 +45,7 @@ import * as environment from './environment'
 import pwa from './pwa'
 
 pwa.init({
-	debugServiceWorker: environment.pwa.debugSW(),
+	debugServiceWorker: environment.pwa.debugServiceWorker,
 	enableWebPush: environment.pwa.enableWebPush
 })
 

--- a/apps/ui/pwa.spec.js
+++ b/apps/ui/pwa.spec.js
@@ -75,7 +75,14 @@ ava('PWA skips initialization if already initialized', (test) => {
 	test.notThrows(() => {
 		// This would throw an exception if it tried to call any methods
 		// on the window or Workbox objects
-		pwa.init(options)
+		const workbox = {
+			addEventListener: sandbox.fake()
+		}
+		pwa.init({
+			...options,
+			workbox
+		})
+		test.true(workbox.addEventListener.notCalled)
 	})
 })
 
@@ -181,8 +188,8 @@ ava('Push notification subscription throws an error if PWA is not initialized', 
 	const {
 		pwa
 	} = test.context
+	test.false(pwa.isInitialized)
 	test.throws(() => {
-		test.false(pwa.isInitialized)
 		pwa.subscribeToPushNotifications({}, {}, {
 			vapidPublicKey
 		})

--- a/apps/ui/pwa.spec.js
+++ b/apps/ui/pwa.spec.js
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import ava from 'ava'
+import sinon from 'sinon'
+import {
+	PWA
+} from './pwa'
+import * as environment from './environment'
+import {
+	errorReporter
+} from './core'
+
+global.window = {
+	atob: _.identity
+}
+
+const pushSubscriptionCardId = 'wps1'
+
+const sandbox = sinon.createSandbox()
+
+const options = {
+	debugServiceWorker: true,
+	enableWebPush: true
+}
+
+const vapidPublicKey = 'testkey'
+
+const user = {
+	id: '1',
+	type: 'user@1.0.0'
+}
+
+const pushSubscriptionData = {
+	endpoint: 'test-endpoint',
+	keys: {
+		auth: 'test-auth',
+		p256dh: 'test-p256dh'
+	}
+}
+
+const getPromiseResolver = () => {
+	let resolver = null
+	const promise = new Promise((resolve) => {
+		resolver = resolve
+	})
+	return {
+		promise,
+		resolver
+	}
+}
+
+ava.beforeEach((test) => {
+	errorReporter.reportException = sandbox.fake()
+	environment.isProduction = _.constant(true)
+	test.context.pwa = new PWA()
+	test.context.pushSubscription = {
+		toJSON: sandbox.fake.returns(pushSubscriptionData)
+	}
+})
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('PWA skips initialization if already initialized', (test) => {
+	const {
+		pwa
+	} = test.context
+	pwa.isInitialized = true
+	test.notThrows(() => {
+		// This would throw an exception if it tried to call any methods
+		// on the window or Workbox objects
+		pwa.init(options)
+	})
+})
+
+ava('PWA skips initialization if not production and debugServiceWorker option not set', (test) => {
+	const {
+		pwa
+	} = test.context
+	environment.isProduction = _.constant(false)
+	test.false(pwa.isInitialized)
+	pwa.init({
+		...options,
+		debugServiceWorker: false
+	})
+	test.false(pwa.isInitialized)
+})
+
+ava('PWA can be initialized', async (test) => {
+	const {
+		pwa
+	} = test.context
+	const eventCallbacks = {}
+	const onWbAddEventListener = {
+		activated: getPromiseResolver(),
+		waiting: getPromiseResolver(),
+		controlling: getPromiseResolver()
+	}
+	const onMessageWS = getPromiseResolver()
+	const onRegister = getPromiseResolver()
+	const postActivation = getPromiseResolver()
+
+	global.navigator = {
+		serviceWorker: {}
+	}
+
+	global.window.location = {
+		reload: sandbox.fake()
+	}
+	global.window.confirm = sandbox.fake.returns(true)
+
+	const fakeRegistration = {
+		__testID: 'fake!'
+	}
+
+	const fakeWorkbox = {
+		addEventListener: (eventName, func) => {
+			eventCallbacks[eventName] = func
+			onWbAddEventListener[eventName].resolver(eventName)
+		},
+		messageSW: (swOptions) => {
+			onMessageWS.resolver(swOptions)
+		},
+		register: () => {
+			onRegister.resolver(fakeRegistration)
+			return onRegister.promise
+		}
+	}
+
+	// HACK: add a task so we know when activation
+	// has been completed
+	pwa.postActivationTasks.push((registration) => {
+		postActivation.resolver(registration)
+	})
+
+	pwa.init({
+		...options,
+		workbox: fakeWorkbox
+	})
+
+	const waitingEvent = await onWbAddEventListener.waiting.promise
+	test.is(waitingEvent, 'waiting')
+
+	eventCallbacks.waiting()
+
+	test.true(window.confirm.calledOnce)
+
+	const controllingEvent = await onWbAddEventListener.controlling.promise
+	test.is(controllingEvent, 'controlling')
+
+	eventCallbacks.controlling()
+
+	test.true(window.location.reload.calledOnce)
+
+	const messageOptions = await onMessageWS.promise
+	test.is(messageOptions.type, 'SKIP_WAITING')
+
+	await onRegister.promise
+
+	const activatedEvent = await onWbAddEventListener.activated.promise
+	test.is(activatedEvent, 'activated')
+
+	eventCallbacks.activated()
+
+	const receivedRegistration = await postActivation.promise
+	// eslint-disable-next-line no-underscore-dangle
+	test.is(receivedRegistration.__testID, fakeRegistration.__testID)
+
+	test.true(pwa.isInitialized)
+	test.truthy(pwa.registration)
+	test.truthy(pwa.wb)
+})
+
+ava('Push notification subscription throws an error if PWA is not initialized', (test) => {
+	const {
+		pwa
+	} = test.context
+	test.throws(() => {
+		test.false(pwa.isInitialized)
+		pwa.subscribeToPushNotifications({}, {}, {
+			vapidPublicKey
+		})
+	}, {
+		message: 'PWA: Cannot subscribe to push notifications until service worker has been initialized'
+	})
+})
+
+ava('Push notification subscription is skipped if enableWebPush is not set', (test) => {
+	const {
+		pwa
+	} = test.context
+	pwa.isInitialized = true
+	pwa.options = {
+		enableWebPush: false
+	}
+	test.notThrows(() => {
+		// This would throw an exception if the subscription logic
+		// was actually executed
+		pwa.subscribeToPushNotifications({}, {}, {
+			vapidPublicKey
+		})
+	})
+})
+
+ava('Push notification subscription reports error and skips if VAPID public key is not provided', (test) => {
+	const {
+		pwa
+	} = test.context
+	pwa.isInitialized = true
+	pwa.options = {
+		enableWebPush: true
+	}
+	pwa.subscribeToPushNotifications({}, {}, {})
+	test.true(errorReporter.reportException.calledOnce)
+	test.is(
+		errorReporter.reportException.getCall(0).args[0].message,
+		'No VAPID public key provided. Make sure you have set the VAPID_PUBLIC_KEY environment variable!'
+	)
+})
+
+ava('PWA does not add a web-push-subscription if a valid one already exists', async (test) => {
+	const {
+		pwa,
+		pushSubscription
+	} = test.context
+
+	const subscribed = getPromiseResolver()
+
+	pwa.isInitialized = true
+	pwa.options = options
+	pwa.registration = {
+		active: {},
+		pushManager: {
+			subscribe: sandbox.fake.resolves(pushSubscription)
+		}
+	}
+
+	const sdk = {
+		card: {
+			create: sandbox.fake()
+		},
+		query: sandbox.fake.resolves([ {
+			id: pushSubscriptionCardId,
+			data: {
+				endpoint: pushSubscriptionData.endpoint,
+				auth: pushSubscriptionData.keys.auth,
+				token: pushSubscriptionData.keys.p256dh
+			}
+		} ])
+	}
+
+	pwa.subscribeToPushNotifications(user, sdk, {
+		vapidPublicKey,
+		onSubscribed: () => {
+			subscribed.resolver()
+		}
+	})
+
+	await subscribed.promise
+	test.true(pwa.registration.pushManager.subscribe.calledOnce)
+	test.true(sdk.card.create.notCalled)
+})
+
+ava('PWA updates existing web-push-subscription if credentials are out-of-date', async (test) => {
+	const {
+		pwa,
+		pushSubscription
+	} = test.context
+
+	const subscribed = getPromiseResolver()
+
+	pwa.isInitialized = true
+	pwa.options = options
+	pwa.registration = {
+		active: {},
+		pushManager: {
+			subscribe: sandbox.fake.resolves(pushSubscription)
+		}
+	}
+
+	const sdk = {
+		card: {
+			update: sandbox.fake(),
+			create: sandbox.fake(),
+			link: sandbox.fake()
+		},
+		query: sandbox.fake.resolves([ {
+			id: pushSubscriptionCardId,
+			data: {
+				endpoint: pushSubscriptionData.endpoint,
+				auth: pushSubscriptionData.keys.auth,
+				token: 'some other token'
+			}
+		} ])
+	}
+
+	pwa.subscribeToPushNotifications(user, sdk, {
+		vapidPublicKey,
+		onSubscribed: () => {
+			subscribed.resolver()
+		}
+	})
+
+	await subscribed.promise
+	test.true(pwa.registration.pushManager.subscribe.calledOnce)
+	test.true(sdk.query.calledOnce)
+	test.true(sdk.card.update.calledOnce)
+	test.true(sdk.card.create.notCalled)
+	test.true(sdk.card.link.notCalled)
+})
+
+ava('PWA creates a new web push subscription if it doesn\'t already exist', async (test) => {
+	const {
+		pwa,
+		pushSubscription
+	} = test.context
+	const subscribed = getPromiseResolver()
+
+	const sdk = {
+		card: {
+			create: sandbox.fake.resolves({
+				id: pushSubscriptionCardId
+			}),
+			link: sandbox.fake()
+		},
+		query: sandbox.fake.resolves([])
+	}
+
+	const expectedData = {
+		endpoint: pushSubscriptionData.endpoint,
+		auth: pushSubscriptionData.keys.auth,
+		token: pushSubscriptionData.keys.p256dh
+	}
+
+	pwa.isInitialized = true
+	pwa.options = options
+	pwa.registration = {
+		active: {},
+		pushManager: {
+			subscribe: sandbox.fake.resolves(pushSubscription)
+		}
+	}
+
+	pwa.subscribeToPushNotifications(user, sdk, {
+		vapidPublicKey,
+		onSubscribed: () => {
+			subscribed.resolver()
+		}
+	})
+
+	await subscribed.promise
+	test.true(pwa.registration.pushManager.subscribe.calledOnce)
+	test.true(sdk.query.calledOnce)
+
+	test.true(sdk.card.create.calledOnce)
+	test.deepEqual(sdk.card.create.getCall(0).args[0].data, expectedData)
+
+	test.true(sdk.card.link.calledOnce)
+	const [ linkedUser, subscription, verb ] = sdk.card.link.getCall(0).args
+	test.deepEqual(linkedUser, user)
+	test.deepEqual(subscription.id, pushSubscriptionCardId)
+	test.is(verb, 'is subscribed with')
+})
+
+ava('Push notification subscription is queued up if service worker not yet activated', async (test) => {
+	const {
+		pwa
+	} = test.context
+
+	const sdk = {}
+	pwa.isInitialized = true
+	pwa.options = options
+
+	test.is(pwa.postActivationTasks.length, 0)
+	test.is(pwa.registration, null)
+	pwa.subscribeToPushNotifications(user, sdk, {
+		vapidPublicKey
+	})
+	test.is(pwa.postActivationTasks.length, 1)
+})

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -20,17 +20,16 @@ const sound = new Howl({
 
 let canUseNotifications = false
 
-export const registerForNotifications = () => {
+export const registerForNotifications = async () => {
 	if (typeof window !== 'undefined') {
 		canUseNotifications = window.Notification && Notification.permission === 'granted'
 
 		if (window.Notification && Notification.permission !== 'denied') {
-			Notification.requestPermission((status) => {
-			// Status is "granted", if accepted by user
-				canUseNotifications = status === 'granted'
-			})
+			const status = await Notification.requestPermission()
+			canUseNotifications = status === 'granted'
 		}
 	}
+	return canUseNotifications
 }
 
 export const createNotification = ({

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -100,6 +100,8 @@ const config = mergeConfig(baseConfig, {
 				SENTRY_DSN_UI: JSON.stringify(process.env.SENTRY_DSN_UI),
 				MIXPANEL_TOKEN_UI: JSON.stringify(process.env.MIXPANEL_TOKEN_UI),
 				JF_DEBUG_SW: JSON.stringify(process.env.JF_DEBUG_SW),
+				JF_WEB_PUSH: JSON.stringify(process.env.JF_WEB_PUSH),
+				VAPID_PUBLIC_KEY: JSON.stringify(process.env.VAPID_PUBLIC_KEY),
 
 				// So that it matches git tags
 				VERSION: JSON.stringify(`v${packageJSON.version}`)

--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -98,3 +98,7 @@ properties:
     type: string?
   QUEUE_CONCURRENCY:
     type: number
+  JF_WEB_PUSH:
+    type: string?
+  VAPID_PUBLIC_KEY:
+    type: string?

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -46,6 +46,16 @@ spec:
             secretKeyRef:
               key: NODE_ENV
               name: node-env
+        - name: JF_WEB_PUSH
+          valueFrom:
+            secretKeyRef:
+              key: JF_WEB_PUSH
+              name: jf-web-push
+        - name: VAPID_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              key: VAPID_PUBLIC_KEY
+              name: vapid-public-key
         ports:
         - containerPort: 80
       imagePullSecrets:

--- a/lib/ui-components/services/error-reporter.js
+++ b/lib/ui-components/services/error-reporter.js
@@ -38,6 +38,9 @@ export default class Reporter {
 	}
 
 	reportException (error, errorInfo) {
+		if (!this.config.isProduction) {
+			console.error(error, errorInfo)
+		}
 		if (this.initialized) {
 			Sentry.withScope((scope) => {
 				scope.setExtra(errorInfo)

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -20,6 +20,21 @@ import {
 	DetectUA
 } from 'detect-ua'
 
+export const urlBase64ToUint8Array = (base64String) => {
+	const padding = '='.repeat((4 - base64String.length % 4) % 4)
+	const base64 = (base64String + padding)
+		.replace(/-/g, '+')
+		.replace(/_/g, '/')
+
+	const rawData = window.atob(base64)
+	const outputArray = new Uint8Array(rawData.length)
+
+	for (let index = 0; index < rawData.length; ++index) {
+		outputArray[index] = rawData.charCodeAt(index)
+	}
+	return outputArray
+}
+
 export const createPermaLink = (card) => {
 	return `${window.location.origin}/${card.id}`
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15100,6 +15100,14 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http_ece": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.1.0.tgz",
+      "integrity": "sha512-bptAfCDdPJxOs5zYSe7Y3lpr772s1G346R4Td5LgRUeCwIGpCGDUTJxRrhTNcAXbx37spge0kWEIH7QAYWNTlA==",
+      "requires": {
+        "urlsafe-base64": "~1.0.0"
+      }
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -17006,8 +17014,7 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
@@ -23693,6 +23700,11 @@
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -24020,6 +24032,86 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "web-push": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.4.4.tgz",
+      "integrity": "sha512-tB0F+ccobsfw5jTWBinWJKyd/YdCdRbKj+CFSnsJeEgFYysOULvWFYyeCxn9KuQvG/3UF1t3cTAcJzBec5LCWA==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.1.0",
+        "https-proxy-agent": "^5.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5",
+        "urlsafe-base64": "^1.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+          "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "asn1.js": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+          "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "typed-errors": "^1.1.0",
     "use-debounce": "^3.4.2",
     "uuid": "^3.2.1",
+    "web-push": "^3.4.4",
     "winston": "^3.3.3"
   }
 }

--- a/scripts/generate-vapid-keys.js
+++ b/scripts/generate-vapid-keys.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// A simple utility script to generate a public/private key
+// pair of VAPID keys using the web-push package.
+// The output of this script should be used to populate the
+// following environment variables:
+// * VAPID_PUBLIC_KEY
+// * VAPID_PRIVATE_KEY
+
+const webpush = require('web-push')
+
+const vapidKeys = webpush.generateVAPIDKeys()
+
+console.log(`
+VAPID KEYS:
+	Public:  ${vapidKeys.publicKey}
+	Private: ${vapidKeys.privateKey}
+`)


### PR DESCRIPTION
This is another preliminary step in the work of adding support for Web Push notifications. See the 'Implementation Plan' section of [this issue](https://github.com/product-os/jellyfish/issues/3651).

Relates to: #3651 

Now when we ask the user for permission to send them notifications (when the `HomeChannel` component is mounted), if permission is granted and the `JF_WEB_PUSH` environment variable is set*, we subscribe the service worker to web push notifications.

The push notification subscription code in the `PWA` class ensures that we only try to subscribe for push notifications once the service worker is registered.

Subscribing to web push notifications requires the VAPID public key associated with the Jellyfish application. This will be stored in the environment variable `VAPID_PUBLIC_KEY`.

After subscribing to the service worker registration's Push Manager, check for an existing `web-push-subscription` on the server for that endpoint and user. If it exists and the subscription data matches (i.e. the keys are still valid) we're done. If a `web-push-subscription` is found for that endpoint and user but the data does not match, we need to update the existing `web-push-subscription`. If no `web-push-subscription` is found for that endpoint and user then we create and link a new one. See the diagram below for details.

![image](https://user-images.githubusercontent.com/2925657/85492666-b9665200-b5ff-11ea-9497-2a1cdce8416c.png)


## Notes
\* The subscription code will not run if the environment variable `JF_WEB_PUSH` is not set. This is deliberately disabled for now until the backend adds support for actually sending push notifications.

