### PR TITLE
When a synced support thread is created, post a whisper containg a link to JF

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -98,6 +98,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('contrib/triggered-action-support-summary.json'),
 		await loadCard('contrib/triggered-action-support-reopen.json'),
 		await loadCard('contrib/triggered-action-support-closed-issue-reopen.json'),
+		await loadCard('contrib/triggered-action-sync-thread-post-link-whisper.json'),
 
 		// User facing views
 		await loadCard('contrib/view-all-views.json'),

--- a/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
+++ b/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
@@ -1,0 +1,76 @@
+{
+  "slug": "triggered-action-sync-thread-post-link-whisper",
+  "type": "triggered-action@1.0.0",
+  "version": "1.0.0",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "filter": {
+      "title": "Support threads created with a 'mirrors' field",
+      "$$links": {
+        "is attached to": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [ "active", "type", "data" ],
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "const": true
+        },
+        "type": {
+          "type": "string",
+          "const": "create@1.0.0"
+        },
+        "data": {
+          "type": "object",
+          "required": [ "payload" ],
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [ "type", "data" ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "support-thread@1.0.0"
+                },
+                "data": {
+                  "type": "object",
+                  "required": [ "mirrors" ],
+                  "properties": {
+                    "mirrors": {
+                      "description": "The 'mirrors' field indicates the thread is sync to an external resource",
+                      "type": "array",
+                      "minItems": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "action": "action-create-event@1.0.0",
+    "target": {
+      "$eval": "source.links['is attached to'][0].id"
+    },
+    "arguments": {
+      "reason": null,
+      "payload": {
+        "message": "[This thread is synced to Jellyfish](https://jel.ly.fish/${source.links['is attached to'][0].id})"
+      },
+      "type": "whisper@1.0.0"
+    }
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -277,7 +277,7 @@ avaTest('should send, but not sync, a whisper to a deleted thread', async (test)
 	test.falsy(thread.data.mirrors)
 
 	const topic = await test.context.getTopic(topicId)
-	test.is(topic.post_stream.posts.length, 1)
+	test.is(topic.post_stream.posts.length, 2)
 })
 
 avaTest('should send, but not sync, a message to a deleted thread', async (test) => {
@@ -312,7 +312,7 @@ avaTest('should send, but not sync, a message to a deleted thread', async (test)
 	test.falsy(thread.data.mirrors)
 
 	const topic = await test.context.getTopic(topicId)
-	test.is(topic.post_stream.posts.length, 1)
+	test.is(topic.post_stream.posts.length, 2)
 })
 
 avaTest('should send a whisper as a non moderator user', async (test) => {

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -558,7 +558,7 @@ avaTest('should be able to comment on an inbound message', async (test) => {
 			return elements.length > 0
 		})
 
-	test.is(comments.length, 1)
+	test.is(comments.length, 2)
 	test.is(comments[0].body, 'First comment')
 	test.is(comments[0].author.username.replace(/_/g, '-'),
 		test.context.username)


### PR DESCRIPTION

This change makes it easier to find the corresponding Jellyfish thread
when viewing an external resource like Front, Discourse or Flowdock

![image](https://user-images.githubusercontent.com/15064535/84757199-c3fb6880-afbb-11ea-85bd-df762420951d.png)


Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
