### PR TITLE
Improves runtime type resolution of query results.

### DIFF
--- a/apps/server/graphql/card-handlers/any-of-handler.js
+++ b/apps/server/graphql/card-handlers/any-of-handler.js
@@ -66,11 +66,7 @@ module.exports = class AnyOfHandler extends BaseHandler {
 
 		return new graphql.GraphQLUnionType({
 			name,
-			types: resultsWithoutNullOptions,
-			resolveType (value) {
-				// FIXME: this needs to figure out how to resolve the types at runtime.
-				return resultsWithoutNullOptions[0]
-			}
+			types: resultsWithoutNullOptions
 		})
 	}
 

--- a/apps/server/graphql/card-handlers/field-overrides.js
+++ b/apps/server/graphql/card-handlers/field-overrides.js
@@ -6,43 +6,92 @@
 
 const graphql = require('graphql')
 
-// All cards must provide the following, and we don't want to rely on
-// inferring type names for them.
-module.exports = {
+// All cards must provide the following, and we don't want to rely on inferring
+// type names for them.
+//
+// Defining them statically allows us to specify resolvers, documentation, etc
+// also.
+const OVERRIDES = {
 	capabilities () {
-		return this.context.getType('JsonValue')
+		return {
+			type: this.getType('JsonValue')
+		}
 	},
 
 	generic_data () {
-		return this.context.getType('JsonValue')
+		return {
+			type: this.getType('JsonValue'),
+			resolve: (source) => { return source.data }
+		}
 	},
 
 	id () {
-		return graphql.GraphQLNonNull(graphql.GraphQLID)
+		return {
+			type: graphql.GraphQLNonNull(graphql.GraphQLID)
+		}
 	},
 
 	linked_at () {
-		return graphql.GraphQLNonNull(new graphql.GraphQLList(this.context.getType('LinkedAt')))
+		return {
+			type: graphql.GraphQLNonNull(new graphql.GraphQLList(this.getType('LinkedAt'))),
+			resolve: (source) => {
+				if (source.linked_at) {
+					return Object
+						.entries(source.linked_at)
+						.map(([ name, at ]) => {
+							return {
+								name, at
+							}
+						})
+				}
+				return []
+			}
+		}
 	},
 
 	links () {
-		return graphql.GraphQLNonNull(new graphql.GraphQLList(this.context.getType('Link')))
+		return {
+			type: graphql.GraphQLNonNull(new graphql.GraphQLList(this.getType('Link')))
+
+		}
 	},
 
 	requires () {
-		return this.context.getType('JsonValue')
+		return {
+			type: this.getType('JsonValue')
+		}
 	},
 
 	slug () {
-		return graphql.GraphQLNonNull(this.context.getType('Slug'))
+		return {
+			type: graphql.GraphQLNonNull(this.getType('Slug'))
+		}
 	},
 
 	type () {
-		return graphql.GraphQLNonNull(this.context.getType('CardType'))
+		return {
+			type: graphql.GraphQLNonNull(this.getType('CardType'))
+		}
 	},
 
 	version () {
-		return graphql.GraphQLNonNull(this.context.getType('SemanticVersion'))
+		return {
+			type: graphql.GraphQLNonNull(this.getType('SemanticVersion'))
+		}
 	}
+}
 
+// Used by `CardHandler` and `CardInterfaceHandler` to override the generated
+// fields.
+const applyOverridesToFields = (fields, context) => {
+	return Object
+		.keys(OVERRIDES)
+		.reduce((result, key) => {
+			result[key] = Reflect.apply(OVERRIDES[key], context, [])
+			return result
+		}, fields)
+}
+
+module.exports = {
+	OVERRIDES, applyOverridesToFields
 }

--- a/apps/server/graphql/helpers/log-wrapper.js
+++ b/apps/server/graphql/helpers/log-wrapper.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// This is just a wrapper around the logger/context combo so that I don't have
+// to pass `context` to everything, especially given the fact that there would
+// be multiple objects with the name "context" floating around the system.
+
+module.exports = class LogWrapper {
+	constructor (logger, context) {
+		this.logger = logger
+		this.context = context
+	}
+
+	debug (message, data) {
+		this.logger.debug(this.context, message, data)
+	}
+	error (message, data) {
+		this.logger.error(this.context, message, data)
+	}
+	info (message, data) {
+		this.logger.info(this.context, message, data)
+	}
+	warn (message, data) {
+		this.logger.warn(this.context, message, data)
+	}
+}

--- a/apps/server/graphql/schema-builder.js
+++ b/apps/server/graphql/schema-builder.js
@@ -9,7 +9,7 @@ const graphql = require('graphql')
 const handlers = require('./card-handlers')
 const HardCodedTypes = require('./types')
 const Resolvers = require('./resolvers')
-const GeneratorContext = require('./generator-context')
+const GeneratorContext = require('./schema-generator-context')
 const {
 	camelCase
 } = require('change-case')

--- a/apps/server/graphql/schema-generator-context.js
+++ b/apps/server/graphql/schema-generator-context.js
@@ -4,34 +4,12 @@
  * Proprietary and confidential.
  */
 
+const LogWrapper = require('./helpers/log-wrapper')
 const graphql = require('graphql')
 const _ = require('lodash')
 const {
 	pascalCase
 } = require('change-case')
-
-// This is just a wrapper around the logger/context combo so that I don't have
-// to pass `context` to everything, especially given the fact that there would
-// be multiple objects with the name "context" floating around the system.
-class Logger {
-	constructor (logger, context) {
-		this.logger = logger
-		this.context = context
-	}
-
-	debug (message, data) {
-		this.logger.debug(this.context, message, data)
-	}
-	error (message, data) {
-		this.logger.error(this.context, message, data)
-	}
-	info (message, data) {
-		this.logger.info(this.context, message, data)
-	}
-	warn (message, data) {
-		this.logger.warn(this.context, message, data)
-	}
-}
 
 // `SchemaGeneratorContext` is a shared, mutable object used to store
 // information about and side-effects of the schema generation process.
@@ -47,7 +25,7 @@ module.exports = class SchemaGeneratorContext {
 		this.typeRegistry = baseTypes
 		this.baseCards = baseCards
 		this.nameStack = []
-		this.logger = new Logger(logger, logContext)
+		this.logger = new LogWrapper(logger, logContext)
 		this.anonymousTypeCounters = {}
 	}
 

--- a/test/unit/apps/server/graphql/card-handlers/card-handler.spec.js
+++ b/test/unit/apps/server/graphql/card-handlers/card-handler.spec.js
@@ -4,18 +4,20 @@
  * Proprietary and confidential.
  */
 
+const _ = require('lodash')
 const ava = require('ava')
+const CardCard = require('../../../../../../lib/core/cards/card')
 const CardHandler = require('../../../../../../apps/server/graphql/card-handlers/card-handler')
 const graphql = require('graphql')
-const CardCard = require('../../../../../../lib/core/cards/card')
-const fieldOverrides = require('../../../../../../apps/server/graphql/card-handlers/field-overrides')
-const _ = require('lodash')
+const {
+	camelCase
+} = require('change-case')
 const {
 	fakeContext
 } = require('../graphql-spec-helpers')
 const {
-	camelCase
-} = require('change-case')
+	OVERRIDES
+} = require('../../../../../../apps/server/graphql/card-handlers/field-overrides')
 
 const card = {
 	slug: 'time-machine',
@@ -73,7 +75,7 @@ ava('`generateTypeName` generates a sensible name', (test) => {
 
 ava('`children` returns the schema of each property minus overriden fields', (test) => {
 	const handler = new CardHandler(card, 0, getContext())
-	const expectedChildren = Object.values(_.omit(CardCard.data.schema.properties, Object.keys(fieldOverrides)))
+	const expectedChildren = Object.values(_.omit(CardCard.data.schema.properties, Object.keys(OVERRIDES)))
 
 	test.deepEqual(handler.children(), expectedChildren)
 })

--- a/test/unit/apps/server/graphql/card-handlers/card-interface-handler.spec.js
+++ b/test/unit/apps/server/graphql/card-handlers/card-interface-handler.spec.js
@@ -9,7 +9,9 @@ const CardHandler = require('../../../../../../apps/server/graphql/card-handlers
 const CardInterfaceHandler = require('../../../../../../apps/server/graphql/card-handlers/card-interface-handler')
 const CardCard = require('../../../../../../lib/core/cards/card')
 const Types = require('../../../../../../apps/server/graphql/types')
-const fieldOverrides = require('../../../../../../apps/server/graphql/card-handlers/field-overrides')
+const {
+	OVERRIDES
+} = require('../../../../../../apps/server/graphql/card-handlers/field-overrides')
 const graphql = require('graphql')
 const {
 	fakeContext
@@ -61,7 +63,7 @@ ava('`children` returns the schema of each property minus overriden fields and `
 	const handler = new CardInterfaceHandler(CardCard, 0, fakeContext())
 	const expectedChildren = Object.values(_.omit(
 		CardCard.data.schema.properties,
-		Object.keys(fieldOverrides).concat([ 'data' ])
+		Object.keys(OVERRIDES).concat([ 'data' ])
 	))
 
 	test.deepEqual(handler.children(), expectedChildren)

--- a/test/unit/apps/server/graphql/graphql-spec-helpers.js
+++ b/test/unit/apps/server/graphql/graphql-spec-helpers.js
@@ -7,7 +7,7 @@
 const ava = require('ava')
 const graphql = require('graphql')
 const Types = require('../../../../../apps/server/graphql/types')
-const GeneratorContext = require('../../../../../apps/server/graphql/generator-context')
+const SchemaGeneratorContext = require('../../../../../apps/server/graphql/schema-generator-context')
 const baseCards = require('../../../../../lib/core/cards')
 const {
 	camelCase
@@ -176,7 +176,7 @@ const sharedObjectSpecs = (type, expectedTypeName = null, expectedFields = []) =
 }
 
 const fakeContext = (extraTypes) => {
-	return new GeneratorContext(Object.assign({}, Types, extraTypes), baseCards, console, '')
+	return new SchemaGeneratorContext(Object.assign({}, Types, extraTypes), baseCards, console, '')
 }
 
 module.exports = {


### PR DESCRIPTION
This change modifies the "field overrides" file to contain more than just type information, which allows us to make sure that custom resolution can take place also.

This small refactor was part of a larger piece of work, but I've split it out because it's useful on it's own.