### PR TITLE
Optimize `pg-live-select`'s database trigger

### DIFF
--- a/lib/core/backend/postgres/pg-live-select/index.js
+++ b/lib/core/backend/postgres/pg-live-select/index.js
@@ -32,6 +32,38 @@ const _ = require('lodash')
 const createTriggerSQL = require('./trigger-sql')
 const payload = require('./payload')
 
+// The notification mechanism has a 8000 byte limit for its payload, and thus
+// some changes have to be broken up into multiple notifications. To that end,
+// we transmit 4 pieces of information in that payload:
+//
+// - An unique message identifier
+// - The total number of pages required to reconstruct the whole message
+// - The current page
+// - A piece of the actual message
+//
+// We reserve 20 bytes for the identifier (fixed), up to 4 bytes for the total
+// and current page counts, and 2 bytes for separators. This leaves 7970 bytes
+// for the message itself.
+//
+// The payload must be a valid string. So each payload component is encoded as
+// follows:
+//
+// - Identifier: random string
+// - Counts: base-10 numbers
+// - Message: base64-encoded slices of an UTF-8 byte buffer. Slices may not be
+//   valid UTF-8, but when decoded concatenated in order they must result in a
+//   valid UTF-8 string containing a valid stringified JSON object
+//
+// The whole payload is encoded as:
+//
+// <Identifier><Total Pages>:<Current Page>:<Message>
+//
+// (note that there is no separator after the identifier)
+const ID_LEN = 20
+const COUNT_MAX_LEN = 4
+const SEPARATOR = ':'
+const MESSAGE_MAX_LEN = 8000 - ID_LEN - 2 * COUNT_MAX_LEN - 2 * SEPARATOR.length
+
 /*
  * Because Postgres doesn't allow us to run CREATE OR REPLACE FUNCTION
  * concurrently. This "random" big int is a key between clients to
@@ -63,14 +95,16 @@ module.exports = class LivePg extends EventEmitter {
 			this.triggerName,
 			this.table,
 			this.channel,
-			this.columns))
+			this.columns,
+			MESSAGE_MAX_LEN
+		))
 		await this.client.query(`LISTEN "${this.channel}"`)
 
 		this.client.on('notification', (info) => {
 			let change = null
 			try {
 				change = payload.reconstruct(
-					this.pendingPayloads, payload.parse(info.payload))
+					this.pendingPayloads, payload.parse(info.payload, ID_LEN, SEPARATOR))
 			} catch (error) {
 				this.emit('error', error)
 				return

--- a/lib/core/backend/postgres/pg-live-select/payload.js
+++ b/lib/core/backend/postgres/pg-live-select/payload.js
@@ -28,6 +28,7 @@
  */
 
 const _ = require('lodash')
+const util = require('util')
 
 const jsonParse = (string) => {
 	try {
@@ -37,29 +38,25 @@ const jsonParse = (string) => {
 	}
 }
 
-exports.parse = (data) => {
-	const positions = []
-
-	// Notification is a 4 parts string split by colons
-	while (positions.length < 3) {
-		const lastSeparatorIndex = positions.length === 0
-			? 0
-			: positions[positions.length - 1] + 1
-		positions.push(data.indexOf(':', lastSeparatorIndex))
-	}
+// See `index.js` for the structure
+exports.parse = (data, idLen, separator) => {
+	const sep0 = data.indexOf(separator, idLen)
+	const sep1 = data.indexOf(separator, sep0 + 1)
 
 	return {
-		checksum: data.slice(0, positions[0]),
-		totalPages: parseInt(data.slice(positions[0] + 1, positions[1]), 10),
-		currentPage: parseInt(data.slice(positions[1] + 1, positions[2]), 10),
-		message: data.slice(positions[2] + 1, positions[3])
+		identity: data.slice(0, idLen),
+		totalPages: parseInt(data.slice(idLen, sep0), 10),
+		currentPage: parseInt(data.slice(sep0 + 1, sep1), 10),
+		message: Buffer.from(data.slice(sep1 + 1), 'base64')
 	}
 }
 
 exports.reconstruct = (cache, object) => {
 	// Payload small enough to fit in single message
 	if (object.totalPages <= 1) {
-		return _.defaults(jsonParse(object.message), {
+		const message = new util.TextDecoder('utf-8').decode(object.message)
+
+		return _.defaults(jsonParse(message), {
 			before: null,
 			after: null
 		})
@@ -70,28 +67,44 @@ exports.reconstruct = (cache, object) => {
 	 * then create an array on the pending payloads cache
 	 * indexed by the message hash, including all "null"
 	 * values for the missing "holes" in the message.
+	 * Also store the number of pending pages so that we
+	 * don't need to check for nulls.
 	 */
-	if (!cache[object.checksum]) {
-		cache[object.checksum] =
-			_.times(object.totalPages, _.constant(null))
+	let partial = cache[object.identity]
+	if (!partial) {
+		partial = {
+			slices: _.times(object.totalPages, _.constant(null)),
+			pendingPages: object.totalPages
+		}
+		cache[object.identity] = partial
 	}
 
 	/*
 	 * Fill in the hole we just got.
 	 */
-	cache[object.checksum][object.currentPage - 1] = object.message
+	partial.slices[object.currentPage - 1] = object.message
+	partial.pendingPages -= 1
 
 	/*
 	 * Don't continue if there are still holes for
 	 * this message on the cache.
 	 */
-	if (cache[object.checksum].includes(null)) {
+	if (partial.pendingPages > 0) {
 		// Must wait for full message
 		return null
 	}
 
-	const result = cache[object.checksum].join('')
-	Reflect.deleteProperty(cache, object.checksum)
+	const decoder = new util.TextDecoder('utf-8')
+	const result = partial
+		.slices
+		.map((chunk) => {
+			return decoder.decode(chunk, {
+				stream: true
+			})
+		})
+		.join('')
+	Reflect.deleteProperty(cache, object.identity)
+
 	return _.defaults(jsonParse(result), {
 		before: null,
 		after: null

--- a/lib/core/backend/postgres/pg-live-select/trigger-sql.js
+++ b/lib/core/backend/postgres/pg-live-select/trigger-sql.js
@@ -28,128 +28,90 @@
  */
 
 /*
- * The "pg_notify" function has a limit of 8000 bytes that is not
- * easily configurable, so we can paginate over the payload as
- * a way to workaround the limit.
- */
-const FULL_MESSAGE_PAGINATED_SIZE = 7800
-
-/*
  * Template for trigger function to send row changes over notification
  */
-module.exports = (lockKey, triggerProcedure, triggerName, table, channel, columns) => {
-	/*
-	 * This function chunks the "before" and "after" payload so that we
-	 * can workaround the 8000 bytes NOTIFY limitation.
-	 *
-	 * This is conceptually straighforward, but the main problem is that
-	 * the JSON objects we get may contain unicode characters, and
-	 * therefore the character length may be smaller than the actual byte
-	 * length, and we end up blowing up the size limitation if not careful.
-	 *
-	 * The algorithm is the following:
-	 *
-	 * - Convert the stringified JSON object into a byte array
-	 * - Take out the amount of bytes that we know we can handle
-	 * - Attempt to convert back that byte array into an UTF-8 string.
-	 *   We might be cutting in the middle of a surrogate, so we need to
-	 *   handle that, otherwise the conversion will fail
-	 * - Use the UTF-8 substring to determine what is the amount of
-	 *   logical characters we need to extract
-	 */
+module.exports = (lockKey, triggerProcedure, triggerName, table, channel, columns, messageMaxLen) => {
+	// We can put up to `messageMaxLen` bytes in each notify payload, but since
+	// it's encoded in base64, the actual amount of data we can push is
+	// slightly lower
+	let pageByteLen = 3 * Math.floor(messageMaxLen / 4)
+
+	// Base64 has a 4-byte padding, so round down to a multiple of 4
+	const rem = pageByteLen % 4
+	if (rem > 0) {
+		pageByteLen += 4 - rem
+	}
+
 	return `
 	BEGIN;
+
 	SELECT pg_advisory_xact_lock(${lockKey});
 
-  CREATE OR REPLACE FUNCTION is_valid_utf8_bytea(buffer BYTEA) RETURNS boolean AS $$
-  BEGIN
-    PERFORM length(buffer, 'UTF8');
-    RETURN true;
-  EXCEPTION WHEN OTHERS THEN
-    RETURN false;
-  END;
-  $$ LANGUAGE plpgsql;
+	CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-  CREATE OR REPLACE FUNCTION "${triggerProcedure}"() RETURNS trigger AS $$
-  DECLARE
-    row_data           RECORD;
-    full_msg_binary    BYTEA;
-    full_msg_text      TEXT;
-    msg_portion_binary BYTEA;
-    msg_portion_text   TEXT;
-    full_len           INT;
-    cur_page           INT;
-    msg_offset_binary  INT;
-    msg_offset_text    INT;
-    page_count         INT;
-    msg_hash           TEXT;
-    cut_size           INT;
-  BEGIN
-    IF (TG_OP = 'INSERT') THEN
-      SELECT
-        TG_TABLE_NAME AS table,
-        TG_OP         AS type,
-        row_to_json(NEW) AS after
-      INTO row_data;
-    ELSIF (TG_OP  = 'DELETE') THEN
-      SELECT
-        TG_TABLE_NAME AS table,
-        TG_OP         AS type,
-        row_to_json(OLD) AS before
-      INTO row_data;
-    ELSIF (TG_OP = 'UPDATE') THEN
-      SELECT
-        TG_TABLE_NAME AS table,
-        TG_OP         AS type,
-        row_to_json(NEW) AS after,
-        row_to_json(OLD) AS before
-      INTO row_data;
-    END IF;
+	CREATE OR REPLACE FUNCTION "${triggerProcedure}"() RETURNS TRIGGER AS $$
+	DECLARE
+	    row_data    RECORD;
+	    id          TEXT;
+	    full_msg    BYTEA;
+	    full_len    INT;
+	    page_count  INT;
+	    msg_prefix  TEXT;
+	    cur_page    INT;
+	    msg_offset  INT;
+	BEGIN
+	    IF (TG_OP = 'INSERT') THEN
+	        SELECT
+	            TG_TABLE_NAME    AS table,
+	            TG_OP            AS type,
+	            row_to_json(NEW) AS after
+	        INTO row_data;
+	    ELSIF (TG_OP = 'DELETE') THEN
+	        SELECT
+	            TG_TABLE_NAME    AS table,
+	            TG_OP            AS type,
+	            row_to_json(OLD) AS before
+	        INTO row_data;
+	    ELSIF (TG_OP = 'UPDATE') THEN
+	        SELECT
+	            TG_TABLE_NAME    AS table,
+	            TG_OP            AS type,
+	            row_to_json(NEW) AS after,
+	            row_to_json(OLD) AS before
+	        INTO row_data;
+	    END IF;
 
-    SELECT convert_to(row_to_json(row_data)::TEXT, 'UTF8')::bytea  INTO full_msg_binary;
-    SELECT length(full_msg_binary)                                 INTO full_len;
-    SELECT convert_from(full_msg_binary, 'UTF8')                   INTO full_msg_text;
-    SELECT ceil(full_len / ${FULL_MESSAGE_PAGINATED_SIZE}.0)       INTO page_count;
-    SELECT md5(full_msg_binary)                                    INTO msg_hash;
+	    id := encode(substring(uuid_send(uuid_generate_v4()) FROM 2), 'base64');
+	    full_msg := convert_to(row_to_json(row_data)::text, 'UTF8');
+	    full_len := length(full_msg);
+	    page_count := ceil(full_len / ${pageByteLen}.0);
+	    msg_offset := 1;
+	    msg_prefix := id || page_count || ':';
 
-    msg_offset_binary := 1;
-    msg_offset_text := 1;
-    cut_size := ${FULL_MESSAGE_PAGINATED_SIZE};
+	    FOR cur_page IN 1..page_count LOOP
+			PERFORM pg_notify(
+				'${channel}',
+				msg_prefix || cur_page || ':' ||
+				replace(encode(substring(full_msg FROM msg_offset FOR ${pageByteLen}), 'base64'), E'\\n', '')
+			);
 
-    FOR cur_page IN 1..page_count LOOP
-      LOOP
-        IF cut_size = 0 THEN
-          RAISE EXCEPTION 'Invalid UTF 8 string';
-        END IF;
-        SELECT substring(full_msg_binary from msg_offset_binary for cut_size) INTO msg_portion_binary;
-        IF is_valid_utf8_bytea(msg_portion_binary) THEN
-          cut_size := ${FULL_MESSAGE_PAGINATED_SIZE};
-          EXIT;
-        END IF;
-        cut_size := cut_size - 1;
-      END LOOP;
-
-      SELECT substr(full_msg_text, msg_offset_text, length(msg_portion_binary, 'UTF8')) INTO msg_portion_text;
-
-      PERFORM pg_notify('${channel}',
-        msg_hash || ':' || page_count || ':' || cur_page || ':' ||
-        substr(full_msg_text, msg_offset_text, length(msg_portion_binary, 'UTF8'))
-      );
-
-      msg_offset_text := msg_offset_text + length(msg_portion_text);
-      msg_offset_binary := msg_offset_binary + length(convert_to(msg_portion_text, 'UTF8')::bytea);
-    END LOOP;
-    RETURN NULL;
-  END;
-	$$ LANGUAGE plpgsql;
+			msg_offset := msg_offset + ${pageByteLen};
+	    END LOOP;
+	    RETURN NULL;
+	END;
+	$$ LANGUAGE PLPGSQL;
 
 	DROP TRIGGER IF EXISTS "${triggerName}" ON "${table}";
+
 	CREATE TRIGGER "${triggerName}" AFTER
 	INSERT
-	OR UPDATE OF ${columns.join(', ')}
-	OR DELETE
-	ON "${table}"
+	OR
+	UPDATE OF ${columns.join(', ')}
+	OR
+	DELETE ON "${table}"
 	FOR EACH ROW EXECUTE PROCEDURE "${triggerProcedure}"();
+
+	DROP FUNCTION IF EXISTS is_valid_utf8_bytea;
 
 	COMMIT;`
 }

--- a/test/unit/core/backend/postgres/pg-live-select/payload.spec.js
+++ b/test/unit/core/backend/postgres/pg-live-select/payload.spec.js
@@ -8,46 +8,53 @@ const ava = require('ava')
 const payload = require(
 	'../../../../../../lib/core/backend/postgres/pg-live-select/payload')
 
+const ID_LEN = 20
+const SEPARATOR = ':'
+
 ava('.parse() should parse a simple object', (test) => {
-	const data = '9BB58F26192E4BA00F01E2E7B136BBD8:1:1:{"foo":"bar"}'
-	const result = payload.parse(data)
+	const buffer = Buffer.from('{"foo":"bar"}')
+	const data = `aaaaaaaaaaaaaaaaaaaa1:1:${buffer.toString('base64')}`
+	const result = payload.parse(data, ID_LEN, SEPARATOR)
 	test.deepEqual(result, {
-		checksum: '9BB58F26192E4BA00F01E2E7B136BBD8',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 1,
 		currentPage: 1,
-		message: '{"foo":"bar"}'
+		message: buffer
 	})
 })
 
 ava('.parse() should parse an incomplete object', (test) => {
-	const data = 'D60FDC24F620015A6FC7127D820C2DCA:1:1:{"foo":"bar","baz":'
-	const result = payload.parse(data)
+	const buffer = Buffer.from('{"foo":"bar","baz":')
+	const data = `aaaaaaaaaaaaaaaaaaaa1:1:${buffer.toString('base64')}`
+	const result = payload.parse(data, ID_LEN, SEPARATOR)
 	test.deepEqual(result, {
-		checksum: 'D60FDC24F620015A6FC7127D820C2DCA',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 1,
 		currentPage: 1,
-		message: '{"foo":"bar","baz":'
+		message: buffer
 	})
 })
 
 ava('.parse() should a chunk of a bigger message', (test) => {
-	const data = '9BB58F26192E4BA00F01E2E7B136BBD8:3:2:{"foo":"bar"}'
-	const result = payload.parse(data)
+	const buffer = Buffer.from('{"foo":"bar"}')
+	const data = `aaaaaaaaaaaaaaaaaaaa3:2:${buffer.toString('base64')}`
+	const result = payload.parse(data, ID_LEN, SEPARATOR)
 	test.deepEqual(result, {
-		checksum: '9BB58F26192E4BA00F01E2E7B136BBD8',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 3,
 		currentPage: 2,
-		message: '{"foo":"bar"}'
+		message: buffer
 	})
 })
 
 ava('.reconstruct() should reconstruct a one page simple object', (test) => {
+	const buffer = Buffer.from('{"after":{"foo":"bar"}}')
 	const cache = {}
 	const result = payload.reconstruct(cache, {
-		checksum: '25BBCD9E75E32643EF9012384B8D8D38',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 1,
 		currentPage: 1,
-		message: '{"after":{"foo":"bar"}}'
+		message: buffer
 	})
 
 	test.deepEqual(cache, {})
@@ -60,16 +67,20 @@ ava('.reconstruct() should reconstruct a one page simple object', (test) => {
 })
 
 ava('.reconstruct() should store a partial chunk', (test) => {
+	const buffer = Buffer.from('{"after":{"foo"')
 	const cache = {}
 	const result = payload.reconstruct(cache, {
-		checksum: '757F699B576B977266F83B0F4F1FE4DD',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 2,
 		currentPage: 1,
-		message: '{"after":{"foo"'
+		message: buffer
 	})
 
 	test.deepEqual(cache, {
-		'757F699B576B977266F83B0F4F1FE4DD': [ '{"after":{"foo"', null ]
+		aaaaaaaaaaaaaaaaaaaa: {
+			slices: [ buffer, null ],
+			pendingPages: 1
+		}
 	})
 
 	test.deepEqual(result, null)
@@ -79,17 +90,17 @@ ava('.reconstruct() should re-assemble a two parts message', (test) => {
 	const cache = {}
 
 	const result1 = payload.reconstruct(cache, {
-		checksum: '757F699B576B977266F83B0F4F1FE4DD',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 2,
 		currentPage: 1,
-		message: '{"after":{"foo"'
+		message: Buffer.from('{"after":{"foo"')
 	})
 
 	const result2 = payload.reconstruct(cache, {
-		checksum: '757F699B576B977266F83B0F4F1FE4DD',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 2,
 		currentPage: 2,
-		message: ':"bar"}}'
+		message: Buffer.from(':"bar"}}')
 	})
 
 	test.deepEqual(cache, {})
@@ -106,17 +117,17 @@ ava('.reconstruct() should re-assemble an out of order two parts message', (test
 	const cache = {}
 
 	const result1 = payload.reconstruct(cache, {
-		checksum: '757F699B576B977266F83B0F4F1FE4DD',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 2,
 		currentPage: 2,
-		message: ':"bar"}}'
+		message: Buffer.from(':"bar"}}')
 	})
 
 	const result2 = payload.reconstruct(cache, {
-		checksum: '757F699B576B977266F83B0F4F1FE4DD',
+		identity: 'aaaaaaaaaaaaaaaaaaaa',
 		totalPages: 2,
 		currentPage: 1,
-		message: '{"after":{"foo"'
+		message: Buffer.from('{"after":{"foo"')
 	})
 
 	test.deepEqual(cache, {})
@@ -134,10 +145,10 @@ ava('.reconstruct() should throw given an invalid object', (test) => {
 
 	test.throws(() => {
 		payload.reconstruct(cache, {
-			checksum: '25BBCD9E75E32643EF9012384B8D8D38',
+			identity: 'aaaaaaaaaaaaaaaaaaaa',
 			totalPages: 1,
 			currentPage: 1,
-			message: '{"after":'
+			message: Buffer.from('{"after":')
 		})
 	}, {
 		message: 'Invalid notification: {"after":'


### PR DESCRIPTION
Basically the trigger was doing too much UTF-8 encoding. This commit also changes the `NOTIFY` payload to a more sensible base64-encoding instead of manually doing UTF-8 boundary detection in the trigger itself.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>
