### PR TITLE
Update mentions, alerts and tags when editing messsages

### DIFF
--- a/apps/ui/lens/misc/CRMTable/SelectWrapper.jsx
+++ b/apps/ui/lens/misc/CRMTable/SelectWrapper.jsx
@@ -11,6 +11,9 @@ import {
 	Badge
 } from 'rendition'
 import styled from 'styled-components'
+import {
+	patchPath
+} from '../../../../../lib/ui-components/services/helpers.js'
 import withCardUpdater from '../../../../../lib/ui-components/HOC/with-card-updater'
 
 const SingleLineSpan = styled.span `
@@ -23,7 +26,8 @@ const SelectWrapper = ({
 	const setValue = ({
 		option
 	}) => {
-		onUpdateCard(card, [ 'data', 'status' ], option)
+		const patch = patchPath(card, [ 'data', 'status' ], option)
+		onUpdateCard(card, patch)
 	}
 
 	const label = _.get(card, [ 'data', 'status' ])

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -8,6 +8,7 @@ import {
 	circularDeepEqual
 } from 'fast-equals'
 import _ from 'lodash'
+import * as jsonpatch from 'fast-json-patch'
 import Mark from 'mark.js'
 import React from 'react'
 import VisibilitySensor from 'react-visibility-sensor'
@@ -117,7 +118,14 @@ export default class Event extends React.Component {
 				this.setState({
 					updating: true
 				}, async () => {
-					onUpdateCard(this.props.card, 'data.payload.message', this.state.editedMessage)
+					const patch = jsonpatch.compare(this.props.card, _.defaultsDeep({
+						data: {
+							payload: {
+								message: this.state.editedMessage
+							}
+						}
+					}, this.props.card))
+					onUpdateCard(this.props.card, patch)
 						.then(this.onStopEditing)
 						.catch(() => {
 							this.setState({

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -118,10 +118,18 @@ export default class Event extends React.Component {
 				this.setState({
 					updating: true
 				}, async () => {
+					const {
+						mentionsUser,
+						alertsUser,
+						tags
+					} = helpers.getMessageMetaData(this.state.editedMessage)
 					const patch = jsonpatch.compare(this.props.card, _.defaultsDeep({
+						tags,
 						data: {
 							payload: {
-								message: this.state.editedMessage
+								message: this.state.editedMessage,
+								mentionsUser,
+								alertsUser
 							}
 						}
 					}, this.props.card))

--- a/lib/ui-components/Event/tests/Event.spec.jsx
+++ b/lib/ui-components/Event/tests/Event.spec.jsx
@@ -199,3 +199,77 @@ ava('A markdown message is displayed when the card is a message', async (test) =
 	const message = event.find(Markdown)
 	test.is(message.text().trim(), messageText)
 })
+
+ava('Editing a message will update the mentions, alerts, tags and message', async (test) => {
+	const author = {
+		...user,
+		id: card.data.actor
+	}
+	const mentionSlug = 'john'
+	const alertSlug = 'paul'
+	const tag = 'ringo'
+	const newMessage = `Test @${mentionSlug} !${alertSlug} #${tag}`
+	const expectedPatchSet = new Set([
+		{
+			op: 'add', path: '/tags/0', value: tag
+		},
+		{
+			op: 'add',
+			path: '/data/payload/mentionsUser/0',
+			value: `user-${mentionSlug}`
+		},
+		{
+			op: 'add', path: '/data/payload/alertsUser/0', value: `user-${alertSlug}`
+		},
+		{
+			op: 'replace',
+			path: '/data/payload/message',
+			value: newMessage
+		}
+	])
+
+	const onUpdateCard = sandbox.stub().resolves(null)
+
+	// HACK to get react-textarea-autosize not to complain
+	// eslint-disable-next-line no-multi-assign
+	global.getComputedStyle = global.window.getComputedStyle = () => {
+		return {
+			height: '100px',
+			getPropertyValue: (name) => {
+				return name === 'box-sizing' ? '' : null
+			}
+		}
+	}
+
+	const event = await mount(
+		<Event
+			{...commonProps}
+			onUpdateCard={onUpdateCard}
+			user={author}
+			card={card}
+		/>, {
+			wrappingComponent: wrapper
+		}
+	)
+
+	// Go into edit mode
+	event.find('button[data-test="event-header__context-menu-trigger"]').simulate('click')
+	event.find('a[data-test="event-header__link--edit-message"]').simulate('click')
+	const autocomplete = event.find('AutoCompleteArea')
+
+	// Force the change via the props (avoid interaction with react-textarea-autosize)
+	autocomplete.props().onChange({
+		target: {
+			value: newMessage
+		}
+	})
+	autocomplete.props().onSubmit()
+
+	// Verify the onUpdateCard prop callback is called with the expected patch
+	test.is(onUpdateCard.callCount, 1)
+	test.is(onUpdateCard.getCall(0).args[0].id, card.id)
+
+	// Use a Set here as we can't be sure of the order of patches in the patch array
+	const updatePatchSet = new Set(onUpdateCard.getCall(0).args[1])
+	test.deepEqual(updatePatchSet, expectedPatchSet)
+})

--- a/lib/ui-components/HOC/with-card-updater.js
+++ b/lib/ui-components/HOC/with-card-updater.js
@@ -6,9 +6,6 @@
 
 import React from 'react'
 import {
-	patchPath
-} from '../services/helpers.js'
-import {
 	useSetup
 } from '../SetupProvider'
 
@@ -21,9 +18,7 @@ export default function withCardUpdater (skipNotification = false) {
 				sdk,
 				analytics
 			} = useSetup()
-			const onUpdateCard = (card, patchKeyPath, newValue) => {
-				const patch = patchPath(card, patchKeyPath, newValue)
-
+			const onUpdateCard = (card, patch) => {
 				if (patch.length) {
 					return sdk.card.update(card.id, card.type, patch)
 						.then((response) => {
@@ -37,7 +32,7 @@ export default function withCardUpdater (skipNotification = false) {
 						})
 						.then((response) => {
 							if (!skipNotification) {
-								actions.addNotification('success', `Updated ${card.name || card.slug} to ${newValue}`)
+								actions.addNotification('success', `Updated ${card.name || card.slug}`)
 							}
 							return response
 						})

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -350,11 +350,11 @@ class Timeline extends React.Component {
 			messageSymbol: false
 		})
 		this.props.setTimelineMessage(this.props.card.id, '')
-		const mentions = helpers.getUserSlugsByPrefix('@', newMessage)
-		const alerts = helpers.getUserSlugsByPrefix('!', newMessage)
-		const tags = helpers.findWordsByPrefix('#', newMessage).map((tag) => {
-			return tag.slice(1).toLowerCase()
-		})
+		const {
+			mentionsUser,
+			alertsUser,
+			tags
+		} = helpers.getMessageMetaData(newMessage)
 		const whisper = allowWhispers && this.state.messageSymbol ? false : this.state.whisper
 		const message = {
 			target: this.props.card,
@@ -362,8 +362,8 @@ class Timeline extends React.Component {
 			slug: `${whisper ? 'whisper' : 'message'}-${uuid()}`,
 			tags,
 			payload: {
-				mentionsUser: mentions,
-				alertsUser: alerts,
+				mentionsUser,
+				alertsUser,
 				message: helpers.replaceEmoji(newMessage.replace(messageSymbolRE, ''))
 			}
 		}

--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -587,6 +587,16 @@ export const userDisplayName = (user) => {
 	return user.name || user.slug.replace('user-', '')
 }
 
+export const getMessageMetaData = (message) => {
+	return {
+		mentionsUser: getUserSlugsByPrefix('@', message),
+		alertsUser: getUserSlugsByPrefix('!', message),
+		tags: findWordsByPrefix('#', message).map((tag) => {
+			return tag.slice(1).toLowerCase()
+		})
+	}
+}
+
 export const px = (val) => {
 	return (typeof val === 'number' ? `${val}px` : val)
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

If you edit a message/whisper, you might modify the tags/mentions/alerts. These fields are now re-calculated and updated on the card when saving an edited message.
