### PR TITLE
Drop 3 useless indexes

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -130,10 +130,6 @@ exports.setup = async (context, connection, database, options = {}) => {
 	}, {
 		column: 'type'
 	}, {
-		column: 'data',
-		indexType: 'GIN',
-		options: 'jsonb_path_ops'
-	}, {
 		name: 'data_mirrors',
 		column: '(data->\'mirrors\')',
 		indexType: 'GIN',

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -70,8 +70,6 @@ exports.setup = async (context, connection, database, options) => {
 		DROP CONSTRAINT IF EXISTS ${LINK_TABLE}_slug_key;`)
 
 	for (const [ name, column ] of [
-		[ 'idx_link_from', 'fromId' ],
-		[ 'idx_link_to', 'toId' ],
 		[ 'idx_links_fromid_name', 'fromid, name' ],
 		[ 'idx_links_toid_inversename', 'toid, inversename' ]
 	]) {


### PR DESCRIPTION
The indexes are:

- `data_cards_idx`: index on `cards.data`. Largest index by far but never actually used due to `jsonschema2sql` (both old and new) never actually generating queries in the right format to take advantage of it. The mechanism introduced in PR #3450 is a far superior mechanism anyway.
- `idx_link_from`: index on `links.fromid`. Fully contained in the `idx_links_fromid_name` index and thus redundant.
- `idx_link_to`: index on `links.toid`. Same thing as above except it's contained in `idx_links_toid_inversename`.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>