### PR TITLE
Add support for full-text-search queries on existing search boxes

### DIFF
--- a/lib/ui-components/services/helpers.js
+++ b/lib/ui-components/services/helpers.js
@@ -360,7 +360,10 @@ export const createFullTextSearchFilter = (schema, term) => {
 	const flatSchema = SchemaSieve.flattenSchema(schema)
 	const stringKeys = _.reduce(flatSchema.properties, (carry, item, key) => {
 		if (item.type === 'string' || (_.isArray(item.type) && _.includes(item.type, 'string'))) {
-			carry.push(key)
+			carry.push({
+				key,
+				fullTextSearch: Boolean(item.fullTextSearch)
+			})
 		}
 		return carry
 	}, [])
@@ -371,16 +374,25 @@ export const createFullTextSearchFilter = (schema, term) => {
 		type: 'object',
 		additionalProperties: true,
 		description: `Any field contains ${term}`,
-		anyOf: stringKeys.map((key) => {
+		anyOf: stringKeys.map(({
+			key, fullTextSearch
+		}) => {
+			const searchFields = fullTextSearch ? {
+				fullTextSearch: {
+					term
+				}
+			} : {
+				regexp: {
+					pattern: regexEscape(term),
+					flags: 'i'
+				}
+			}
 			return {
 				type: 'object',
 				properties: {
 					[key]: {
 						type: 'string',
-						regexp: {
-							pattern: regexEscape(term),
-							flags: 'i'
-						}
+						...searchFields
 					}
 				},
 				required: [ key ]

--- a/lib/ui-components/services/helpers.spec.js
+++ b/lib/ui-components/services/helpers.spec.js
@@ -137,6 +137,103 @@ ava('.createPrefixRegExp() match period characters', (test) => {
 	test.deepEqual(match[2], '@user.name')
 })
 
+ava('.createFullTextSearchFilter() uses regex by default on string properties', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: 'string'
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf[0].properties.title.regexp.pattern, searchTerm)
+})
+
+ava('.createFullTextSearchFilter() uses regex on properties where the type array includes string', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: [ 'array', 'string' ]
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf[0].properties.title.regexp.pattern, searchTerm)
+})
+
+ava('.createFullTextSearchFilter() uses fullTextSearch on properties with the \'fullTextSearch\' field set', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: 'string',
+				fullTextSearch: true
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf[0].properties.title.fullTextSearch.term, searchTerm)
+})
+
+ava('.createFullTextSearchFilter() works on deeply nested objects', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: 'object',
+				properties: {
+					label: {
+						type: 'string'
+					}
+				}
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf[0].properties.title.properties.label.regexp.pattern, searchTerm)
+})
+
+// TODO: Unskip this test once we fix the flattening of arrays.
+ava.skip('.createFullTextSearchFilter() works on arrays of strings', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			folders: {
+				type: 'array',
+				items: {
+					type: 'string'
+				}
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf[0].properties.folders.items.regexp.pattern, searchTerm)
+})
+
+// TODO: Unskip this test once we fix the flattening of arrays of objects.
+ava.skip('.createFullTextSearchFilter() works on arrays of objects', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			folders: {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						label: {
+							type: 'string'
+						}
+					}
+				}
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf[0].properties.folders.items.label.regexp.pattern, searchTerm)
+})
+
 ava('.getUpdateObjectFromSchema() should parse the `const` keyword', (test) => {
 	const schema = {
 		type: 'object',


### PR DESCRIPTION
This change covers the CreateView, AutoCompleteCardSelect and AutocompleteTextarea components.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

The `createFullTextSearchFilter` helper method now checks for the existence of a `fullTextSearch` field. If it's set, we use the `fullTextSearch` mechanism for querying against that field. Otherwise we resort to the usual/old method of `regexp`.

I've added some unit tests for this behaviour. Note the two skipped tests which test for behaviour that isn't currently supported by `SchemaSieve` (as it doesn't flatten arrays in schemas).