### PR TITLE
test: Fix e2e test that was failing intermittently

### DIFF
--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -113,10 +113,10 @@ ava.serial('You can assign an unassigned thread to yourself', async (test) => {
 	await macros.waitForThenClickSelector(page, selectors.threadMoreButton)
 
 	// Verify its currently unassigned
-	const cardOwnerButton = await verifyCardOwner(test, page, false, unassignedButtonText)
+	await verifyCardOwner(test, page, false, unassignedButtonText)
 
 	// Assign the thread to ourselves
-	cardOwnerButton.click()
+	await macros.waitForThenClickSelector(page, 'button[data-test="card-owner-dropdown"]:first-child')
 
 	// Verify the new owner is me!
 	await verifyCardOwner(test, page, true, currentUserSlug)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This change ensures we wait for and click the CardOwner button all in one go. This avoids the situation we were sometimes seeing where, because of React component updates, the CardOwner button node that we'd previously saved a reference to was being detached from the DOM (and replaced with a new node representing the same button) before we came to try and click it and so couldn't be interacted with.
