### PR TITLE
Add index for endpoint field of a web-push-subscription

### DIFF
--- a/apps/server/default-cards/contrib/web-push-subscription.json
+++ b/apps/server/default-cards/contrib/web-push-subscription.json
@@ -34,6 +34,9 @@
           }
         }
       }
-    }
+    },
+    "indexed_fields": [
+      [ "data.endpoint" ]
+    ]
   }
 }


### PR DESCRIPTION
We will want to query web-push-subscriptions by endpoint when checking for existing subscriptions.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

When we start-up the front-end we fetch the existing push subscription from the `PushManager`. If there is a subscription we check that we've cached the subscription on the server by querying for a `web-push-subscription` card with that endpoint specified that is also linked to the authenticated user. For this reason we want to index the `data.endpoint` field of a `web-push-subscription` card.
