### PR TITLE
Fix quick search from message textarea

### DIFF
--- a/lib/ui-components/CardChatSummary/index.jsx
+++ b/lib/ui-components/CardChatSummary/index.jsx
@@ -169,7 +169,7 @@ export class CardChatSummary extends React.Component {
 				<Flex justifyContent="space-between" mb={3}>
 					<Flex alignItems="flex-start" flexWrap="wrap">
 						{_.map(highlightedFields, (keypath) => {
-							return <ColorHashPill value={_.get(card, keypath)} mr={2} mb={1} />
+							return <ColorHashPill key={keypath} value={_.get(card, keypath)} mr={2} mb={1} />
 						})}
 
 						<TagList

--- a/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
@@ -37,6 +37,7 @@ const QuickSearchPanel = styled(Card) `
 `
 
 const LoaderSpan = styled.span `
+	color: ${(props) => { return props.theme.colors.text.main }};
 	background-color: ${(props) => { return props.theme.colors.background }};
 `
 

--- a/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
+++ b/lib/ui-components/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
@@ -23,11 +23,12 @@ import {
 	getTrigger
 } from './triggers'
 
-const QUICK_SEARCH_RE = /^\s*\?[\w_-]+/
+const QUICK_SEARCH_RE = /^\s*\?[\w_-]+\s+[\w_-]+/
 
 const QuickSearchPanel = styled(Card) `
 	position: fixed;
 	background: white;
+	color: ${(props) => { return props.theme.colors.text.main }};
 	bottom: 80px;
 	right: 10px;
 	width: 400px;
@@ -146,7 +147,7 @@ class QuickSearchItem extends React.Component {
 			card, connectDragSource
 		} = this.props
 		return connectDragSource(<span>
-			<Link append={card.slug || card.id}>
+			<Link append={card.slug || card.id} data-test="quick-search__result">
 				{card.name || card.slug || card.id}
 			</Link>
 		</span>)
@@ -177,7 +178,7 @@ class AutoCompleteArea extends React.Component {
 		const filter = helpers.createFullTextSearchFilter(typeCard.data.schema, value)
 		_.set(filter, [ 'properties', 'type' ], {
 			type: 'string',
-			enum: `${typeCard.slug}@${typeCard.version}`
+			const: `${typeCard.slug}@${typeCard.version}`
 		})
 		this.props.sdk.query(filter, {
 			limit: 20,


### PR DESCRIPTION
Fix Quick Search Results behaviour on the AutocompleteTextarea component
Note: Previously this was broken and would never trigger any results.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

I've fixed the Quick Search Results functionality of the message textarea. You can trigger a quick 'full-text'* of cards using the following trigger (note the leading space):
```
 ?<card-type> <search-term>
```
For example:
![Quick Search Results](https://user-images.githubusercontent.com/2925657/83834736-4745d000-a719-11ea-9398-c531a0e77e53.gif)

You can then click on a search result to open that card in a new channel or drag the search result over another card channel to create a link between the respective cards.

\* we still need to update the logic of the full text search to not use regexp.

_Note: this PR also fixes a small issue with a missing `key` prop on the `CardChatSummary` component and the color of the 'Loading' placeholder when writing a whisper message (as opposed to a public message). These fixes are so trivial its not worth clogging up the CI pipeline with them as separate PRs._