### PR TITLE
Remove references to CircularStd and Nunito fonts

### DIFF
--- a/apps/livechat/index.html
+++ b/apps/livechat/index.html
@@ -7,7 +7,6 @@
 		<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 		<link rel="icon" href="/favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
-		<link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700" rel="stylesheet" onload="this.setAttribute('loaded', 'loaded')">
         <style>
             html,
             body,

--- a/apps/livechat/index.html
+++ b/apps/livechat/index.html
@@ -7,7 +7,7 @@
 		<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 		<link rel="icon" href="/favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
-		<link href="https://fonts.googleapis.com/css?family=Nunito:400,700|Ubuntu+Mono:400,700" rel="stylesheet" onload="this.setAttribute('loaded', 'loaded')">
+		<link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700" rel="stylesheet" onload="this.setAttribute('loaded', 'loaded')">
         <style>
             html,
             body,

--- a/apps/livechat/index.jsx
+++ b/apps/livechat/index.jsx
@@ -13,7 +13,6 @@ import '@babel/polyfill'
 import {
 	getSdk
 } from '@balena/jellyfish-client-sdk'
-import 'circular-std'
 import {
 	Alert,
 	Provider as ThemeProvider

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -19,7 +19,7 @@
 
 				<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
 				<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
-				<link href="https://fonts.googleapis.com/css?family=Nunito:400,700|Ubuntu+Mono:400,700" rel="stylesheet" onload="this.setAttribute('loaded', 'loaded')" crossorigin="anonymous">
+				<link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700" rel="stylesheet" onload="this.setAttribute('loaded', 'loaded')" crossorigin="anonymous">
     </head>
 
     <body>

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -19,7 +19,6 @@
 
 				<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
 				<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
-				<link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700" rel="stylesheet" onload="this.setAttribute('loaded', 'loaded')" crossorigin="anonymous">
     </head>
 
     <body>

--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import '@babel/polyfill'
-import 'circular-std'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1858,9 +1858,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.9.6.tgz",
-      "integrity": "sha512-TcdM3xc7weMrwTawuG3BTjtVE3mQLXUPQ9CxTbSKOrhn3QAcqCJ2fz+IIv25wztzUnhNZat7hr655YJa61F3zg==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.2.tgz",
+      "integrity": "sha512-ZLwsFnNm3WpIARU1aLFtufjMHsmEnc8TjtrfAjmbgMbeoyR+LuQoyESoNdTfeDhL6IdY12SpeycXMgSgl8XGXA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -2130,9 +2130,9 @@
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.9.tgz",
-      "integrity": "sha512-49V3WNysLZU5fZ3sqSuys4nGRytsrxJktbv3vuaXkEoxv22C6T7TEG0TW6+nqVjMnkfCQd5xOnmJoZHMF78tOw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.10.tgz",
+      "integrity": "sha512-UGdpJiLBIqR/8xcLrCarf2pChqQFKjDTD02C7ZS/odpOVVl2YuHYRCLEOQ0GpfOk6jtYhmouSFOFoC8qNCe5cg==",
       "requires": {
         "prop-types": "^15.7.2"
       }
@@ -3057,19 +3057,27 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-helmet": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.0.0.tgz",
+      "integrity": "sha512-NBMPAxgjpaMooXa51cU1BTgrX6T+hQbMiLm77JhBbfOzPQea3RB5rNpPOD5xGWHIVpGXHd59cltEzIq0qglGcQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-jsonschema-form": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@types/react-jsonschema-form/-/react-jsonschema-form-1.7.2.tgz",
-      "integrity": "sha512-f9p5EvK7Ok3OgDKOaDogqYzYg5DqYcQLZuRJaYx6V2ZHGI0UbbCN48IffQ3PFsFVnhP3Cx8KUqzy4rAvg0EGYQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@types/react-jsonschema-form/-/react-jsonschema-form-1.7.3.tgz",
+      "integrity": "sha512-YiUCSnTA84e8g3zQobA+Iheh3+i3pb7TiIIXT4oEHwenhyrHVB5vPSIi/QeURy6PwVP1LfSCGOAHFRDpE/hAtQ==",
       "requires": {
         "@types/json-schema": "*",
         "@types/react": "*"
       }
     },
     "@types/react-native": {
-      "version": "0.62.4",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.4.tgz",
-      "integrity": "sha512-AKImyybUzqqPItKNuURkMe7y1X5cxuSJh5td8qbFSEXO58S5qjw01eZweWkKyTVCvrWGXkfm43u1zoYcZSGL6w==",
+      "version": "0.62.13",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.13.tgz",
+      "integrity": "sha512-hs4/tSABhcJx+J8pZhVoXHrOQD89WFmbs8QiDLNSA9zNrD46pityAuBWuwk1aMjPk9I3vC5ewkJroVRHgRIfdg==",
       "requires": {
         "@types/react": "*"
       }
@@ -3164,9 +3172,9 @@
           }
         },
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
         },
         "htmlparser2": {
           "version": "4.1.0",
@@ -6215,6 +6223,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "codemirror": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
+      "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q=="
+    },
     "codemirror-spell-checker": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
@@ -8115,11 +8128,6 @@
         "marked": "^0.8.2"
       },
       "dependencies": {
-        "codemirror": {
-          "version": "5.53.2",
-          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.53.2.tgz",
-          "integrity": "sha512-wvSQKS4E+P8Fxn/AQ+tQtJnF1qH5UOlxtugFLpubEZ5jcdH2iXTVinb+Xc/4QjshuOxRm4fUsU2QPF1JJKiyXA=="
-        },
         "marked": {
           "version": "0.8.2",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
@@ -11965,14 +11973,6 @@
         "recompose": "^0.30.0"
       },
       "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
         "recompose": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
@@ -12261,6 +12261,11 @@
         "tslib": "^1.10.0"
       }
     },
+    "highlight.js": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
+      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -12286,9 +12291,12 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -12367,9 +12375,9 @@
       },
       "dependencies": {
         "uglify-js": {
-          "version": "3.9.2",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.2.tgz",
-          "integrity": "sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==",
+          "version": "3.9.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
+          "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
           "requires": {
             "commander": "~2.20.3"
           }
@@ -13772,7 +13780,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.concat": {
       "version": "4.5.0",
@@ -13784,11 +13793,6 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
       "dev": true
-    },
-    "lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -14053,9 +14057,9 @@
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
     },
     "markdown-to-jsx": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.1.tgz",
-      "integrity": "sha512-FdtDAv8d9/tjyHxdCvWZxxOgK2icwzBkTq/dPk+XlQ2B+DYDcwE89FWGzT92erXQ0CQR/bQbpNK3loNYhYL70g==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
       "requires": {
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
@@ -16304,17 +16308,17 @@
       "dev": true
     },
     "polished": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.5.2.tgz",
-      "integrity": "sha512-vWoRDg3gY5RQBtUfcj9MRN10VCIf4EkdUikGxyXItg2Hnwk+eIVtdBiLajN0ldFeT3Vq4r/QNbjrQdhqBKrTug==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.4.tgz",
+      "integrity": "sha512-21moJXCm/7EvjeKQz5w89QDDKNPCoimc83CqwZZGJluFdMXsFlMQl9lPA/OMRkoceZ19kU0anKlMgZmY7LJSJw==",
       "requires": {
-        "@babel/runtime": "^7.8.7"
+        "@babel/runtime": "^7.9.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.9.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -16831,16 +16835,6 @@
       "requires": {
         "hoist-non-react-statics": "^3.3.0",
         "prop-types": "^15.5.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
       }
     },
     "react-chartjs-2": {
@@ -16907,9 +16901,9 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-google-recaptcha": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-2.0.1.tgz",
-      "integrity": "sha512-4Y8awVnarn7+gdVpu8uvSmRJzzlMMoXqdhLoyToTOfVK6oM+NaChNI8NShnu75Q2YGHLvR1IA1FWZesuYHwn5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-2.1.0.tgz",
+      "integrity": "sha512-K9jr7e0CWFigi8KxC3WPvNqZZ47df2RrMAta6KmRoE4RUi7Ys6NmNjytpXpg4HI/svmQJLKR+PncEPaNJ98DqQ==",
       "requires": {
         "prop-types": "^15.5.0",
         "react-async-script": "^1.1.1"
@@ -17090,9 +17084,9 @@
       "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "react-simplemde-editor": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-simplemde-editor/-/react-simplemde-editor-4.1.1.tgz",
-      "integrity": "sha512-Mbe7xHmD154aLL7xES3GnJ+JUep1BoeWA9oEiHy8Fz9upgRnvGLbkHX9elqlEyyZYX8+o+GrXUSvZFjJ7sz1/Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-simplemde-editor/-/react-simplemde-editor-4.1.2.tgz",
+      "integrity": "sha512-0eEPhrOTRNNCxnuJMmUuPm/DHIijsm9H2aGrY9+nmMksccNHi7mfBM9ajoIzo9XzWZrXSvjBu+svzRdt48MjLw==",
       "requires": {
         "@types/codemirror": "^0.0.88",
         "@types/marked": "^0.7.4",
@@ -17325,6 +17319,24 @@
         "esprima": "~4.0.0",
         "private": "~0.1.5",
         "source-map": "~0.6.1"
+      }
+    },
+    "recompose": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+      "requires": {
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "reconnect-core": {
@@ -17576,9 +17588,9 @@
       }
     },
     "rendition": {
-      "version": "14.11.5",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-14.11.5.tgz",
-      "integrity": "sha512-RFEl5s3SVc3U5oTRUybgdLeMRZRffBVtIBtKGCVngv/N3ff/xxGd8kHJiT3SGOsfz4QrnAMNKt75YDo5Ab7XEw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-15.0.0.tgz",
+      "integrity": "sha512-fVJLfuo4ontLeLJna+gOQDpMcMUtZE61YQSo4OoYxSgQc2Vv6nU8ePKdWhO8AS4vHXXWVJkckjE0TB9YrtGhJA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.25",
         "@fortawesome/free-regular-svg-icons": "^5.11.2",
@@ -17590,6 +17602,7 @@
         "@types/marked": "^0.7.2",
         "@types/node": "^13.13.4",
         "@types/prop-types": "^15.7.0",
+        "@types/react-helmet": "^6.0.0",
         "@types/react-jsonschema-form": "^1.3.2",
         "@types/recompose": "^0.26.2",
         "@types/sanitize-html": "^1.18.3",
@@ -17602,16 +17615,18 @@
         "color": "^3.1.2",
         "color-hash": "^1.0.3",
         "copy-to-clipboard": "^3.0.8",
-        "grommet": "^2.11.3",
+        "grommet": "^2.13.0",
+        "highlight.js": "^10.0.3",
         "jellyschema": "^0.11.9",
         "lodash": "^4.17.11",
         "marked": "^0.8.0",
         "mermaid": "8.4.0",
         "prop-types": "^15.7.2",
         "react-google-recaptcha": "^2.0.0-rc.1",
+        "react-helmet": "^6.0.0",
         "react-jsonschema-form": "^1.3.0",
         "react-notifications-component": "^2.2.3",
-        "react-simplemde-editor": "^4.1.0",
+        "react-simplemde-editor": "^4.1.1",
         "recompose": "0.26.0",
         "regex-parser": "^2.2.7",
         "sanitize-html": "^1.20.1",
@@ -17623,25 +17638,14 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-          "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
+          "version": "13.13.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.10.tgz",
+          "integrity": "sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q=="
         },
         "marked": {
           "version": "0.8.2",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
           "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
-        },
-        "recompose": {
-          "version": "0.26.0",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-          "requires": {
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "symbol-observable": "^1.0.4"
-          }
         }
       }
     },
@@ -18008,17 +18012,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-html": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.23.0.tgz",
-      "integrity": "sha512-7MgUrbZpaig6zHwuHjpNqhkiuutFPWWoFY/RmdtEnvrFKMLafzSHfFyOozVpKWytkZIUhbYu3VQ/93OmYdo3ag==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.26.0.tgz",
+      "integrity": "sha512-xriDBT2FbfN0ZKCcX6H6svkh1bZpO2e5ny05RQGZY6vFOMAU13La2L5YYf3XpcjXSksCYXzPj7YPvyGp5wbaUA==",
       "requires": {
         "chalk": "^2.4.1",
         "htmlparser2": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.2",
+        "lodash": "^4.17.15",
         "postcss": "^7.0.27",
         "srcset": "^2.0.1",
         "xtend": "^4.0.1"
@@ -18057,9 +18057,9 @@
           }
         },
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
         },
         "htmlparser2": {
           "version": "4.1.0",
@@ -18073,9 +18073,9 @@
           }
         },
         "postcss": {
-          "version": "7.0.30",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.30.tgz",
-          "integrity": "sha512-nu/0m+NtIzoubO+xdAlwZl/u5S5vi/y6BCsoL8D+8IxsD3XvBS8X4YEADNIVXKVuQvduiucnRv+vPIqj56EGMQ==",
+          "version": "7.0.32",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
@@ -18592,7 +18592,7 @@
       "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "smooth-dnd": {
-      "version": "git+https://github.com/rcdexta/smooth-dnd.git#223f4672bea94f65b98af4fd28ab0db2c3b9c8a2",
+      "version": "git+https://github.com/rcdexta/smooth-dnd.git#f13924c67bf6ffe4613d97bb1ee83f11d364eb1e",
       "from": "git+https://github.com/rcdexta/smooth-dnd.git"
     },
     "snake-case": {
@@ -20298,9 +20298,9 @@
       "integrity": "sha512-W3kLbx+ML9PBl5Bzso/lTvVxk4BCveSNAtQeht59FEtxCdGThmn6wSHA4Xq3eQYAK24NHdisMM4JmsK0GFy/pg=="
     },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uglify-js": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5970,11 +5970,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "circular-std": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/circular-std/-/circular-std-1.0.3.tgz",
-      "integrity": "sha512-GV4DJpJTfW+I/Fh7N/kjlQVxFp2P4tkJtBBBhaWuO5o7exEpvReOilcWwkmFjonhOKPR5HAZAV0zUNMT6KxdQQ=="
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "redux": "^4.0.5",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.2.0",
-    "rendition": "^14.11.0",
+    "rendition": "^15.0.0",
     "request-promise": "^4.2.2",
     "response-time": "^2.3.2",
     "semver": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "body-parser": "^1.18.2",
     "change-case": "^4.1.1",
     "chart.js": "^2.8.0",
-    "circular-std": "^1.0.3",
     "classnames": "^2.2.6",
     "color-hash": "^1.0.3",
     "common-tags": "^1.8.0",


### PR DESCRIPTION
Also remove references to Nunito font which will also be replaced by Source Sans Pro in Rendition.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3985 

The `circular-std` NPM package has been removed. Rendition is [switching to Source Sans Pro](https://github.com/balena-io-modules/rendition/pull/1120) and will pull in all the necessary fonts it needs itself. So this PR just removes references to CircularStd - as well as Nunito as Rendition is also removing references to this.

Depends on: https://github.com/balena-io-modules/rendition/pull/1120
