### PR TITLE
Add support for full-text-search in views

### DIFF
--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -707,6 +707,7 @@ class ViewRenderer extends React.Component {
 											/>
 											<Box mb={3} flex="0 1 500px">
 												<Search
+													className="view__search"
 													value={this.state.searchTerm}
 													onChange={this.updateSearch}
 												/>
@@ -717,7 +718,7 @@ class ViewRenderer extends React.Component {
 							</Flex>
 
 							{useFilters && summaryFilters.length > 0 && (
-								<Box flex="1 0 auto" mt={-3}>
+								<Box flex="1 0 auto" mt={-3} data-test="view__filters-summary-wrapper">
 									<Filters
 										schema={schemaForFilters}
 										filters={summaryFilters}

--- a/apps/ui/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lens/snippet/SingleCard/SingleCard.jsx
@@ -41,7 +41,7 @@ export default class SingleCard extends React.Component {
 		}, 0)
 
 		return (
-			<Box pb={3}>
+			<Box pb={3} data-test="snippet--card" data-test-id={`snippet-card-${card.id}`}>
 				<Flex justifyContent="space-between">
 					<Txt>
 						<Link append={card.slug || card.id}>


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR adds the following functionality:
* The search box in a 'View' lens now supports `fullTextSearch` when querying the view's data
* The search box is now correctly kept in sync with the Filters summary

Note that we are now not using Rendition's 'search' filter, but we're making use of our own, directly rendering Rendition's `Search` component.

A new e2e test has been added to exercise the search functionality - primarily to verify the interaction between the search box and the filters summary.

Note: this PR does **not** address the following:
* #3348 searching within events associated with the view's cards
* #4030 clearing the slice filter from the Filters summary does not afffect the slice dropdown
* #3744 the custom filters are broken for any deeply nested fields
* #3824 / #3941 searching within arrays of objects