### PR TITLE
backend: Fix queue saturation metrics call placement

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -202,12 +202,11 @@ exports.worker = async (context, options) => {
 		enablePriorityBuffer: true,
 		onError: options.onError,
 		onActionRequest: async (serverContext, jellyfish, worker, queue, session, actionRequest, errorHandler) => {
+			metrics.markActionRequest(actionRequest.data.action.split('@')[0])
 			return getActorKey(serverContext, jellyfish, session, actionRequest.data.actor)
 				.then((key) => {
 					actionRequest.data.context.worker = serverContext.id
-					return metrics.measureActionRequestExecution(actionRequest, async () => {
-						return worker.execute(key.id, actionRequest)
-					})
+					return worker.execute(key.id, actionRequest)
 				})
 				.catch(errorHandler)
 		}

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -258,30 +258,58 @@ exports.markBackSync = (integration) => {
 }
 
 /**
- * @summary Execute an action request, recording duration and worker saturation
+ * @summary Mark that an action request was received
  * @function
  *
- * @param {Object} actionRequest - action request definition
- * @param {Promise} fn - action request function to execute
- * @returns {Any} action request execution result
+ * @param {String} action - action name
  *
  * @example
- * const result = await metrics.measureActionRequestExecution(actionRequest, async () => {
- *   worker.execute(id, actionRequest)
- * })
+ * metrics.markActionRequest('action-create-card')
  */
-exports.measureActionRequestExecution = async (actionRequest, fn) => {
-	const labels = {
-		type: actionRequest.data.action.split('@')[0]
-	}
-	metrics.inc(metricNames.WORKER_ACTION_REQUEST_TOTAL, 1, labels)
-	metrics.inc(metricNames.WORKER_SATURATION, 1, labels)
-	const result = await measureAsync(metricNames.WORKER_JOB_DURATION, labels, fn).catch((err) => {
-		metrics.dec(metricNames.WORKER_SATURATION, 1, labels)
-		throw err
+exports.markActionRequest = (action) => {
+	metrics.inc(metricNames.WORKER_ACTION_REQUEST_TOTAL, 1, {
+		type: action
 	})
+}
+
+/**
+ * @summary Mark that a new job was added to the queue
+ * @function
+ *
+ * @param {String} action - action name
+ *
+ * @example
+ * metrics.markJobAdd('action-create-card')
+ */
+exports.markJobAdd = (action) => {
+	const labels = {
+		type: action
+	}
+	metrics.inc(metricNames.WORKER_SATURATION, 1, labels)
+	metrics.inc(metricNames.WORKER_SATURATION, 1, {
+		type: action
+	})
+}
+
+/**
+ * @summary Mark that a job in the queue has completed
+ * @function
+ *
+ * @param {String} action - action name
+ * @param {String} timestamp - when action was completed
+ *
+ * @example
+ * const action = 'action-create-card'
+ * const timestamp = '2020-06-08T09:33:27.481Z'
+ * metrics.markJobDone(action, timestamp)
+ */
+exports.markJobDone = (action, timestamp) => {
+	const labels = {
+		type: action
+	}
+	const duration = new Date().getTime() - new Date(timestamp).getTime()
+	metrics.histogram(metricNames.WORKER_JOB_DURATION, duration, labels)
 	metrics.dec(metricNames.WORKER_SATURATION, 1, labels)
-	return result
 }
 
 /**

--- a/lib/queue/producer.js
+++ b/lib/queue/producer.js
@@ -11,6 +11,7 @@ const assert = require('../assert')
 const errors = require('./errors')
 const events = require('./events')
 const CARDS = require('./cards')
+const metrics = require('../metrics')
 
 module.exports = class Producer {
 	constructor (jellyfish, session) {
@@ -119,6 +120,8 @@ module.exports = class Producer {
 			}
 		})
 
+		metrics.markJobAdd(options.action.split('@')[0])
+
 		await this.jellyfish.backend.connection.any({
 			name: 'enqueue-action-request',
 			text: 'SELECT graphile_worker.add_job(\'actionRequest\', $1);',
@@ -176,6 +179,7 @@ module.exports = class Producer {
 			() => {
 				return `Execute event has no payload: ${JSON.stringify(request, null, 2)}`
 			})
+		metrics.markJobDone(request.data.payload.action.split('@')[0], request.data.payload.timestamp)
 
 		return {
 			error: request.data.payload.error,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Closes https://github.com/product-os/jellyfish/issues/3999

This PR fixes the placement of the queue job enqueue/dequeue/duration metrics calls. The previous location caught some job data, but was not deep enough to catch __all__ queue job data. These changes place metrics hooks inside of `lib/queue` to catch when jobs are added to the queue, when job results are returned, and how long it took for the job to get through the queue.