### PR TITLE
Fix flaky My Participation e2e test

### DIFF
--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -601,35 +601,28 @@ ava.serial('Support threads should close correctly in the UI even when being upd
 
 ava.serial('My Participation shows only support threads that the logged-in user has participated in', async (test) => {
 	const {
+		sdk,
 		page
 	} = context
 
 	// Add a support thread and message that should _not_ appear in the new user's My Participation view
-	const supportThread1 = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'support-thread@1.0.0',
-			data: {
-				inbox: 'S/Paid_Support',
-				status: 'open'
-			}
-		})
+	const supportThread1 = await sdk.card.create({
+		type: 'support-thread@1.0.0',
+		data: {
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
 	})
 
-	const messageText1 = uuid()
-
-	const messageEvent1 = {
+	await sdk.event.create({
 		target: supportThread1,
 		slug: `message-${uuid()}`,
 		tags: [],
 		type: 'message',
 		payload: {
-			message: messageText1
+			message: uuid()
 		}
-	}
-
-	await page.evaluate((event) => {
-		return window.sdk.event.create(event)
-	}, messageEvent1)
+	})
 
 	// Create a new user and login as that user
 	const otherUser = helpers.generateUserDetails()
@@ -637,6 +630,8 @@ ava.serial('My Participation shows only support threads that the logged-in user 
 	await context.addUserToBalenaOrg(otherCommunityUser.id)
 	await macros.logout(page)
 	await macros.loginUser(page, otherUser)
+
+	await page.waitForSelector('[data-test="home-channel__group-toggle--org-balena"]')
 
 	// Go to the My Participation view and verify there are no threads listed
 	await page.goto(`${environment.ui.host}:${environment.ui.port}/view-support-threads-participation`)
@@ -675,7 +670,7 @@ ava.serial('My Participation shows only support threads that the logged-in user 
 		page,
 		`[data-test-id="${supportThread2.id}"] [data-test="card-chat-summary__message"] p`
 	)
-	test.is(actualMessageText2, messageText2)
+	test.is(actualMessageText2.trim(), messageText2)
 })
 
 ava.serial('A user can edit their own message', async (test) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Various tweaks to make the ['My Participation shows only support threads that the logged-in user has participated in'](https://github.com/product-os/jellyfish/blob/fix-my-participation-e2e-test/test/e2e/ui/support.spec.js#L602) less flaky.
