### PR TITLE
Add queue concurrency env var to deploy templates

### DIFF
--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -94,3 +94,5 @@ properties:
     type: string?
   RESET_PASSWORD_SECRET_TOKEN:
     type: string?
+  QUEUE_CONCURRENCY:
+    type: number

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -216,6 +216,11 @@ spec:
             secretKeyRef:
               key: MONITOR_SECRET_TOKEN
               name: monitor-secret-token
+        - name: QUEUE_CONCURRENCY
+          valueFrom:
+            secretKeyRef:
+              key: QUEUE_CONCURRENCY
+              name: queue-concurrency
         ports:
           - containerPort: {{{METRICS_PORT}}}
             name: prometheus-a


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add new `QUEUE_CONCURRENCY` environment variable to deploy templates.
For more about this variable, see https://github.com/product-os/jellyfish/pull/4032