### PR TITLE
Only reopen a support thread linked to an issue on the "closed" event

### DIFF
--- a/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -9,13 +9,41 @@
   "data": {
     "filter": {
       "$$links": {
-        "issue has attached support thread": {
+        "is attached to": {
+          "$$links": {
+            "issue has attached support thread": {
+              "type": "object",
+              "required": [ "type", "data" ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "support-thread@1.0.0"
+                },
+                "data": {
+                  "type": "object",
+                  "required": [ "status" ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "not": {
+                        "const": "open"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "type": "object",
-          "required": [ "type", "data" ],
+          "required": [ "active", "type", "data" ],
           "properties": {
+            "active": {
+              "type": "boolean",
+              "const": true
+            },
             "type": {
               "type": "string",
-              "const": "support-thread@1.0.0"
+              "const": "issue@1.0.0"
             },
             "data": {
               "type": "object",
@@ -23,9 +51,7 @@
               "properties": {
                 "status": {
                   "type": "string",
-                  "not": {
-                    "const": "open"
-                  }
+                  "const": "closed"
                 }
               }
             }
@@ -41,15 +67,32 @@
         },
         "type": {
           "type": "string",
-          "const": "issue@1.0.0"
+          "const": "update@1.0.0"
         },
         "data": {
           "type": "object",
-          "required": [ "status" ],
+          "required": [ "payload" ],
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "closed"
+            "payload": {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "required": [ "op", "path", "value" ],
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "replace"
+                  },
+                  "path": {
+                    "type": "string",
+                    "const": "/data/status"
+                  },
+                  "value": {
+                    "type": "string",
+                    "const": "closed"
+                  }
+                }
+              }
             }
           }
         }
@@ -58,7 +101,7 @@
     "action": "action-update-card@1.0.0",
     "target": {
       "$map": {
-        "$eval": "source.links['issue has attached support thread'][0:]"
+        "$eval": "source.links['is attached to'][0].links['issue has attached support thread'][0:]"
       },
       "each(link)": {
         "$eval": "link.id"


### PR DESCRIPTION
The triggered action that re-opens a support thread when an issue it's
attached to is closed has been changed so that it will only trigger when
an update event that closes the issue is created.
Previously the trigger would run on every worker job that matched the
state where an issue and a support thread are linked and they are both
closed. This had the side effect of triggering the action when you link
to an issue that is already closed, or if you edit a field of a closed
issue.

Connects-to: #4039
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
