### PR TITLE
backend: Move queue metric calls

### DIFF
--- a/lib/queue/consumer.js
+++ b/lib/queue/consumer.js
@@ -11,6 +11,7 @@ const graphileWorker = require('graphile-worker')
 const logger = require('../logger').getLogger(__filename)
 const CARDS = require('./cards')
 const environment = require('../environment')
+const metrics = require('../metrics')
 
 const LINK_EXECUTE = {
 	NAME: 'executes',
@@ -69,9 +70,11 @@ module.exports = class Consumer {
 				actionRequest: async (payload, helpers) => {
 					try {
 						this.messagesBeingHandled++
+						metrics.markJobAdd(payload.data.action.split('@')[0])
 						await onMessageEventHandler(payload)
 					} finally {
 						this.messagesBeingHandled--
+						metrics.markJobDone(payload.data.action.split('@')[0], payload.data.timestamp)
 					}
 				}
 			}

--- a/lib/queue/producer.js
+++ b/lib/queue/producer.js
@@ -11,7 +11,6 @@ const assert = require('../assert')
 const errors = require('./errors')
 const events = require('./events')
 const CARDS = require('./cards')
-const metrics = require('../metrics')
 
 module.exports = class Producer {
 	constructor (jellyfish, session) {
@@ -120,8 +119,6 @@ module.exports = class Producer {
 			}
 		})
 
-		metrics.markJobAdd(options.action.split('@')[0])
-
 		await this.jellyfish.backend.connection.any({
 			name: 'enqueue-action-request',
 			text: 'SELECT graphile_worker.add_job(\'actionRequest\', $1);',
@@ -179,7 +176,6 @@ module.exports = class Producer {
 			() => {
 				return `Execute event has no payload: ${JSON.stringify(request, null, 2)}`
 			})
-		metrics.markJobDone(request.data.payload.action.split('@')[0], request.data.payload.timestamp)
 
 		return {
 			error: request.data.payload.error,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move queue saturation and duration metric calls to inside the graphile runner task list handler to make sure we don't miss any job increments or decrements.

There are cases, such as webhook requests, in which `waitResults` isn't called. This means that the metric would be incremented, but not decremented with the current code.

Was able to confirm that all worker integration tests trigger metric calls, translate tests also correctly trigger both increment and decrement metric calls. And common actions such as create-card, update-card, create-session, create-event are properly incremented and decremented.

![queue-metrics](https://user-images.githubusercontent.com/45343541/84235183-5f11bf80-ab30-11ea-8101-c60b812528c5.png)
