### PR TITLE
backend: Fix metrics job add typo

### DIFF
--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -282,10 +282,6 @@ exports.markActionRequest = (action) => {
  * metrics.markJobAdd('action-create-card')
  */
 exports.markJobAdd = (action) => {
-	const labels = {
-		type: action
-	}
-	metrics.inc(metricNames.WORKER_SATURATION, 1, labels)
 	metrics.inc(metricNames.WORKER_SATURATION, 1, {
 		type: action
 	})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Because of a typo (leftover copy paste), metrics for jobs added to queue are incremented twice...
