### PR TITLE
Combine npm ci steps into production of a single layer

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,9 +10,9 @@ COPY webpack.config.base.js /usr/src/jellyfish/
 COPY ./scripts ./scripts
 COPY package.json package-lock.json /usr/src/jellyfish/
 ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-RUN rm -f ~/.npmrc
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci && \
+    rm -f ~/.npmrc
 
 COPY ./apps ./apps
 COPY ./lib ./lib


### PR DESCRIPTION
The previous implementation was creating layers with NPM token persisted.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>
