### PR TITLE
Augment type cards when loading

### DIFF
--- a/apps/server/default-cards/contrib/link.json
+++ b/apps/server/default-cards/contrib/link.json
@@ -1,0 +1,101 @@
+{
+  "slug": "link",
+  "type": "type@1.0.0",
+  "version": "1.0.0",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "schema": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "has member"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "inverseName": {
+                  "type": "string",
+                  "const": "is member of"
+                },
+                "from": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "org@1.0.0"
+                    }
+                  }
+                },
+                "to": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "executes"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "inverseName": {
+                  "type": "string",
+                  "const": "is executed by"
+                },
+                "from": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "execute@1.0.0"
+                    }
+                  }
+                },
+                "to": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "action-request@1.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "required": [
+        "name",
+        "type",
+        "links",
+        "data"
+      ]
+    },
+    "indexed_fields": [
+      [
+        "data.from.id",
+        "name",
+        "data.to.id"
+      ]
+    ]
+  },
+  "requires": [],
+  "capabilities": []
+}


### PR DESCRIPTION
This is a demo of how we could add type card augmentation as a generic
feature, and then use that feature to apply constraints to links on the
server side without hardcoding relationship data in the core lib

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
