### PR TITLE
Do not display mentions count overlay on favicon if no mentions

### DIFF
--- a/apps/ui/components/CountFavicon/index.js
+++ b/apps/ui/components/CountFavicon/index.js
@@ -13,7 +13,7 @@ import {
 import CountFavicon from './CountFavicon'
 
 const getMentionsCount = (mentions) => {
-	if (!mentions) {
+	if (!mentions || !mentions.length) {
 		return null
 	}
 	if (mentions.length > 99) {

--- a/apps/ui/hooks/use-labeled-image.js
+++ b/apps/ui/hooks/use-labeled-image.js
@@ -30,8 +30,8 @@ const defaults = {
 
 const getCoords = (options) => {
 	return {
-		x: options.align.toLowerCase() === 'left' ? 0 : options.width,
-		y: options.valign.toLowerCase() === 'top' ? 0 : options.height
+		x: options.align.toLowerCase() === 'left' ? 0 : options.width - options.lineWidth,
+		y: options.valign.toLowerCase() === 'top' ? 0 : options.height + options.lineWidth
 	}
 }
 


### PR DESCRIPTION
Also tweak the position to ensure the letters are not clipped.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Tiny follow-up PR to fix something that 'slipped through the net' on the [original PR](https://github.com/product-os/jellyfish/pull/3998). It was never intended to show the mentions count if it is zero.
