### PR TITLE
Overlay favicon with mentions count

### DIFF
--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -32,6 +32,7 @@ import Notifications from './components/HOC/Notifications'
 import RouteHandler from './components/RouteHandler'
 import Oauth from './components/HOC/Oauth'
 import Login from './components/HOC/Login'
+import CountFavicon from './components/CountFavicon'
 import RequestPasswordReset from './components/HOC/RequestPasswordReset'
 import CompletePasswordReset from './components/HOC/CompletePasswordReset'
 import CompleteFirstTimeLogin from './components/HOC/CompleteFirstTimeLogin'
@@ -125,6 +126,7 @@ class JellyfishUI extends React.Component {
 				<Flex flex="1" style={{
 					height: '100%'
 				}}>
+					<CountFavicon baseIcon="/icons/jellyfish.svg" />
 					<HomeChannel channel={home}/>
 
 					<Switch>

--- a/apps/ui/components/CountFavicon/CountFavicon.jsx
+++ b/apps/ui/components/CountFavicon/CountFavicon.jsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Helmet
+} from 'react-helmet'
+import {
+	useLabeledImage
+} from '../../hooks'
+
+export default function CountFavicon ({
+	label, baseIcon
+}) {
+	const href = useLabeledImage(label, baseIcon, {
+		fontSize: label && label.length > 2 ? 9 : 10
+	})
+
+	return (
+		<Helmet>
+			<link rel="shortcut icon" href={href} type="image/x-icon"/>
+		</Helmet>
+	)
+}

--- a/apps/ui/components/CountFavicon/index.js
+++ b/apps/ui/components/CountFavicon/index.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	connect
+} from 'react-redux'
+import {
+	selectors
+} from '../../core'
+import CountFavicon from './CountFavicon'
+
+const getMentionsCount = (mentions) => {
+	if (!mentions) {
+		return null
+	}
+	if (mentions.length > 99) {
+		return '99+'
+	}
+	return mentions.length.toString()
+}
+
+const mapStateToProps = (state) => {
+	const mentions = selectors.getViewData(state, 'view-my-inbox')
+	return {
+		label: getMentionsCount(mentions)
+	}
+}
+
+export default connect(mapStateToProps)(CountFavicon)

--- a/apps/ui/hooks/index.js
+++ b/apps/ui/hooks/index.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as useLabeledImage
+} from './use-labeled-image'

--- a/apps/ui/hooks/use-labeled-image.js
+++ b/apps/ui/hooks/use-labeled-image.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/* eslint-disable id-length */
+
+import React from 'react'
+import _ from 'lodash'
+
+const canvasSupported = (() => {
+	try {
+		return typeof document !== 'undefined' && Boolean(document.createElement('canvas').getContext)
+	} catch (error) {
+		return false
+	}
+})()
+
+const defaults = {
+	width: 16,
+	height: 16,
+	fontSize: 10,
+	color: '#000000',
+	stroke: 'rgba(255,255,255,0.85)',
+	align: 'right',
+	valign: 'bottom',
+	lineWidth: 2
+}
+
+const getCoords = (options) => {
+	return {
+		x: options.align.toLowerCase() === 'left' ? 0 : options.width,
+		y: options.valign.toLowerCase() === 'top' ? 0 : options.height
+	}
+}
+
+const drawLabel = (canvas, label, options) => {
+	const context = canvas.getContext('2d')
+	const coords = getCoords(options)
+	context.font = `${options.fontSize}px monospace`
+	context.fillStyle = options.color
+	context.textAlign = options.align
+	context.textBaseline = options.valign
+	context.strokeStyle = options.stroke
+	context.lineWidth = options.lineWidth
+	context.strokeText(label, coords.x, coords.y)
+	context.fillText(label, coords.x, coords.y)
+}
+
+const imgToCanvas = (img) => {
+	const canvas = document.createElement('canvas')
+	canvas.width = img.width
+	canvas.height = img.height
+	const context = canvas.getContext('2d')
+	context.drawImage(img, 0, 0)
+	return canvas
+}
+
+export default function useLabeledImage (label, baseImage, options = {}) {
+	const [ href, setHref ] = React.useState(baseImage)
+
+	React.useEffect(() => {
+		let unmounted = false
+
+		if (!canvasSupported || !label) {
+			setHref(baseImage)
+			return _.noop
+		}
+
+		const mergedOptions = _.defaultsDeep(options, defaults, {
+			src: baseImage
+		})
+
+		const img = document.createElement('img')
+		img.src = mergedOptions.src
+		img.width = mergedOptions.width
+		img.height = mergedOptions.height
+		img.crossOrigin = 'anonymous'
+		img.onload = () => {
+			const canvas = imgToCanvas(img)
+			drawLabel(canvas, label, mergedOptions)
+			try {
+				if (!unmounted) {
+					setHref(canvas.toDataURL('image/png'))
+				}
+			} catch (error) {
+				setHref(baseImage)
+			}
+		}
+		img.onerror = () => {
+			setHref(baseImage)
+		}
+		return () => {
+			unmounted = true
+		}
+	}, [ label, baseImage ])
+	return href
+}

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -5,8 +5,6 @@
         <title>Jellyfish</title>
 				<meta name="viewport" content="width=device-width, initial-scale=1">
 				<meta name="apple-mobile-web-app-capable" content="yes">
-				<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-				<link rel="icon" href="/favicon.ico" type="image/x-icon">
 
 				<link rel="apple-touch-icon" sizes="72x72" href="icons/jellyfish-icon-72.png">
 				<link rel="apple-touch-icon" sizes="96x96" href="icons/jellyfish-icon-96.png">

--- a/package-lock.json
+++ b/package-lock.json
@@ -16901,6 +16901,11 @@
         "scheduler": "^0.17.0"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-google-recaptcha": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-2.0.1.tgz",
@@ -16908,6 +16913,17 @@
       "requires": {
         "prop-types": "^15.5.0",
         "react-async-script": "^1.1.1"
+      }
+    },
+    "react-helmet": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.0.0.tgz",
+      "integrity": "sha512-My6S4sa0uHN/IuVUn0HFmasW5xj9clTkB9qmMngscVycQ5vVG51Qp44BEvLJ4lixupTwDlU9qX1/sCrMN4AEPg==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^2.0.4",
+        "react-side-effect": "^2.1.0"
       }
     },
     "react-icons": {
@@ -17067,6 +17083,11 @@
         "react-input-autosize": "^2.2.2",
         "react-transition-group": "^4.3.0"
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "react-simplemde-editor": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "react-dnd": "^11.1.3",
     "react-dnd-html5-backend": "^11.1.3",
     "react-dom": "^16.8.5",
+    "react-helmet": "^6.0.0",
     "react-icons": "^3.9.0",
     "react-redux": "^7.1.0",
     "react-resize-observer": "^1.1.1",


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3975

This nifty little component uses `react-helmet` to update the page's favicon link with a dynamically created image (as base64 data) that overlays the jellyfish icon with the count of mentions (unread messages).

The bulk of the cleverness is done in a reusable React hook, `useLabeledImage`, that is responsible for drawing the label (mentions count) on top of the base image on a HTML5 canvas.

If there are no unread messages, no overlay is added (i.e. we do not display `0` like Gmail does). If there are more than 99 unread messages, `99+` is displayed.

Check it out in operation (look at the icon in the tab header):
![Favicon Count](https://user-images.githubusercontent.com/2925657/83865813-f94cbe80-a750-11ea-96b3-487c10e0655b.gif)
