### PR TITLE
Add mime-type to attachment image blobs

### DIFF
--- a/lib/ui-components/AuthenticatedImage/index.jsx
+++ b/lib/ui-components/AuthenticatedImage/index.jsx
@@ -33,9 +33,17 @@ class AuthenticatedImage extends React.Component {
 	}
 
 	componentDidMount () {
-		this.props.sdk.getFile(this.props.cardId, this.props.fileName)
+		const {
+			sdk,
+			cardId,
+			fileName,
+			mimeType
+		} = this.props
+		sdk.getFile(cardId, fileName)
 			.then((data) => {
-				const blob = new Blob([ data ])
+				const blob = new Blob([ data ], {
+					type: mimeType
+				})
 				this.setState({
 					imageSrc: URL.createObjectURL(blob)
 				})

--- a/lib/ui-components/Event/EventBody.jsx
+++ b/lib/ui-components/Event/EventBody.jsx
@@ -188,6 +188,7 @@ export default class EventBody extends React.Component {
 										fileName={attachment.slug}
 										addNotification={addNotification}
 										sdk={sdk}
+										mimeType={attachment.mime}
 									/>
 								</MessageContainer>
 							)


### PR DESCRIPTION
Currently, if you click 'Open Image in New Tab' on one of the image attachments in chrome, it will render the blob as text. Similar if you request to save the image it attempts to save it as txt.

Setting the mime type in the options when we create the blob fixes this issue