### PR TITLE
Move Prometheus and Grafana into separate compose config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,8 +249,13 @@ export CI
 VISUAL ?=
 export VISUAL
 
+DOCKER_COMPOSE_FILES = --file docker-compose.yml
+ifdef MONITOR
+DOCKER_COMPOSE_FILES += --file docker-compose.monitor.yml
+endif
+
 DOCKER_COMPOSE_OPTIONS = \
-	--file docker-compose.yml \
+	$(DOCKER_COMPOSE_FILES) \
 	--project-name $(NAME) \
 	--compatibility
 ifeq ($(DETACH),1)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Open `http://jel.ly.fish.local` and login as:
 - Username: `jellyfish`
 - Password: `jellyfish`
 
+To include instances of Prometheus and Grafana, build and start your cluster with `MONITOR=1`:
+```
+make compose-build MONITOR=1
+make compose-up MONITOR=1
+```
+
 Prometheus can be accessed at `http://localhost:9090`.
 Grafana is available at `http://localhost:3000` with the Jellyfish graphs located under the `standard` folder.
 

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -1,0 +1,22 @@
+version: '2.1'
+
+services:
+  prometheus:
+    build:
+      context: ./prometheus
+      dockerfile: Dockerfile
+    command: "--config.file=/etc/prometheus/prometheus.yaml"
+    ports:
+      - '9090:9090'
+    restart: always
+    networks:
+      - internal
+  grafana:
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    restart: always
+    networks:
+      - internal

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -300,25 +300,6 @@ services:
         ["jel", "livechat", "api"]
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
-  prometheus:
-    build:
-      context: ./prometheus
-      dockerfile: Dockerfile
-    command: "--config.file=/etc/prometheus/prometheus.yaml"
-    ports:
-      - '9090:9090'
-    restart: always
-    networks:
-      - internal
-  grafana:
-    build:
-      context: ./grafana
-      dockerfile: Dockerfile
-    ports:
-      - '3000:3000'
-    restart: always
-    networks:
-      - internal
   haproxy:
     image: 'balena/open-balena-haproxy:2.11.3'
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -414,25 +414,6 @@ services:
         ["jel", "livechat", "api"]
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
-  prometheus:
-    build:
-      context: ./prometheus
-      dockerfile: Dockerfile
-    command: "--config.file=/etc/prometheus/prometheus.yaml"
-    ports:
-      - '9090:9090'
-    restart: always
-    networks:
-      - internal
-  grafana:
-    build:
-      context: ./grafana
-      dockerfile: Dockerfile
-    ports:
-      - '3000:3000'
-    restart: always
-    networks:
-      - internal
   haproxy:
     image: 'balena/open-balena-haproxy:2.11.3'
     cap_add:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- separates the Prometheus and Grafana services to a separate Docker Compose config
- adds a note about how to start Prometheus and Grafana to README

The problem with including Prometheus and Grafana in the main Docker Compose config is that this config is used when running tests in balenaCI. As Prometheus and Grafana are not necessary to run Jellyfish or its tests, moving these services to a separate file will speed up CI a bit.

To run Jellyfish with Prometheus and Grafana, just set `MONITOR=1` and the new `docker-compose.monitor.yml` will be included in the list of files to use.
