### PR TITLE
ci: Update worker integration tests to use a shared backend

### DIFF
--- a/scripts/ci/skip_tests_if_only.sh
+++ b/scripts/ci/skip_tests_if_only.sh
@@ -32,8 +32,6 @@ AFFECTED_MODULES="$(git diff --name-only master..."$CURRENT_BRANCH" \
 # If no module was actually affected, then there is no need to run the tests
 if [ -z "$AFFECTED_MODULES" ]
 then
-	echo "Current branch: $CURRENT_BRANCH"
-	git diff --name-only master..."$CURRENT_BRANCH"
 	echo "No affected modules. Skipping tests..."
 	exit 0
 fi

--- a/test/integration/sync/helpers.js
+++ b/test/integration/sync/helpers.js
@@ -10,7 +10,7 @@ const syncContext = require('../../../lib/action-library/handlers/sync-context')
 
 module.exports = {
 	beforeEach: async (test, options) => {
-		await helpers.worker.beforeEach(test, actionLibrary, options)
+		await helpers.worker.before(test, actionLibrary, options)
 		test.context.syncContext = syncContext.fromWorkerContext(
 			'test',
 			test.context.worker.getActionContext(test.context.context),
@@ -18,6 +18,6 @@ module.exports = {
 			test.context.session)
 	},
 	afterEach: async (test) => {
-		await helpers.worker.afterEach(test)
+		await helpers.worker.after(test)
 	}
 }

--- a/test/integration/worker/actions/broadcast.spec.js
+++ b/test/integration/worker/actions/broadcast.spec.js
@@ -9,18 +9,18 @@ const _ = require('lodash')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should post a broadcast message to an empty thread', async (test) => {
 	const thread = await test.context.jellyfish.insertCard(
 		test.context.context, test.context.session, {
 			type: 'card@1.0.0',
 			version: '1.0.0',
-			slug: 'thread-1',
+			slug: test.context.generateRandomSlug(),
 			data: {}
 		})
 
@@ -93,7 +93,7 @@ ava('should post a broadcast message to a non empty thread', async (test) => {
 		test.context.context, test.context.session, {
 			type: 'card@1.0.0',
 			version: '1.0.0',
-			slug: 'thread-1',
+			slug: test.context.generateRandomSlug(),
 			data: {}
 		})
 
@@ -201,7 +201,7 @@ ava('should not broadcast the same message twice', async (test) => {
 		test.context.context, test.context.session, {
 			type: 'card@1.0.0',
 			version: '1.0.0',
-			slug: 'thread-1',
+			slug: test.context.generateRandomSlug(),
 			data: {}
 		})
 
@@ -325,7 +325,7 @@ ava('should broadcast different messages', async (test) => {
 		test.context.context, test.context.session, {
 			type: 'card@1.0.0',
 			version: '1.0.0',
-			slug: 'thread-1',
+			slug: test.context.generateRandomSlug(),
 			data: {}
 		})
 
@@ -463,7 +463,7 @@ ava('should broadcast the same message twice given different actors', async (tes
 		test.context.context, test.context.session, {
 			type: 'card@1.0.0',
 			version: '1.0.0',
-			slug: 'thread-1',
+			slug: test.context.generateRandomSlug(),
 			data: {}
 		})
 
@@ -471,7 +471,9 @@ ava('should broadcast the same message twice given different actors', async (tes
 		test.context.context, test.context.session, {
 			type: 'user@1.0.0',
 			version: '1.0.0',
-			slug: 'user-admin-fake-test',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			data: {
 				email: 'accounts+jellyfish@resin.io',
 				hash: 'PASSWORDLESS',
@@ -483,7 +485,9 @@ ava('should broadcast the same message twice given different actors', async (tes
 		test.context.context, test.context.session, {
 			type: 'session@1.0.0',
 			version: '1.0.0',
-			slug: 'session-rogue-user-test',
+			slug: test.context.generateRandomSlug({
+				prefix: 'session'
+			}),
 			data: {
 				actor: rogueUser.id
 			}

--- a/test/integration/worker/actions/complete-password-reset.spec.js
+++ b/test/integration/worker/actions/complete-password-reset.spec.js
@@ -16,9 +16,11 @@ const {
 	resetPasswordSecretToken
 } = environment.actions
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
+})
 
+ava.beforeEach(async (test) => {
 	const {
 		worker,
 		session,
@@ -31,7 +33,7 @@ ava.beforeEach(async (test) => {
 
 	const userEmail = 'test@test.com'
 	const userPassword = 'original-password'
-	const username = 'johndoe'
+	const username = test.context.generateRandomSlug()
 
 	const createUserAction = await worker.pre(session, {
 		action: 'action-create-user@1.0.0',
@@ -72,7 +74,7 @@ ava.beforeEach(async (test) => {
 	}
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should replace the user password when the requestToken is valid', async (test) => {
 	const {

--- a/test/integration/worker/actions/create-card.spec.js
+++ b/test/integration/worker/actions/create-card.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should fail to create an event with an action-create-card', async (test) => {
 	const cardType = await test.context.jellyfish.getCardBySlug(
@@ -71,7 +71,7 @@ ava('should fail to create an event with an action-create-card', async (test) =>
 			reason: null,
 			properties: {
 				version: '1.0.0',
-				slug: 'foo',
+				slug: test.context.generateRandomSlug(),
 				data: {
 					mentions: []
 				}
@@ -126,7 +126,7 @@ ava('should create a new card along with a reason', async (test) => {
 			arguments: {
 				reason: 'My new card',
 				properties: {
-					slug: 'foo',
+					slug: test.context.generateRandomSlug(),
 					version: '1.0.0'
 				}
 			}
@@ -204,6 +204,7 @@ ava('should be able to insert a deeply nested card', async (test) => {
 
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+	const slug = test.context.generateRandomSlug()
 	const createRequest = await test.context.queue.producer.enqueue(test.context.worker.getId(), test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -212,7 +213,7 @@ ava('should be able to insert a deeply nested card', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug,
 				version: '1.0.0',
 				data
 			}
@@ -229,7 +230,7 @@ ava('should be able to insert a deeply nested card', async (test) => {
 			type: createResult.data.type
 		})
 
-	test.deepEqual(card.slug, 'foo')
+	test.deepEqual(card.slug, slug)
 	test.deepEqual(card.version, '1.0.0')
 	test.deepEqual(card.data, data)
 })

--- a/test/integration/worker/actions/create-event.spec.js
+++ b/test/integration/worker/actions/create-event.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('action-create-event should create a link card', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(

--- a/test/integration/worker/actions/create-session.spec.js
+++ b/test/integration/worker/actions/create-session.spec.js
@@ -9,11 +9,11 @@ const Bluebird = require('bluebird')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should not store the password in the queue when using action-create-session', async (test) => {
 	const userCard = await test.context.jellyfish.getCardBySlug(

--- a/test/integration/worker/actions/create-user.spec.js
+++ b/test/integration/worker/actions/create-user.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should not store the password in the queue when using action-create-user', async (test) => {
 	const {

--- a/test/integration/worker/actions/delete-card.spec.js
+++ b/test/integration/worker/actions/delete-card.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should delete a card using action-delete-card', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(

--- a/test/integration/worker/actions/google-meet.spec.js
+++ b/test/integration/worker/actions/google-meet.spec.js
@@ -13,8 +13,8 @@ const actionLibrary = require('../../../../lib/action-library')
 
 const GOOGLE_MEET_URL = 'https://meet.google.com/some-fake-room'
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 
 	// Fake the Google APIs calls
 	const auth = {
@@ -48,7 +48,7 @@ ava.beforeEach(async (test) => {
 	}
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should return a conference URL', async (test) => {
 	const {

--- a/test/integration/worker/actions/send-email.spec.js
+++ b/test/integration/worker/actions/send-email.spec.js
@@ -13,12 +13,12 @@ const environment = require('../../../../lib/environment')
 
 const MAILGUN = environment.mail
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(async (test) => {
-	helpers.worker.afterEach(test)
+ava.after(async (test) => {
+	helpers.worker.after(test)
 	nock.cleanAll()
 })
 

--- a/test/integration/worker/actions/set-password.spec.js
+++ b/test/integration/worker/actions/set-password.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should not store the passwords in the queue when using action-set-password', async (test) => {
 	const userCard = await test.context.jellyfish.getCardBySlug(
@@ -25,7 +25,9 @@ ava('should not store the passwords in the queue when using action-set-password'
 		type: userCard.type,
 		arguments: {
 			email: 'johndoe@example.com',
-			username: 'user-johndoe',
+			username: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			password: 'foobarbaz'
 		}
 	})
@@ -66,7 +68,9 @@ ava('should not store the passwords in the queue when using action-set-password'
 ava('should change the password of a password-less user given no password', async (test) => {
 	const userCard = await test.context.jellyfish.insertCard(
 		test.context.context, test.context.session, {
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			type: 'user@1.0.0',
 			data: {
 				email: 'johndoe@example.com',
@@ -126,7 +130,9 @@ ava('should change a user password', async (test) => {
 		type: userCard.type,
 		arguments: {
 			email: 'johndoe@example.com',
-			username: 'user-johndoe',
+			username: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			password: 'foobarbaz'
 		}
 	})
@@ -200,7 +206,9 @@ ava('should not change a user password given invalid current password', async (t
 		type: userCard.type,
 		arguments: {
 			email: 'johndoe@example.com',
-			username: 'user-johndoe',
+			username: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			password: 'foobarbaz'
 		}
 	})
@@ -238,7 +246,9 @@ ava('should not change a user password given a null current password', async (te
 		type: userCard.type,
 		arguments: {
 			email: 'johndoe@example.com',
-			username: 'user-johndoe',
+			username: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			password: 'foobarbaz'
 		}
 	})
@@ -323,7 +333,9 @@ ava('should change the hash when updating a user password', async (test) => {
 ava('should not store the passwords when using action-set-password on a first time password', async (test) => {
 	const userCard = await test.context.jellyfish.insertCard(
 		test.context.context, test.context.session, {
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			type: 'user@1.0.0',
 			data: {
 				email: 'johndoe@example.com',
@@ -357,7 +369,9 @@ ava('should not store the passwords when using action-set-password on a first ti
 ava('should not change the password of a password-less user given a password', async (test) => {
 	const userCard = await test.context.jellyfish.insertCard(
 		test.context.context, test.context.session, {
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			type: 'user@1.0.0',
 			data: {
 				email: 'johndoe@example.com',

--- a/test/integration/worker/actions/update-card.spec.js
+++ b/test/integration/worker/actions/update-card.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('../helpers')
 const actionLibrary = require('../../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('should fail to update a card if the schema does not match', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
@@ -25,7 +25,7 @@ ava('should fail to update a card if the schema does not match', async (test) =>
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug: test.context.generateRandomSlug(),
 				version: '1.0.0',
 				data: {
 					foo: 'bar'
@@ -66,6 +66,7 @@ ava('should fail to update a card if the schema does not match', async (test) =>
 ava('should update a card to add an extra property', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+	const slug = test.context.generateRandomSlug()
 	const createRequest = await test.context.queue.producer.enqueue(test.context.worker.getId(), test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -74,7 +75,7 @@ ava('should update a card to add an extra property', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug,
 				version: '1.0.0',
 				data: {
 					foo: 'bar'
@@ -122,7 +123,7 @@ ava('should update a card to add an extra property', async (test) => {
 		updated_at: updateCard.updated_at,
 		linked_at: card.linked_at,
 		id: updateResult.data.id,
-		slug: 'foo',
+		slug,
 		name: null,
 		version: '1.0.0',
 		type: 'card@1.0.0',
@@ -137,6 +138,7 @@ ava('should update a card to add an extra property', async (test) => {
 ava('should update a card to set active to false', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+	const slug = test.context.generateRandomSlug()
 	const createRequest = await test.context.queue.producer.enqueue(test.context.worker.getId(), test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -145,7 +147,7 @@ ava('should update a card to set active to false', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug,
 				version: '1.0.0'
 			}
 		}
@@ -187,7 +189,7 @@ ava('should update a card to set active to false', async (test) => {
 		id: updateResult.data.id,
 		version: '1.0.0',
 		name: null,
-		slug: 'foo',
+		slug,
 		type: 'card@1.0.0',
 		active: false,
 		links: card.links
@@ -206,7 +208,7 @@ ava('should update a card along with a reason', async (test) => {
 			arguments: {
 				reason: null,
 				properties: {
-					slug: 'foo',
+					slug: test.context.generateRandomSlug(),
 					version: '1.0.0'
 				}
 			}
@@ -333,6 +335,7 @@ ava('should update a card to set active to false using the card slug as input', 
 ava('should update a card to override an array property', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+	const slug = test.context.generateRandomSlug()
 	const createRequest = await test.context.queue.producer.enqueue(test.context.worker.getId(), test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -341,7 +344,7 @@ ava('should update a card to override an array property', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug,
 				version: '1.0.0',
 				data: {
 					roles: [ 'guest' ]
@@ -388,7 +391,7 @@ ava('should update a card to override an array property', async (test) => {
 		id: updateResult.data.id,
 		type: 'card@1.0.0',
 		name: null,
-		slug: 'foo',
+		slug,
 		version: '1.0.0',
 		links: card.links,
 		data: {
@@ -400,6 +403,7 @@ ava('should update a card to override an array property', async (test) => {
 ava('should add an update event if updating a card', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+	const slug = test.context.generateRandomSlug()
 	const createRequest = await test.context.queue.producer.enqueue(test.context.worker.getId(), test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -408,7 +412,7 @@ ava('should add an update event if updating a card', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug,
 				version: '1.0.0',
 				data: {
 					foo: 1
@@ -481,7 +485,7 @@ ava('should add an update event if updating a card', async (test) => {
 				target: createResult.data.id,
 				timestamp: timeline[0].data.timestamp,
 				payload: {
-					slug: 'foo',
+					slug,
 					type: 'card@1.0.0',
 					version: '1.0.0',
 					data: {
@@ -519,6 +523,7 @@ ava('should add an update event if updating a card', async (test) => {
 ava('should delete a card using action-update-card', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+	const slug = test.context.generateRandomSlug()
 	const createRequest = await test.context.queue.producer.enqueue(test.context.worker.getId(), test.context.session, {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -527,7 +532,7 @@ ava('should delete a card using action-update-card', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo',
+				slug,
 				version: '1.0.0'
 			}
 		}
@@ -570,7 +575,7 @@ ava('should delete a card using action-update-card', async (test) => {
 		id: updateResult.data.id,
 		name: null,
 		type: 'card@1.0.0',
-		slug: 'foo',
+		slug,
 		version: '1.0.0',
 		active: false,
 		links: card.links

--- a/test/integration/worker/executor.spec.js
+++ b/test/integration/worker/executor.spec.js
@@ -13,8 +13,8 @@ const executor = require('../../../lib/worker/executor')
 const utils = require('../../../lib/worker/utils')
 const Promise = require('bluebird')
 
-ava.serial.beforeEach(async (test) => {
-	await helpers.jellyfish.beforeEach(test)
+ava.serial.before(async (test) => {
+	await helpers.jellyfish.before(test)
 
 	test.context.triggers = []
 	test.context.stubQueue = []
@@ -50,11 +50,13 @@ ava.serial.beforeEach(async (test) => {
 	}
 })
 
-ava.serial.afterEach(helpers.jellyfish.afterEach)
+ava.serial.after(helpers.jellyfish.after)
 
 ava('.replaceCard() updating a card must have the correct tail', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const slug = test.context.generateRandomSlug()
 	const result1 = await executor.insertCard(
 		test.context.context, test.context.jellyfish, test.context.session, typeCard, {
 			currentTime: new Date(),
@@ -64,7 +66,7 @@ ava('.replaceCard() updating a card must have the correct tail', async (test) =>
 			actor: test.context.actor.id,
 			executeAction: test.context.executeAction
 		}, {
-			slug: 'foo',
+			slug,
 			version: '1.0.0',
 			data: {
 				foo: 1
@@ -80,7 +82,7 @@ ava('.replaceCard() updating a card must have the correct tail', async (test) =>
 			actor: test.context.actor.id,
 			executeAction: test.context.executeAction
 		}, {
-			slug: 'foo',
+			slug,
 			version: '1.0.0',
 			data: {
 				foo: 2
@@ -96,7 +98,7 @@ ava('.replaceCard() updating a card must have the correct tail', async (test) =>
 		linked_at: card.linked_at,
 		id: result1.id,
 		name: null,
-		slug: 'foo',
+		slug,
 		type: 'card@1.0.0',
 		data: {
 			foo: 2
@@ -142,6 +144,8 @@ ava('.replaceCard() updating a card must have the correct tail', async (test) =>
 ava('.insertCard() should insert a card', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const slug = test.context.generateRandomSlug()
 	const result = await executor.insertCard(
 		test.context.context, test.context.jellyfish, test.context.session, typeCard, {
 			currentTime: new Date(),
@@ -151,7 +155,7 @@ ava('.insertCard() should insert a card', async (test) => {
 			actor: test.context.actor.id,
 			executeAction: test.context.executeAction
 		}, {
-			slug: 'foo',
+			slug,
 			data: {
 				foo: 1
 			}
@@ -164,7 +168,7 @@ ava('.insertCard() should insert a card', async (test) => {
 		created_at: result.created_at,
 		id: result.id,
 		name: null,
-		slug: 'foo',
+		slug,
 		type: 'card@1.0.0',
 		data: {
 			foo: 1
@@ -175,6 +179,8 @@ ava('.insertCard() should insert a card', async (test) => {
 ava('.insertCard() should ignore an explicit type property', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const slug = test.context.generateRandomSlug()
 	const result = await executor.insertCard(test.context.context, test.context.jellyfish, test.context.session, typeCard, {
 		currentTime: new Date(),
 		attachEvents: false,
@@ -184,8 +190,8 @@ ava('.insertCard() should ignore an explicit type property', async (test) => {
 		executeAction: test.context.executeAction
 	}, {
 		active: true,
-		slug: 'foo',
-		type: 'foo@1.0.0',
+		slug,
+		type: `${slug}@1.0.0`,
 		version: '1.0.0',
 		links: {},
 		tags: [],
@@ -213,7 +219,7 @@ ava('.insertCard() should default active to true', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0'
 	})
 
@@ -235,7 +241,7 @@ ava('.patchCard() should ignore pointless updates', async (test) => {
 			actor: test.context.actor.id,
 			executeAction: test.context.executeAction
 		}, {
-			slug: 'foo',
+			slug: test.context.generateRandomSlug(),
 			version: '1.0.0',
 			active: true
 		})
@@ -287,7 +293,7 @@ ava('.insertCard() should be able to set active to false', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0',
 		active: false
 	})
@@ -308,7 +314,7 @@ ava('.insertCard() should provide sane defaults for links', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0'
 	})
 
@@ -328,7 +334,7 @@ ava('.insertCard() should provide sane defaults for tags', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0'
 	})
 
@@ -348,7 +354,7 @@ ava('.insertCard() should provide sane defaults for data', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0'
 	})
 
@@ -360,6 +366,8 @@ ava('.insertCard() should provide sane defaults for data', async (test) => {
 ava('.insertCard() should be able to set a slug', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const slug = test.context.generateRandomSlug()
 	const result = await executor.insertCard(test.context.context, test.context.jellyfish, test.context.session, typeCard, {
 		currentTime: new Date(),
 		attachEvents: false,
@@ -368,13 +376,13 @@ ava('.insertCard() should be able to set a slug', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo-bar',
+		slug,
 		version: '1.0.0'
 	})
 
 	test.deepEqual(test.context.stubQueue, [])
 	const card = await test.context.jellyfish.getCardById(test.context.context, test.context.session, result.id)
-	test.is(card.slug, 'foo-bar')
+	test.is(card.slug, slug)
 })
 
 ava('.insertCard() should be able to set a name', async (test) => {
@@ -388,7 +396,7 @@ ava('.insertCard() should be able to set a name', async (test) => {
 		actor: test.context.actor.id,
 		executeAction: test.context.executeAction
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0',
 		name: 'Hello'
 	})
@@ -400,7 +408,7 @@ ava('.insertCard() should be able to set a name', async (test) => {
 
 ava('.patchCard() should not upsert if no changes were made', async (test) => {
 	const element = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar-baz',
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
@@ -421,7 +429,7 @@ ava('.patchCard() should not upsert if no changes were made', async (test) => {
 
 ava('.patchCard() should set a card to inactive', async (test) => {
 	const previousCard = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar-baz',
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
@@ -449,8 +457,9 @@ ava('.patchCard() should set a card to inactive', async (test) => {
 })
 
 ava('.insertCard() throw if card already exists and override is false', async (test) => {
+	const slug = test.context.generateRandomSlug()
 	await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar-baz',
+		slug,
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
@@ -466,7 +475,7 @@ ava('.insertCard() throw if card already exists and override is false', async (t
 		executeAction: test.context.executeAction
 	}, {
 		version: '1.0.0',
-		slug: 'foo-bar-baz',
+		slug,
 		active: false
 	}), {
 		instanceOf: test.context.jellyfish.errors.JellyfishElementAlreadyExists
@@ -486,7 +495,7 @@ ava('.insertCard() should add a create event if attachEvents is true', async (te
 			executeAction: test.context.executeAction
 		}, {
 			version: '1.0.0',
-			slug: 'foo-bar-baz'
+			slug: test.context.generateRandomSlug()
 		})
 
 	test.deepEqual(test.context.stubQueue, [])
@@ -518,7 +527,7 @@ ava('.insertCard() should add a create event if attachEvents is true', async (te
 
 ava('.patchCard() should add an update event if attachEvents is true', async (test) => {
 	const element = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar-baz',
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
@@ -570,6 +579,8 @@ ava('.patchCard() should add an update event if attachEvents is true', async (te
 ava('.insertCard() should pass a triggered action as an action originator', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const command = test.context.generateRandomSlug()
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -583,7 +594,7 @@ ava('.insertCard() should pass a triggered action as an action originator', asyn
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command
 							}
 						}
 					}
@@ -594,7 +605,7 @@ ava('.insertCard() should pass a triggered action as an action originator', asyn
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command
 				}
 			}
 		}
@@ -622,15 +633,15 @@ ava('.insertCard() should pass a triggered action as an action originator', asyn
 			executeAction: test.context.executeAction,
 			triggers
 		}, {
-			slug: 'foo',
+			slug: test.context.generateRandomSlug(),
 			version: '1.0.0',
 			data: {
-				command: 'foo-bar-baz'
+				command
 			}
 		})
 
 	const resultCard = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0', {
+		test.context.context, test.context.session, `${command}@1.0.0`, {
 			type: typeCard.slug
 		})
 
@@ -640,6 +651,8 @@ ava('.insertCard() should pass a triggered action as an action originator', asyn
 ava('.insertCard() should be able to override a triggered action originator', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const command = test.context.generateRandomSlug()
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -653,7 +666,7 @@ ava('.insertCard() should be able to override a triggered action originator', as
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command
 							}
 						}
 					}
@@ -664,7 +677,7 @@ ava('.insertCard() should be able to override a triggered action originator', as
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command
 				}
 			}
 		}
@@ -693,15 +706,15 @@ ava('.insertCard() should be able to override a triggered action originator', as
 			executeAction: test.context.executeAction,
 			triggers
 		}, {
-			slug: 'foo',
+			slug: test.context.generateRandomSlug(),
 			version: '1.0.0',
 			data: {
-				command: 'foo-bar-baz'
+				command
 			}
 		})
 
 	const resultCard = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0', {
+		test.context.context, test.context.session, `${command}@1.0.0`, {
 			type: typeCard.slug
 		})
 
@@ -711,6 +724,8 @@ ava('.insertCard() should be able to override a triggered action originator', as
 ava('.insertCard() should execute one matching triggered action', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const command = test.context.generateRandomSlug()
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -724,7 +739,7 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command
 							}
 						}
 					}
@@ -735,7 +750,7 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command
 				}
 			}
 		}
@@ -750,10 +765,10 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 		executeAction: test.context.executeAction,
 		triggers
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0',
 		data: {
-			command: 'foo-bar-baz'
+			command
 		}
 	})
 
@@ -784,7 +799,7 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 	test.deepEqual(test.context.stubQueue, [])
 
 	const resultCard = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0', {
+		test.context.context, test.context.session, `${command}@1.0.0`, {
 			type: typeCard.slug
 		})
 
@@ -794,6 +809,8 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 ava('.insertCard() should not execute non-matching triggered actions', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const command = test.context.generateRandomSlug()
 	const triggers = [
 		{
 			filter: {
@@ -806,7 +823,7 @@ ava('.insertCard() should not execute non-matching triggered actions', async (te
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command
 							}
 						}
 					}
@@ -816,7 +833,7 @@ ava('.insertCard() should not execute non-matching triggered actions', async (te
 			target: typeCard.id,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command
 				}
 			}
 		}
@@ -831,16 +848,16 @@ ava('.insertCard() should not execute non-matching triggered actions', async (te
 		executeAction: test.context.executeAction,
 		triggers
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0',
 		data: {
-			command: 'qux-bar-baz'
+			command: test.context.generateRandomSlug()
 		}
 	})
 
 	test.deepEqual(test.context.stubQueue, [])
 	const resultCard = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0', {
+		test.context.context, test.context.session, `${command}@1.0.0`, {
 			type: typeCard.slug
 		})
 
@@ -850,6 +867,9 @@ ava('.insertCard() should not execute non-matching triggered actions', async (te
 ava('.insertCard() should execute more than one matching triggered action', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const command1 = test.context.generateRandomSlug()
+	const command2 = test.context.generateRandomSlug()
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -863,7 +883,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command1
 							}
 						}
 					}
@@ -874,7 +894,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command1
 				}
 			}
 		},
@@ -890,7 +910,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command1
 							}
 						}
 					}
@@ -901,7 +921,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'bar-baz-qux'
+					slug: command2
 				}
 			}
 		}
@@ -916,22 +936,22 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 		executeAction: test.context.executeAction,
 		triggers
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0',
 		data: {
-			command: 'foo-bar-baz'
+			command: command1
 		}
 	})
 
 	test.deepEqual(test.context.stubQueue, [])
 
 	const resultCard1 = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0', {
+		test.context.context, test.context.session, `${command1}@1.0.0`, {
 			type: typeCard.slug
 		})
 
 	const resultCard2 = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'bar-baz-qux@1.0.0', {
+		test.context.context, test.context.session, `${command2}@1.0.0`, {
 			type: typeCard.slug
 		})
 
@@ -942,6 +962,9 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 ava('.insertCard() should execute the matching triggered actions given more than one', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const command1 = test.context.generateRandomSlug()
+	const command2 = test.context.generateRandomSlug()
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -955,7 +978,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command1
 							}
 						}
 					}
@@ -966,7 +989,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command1
 				}
 			}
 		},
@@ -982,7 +1005,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 						properties: {
 							command: {
 								type: 'string',
-								const: 'bar-baz-qux'
+								const: command2
 							}
 						}
 					}
@@ -993,7 +1016,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 			type: typeCard.type,
 			arguments: {
 				properties: {
-					slug: 'bar-baz-qux'
+					slug: command2
 				}
 			}
 		}
@@ -1008,22 +1031,22 @@ ava('.insertCard() should execute the matching triggered actions given more than
 		executeAction: test.context.executeAction,
 		triggers
 	}, {
-		slug: 'foo',
+		slug: test.context.generateRandomSlug(),
 		version: '1.0.0',
 		data: {
-			command: 'foo-bar-baz'
+			command: command1
 		}
 	})
 
 	test.deepEqual(test.context.stubQueue, [])
 
 	const resultCard1 = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0', {
+		test.context.context, test.context.session, `${command1}@1.0.0`, {
 			type: typeCard.slug
 		})
 
 	const resultCard2 = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'bar-baz-qux@1.0.0', {
+		test.context.context, test.context.session, `${command2}@1.0.0`, {
 			type: typeCard.slug
 		})
 
@@ -1034,6 +1057,13 @@ ava('.insertCard() should execute the matching triggered actions given more than
 ava('.insertCard() should remove previously inserted type triggered actions if inserting a type', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const fooType = test.context.generateRandomSlug({
+		prefix: 'foo'
+	})
+	const barType = test.context.generateRandomSlug({
+		prefix: 'bar'
+	})
 	const cards = [
 		{
 			type: 'triggered-action@1.0.0',
@@ -1042,7 +1072,7 @@ ava('.insertCard() should remove previously inserted type triggered actions if i
 			}),
 			version: '1.0.0',
 			data: {
-				type: 'foo@1.0.0',
+				type: `${fooType}@1.0.0`,
 				filter: {
 					type: 'object',
 					required: [ 'data' ],
@@ -1083,7 +1113,7 @@ ava('.insertCard() should remove previously inserted type triggered actions if i
 			}),
 			version: '1.0.0',
 			data: {
-				type: 'bar@1.0.0',
+				type: `${barType}@1.0.0`,
 				filter: {
 					type: 'object',
 					required: [ 'data' ],
@@ -1137,7 +1167,7 @@ ava('.insertCard() should remove previously inserted type triggered actions if i
 			actor: test.context.actor.id,
 			executeAction: test.context.executeAction
 		}, {
-			slug: 'foo',
+			slug: fooType,
 			version: '1.0.0',
 			data: {
 				schema: {
@@ -1159,6 +1189,24 @@ ava('.insertCard() should remove previously inserted type triggered actions if i
 			type: {
 				type: 'string',
 				const: 'triggered-action@1.0.0'
+			},
+			data: {
+				type: 'object',
+				required: [ 'type' ],
+				properties: {
+					type: {
+						anyOf: [
+							{
+								type: 'string',
+								const: `${fooType}@1.0.0`
+							},
+							{
+								type: 'string',
+								const: `${barType}@1.0.0`
+							}
+						]
+					}
+				}
 			}
 		}
 	})
@@ -1172,10 +1220,11 @@ ava('.insertCard() should remove previously inserted type triggered actions if i
 })
 
 ava('.patchCard() should remove previously inserted type triggered actions if deactivating a type', async (test) => {
+	const slug = test.context.generateRandomSlug()
 	const type = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
 		type: 'type@1.0.0',
 		version: '1.0.0',
-		slug: 'foo',
+		slug,
 		data: {
 			schema: {
 				type: 'object'
@@ -1192,7 +1241,7 @@ ava('.patchCard() should remove previously inserted type triggered actions if de
 		}),
 		version: '1.0.0',
 		data: {
-			type: 'foo@1.0.0',
+			type: `${slug}@1.0.0`,
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1262,6 +1311,16 @@ ava('.patchCard() should remove previously inserted type triggered actions if de
 			type: {
 				type: 'string',
 				const: 'triggered-action@1.0.0'
+			},
+			data: {
+				type: 'object',
+				required: [ 'type' ],
+				properties: {
+					type: {
+						type: 'string',
+						const: `${slug}@1.0.0`
+					}
+				}
 			}
 		}
 	})
@@ -1272,6 +1331,8 @@ ava('.patchCard() should remove previously inserted type triggered actions if de
 ava('.insertCard() should add a triggered action given a type with an AGGREGATE formula', async (test) => {
 	const typeType = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
+
+	const slug = test.context.generateRandomSlug()
 	await executor.insertCard(test.context.context, test.context.jellyfish, test.context.session, typeType, {
 		currentTime: new Date(),
 		attachEvents: false,
@@ -1281,7 +1342,7 @@ ava('.insertCard() should add a triggered action given a type with an AGGREGATE 
 		actor: test.context.actor.id,
 		setTriggers: test.context.actionContext.setTriggers
 	}, {
-		slug: 'test-thread',
+		slug,
 		version: '1.0.0',
 		data: {
 			schema: {
@@ -1289,7 +1350,7 @@ ava('.insertCard() should add a triggered action given a type with an AGGREGATE 
 				properties: {
 					type: {
 						type: 'string',
-						const: 'test-thread@1.0.0'
+						const: `${slug}@1.0.0`
 					},
 					data: {
 						type: 'object',
@@ -1320,6 +1381,16 @@ ava('.insertCard() should add a triggered action given a type with an AGGREGATE 
 			type: {
 				type: 'string',
 				const: 'triggered-action@1.0.0'
+			},
+			data: {
+				type: 'object',
+				required: [ 'type' ],
+				properties: {
+					type: {
+						type: 'string',
+						const: `${slug}@1.0.0`
+					}
+				}
 			}
 		}
 	})
@@ -1330,7 +1401,7 @@ ava('.insertCard() should add a triggered action given a type with an AGGREGATE 
 			updated_at: null,
 			linked_at: triggers[0].linked_at,
 			id: triggers[0].id,
-			slug: 'triggered-action-test-thread-data-mentions',
+			slug: `triggered-action-${slug}-data-mentions`,
 			type: triggers[0].type,
 			version: '1.0.0',
 			name: null,
@@ -1354,6 +1425,9 @@ ava('.insertCard() should add a triggered action given a type with an AGGREGATE 
 ava('.insertCard() should pre-register a triggered action if using AGGREGATE', async (test) => {
 	const typeType = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
+
+	let localTriggers = []
+	const slug = test.context.generateRandomSlug()
 	await executor.insertCard(test.context.context, test.context.jellyfish, test.context.session, typeType, {
 		currentTime: new Date(),
 		attachEvents: false,
@@ -1361,9 +1435,11 @@ ava('.insertCard() should pre-register a triggered action if using AGGREGATE', a
 		context: test.context.actionContext,
 		library: actionLibrary,
 		actor: test.context.actor.id,
-		setTriggers: test.context.actionContext.setTriggers
+		setTriggers: (context, triggers) => {
+			localTriggers = triggers
+		}
 	}, {
-		slug: 'test-thread',
+		slug,
 		version: '1.0.0',
 		data: {
 			schema: {
@@ -1371,7 +1447,7 @@ ava('.insertCard() should pre-register a triggered action if using AGGREGATE', a
 				properties: {
 					type: {
 						type: 'string',
-						const: 'test-thread@1.0.0'
+						const: `${slug}@1.0.0`
 					},
 					data: {
 						type: 'object',
@@ -1390,15 +1466,15 @@ ava('.insertCard() should pre-register a triggered action if using AGGREGATE', a
 		}
 	})
 
-	test.deepEqual(test.context.triggers, [
+	test.deepEqual(localTriggers, [
 		{
-			id: test.context.triggers[0].id,
-			slug: 'triggered-action-test-thread-data-mentions',
+			id: localTriggers[0].id,
+			slug: `triggered-action-${slug}-data-mentions`,
 			action: 'action-set-add@1.0.0',
 			target: {
 				$eval: 'source.links[\'is attached to\'][0].id'
 			},
-			filter: test.context.triggers[0].filter,
+			filter: localTriggers[0].filter,
 			arguments: {
 				property: 'data.mentions',
 				value: {
@@ -1416,18 +1492,21 @@ ava('.insertCard() should pre-register a triggered action if using AGGREGATE', a
 ava('.insertCard() should update pre-registered triggered actions if removing an AGGREGATE', async (test) => {
 	const typeType = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
+
+	const localTriggers = []
+	const slug = test.context.generateRandomSlug()
 	const element = await executor.insertCard(
 		test.context.context, test.context.jellyfish, test.context.session, typeType, {
 			currentTime: new Date(),
 			attachEvents: false,
 			executeAction: test.context.executeAction,
-			triggers: test.context.triggers,
 			context: test.context.actionContext,
 			library: actionLibrary,
 			actor: test.context.actor.id,
-			setTriggers: test.context.actionContext.setTriggers
+			setTriggers: test.context.actionContext.setTriggers,
+			triggers: localTriggers
 		}, {
-			slug: 'test-thread',
+			slug,
 			version: '1.0.0',
 			data: {
 				schema: {
@@ -1435,7 +1514,7 @@ ava('.insertCard() should update pre-registered triggered actions if removing an
 					properties: {
 						type: {
 							type: 'string',
-							const: 'test-thread@1.0.0'
+							const: `${slug}@1.0.0`
 						},
 						data: {
 							type: 'object',
@@ -1458,11 +1537,11 @@ ava('.insertCard() should update pre-registered triggered actions if removing an
 		currentTime: new Date(),
 		attachEvents: false,
 		executeAction: test.context.executeAction,
-		triggers: test.context.triggers,
 		context: test.context.actionContext,
 		library: actionLibrary,
 		actor: test.context.actor.id,
-		setTriggers: test.context.actionContext.setTriggers
+		setTriggers: test.context.actionContext.setTriggers,
+		triggers: localTriggers
 	}, element, [
 		{
 			op: 'remove',
@@ -1470,14 +1549,16 @@ ava('.insertCard() should update pre-registered triggered actions if removing an
 		}
 	])
 
-	test.deepEqual(test.context.triggers, [])
+	test.deepEqual(localTriggers, [])
 })
 
 ava('.insertCard() should add multiple triggered actions given a type with an AGGREGATE formula', async (test) => {
 	const typeType = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
+
+	const slug = test.context.generateRandomSlug()
 	const type = {
-		slug: 'test-thread',
+		slug,
 		version: '1.0.0',
 		data: {
 			schema: {
@@ -1485,7 +1566,7 @@ ava('.insertCard() should add multiple triggered actions given a type with an AG
 				properties: {
 					type: {
 						type: 'string',
-						const: 'test-thread@1.0.0'
+						const: `${slug}@1.0.0`
 					},
 					data: {
 						type: 'object',
@@ -1561,6 +1642,16 @@ ava('.insertCard() should add multiple triggered actions given a type with an AG
 			type: {
 				type: 'string',
 				const: 'triggered-action@1.0.0'
+			},
+			data: {
+				type: 'object',
+				required: [ 'type' ],
+				properties: {
+					type: {
+						type: 'string',
+						const: `${slug}@1.0.0`
+					}
+				}
 			}
 		}
 	})
@@ -1574,6 +1665,7 @@ ava('.run() should create a card', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const result = await executor.run(test.context.jellyfish, test.context.session, test.context.actionContext, {
 		'action-create-card': actionLibrary['action-create-card']
 	}, {
@@ -1586,7 +1678,7 @@ ava('.run() should create a card', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'foo-bar-baz',
+				slug,
 				version: '1.0.0'
 			}
 		}
@@ -1596,7 +1688,7 @@ ava('.run() should create a card', async (test) => {
 		id: result.id,
 		type: 'card@1.0.0',
 		version: '1.0.0',
-		slug: 'foo-bar-baz'
+		slug
 	})
 })
 

--- a/test/integration/worker/helpers.js
+++ b/test/integration/worker/helpers.js
@@ -9,7 +9,7 @@ const helpers = require('../queue/helpers')
 const errio = require('errio')
 
 exports.jellyfish = {
-	beforeEach: async (test) => {
+	before: async (test) => {
 		await helpers.before(test)
 
 		await test.context.jellyfish.insertCard(test.context.context, test.context.session,
@@ -20,13 +20,13 @@ exports.jellyfish = {
 			require('../../../lib/worker/cards/triggered-action'))
 	},
 
-	afterEach: async (test) => {
+	after: async (test) => {
 		await helpers.after(test)
 	}
 }
 
 exports.worker = {
-	beforeEach: async (test, actionLibrary, options = {}) => {
+	before: async (test, actionLibrary, options = {}) => {
 		await helpers.before(test, {
 			suffix: options.suffix
 		})
@@ -83,5 +83,5 @@ exports.worker = {
 			return test.context.queue.producer.waitResults(test.context, createRequest)
 		}
 	},
-	afterEach: helpers.after
+	after: helpers.after
 }

--- a/test/integration/worker/index.spec.js
+++ b/test/integration/worker/index.spec.js
@@ -12,11 +12,11 @@ const actionLibrary = require('../../../lib/action-library')
 const Worker = require('../../../lib/worker')
 const uuid = require('../../../lib/uuid')
 
-ava.serial.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.serial.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.serial.afterEach(helpers.worker.afterEach)
+ava.serial.after(helpers.worker.after)
 
 ava('.getId() should preserve the same id during its lifetime', async (test) => {
 	const id1 = test.context.worker.getId()
@@ -61,6 +61,7 @@ ava('should not re-enqueue requests after duplicated execute events', async (tes
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
 
+	const slug = test.context.generateRandomSlug()
 	await test.context.queue.producer.enqueue(
 		test.context.worker.getId(), test.context.session, {
 			action: 'action-create-card@1.0.0',
@@ -70,7 +71,7 @@ ava('should not re-enqueue requests after duplicated execute events', async (tes
 			arguments: {
 				reason: null,
 				properties: {
-					slug: 'foo',
+					slug,
 					version: '1.0.0',
 					data: {
 						foo: 'bar'
@@ -87,7 +88,7 @@ ava('should not re-enqueue requests after duplicated execute events', async (tes
 			data: {
 				id: await uuid.random(),
 				type: 'card@1.0.0',
-				slug: 'foo'
+				slug
 			}
 		})
 
@@ -105,6 +106,7 @@ ava('should evaluate a simple computed property on insertion', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -113,14 +115,14 @@ ava('should evaluate a simple computed property on insertion', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -184,7 +186,7 @@ ava('should evaluate a simple computed property on insertion', async (test) => {
 		linked_at: card.linked_at,
 		updated_at: card.updated_at,
 		created_at: card.created_at,
-		type: 'test-type@1.0.0',
+		type: `${slug}@1.0.0`,
 		active: true,
 		links: {},
 		tags: [],
@@ -198,6 +200,7 @@ ava('should evaluate a simple SUM property on a insertAction', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -206,14 +209,14 @@ ava('should evaluate a simple SUM property on a insertAction', async (test) => {
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -284,7 +287,7 @@ ava('should evaluate a simple SUM property on a insertAction', async (test) => {
 		linked_at: card.linked_at,
 		updated_at: card.updated_at,
 		created_at: card.created_at,
-		type: 'test-type@1.0.0',
+		type: `${slug}@1.0.0`,
 		active: true,
 		links: {},
 		tags: [],
@@ -300,6 +303,7 @@ ava('should evaluate a simple computed property on a JSON Patch move', async (te
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -308,14 +312,14 @@ ava('should evaluate a simple computed property on a JSON Patch move', async (te
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -404,7 +408,7 @@ ava('should evaluate a simple computed property on a JSON Patch move', async (te
 		linked_at: card.linked_at,
 		updated_at: card.updated_at,
 		created_at: card.created_at,
-		type: 'test-type@1.0.0',
+		type: `${slug}@1.0.0`,
 		active: true,
 		links: {},
 		tags: [],
@@ -419,6 +423,7 @@ ava('should evaluate a simple computed property on a JSON Patch copy', async (te
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -427,14 +432,14 @@ ava('should evaluate a simple computed property on a JSON Patch copy', async (te
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -523,7 +528,7 @@ ava('should evaluate a simple computed property on a JSON Patch copy', async (te
 		linked_at: card.linked_at,
 		updated_at: card.updated_at,
 		created_at: card.created_at,
-		type: 'test-type@1.0.0',
+		type: `${slug}@1.0.0`,
 		active: true,
 		links: {},
 		tags: [],
@@ -538,6 +543,7 @@ ava('should evaluate a simple computed property on a JSON Patch replace', async 
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -546,14 +552,14 @@ ava('should evaluate a simple computed property on a JSON Patch replace', async 
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -641,7 +647,7 @@ ava('should evaluate a simple computed property on a JSON Patch replace', async 
 		linked_at: card.linked_at,
 		updated_at: card.updated_at,
 		created_at: card.created_at,
-		type: 'test-type@1.0.0',
+		type: `${slug}@1.0.0`,
 		active: true,
 		links: {},
 		tags: [],
@@ -655,6 +661,7 @@ ava('should evaluate a simple computed property on a JSON Patch addition', async
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -663,14 +670,14 @@ ava('should evaluate a simple computed property on a JSON Patch addition', async
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -756,7 +763,7 @@ ava('should evaluate a simple computed property on a JSON Patch addition', async
 		linked_at: card.linked_at,
 		updated_at: card.updated_at,
 		created_at: card.created_at,
-		type: 'test-type@1.0.0',
+		type: `${slug}@1.0.0`,
 		active: true,
 		links: {},
 		tags: [],
@@ -770,6 +777,7 @@ ava('should throw if the result of the formula is incompatible with the given ty
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'type@latest')
 
+	const slug = test.context.generateRandomSlug()
 	const typeAction = {
 		action: 'action-create-card@1.0.0',
 		context: test.context.context,
@@ -778,14 +786,14 @@ ava('should throw if the result of the formula is incompatible with the given ty
 		arguments: {
 			reason: null,
 			properties: {
-				slug: 'test-type',
+				slug,
 				data: {
 					schema: {
 						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
-								pattern: '^test-type@'
+								pattern: `^${slug}@`
 							},
 							data: {
 								type: 'object',
@@ -902,7 +910,9 @@ ava('should be able to login as a user with a password', async (test) => {
 		type: typeCard.type,
 		arguments: {
 			email: 'johndoe@example.com',
-			username: 'user-johndoe',
+			username: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			password: 'foobarbaz'
 		}
 	})
@@ -960,7 +970,9 @@ ava('should not be able to login as a password-less user', async (test) => {
 		test.context.context, test.context.session, {
 			type: 'user@1.0.0',
 			version: '1.0.0',
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			data: {
 				email: 'johndoe@example.com',
 				hash: 'PASSWORDLESS',
@@ -989,7 +1001,9 @@ ava('should not be able to login as a password-less user given a random password
 		test.context.context, test.context.session, {
 			type: 'user@1.0.0',
 			version: '1.0.0',
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			data: {
 				email: 'johndoe@example.com',
 				hash: 'PASSWORDLESS',
@@ -1015,7 +1029,9 @@ ava('should not be able to login as a password-less non-disallowed user', async 
 		test.context.context, test.context.session, {
 			type: 'user@1.0.0',
 			version: '1.0.0',
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			data: {
 				disallowLogin: false,
 				email: 'johndoe@example.com',
@@ -1045,7 +1061,9 @@ ava('should not be able to login as a password-less disallowed user', async (tes
 		test.context.context, test.context.session, {
 			type: 'user@1.0.0',
 			version: '1.0.0',
-			slug: 'user-johndoe',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			data: {
 				disallowLogin: true,
 				email: 'johndoe@example.com',
@@ -1081,7 +1099,9 @@ ava('should fail if signing up with the wrong password', async (test) => {
 		type: typeCard.type,
 		arguments: {
 			email: 'johndoe@example.com',
-			username: 'user-johndoe',
+			username: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			password: 'xxxxxxxxxxxx'
 		}
 	})
@@ -1127,10 +1147,11 @@ ava('should post an error execute event if logging in as a disallowed user', asy
 
 ava('a triggered action can update a dynamic list of cards (ids as array of strings)', async (test) => {
 	const cardIds = []
+	const slug = test.context.generateRandomSlug()
 	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
 		const card = await test.context.jellyfish.insertCard(
 			test.context.context, test.context.session, {
-				slug: `foo${idx}`,
+				slug: `${slug}${idx}`,
 				type: 'card@1.0.0',
 				version: '1.0.0',
 				data: {
@@ -1207,17 +1228,18 @@ ava('a triggered action can update a dynamic list of cards (ids as array of stri
 
 	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
 		const card = await test.context.jellyfish.getCardBySlug(
-			test.context.context, test.context.session, `foo${idx}@latest`)
+			test.context.context, test.context.session, `${slug}${idx}@latest`)
 		test.true(card.data.updated)
 	})
 })
 
 ava('a triggered action can update a dynamic list of cards (ids as array of objects with field id)', async (test) => {
 	const cardsWithId = []
+	const slug = test.context.generateRandomSlug()
 	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
 		const card = await test.context.jellyfish.insertCard(
 			test.context.context, test.context.session, {
-				slug: `foo${idx}`,
+				slug: `${slug}${idx}`,
 				type: 'card@1.0.0',
 				version: '1.0.0',
 				data: {
@@ -1305,7 +1327,7 @@ ava('a triggered action can update a dynamic list of cards (ids as array of obje
 
 	await Bluebird.each([ 1, 2, 3 ], async (idx) => {
 		const card = await test.context.jellyfish.getCardBySlug(
-			test.context.context, test.context.session, `foo${idx}@latest`)
+			test.context.context, test.context.session, `${slug}${idx}@latest`)
 		test.true(card.data.updated)
 	})
 })
@@ -1356,7 +1378,7 @@ ava('should fail when attempting to insert a triggered-action card with duplicat
 ava('should fail to set a trigger when the list of card ids contains duplicates', async (test) => {
 	const card = await test.context.jellyfish.insertCard(
 		test.context.context, test.context.session, {
-			slug: 'foo1',
+			slug: test.context.generateRandomSlug(),
 			type: 'card@1.0.0',
 			version: '1.0.0',
 			data: {
@@ -1409,7 +1431,9 @@ ava('should fail to set a trigger when the list of card ids contains duplicates'
 ava('trigger should update card if triggered by a user not owning the card', async (test) => {
 	const card = await test.context.jellyfish.insertCard(
 		test.context.context, test.context.session, {
-			slug: 'foo-admin',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			type: 'card@1.0.0',
 			version: '1.0.0',
 			data: {
@@ -1476,7 +1500,9 @@ ava('trigger should update card if triggered by a user not owning the card', asy
 		test.context.context, test.context.session, {
 			type: 'user@1.0.0',
 			version: '1.0.0',
-			slug: 'user-john-doe-user',
+			slug: test.context.generateRandomSlug({
+				prefix: 'user'
+			}),
 			data: {
 				email: 'accounts+jellyfish@resin.io',
 				roles: [ 'user-community' ],
@@ -1488,7 +1514,7 @@ ava('trigger should update card if triggered by a user not owning the card', asy
 		test.context.context, test.context.session, {
 			type: 'session@1.0.0',
 			version: '1.0.0',
-			slug: 'session-john-doe-user',
+			slug: `session-${userJohnDoe.slug}`,
 			data: {
 				actor: userJohnDoe.id
 			}
@@ -1521,7 +1547,12 @@ ava('trigger should update card if triggered by a user not owning the card', asy
 	test.true(result.data.updated)
 })
 
-ava('.getTriggers() should initially be an empty array', (test) => {
-	const triggers = test.context.worker.getTriggers()
+ava('.getTriggers() should initially be an empty array', async (test) => {
+	const newInstance = {
+		context: {}
+	}
+	await helpers.worker.before(newInstance, actionLibrary)
+
+	const triggers = newInstance.context.worker.getTriggers()
 	test.deepEqual(triggers, [])
 })

--- a/test/integration/worker/insert-card.spec.js
+++ b/test/integration/worker/insert-card.spec.js
@@ -8,16 +8,17 @@ const ava = require('ava')
 const helpers = require('./helpers')
 const actionLibrary = require('../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('.insertCard() should pass a triggered action originator', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
 
+	const command = test.context.generateRandomSlug()
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -32,7 +33,7 @@ ava('.insertCard() should pass a triggered action originator', async (test) => {
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command
 							}
 						}
 					}
@@ -42,7 +43,7 @@ ava('.insertCard() should pass a triggered action originator', async (test) => {
 			target: typeCard.id,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz',
+					slug: command,
 					version: '1.0.0'
 				}
 			}
@@ -55,15 +56,15 @@ ava('.insertCard() should pass a triggered action originator', async (test) => {
 			actor: test.context.actor.id,
 			attachEvents: true
 		}, {
-			slug: 'foo',
+			slug: test.context.generateRandomSlug(),
 			version: '1.0.0',
 			data: {
-				command: 'foo-bar-baz'
+				command
 			}
 		})
 
 	const card = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@1.0.0')
+		test.context.context, test.context.session, `${command}@1.0.0`)
 	test.is(card.data.originator, 'cb3523c5-b37d-41c8-ae32-9e7cc9309165')
 })
 
@@ -71,6 +72,7 @@ ava('.insertCard() should take an originator option', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
 
+	const command = test.context.generateRandomSlug()
 	test.context.worker.setTriggers(test.context.context, [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -85,7 +87,7 @@ ava('.insertCard() should take an originator option', async (test) => {
 						properties: {
 							command: {
 								type: 'string',
-								const: 'foo-bar-baz'
+								const: command
 							}
 						}
 					}
@@ -95,7 +97,7 @@ ava('.insertCard() should take an originator option', async (test) => {
 			target: typeCard.id,
 			arguments: {
 				properties: {
-					slug: 'foo-bar-baz'
+					slug: command
 				}
 			}
 		}
@@ -108,14 +110,14 @@ ava('.insertCard() should take an originator option', async (test) => {
 			originator: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 			attachEvents: true
 		}, {
-			slug: 'foo',
+			slug: test.context.generateRandomSlug(),
 			version: '1.0.0',
 			data: {
-				command: 'foo-bar-baz'
+				command
 			}
 		})
 
 	const card = await test.context.jellyfish.getCardBySlug(
-		test.context.context, test.context.session, 'foo-bar-baz@latest')
+		test.context.context, test.context.session, `${command}@latest`)
 	test.is(card.data.originator, '4a962ad9-20b5-4dd8-a707-bf819593cc84')
 })

--- a/test/integration/worker/tick.spec.js
+++ b/test/integration/worker/tick.spec.js
@@ -9,11 +9,11 @@ const _ = require('lodash')
 const helpers = require('./helpers')
 const actionLibrary = require('../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('.tick() should not enqueue actions if there are no triggers', async (test) => {
 	test.context.worker.setTriggers(test.context.context, [])
@@ -252,6 +252,9 @@ ava('.tick() should not enqueue an action using a past timestamp', async (test) 
 ava('.tick() should enqueue two actions if there are two time triggers with a past start dates', async (test) => {
 	const actionCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'action-create-card@latest')
+
+	const slug1 = test.context.generateRandomSlug()
+	const slug2 = test.context.generateRandomSlug()
 	test.context.worker.setTriggers(test.context.context, [
 		test.context.jellyfish.defaults({
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
@@ -266,7 +269,7 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 				reason: null,
 				properties: {
 					version: '1.0.0',
-					slug: 'foo'
+					slug: slug1
 				}
 			}
 		}),
@@ -283,7 +286,7 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 				reason: null,
 				properties: {
 					version: '1.0.0',
-					slug: 'bar'
+					slug: slug2
 				}
 			}
 		})
@@ -302,6 +305,28 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 				type: {
 					type: 'string',
 					const: 'action-request@1.0.0'
+				},
+				data: {
+					type: 'object',
+					required: [ 'arguments' ],
+					properties: {
+						arguments: {
+							type: 'object',
+							required: [ 'properties' ],
+							properties: {
+								properties: {
+									type: 'object',
+									required: [ 'slug' ],
+									properties: {
+										slug: {
+											type: 'string',
+											enum: [ slug1, slug2 ]
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}), (actionRequest) => {
@@ -330,7 +355,7 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 					reason: null,
 					properties: {
 						version: '1.0.0',
-						slug: 'bar'
+						slug: slug2
 					}
 				}
 			}
@@ -356,7 +381,7 @@ ava('.tick() should enqueue two actions if there are two time triggers with a pa
 					reason: null,
 					properties: {
 						version: '1.0.0',
-						slug: 'foo'
+						slug: slug1
 					}
 				}
 			}

--- a/test/integration/worker/trigger-updates.spec.js
+++ b/test/integration/worker/trigger-updates.spec.js
@@ -8,11 +8,11 @@ const ava = require('ava')
 const helpers = require('./helpers')
 const actionLibrary = require('../../../lib/action-library')
 
-ava.beforeEach(async (test) => {
-	await helpers.worker.beforeEach(test, actionLibrary)
+ava.before(async (test) => {
+	await helpers.worker.before(test, actionLibrary)
 })
 
-ava.afterEach(helpers.worker.afterEach)
+ava.after(helpers.worker.after)
 
 ava('.setTriggers() should be able to set a trigger with a start date', (test) => {
 	test.context.worker.setTriggers(test.context.context, [

--- a/test/integration/worker/triggers.spec.js
+++ b/test/integration/worker/triggers.spec.js
@@ -10,8 +10,8 @@ const triggers = require('../../../lib/worker/triggers')
 const errors = require('../../../lib/worker/errors')
 const Promise = require('bluebird')
 
-ava.serial.beforeEach(helpers.jellyfish.beforeEach)
-ava.serial.afterEach(helpers.jellyfish.afterEach)
+ava.serial.before(helpers.jellyfish.before)
+ava.serial.after(helpers.jellyfish.after)
 
 ava('.getRequest() should return null if the filter only has a type but there is no match', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
@@ -793,6 +793,8 @@ ava('.getTypeTriggers() should return a trigger card with a matching type', asyn
 ava('.getTypeTriggers() should not return inactive cards', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const typeSlug = test.context.generateRandomSlug()
 	const cards = [
 		{
 			type: 'triggered-action@1.0.0',
@@ -802,7 +804,7 @@ ava('.getTypeTriggers() should not return inactive cards', async (test) => {
 			version: '1.0.0',
 			active: false,
 			data: {
-				type: 'foo@1.0.0',
+				type: `${typeSlug}@1.0.0`,
 				filter: {
 					type: 'object',
 					required: [ 'data' ],
@@ -845,7 +847,7 @@ ava('.getTypeTriggers() should not return inactive cards', async (test) => {
 	const result = await triggers.getTypeTriggers(
 		test.context.context,
 		test.context.jellyfish,
-		test.context.session, 'foo@1.0.0')
+		test.context.session, `${typeSlug}@1.0.0`)
 
 	test.deepEqual(result, [])
 })
@@ -853,6 +855,8 @@ ava('.getTypeTriggers() should not return inactive cards', async (test) => {
 ava('.getTypeTriggers() should ignore non-matching cards', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const typeSlug = test.context.generateRandomSlug()
 	const cards = [
 		{
 			type: 'triggered-action@1.0.0',
@@ -861,7 +865,7 @@ ava('.getTypeTriggers() should ignore non-matching cards', async (test) => {
 			}),
 			version: '1.0.0',
 			data: {
-				type: 'foo@1.0.0',
+				type: `${typeSlug}@1.0.0`,
 				filter: {
 					type: 'object',
 					required: [ 'data' ],
@@ -944,7 +948,7 @@ ava('.getTypeTriggers() should ignore non-matching cards', async (test) => {
 	const result = await triggers.getTypeTriggers(
 		test.context.context,
 		test.context.jellyfish,
-		test.context.session, 'foo@1.0.0')
+		test.context.session, `${typeSlug}@1.0.0`)
 
 	const updatedCard = await test.context.jellyfish.getCardById(
 		test.context.context, test.context.session, insertedCards[0].id)
@@ -959,6 +963,8 @@ ava('.getTypeTriggers() should ignore non-matching cards', async (test) => {
 ava('.getTypeTriggers() should ignore cards that are not triggered actions', async (test) => {
 	const typeCard = await test.context.jellyfish.getCardBySlug(
 		test.context.context, test.context.session, 'card@latest')
+
+	const typeSlug = test.context.generateRandomSlug()
 	const cards = [
 		{
 			type: 'triggered-action@1.0.0',
@@ -967,7 +973,7 @@ ava('.getTypeTriggers() should ignore cards that are not triggered actions', asy
 			}),
 			version: '1.0.0',
 			data: {
-				type: 'foo@1.0.0',
+				type: `${typeSlug}@1.0.0`,
 				filter: {
 					type: 'object',
 					required: [ 'data' ],
@@ -1007,7 +1013,7 @@ ava('.getTypeTriggers() should ignore cards that are not triggered actions', asy
 			}),
 			version: '1.0.0',
 			data: {
-				type: 'foo@1.0.0',
+				type: `${typeSlug}@1.0.0`,
 				filter: {
 					type: 'object',
 					required: [ 'data' ],
@@ -1050,7 +1056,7 @@ ava('.getTypeTriggers() should ignore cards that are not triggered actions', asy
 	const result = await triggers.getTypeTriggers(
 		test.context.context,
 		test.context.jellyfish,
-		test.context.session, 'foo@1.0.0')
+		test.context.session, `${typeSlug}@1.0.0`)
 
 	const updatedCard = await test.context.jellyfish.getCardById(
 		test.context.context, test.context.session, insertedCards[0].id)
@@ -1115,7 +1121,7 @@ ava('.getTypeTriggers() should not return triggered actions not associated with 
 	const result = await triggers.getTypeTriggers(
 		test.context.context,
 		test.context.jellyfish,
-		test.context.session, 'foo@1.0.0')
+		test.context.session, `${test.context.generateRandomSlug()}@1.0.0`)
 	test.deepEqual(result, [])
 })
 

--- a/test/integration/worker/utils.spec.js
+++ b/test/integration/worker/utils.spec.js
@@ -7,13 +7,14 @@
 const ava = require('ava')
 const helpers = require('./helpers')
 const utils = require('../../../lib/worker/utils')
+const uuid = require('uuid/v4')
 
-ava.serial.beforeEach(helpers.jellyfish.beforeEach)
-ava.serial.afterEach(helpers.jellyfish.afterEach)
+ava.serial.before(helpers.jellyfish.before)
+ava.serial.after(helpers.jellyfish.after)
 
 ava('.hasCard() id = yes (exists), slug = yes (exists)', async (test) => {
 	const card = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar',
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
@@ -21,13 +22,13 @@ ava('.hasCard() id = yes (exists), slug = yes (exists)', async (test) => {
 	test.true(await utils.hasCard(test.context.context, test.context.jellyfish, test.context.session, {
 		id: card.id,
 		version: '1.0.0',
-		slug: 'foo-bar'
+		slug: card.slug
 	}))
 })
 
 ava('.hasCard() id = yes (exists), slug = yes (not exist)', async (test) => {
 	const card = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'bar-baz',
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
@@ -35,48 +36,48 @@ ava('.hasCard() id = yes (exists), slug = yes (not exist)', async (test) => {
 	test.true(await utils.hasCard(test.context.context, test.context.jellyfish, test.context.session, {
 		id: card.id,
 		version: '1.0.0',
-		slug: 'foo-bar'
+		slug: test.context.generateRandomSlug()
 	}))
 })
 
 ava('.hasCard() id = yes (not exist), slug = yes (exists)', async (test) => {
-	await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar',
+	const card = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
 
 	test.true(await utils.hasCard(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		id: uuid(),
 		version: '1.0.0',
-		slug: 'foo-bar'
+		slug: card.slug
 	}))
 })
 
 ava('.hasCard() id = yes (not exist), slug = yes (not exist)', async (test) => {
 	test.false(await utils.hasCard(test.context.context, test.context.jellyfish, test.context.session, {
-		id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
+		id: uuid(),
 		version: '1.0.0',
-		slug: 'foo-bar'
+		slug: test.context.generateRandomSlug()
 	}))
 })
 
 ava('.hasCard() id = no, slug = yes (exists)', async (test) => {
-	await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
-		slug: 'foo-bar',
+	const card = await test.context.jellyfish.insertCard(test.context.context, test.context.session, {
+		slug: test.context.generateRandomSlug(),
 		type: 'card@1.0.0',
 		version: '1.0.0'
 	})
 
 	test.true(await utils.hasCard(test.context.context, test.context.jellyfish, test.context.session, {
 		version: '1.0.0',
-		slug: 'foo-bar'
+		slug: card.slug
 	}))
 })
 
 ava('.hasCard() id = no, slug = yes (not exist)', async (test) => {
 	test.false(await utils.hasCard(test.context.context, test.context.jellyfish, test.context.session, {
 		version: '1.0.0',
-		slug: 'foo-bar'
+		slug: test.context.generateRandomSlug()
 	}))
 })


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- Changes worker integration tests to use shared backend instances instead of instantiating a new one with each test case
- Removes unnecessary output from the CI skip test script (`skip_tests_if_only.sh`). The output is only necessary during debugging and can cause CircleCI to fail your tests because `git diff` by default outputs using a pager. We could also add `--no-pager` to the command if we decide that this output is necessary.

On my local machine, I found a decent speed gain of a little over 2 minutes. This work also reduces the number of `graphile_worker.migrations` Postgres errors described in https://github.com/product-os/jellyfish/issues/3736.

## Speed gain
- Before: 4 minutes 6 seconds
- After:   1 minute 50 seconds

## Error output decrease
`graphile_worker.migrations` error output count:
- Before: 206 times
- After: 23 times