### PR TITLE
ci: Fix flaky e2e support test

### DIFF
--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -580,18 +580,17 @@ ava.serial('Support threads should close correctly in the UI even when being upd
 				}
 			]))
 		}
-
-		updates.push(
-			window.sdk.card.update(id, 'support-thread@1.0.0', [
-				{
-					op: 'replace',
-					path: '/data/status',
-					value: 'closed'
-				}
-			])
-		)
-
 		return window.Promise.all(updates)
+	}, supportThread.id)
+
+	await page.evaluate((id) => {
+		return window.sdk.card.update(id, 'support-thread@1.0.0', [
+			{
+				op: 'replace',
+				path: '/data/status',
+				value: 'closed'
+			}
+		])
 	}, supportThread.id)
 
 	await macros.waitForSelectorToDisappear(page, summarySelector, 150)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Fix flakiness of `e2e > ui > support > Support threads should close correctly in the UI even when being updated at a high frequency` test. The test requires that all updates on the `support-thread` card be executed in order, with the set status to `closed` update being last, but the code was not written in such a way to ensure this.

Ran `FILES=test/e2e/ui/support.spec.js make test` 20 times after making this change. All tests passed every time. This was definitely not the case before.