### PR TITLE
ci: Update queue integration tests to use a shared backend

### DIFF
--- a/test/integration/core/helpers.js
+++ b/test/integration/core/helpers.js
@@ -4,18 +4,9 @@
  * Proprietary and confidential.
  */
 
-const uuid = require('uuid/v4')
 const helpers = require('./backend/helpers')
 const Kernel = require('../../../lib/core/kernel')
-
-const generateRandomSlug = (options = {}) => {
-	const suffix = uuid()
-	if (options.prefix) {
-		return `${options.prefix}-${suffix}`
-	}
-
-	return suffix
-}
+const utils = require('../utils')
 
 exports.beforeEach = async (test, options = {}) => {
 	await helpers.beforeEach(test, {
@@ -30,7 +21,7 @@ exports.beforeEach = async (test, options = {}) => {
 
 	test.context.kernel = new Kernel(test.context.backend)
 	await test.context.kernel.initialize(test.context.context)
-	test.context.generateRandomSlug = generateRandomSlug
+	test.context.generateRandomSlug = utils.generateRandomSlug
 }
 
 exports.afterEach = async (test) => {

--- a/test/integration/queue/events.spec.js
+++ b/test/integration/queue/events.spec.js
@@ -10,19 +10,20 @@ const Bluebird = require('bluebird')
 const helpers = require('./helpers')
 const events = require('../../../lib/queue/events')
 
-ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
 ava('.post() should insert an active execute card', async (test) => {
+	const id = test.context.generateRandomID()
 	const event = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	})
 
 	const card = await test.context.jellyfish.getCardById(test.context.context, test.context.session, event.id)
@@ -32,24 +33,26 @@ ava('.post() should insert an active execute card', async (test) => {
 
 ava('.post() should set a present timestamp', async (test) => {
 	const currentDate = new Date()
+	const id = test.context.generateRandomID()
 
 	const card = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	})
 
 	test.true(new Date(card.data.timestamp) >= currentDate)
 })
 
 ava('.post() should not use a passed id', async (test) => {
+	const id = test.context.generateRandomID()
 	const card = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '8fd7be57-4f68-4faf-bbc6-200a7c62c41a',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -59,33 +62,35 @@ ava('.post() should not use a passed id', async (test) => {
 		data: '414f2345-4f5e-4571-820f-28a49731733d'
 	})
 
-	test.not(card.id, '8fd7be57-4f68-4faf-bbc6-200a7c62c41a')
+	test.not(card.id, id)
 })
 
 ava('.post() should fail if no result error', async (test) => {
+	const id = test.context.generateRandomID()
 	await test.throwsAsync(events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: 'action-create-card@1.0.0',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	}), {
 		instanceOf: test.context.jellyfish.errors.JellyfishSchemaMismatch
 	})
 })
 
 ava('.post() should use the passed timestamp in the payload', async (test) => {
+	const id = test.context.generateRandomID()
 	const card = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	})
 
 	test.is(card.data.payload.timestamp, '2018-06-30T19:34:42.829Z')
@@ -94,7 +99,7 @@ ava('.post() should use the passed timestamp in the payload', async (test) => {
 
 ava('.post() should allow an object result', async (test) => {
 	const card = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id: test.context.generateRandomID(),
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -112,8 +117,9 @@ ava('.post() should allow an object result', async (test) => {
 })
 
 ava.cb('.wait() should return when a certain execute event is inserted', (test) => {
+	const id = test.context.generateRandomID()
 	events.wait(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef'
@@ -128,39 +134,40 @@ ava.cb('.wait() should return when a certain execute event is inserted', (test) 
 
 	Bluebird.delay(500).then(() => {
 		return events.post(test.context.context, test.context.jellyfish, test.context.session, {
-			id: '414f2345-4f5e-4571-820f-28a49731733d',
+			id,
 			action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			timestamp: '2018-06-30T19:34:42.829Z'
 		}, {
 			error: false,
-			data: '414f2345-4f5e-4571-820f-28a49731733d'
+			data: id
 		})
 	}).catch(test.end)
 })
 
 ava('.wait() should return if the card already exists', async (test) => {
+	const id = test.context.generateRandomID()
 	await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	})
 
 	const card = await events.wait(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef'
 	})
 
 	test.is(card.type, 'execute@1.0.0')
-	test.is(card.data.target, '414f2345-4f5e-4571-820f-28a49731733d')
+	test.is(card.data.target, id)
 	test.is(card.data.actor, '57692206-8da2-46e1-91c9-159b2c6928ef')
 	test.is(card.data.payload.card, '033d9184-70b2-4ec9-bc39-9a249b186422')
 })
@@ -199,19 +206,20 @@ ava.cb('.wait() should be able to access the event payload of a huge event', (te
 })
 
 ava('.wait() should be able to access the event payload', async (test) => {
+	const id = test.context.generateRandomID()
 	await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	})
 
 	const card = await events.wait(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef'
@@ -222,13 +230,14 @@ ava('.wait() should be able to access the event payload', async (test) => {
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		timestamp: '2018-06-30T19:34:42.829Z',
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: id
 	})
 })
 
 ava.cb('.wait() should ignore cards that do not match the id', (test) => {
+	const id1 = test.context.generateRandomID()
 	events.wait(test.context.context, test.context.jellyfish, test.context.session, {
-		id: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+		id: id1,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef'
@@ -243,45 +252,47 @@ ava.cb('.wait() should ignore cards that do not match the id', (test) => {
 		test.end()
 	}).catch(test.end)
 
+	const id2 = test.context.generateRandomID()
 	Bluebird.delay(500).then(async () => {
 		await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-			id: '414f2345-4f5e-4571-820f-28a49731733d',
+			id: id2,
 			action: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 			actor: '414f2345-4f5e-4571-820f-28a49731733d',
 			timestamp: '2018-06-30T19:34:42.829Z'
 		}, {
 			error: false,
-			data: '414f2345-4f5e-4571-820f-28a49731733d'
+			data: id2
 		})
 
 		await events.post(test.context.context, test.context.jellyfish, test.context.session, {
 			id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			action: '033d9184-70b2-4ec9-bc39-9a249b186422',
-			card: '414f2345-4f5e-4571-820f-28a49731733d',
+			card: id2,
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			timestamp: '2019-06-30T19:34:42.829Z'
 		}, {
 			error: false,
-			data: '414f2345-4f5e-4571-820f-28a49731733d'
+			data: id2
 		})
 
 		await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-			id: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+			id: id1,
 			action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			timestamp: '2020-06-30T19:34:42.829Z'
 		}, {
 			error: false,
-			data: '414f2345-4f5e-4571-820f-28a49731733d'
+			data: id2
 		})
 	}).catch(test.end)
 })
 
 ava('.getLastExecutionEvent() should return the last execution event given one event', async (test) => {
+	const id = test.context.generateRandomID()
 	const card = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+		id,
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -309,7 +320,7 @@ ava('.getLastExecutionEvent() should return the last execution event given one e
 		data: {
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			target: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+			target: id,
 			timestamp: event.data.timestamp,
 			payload: {
 				action: '57692206-8da2-46e1-91c9-159b2c6928ef',
@@ -323,24 +334,26 @@ ava('.getLastExecutionEvent() should return the last execution event given one e
 })
 
 ava('.getLastExecutionEvent() should return the last event given a matching and non-matching event', async (test) => {
+	const originator = test.context.generateRandomID()
+
 	const card1 = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+		id: test.context.generateRandomID(),
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
-		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		originator,
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
-		data: '414f2345-4f5e-4571-820f-28a49731733d'
+		data: test.context.generateRandomID()
 	})
 
 	await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id: test.context.generateRandomID(),
 		action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
 		card: '5201aae8-c937-4f92-940d-827d857bbcc2',
 		actor: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
-		originator: '6f3ff72e-5305-4397-b86f-ca1ea5f06f5f',
+		originator,
 		timestamp: '2018-08-30T19:34:42.829Z'
 	}, {
 		error: false,
@@ -351,7 +364,7 @@ ava('.getLastExecutionEvent() should return the last event given a matching and 
 		test.context.context,
 		test.context.jellyfish,
 		test.context.session,
-		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+		originator)
 
 	test.deepEqual(event, test.context.kernel.defaults({
 		created_at: card1.created_at,
@@ -363,13 +376,13 @@ ava('.getLastExecutionEvent() should return the last event given a matching and 
 		links: {},
 		data: {
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
-			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			target: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+			originator,
+			target: card1.data.target,
 			timestamp: event.data.timestamp,
 			payload: {
 				action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
-				data: '414f2345-4f5e-4571-820f-28a49731733d',
+				data: card1.data.payload.data,
 				error: false,
 				timestamp: '2018-06-30T19:34:42.829Z'
 			}
@@ -378,12 +391,14 @@ ava('.getLastExecutionEvent() should return the last event given a matching and 
 })
 
 ava('.getLastExecutionEvent() should return the last execution event given two matching events', async (test) => {
+	const originator = test.context.generateRandomID()
+
 	const card1 = await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '414f2345-4f5e-4571-820f-28a49731733d',
+		id: test.context.generateRandomID(),
 		action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 		card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 		actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
-		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		originator,
 		timestamp: '2018-06-30T19:34:42.829Z'
 	}, {
 		error: false,
@@ -391,11 +406,11 @@ ava('.getLastExecutionEvent() should return the last execution event given two m
 	})
 
 	await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+		id: test.context.generateRandomID(),
 		action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
 		card: '5201aae8-c937-4f92-940d-827d857bbcc2',
 		actor: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
-		originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+		originator,
 		timestamp: '2018-03-30T19:34:42.829Z'
 	}, {
 		error: false,
@@ -406,7 +421,7 @@ ava('.getLastExecutionEvent() should return the last execution event given two m
 		test.context.context,
 		test.context.jellyfish,
 		test.context.session,
-		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+		originator)
 
 	test.deepEqual(event, test.context.kernel.defaults({
 		created_at: card1.created_at,
@@ -418,13 +433,13 @@ ava('.getLastExecutionEvent() should return the last execution event given two m
 		links: {},
 		data: {
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
-			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			target: '414f2345-4f5e-4571-820f-28a49731733d',
+			originator,
+			target: card1.data.target,
 			timestamp: event.data.timestamp,
 			payload: {
 				action: '57692206-8da2-46e1-91c9-159b2c6928ef',
 				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
-				data: '414f2345-4f5e-4571-820f-28a49731733d',
+				data: card1.data.payload.data,
 				error: false,
 				timestamp: '2018-06-30T19:34:42.829Z'
 			}
@@ -434,7 +449,7 @@ ava('.getLastExecutionEvent() should return the last execution event given two m
 
 ava('.getLastExecutionEvent() should return null given no matching event', async (test) => {
 	await events.post(test.context.context, test.context.jellyfish, test.context.session, {
-		id: 'b9999e1e-e707-4124-98b4-f4bcf1643b4c',
+		id: test.context.generateRandomID(),
 		action: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
 		card: '5201aae8-c937-4f92-940d-827d857bbcc2',
 		actor: 'e4fe3f19-13ae-4421-b28f-6507af78d1f6',
@@ -449,20 +464,21 @@ ava('.getLastExecutionEvent() should return null given no matching event', async
 		test.context.context,
 		test.context.jellyfish,
 		test.context.session,
-		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+		test.context.generateRandomID())
 	test.deepEqual(event, null)
 })
 
 ava('.getLastExecutionEvent() should only consider execute cards', async (test) => {
+	const id = test.context.generateRandomID()
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
 		type: 'card@1.0.0',
-		slug: 'foobarbaz',
+		slug: test.context.generateRandomID(),
 		version: '1.0.0',
 		data: {
 			timestamp: '2018-06-30T19:34:42.829Z',
 			target: '57692206-8da2-46e1-91c9-159b2c6928ef',
 			actor: '57692206-8da2-46e1-91c9-159b2c6928ef',
-			originator: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
+			originator: id,
 			payload: {
 				card: '033d9184-70b2-4ec9-bc39-9a249b186422',
 				timestamp: '2018-06-32T19:34:42.829Z',
@@ -476,6 +492,6 @@ ava('.getLastExecutionEvent() should only consider execute cards', async (test) 
 		test.context.context,
 		test.context.jellyfish,
 		test.context.session,
-		'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
+		id)
 	test.deepEqual(event, null)
 })

--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -11,8 +11,9 @@ const Consumer = require('../../../lib/queue').Consumer
 const Producer = require('../../../lib/queue').Producer
 const actionLibrary = require('../../../lib/action-library')
 const queueErrors = require('../../../lib/queue/errors')
+const utils = require('../utils')
 
-exports.beforeEach = async (test, options) => {
+exports.before = async (test, options) => {
 	await helpers.beforeEach(test, options && {
 		suffix: options.suffix
 	})
@@ -82,9 +83,11 @@ exports.beforeEach = async (test, options) => {
 		test.context.session)
 
 	await test.context.queue.producer.initialize(test.context.context)
+	test.context.generateRandomSlug = utils.generateRandomSlug
+	test.context.generateRandomID = utils.generateRandomID
 }
 
-exports.afterEach = async (test) => {
+exports.after = async (test) => {
 	if (test.context.queue) {
 		await test.context.queue.consumer.cancel()
 	}

--- a/test/integration/queue/index.spec.js
+++ b/test/integration/queue/index.spec.js
@@ -9,8 +9,8 @@ const ava = require('ava')
 const errors = require('../../../lib/queue/errors')
 const helpers = require('./helpers')
 
-ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.before(helpers.before)
+ava.serial.after(helpers.after)
 
 ava('.dequeue() should return nothing if no requests', async (test) => {
 	const request = await test.context.dequeue()

--- a/test/integration/server/helpers.js
+++ b/test/integration/server/helpers.js
@@ -14,6 +14,7 @@ const {
 const environment = require('../../../lib/environment')
 const bootstrap = require('../../../apps/server/bootstrap')
 const actionServer = require('../../../apps/action-server/bootstrap')
+const utils = require('../utils')
 
 const workerOptions = {
 	metricsPort: 9100,
@@ -81,14 +82,7 @@ module.exports = {
 		await test.context.server.close()
 	},
 	beforeEach: (test) => {
-		test.context.generateRandomSlug = (options) => {
-			const suffix = uuid()
-			if (options.prefix) {
-				return `${options.prefix}-${suffix}`
-			}
-
-			return suffix
-		}
+		test.context.generateRandomSlug = utils.generateRandomSlug
 
 		test.context.http = (method, uri, payload, headers, options = {}) => {
 			return new Bluebird((resolve, reject) => {

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const uuid = require('uuid/v4')
+
+exports.generateRandomID = () => {
+	return uuid()
+}
+
+exports.generateRandomSlug = (options = {}) => {
+	const slug = exports.generateRandomID()
+	if (options.prefix) {
+		return `${options.prefix}-${slug}`
+	}
+
+	return slug
+}

--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -10,7 +10,7 @@ const errio = require('errio')
 
 exports.jellyfish = {
 	beforeEach: async (test) => {
-		await helpers.beforeEach(test)
+		await helpers.before(test)
 
 		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
 			require('../../../lib/worker/cards/update'))
@@ -21,13 +21,13 @@ exports.jellyfish = {
 	},
 
 	afterEach: async (test) => {
-		await helpers.afterEach(test)
+		await helpers.after(test)
 	}
 }
 
 exports.worker = {
 	beforeEach: async (test, actionLibrary, options = {}) => {
-		await helpers.beforeEach(test, {
+		await helpers.before(test, {
 			suffix: options.suffix
 		})
 
@@ -83,5 +83,5 @@ exports.worker = {
 			return test.context.queue.producer.waitResults(test.context, createRequest)
 		}
 	},
-	afterEach: helpers.afterEach
+	afterEach: helpers.after
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- modifies queue integration tests to use a shared backend instance instead of creating a new one for each test
- moves slug/id generation utils to a shared location

These changes will help clear up the test log noise described in https://github.com/product-os/jellyfish/issues/3736 and will speed up tests a bit. Going to be opening PRs for other integration tests as well.