### PR TITLE
core: Fix query for Sales and Support meta relationships on user card

### DIFF
--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -240,7 +240,7 @@ module.exports = {
 									type: 'object',
 									properties: {
 										type: {
-											const: 'create'
+											const: 'create@1.0.0'
 										},
 										data: {
 											type: 'object',
@@ -264,7 +264,7 @@ module.exports = {
 							type: 'object',
 							properties: {
 								type: {
-									const: 'sales-thread'
+									const: 'sales-thread@1.0.0'
 								}
 							},
 							additionalProperties: true
@@ -280,7 +280,7 @@ module.exports = {
 									type: 'object',
 									properties: {
 										type: {
-											const: 'create'
+											const: 'create@1.0.0'
 										},
 										data: {
 											type: 'object',
@@ -304,7 +304,7 @@ module.exports = {
 							type: 'object',
 							properties: {
 								type: {
-									const: 'support-thread'
+									const: 'support-thread@1.0.0'
 								}
 							},
 							additionalProperties: true


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3912 

The query was previously specifying old types (without the `@1.0.0` suffix that we use everywhere now).