### PR TITLE
backend: Handle init db duplicate errors

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -387,8 +387,14 @@ module.exports = class PostgresBackend {
 			 * it again, but then we might fail to do the operations we need
 			 * because it doesn't belong to us.
 			 */
-			await this.connection.any(`
-				CREATE DATABASE ${this.database} OWNER = ${this.options.user};`)
+			try {
+				await this.connection.any(`
+					CREATE DATABASE ${this.database} OWNER = ${this.options.user};`)
+			} catch (error) {
+				if (!utils.isIgnorableInitError(error.code)) {
+					throw error
+				}
+			}
 
 			/*
 			 * If the database is fresh, then the in-memory cache should be
@@ -410,16 +416,34 @@ module.exports = class PostgresBackend {
 			database: this.database
 		}))
 
-		await cards.setup(context, this.connection, this.database)
+		try {
+			await cards.setup(context, this.connection, this.database)
+		} catch (error) {
+			if (!utils.isIgnorableInitError(error.code)) {
+				throw error
+			}
+		}
 
-		await links.setup(context, this.connection, this.database, {
-			cards: cards.TABLE
-		})
+		try {
+			await links.setup(context, this.connection, this.database, {
+				cards: cards.TABLE
+			})
+		} catch (error) {
+			if (!utils.isIgnorableInitError(error.code)) {
+				throw error
+			}
+		}
 
-		await markers.setup(context, this.connection, {
-			source: cards.TABLE,
-			links: links.TABLE
-		})
+		try {
+			await markers.setup(context, this.connection, {
+				source: cards.TABLE,
+				links: links.TABLE
+			})
+		} catch (error) {
+			if (!utils.isIgnorableInitError(error.code)) {
+				throw error
+			}
+		}
 
 		this.streamClient = await streams.setup(
 			context, this.connection, cards.TABLE, cards.TRIGGER_COLUMNS)

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -7,6 +7,12 @@
 const _ = require('lodash')
 const skhema = require('skhema')
 
+// List of Postgres error codes we can safely ignore during initial db setup.
+// All error codes: https://www.postgresql.org/docs/12/errcodes-appendix.html
+// 23505: unique violation error
+// 42P07: duplicate table error
+const INIT_IGNORE_CODES = [ '23505', '42P07' ]
+
 exports.filter = (schema, element, errors) => {
 	if (_.isNil(schema)) {
 		return element
@@ -90,4 +96,29 @@ exports.removeVersionFields = (row) => {
 	}
 
 	return row
+}
+
+/**
+ * Check if a database error encountered on init is safe to ignore.
+ * These errors can occur when multiple services starting at the same time
+ * attempt to execute the same SQL simultaneously, resulting in duplicate key
+ * or unique violation errors.
+ * See: https://www.postgresql.org/docs/12/errcodes-appendix.html
+ *
+ * @function
+ *
+ * @param {String} code - Postgres error code
+ * @returns {Boolean} flag denoting if error is OK to ignore or not
+ *
+ * @example
+ * try {
+ *   await this.connection.any(`CREATE DATABASE mydb`)
+ * } catch (error) {
+ *   if (!utils.isIgnorableInitError(error.code)) {
+ *     throw error
+ *   }
+ * }
+ */
+exports.isIgnorableInitError = (code) => {
+	return _.includes(INIT_IGNORE_CODES, code)
 }

--- a/lib/queue/consumer.js
+++ b/lib/queue/consumer.js
@@ -20,6 +20,9 @@ const LINK_EXECUTE = {
 
 const EXECUTE_LINK_VERSION = '1.0.0'
 
+const RUN_RETRIES = 10
+const RUN_RETRY_DELAY = 1000
+
 const getExecuteLinkSlug = (actionRequest) => {
 	return `link-execute-${actionRequest.slug}`
 }
@@ -58,28 +61,46 @@ module.exports = class Consumer {
 			return this.jellyfish.replaceCard(context, this.session, card)
 		})
 
-		this.graphileRunner = await graphileWorker.run({
-			noHandleSignals: true,
-			pgPool: this.jellyfish.backend.connection.$pool,
-			concurrency: environment.queue.concurrency,
-			pollInterval: 1000,
-			logger: new graphileWorker.Logger((scope) => {
-				return _.noop
-			}),
-			taskList: {
-				actionRequest: async (payload, helpers) => {
-					try {
-						this.messagesBeingHandled++
-						metrics.markJobAdd(payload.data.action.split('@')[0])
-						await onMessageEventHandler(payload)
-					} finally {
-						this.messagesBeingHandled--
-						metrics.markJobDone(payload.data.action.split('@')[0], payload.data.timestamp)
+		await this.run(context, onMessageEventHandler)
+		this.graphileRunner.stop = _.once(this.graphileRunner.stop)
+	}
+
+	async run (context, onMessageEventHandler, retries = RUN_RETRIES) {
+		try {
+			this.graphileRunner = await graphileWorker.run({
+				noHandleSignals: true,
+				pgPool: this.jellyfish.backend.connection.$pool,
+				concurrency: environment.queue.concurrency,
+				pollInterval: 1000,
+				logger: new graphileWorker.Logger((scope) => {
+					return _.noop
+				}),
+				taskList: {
+					actionRequest: async (payload, helpers) => {
+						try {
+							this.messagesBeingHandled++
+							metrics.markJobAdd(payload.data.action.split('@')[0])
+							await onMessageEventHandler(payload)
+						} finally {
+							this.messagesBeingHandled--
+							metrics.markJobDone(payload.data.action.split('@')[0], payload.data.timestamp)
+						}
 					}
 				}
+			})
+		} catch (error) {
+			if (retries > 0) {
+				logger.info(context, 'Graphile worker failed to run', {
+					retries,
+					error
+				})
+				await Bluebird.delay(RUN_RETRY_DELAY)
+				return this.run(context, onMessageEventHandler, retries - 1)
 			}
-		})
-		this.graphileRunner.stop = _.once(this.graphileRunner.stop)
+			throw error
+		}
+
+		return true
 	}
 
 	async cancel () {

--- a/test/unit/core/backend/postgres/utils.spec.js
+++ b/test/unit/core/backend/postgres/utils.spec.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const utils = require('../../../../../lib/core/backend/postgres/utils')
+const uuid = require('uuid/v4')
+
+ava.before((test) => {
+	test.context.context = {
+		id: `UNIT-TEST-${uuid()}`
+	}
+})
+
+ava('isIgnorableInitError should return true for expected codes', (test) => {
+	test.truthy(utils.isIgnorableInitError('23505'))
+	test.truthy(utils.isIgnorableInitError('42P07'))
+})
+
+ava('isIgnorableInitError should return false for unexpected codes', (test) => {
+	test.falsy(utils.isIgnorableInitError('08000'))
+})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- adds logic to check for and allow specific errors to occur during initial db setup
- adds retry logic when starting the Graphile worker

in order to handle the errors described in https://github.com/product-os/jellyfish/issues/4095: catch and handle Postgres `duplicate key` and `unique violation` errors that occur when multiple services are starting up at the same time and attempting to execute the same SQL simultaneously

Closes https://github.com/product-os/jellyfish/issues/4095