### PR TITLE
Improve message styling

### DIFF
--- a/apps/ui/components/Inbox/MessageList.jsx
+++ b/apps/ui/components/Inbox/MessageList.jsx
@@ -123,15 +123,15 @@ class MessageList extends React.Component {
 					position: 'relative'
 				}}
 			>
-				<div
+				<Box
+					py={2}
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
 					data-test={'messageList-ListWrapper'}
 					style={{
 						flex: 1,
 						overflowY: 'auto',
-						borderTop: '1px solid #eee',
-						paddingTop: 8
+						borderTop: '1px solid #eee'
 					}}
 				>
 					{(Boolean(tail) && tail.length > 0) && _.map(tail, (card) => {
@@ -163,7 +163,7 @@ class MessageList extends React.Component {
 							</Box>
 						)
 					})}
-				</div>
+				</Box>
 			</Column>
 		)
 	}

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -252,14 +252,14 @@ export class Interleaved extends BaseLens {
 				}}
 			>
 				<ReactResizeObserver onResize={this.scrollToBottom}/>
-				<div
+				<Box
+					py={2}
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
 					style={{
 						flex: 1,
 						overflowY: 'auto',
-						borderTop: '1px solid #eee',
-						paddingTop: 8
+						borderTop: '1px solid #eee'
 					}}
 				>
 					{this.props.totalPages > this.props.page + 1 && (
@@ -289,7 +289,7 @@ export class Interleaved extends BaseLens {
 							</Box>
 						)
 					})}
-				</div>
+				</Box>
 
 				{head && head.slug !== 'view-my-alerts' && head.slug !== 'view-my-mentions' && (
 					<Flex

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -304,7 +304,6 @@ export default class Event extends React.Component {
 					<Box
 						pt={squashTop ? 0 : 2}
 						flex="1"
-						pb={squashBottom || messageOverflows ? 0 : 2}
 						style={{
 							minWidth: 0
 						}}

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -127,8 +127,8 @@ export default class Event extends React.Component {
 				card,
 				onUpdateCard
 			} = this.props
-			if (this.state.editedMessage === getMessage(card)) {
-				// No change - just finish editing now
+			if (this.state.editedMessage === getMessage(card) || this.state.editedMessage.length === 0) {
+				// No change or empty message - just finish editing now
 				this.onStopEditing()
 			} else {
 				this.setState({

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -29,9 +29,16 @@ const MESSAGE_COLLAPSED_HEIGHT = 400
 
 const tagMatchRE = helpers.createPrefixRegExp('@|#|!')
 const EventButton = styled.button `
-	cursor: pointer;
+	cursor: ${(props) => { return props.openChannel ? 'pointer' : 'default' }};
+	${(props) => {
+		return props.openChannel ? '' : `
+		  &:focus {
+				outline:0;
+			}
+		`
+	}}
 	border: 0;
-	background: none;
+	background: transparent;
 	display: block;
 	display: flex;
 	flex-direction: column;
@@ -40,6 +47,14 @@ const EventButton = styled.button `
 	border-left-style: solid;
 	border-left-width: 3px;
 	width: 43px;
+`
+
+const MessageIconWrapper = styled(Box) `
+	transition: 150ms ease-in-out transform, 150ms ease-in-out filter;
+	.event-card:hover & {
+		filter: brightness(85%);
+		transform: scale(1.2);
+	}
 `
 
 const getTargetId = (card) => {
@@ -269,8 +284,9 @@ export default class Event extends React.Component {
 
 		return (
 			<VisibilitySensor onChange={this.handleVisibilityChange}>
-				<EventWrapper {...rest} squashTop={squashTop} className={`event-card--${typeBase}`}>
+				<EventWrapper {...rest} squashTop={squashTop} className={`event-card event-card--${typeBase}`}>
 					<EventButton
+						openChannel={openChannel}
 						onClick={this.openChannel}
 						style={{
 							borderLeftColor: threadColor
@@ -286,7 +302,7 @@ export default class Event extends React.Component {
 								/>
 
 								{openChannel && (
-									<Box
+									<MessageIconWrapper
 										tooltip={{
 											placement: 'bottom',
 											text: `Open ${card.type.split('@')[0]}`
@@ -296,7 +312,7 @@ export default class Event extends React.Component {
 											threadColor={threadColor}
 											firstInThread={firstInThread}
 										/>
-									</Box>
+									</MessageIconWrapper>
 								)}
 							</React.Fragment>
 						)}

--- a/lib/ui-components/Event/EventBody.jsx
+++ b/lib/ui-components/Event/EventBody.jsx
@@ -168,14 +168,14 @@ export default class EventBody extends React.Component {
 							ref={setMessageElement}
 							card={card}
 							actor={actor}
-							editing={Boolean(editedMessage)}
+							editing={editedMessage !== null}
 							squashTop={squashTop}
 							squashBottom={squashBottom}
 							py={2}
 							px={3}
 							mr={1}
 						>
-							{editedMessage && !updating ? (
+							{editedMessage !== null && !updating ? (
 								<EditingAutocompleteTextarea
 									data-test="event__textarea"
 									enableAutocomplete={enableAutocomplete}

--- a/lib/ui-components/Event/EventContext.jsx
+++ b/lib/ui-components/Event/EventContext.jsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import copy from 'copy-to-clipboard'
+import styled from 'styled-components'
+import {
+	Theme, Txt, Flex, Button
+} from 'rendition'
+import {
+	formatTimestamp
+} from '../services/helpers'
+import Icon from '../shame/Icon'
+import {
+	ActionLink
+} from '../shame/ActionLink'
+import {
+	MirrorIcon
+} from '../MirrorIcon'
+import ContextMenu from '../ContextMenu'
+
+const ContextWrapper = styled(Flex) `
+	padding: 2px 4px 2px 2px;
+ 	border-radius: 6px;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+ 	border: solid 0.5px #e8ebf2;
+ 	position: absolute;
+ 	right: 16px;
+ 	bottom: -6px;
+ 	background: #fff;
+	opacity: ${(props) => { return props.card.pending || props.updating ? 1 : 0 }};
+	transition: 150ms ease-in-out opacity, 150ms ease-in-out width;
+	.event-card:hover & {
+		opacity: 1;
+	}
+`
+
+export default function EventContext ({
+	card,
+	menuOptions,
+	updating,
+	isOwnMessage,
+	isMessage,
+	threadIsMirrored,
+	onEditMessage
+}) {
+	const [ showMenu, setShowMenu ] = React.useState(false)
+	const toggleMenu = () => {
+		setShowMenu(!showMenu)
+	}
+
+	const timestamp = _.get(card, [ 'data', 'timestamp' ]) || card.created_at
+
+	const copyJSON = (event) => {
+		event.preventDefault()
+		event.stopPropagation()
+		copy(JSON.stringify(card, null, 2))
+	}
+
+	const copyRawMessage = (event) => {
+		event.preventDefault()
+		event.stopPropagation()
+		copy(card.data.payload.message)
+	}
+
+	return (
+		<ContextWrapper alignItems="center" card={card} updating={updating}>
+			{(card.pending || updating) && (
+				<Txt color={Theme.colors.text.light} fontSize={1} ml="6px" data-test="event-header__status">
+					<Icon spin name="cog" />
+					<Txt.span ml={1}>{ updating ? 'updating...' : 'sending...' }</Txt.span>
+				</Txt>
+			)}
+			{ threadIsMirrored && <MirrorIcon mirrors={_.get(card, [ 'data', 'mirrors' ])} /> }
+			{Boolean(card.data) && Boolean(timestamp) && (
+				<Txt
+					className="event-card--timestamp"
+					color={Theme.colors.text.light}
+					fontSize={1}
+					ml={1}
+				>
+					{formatTimestamp(timestamp, true)}
+				</Txt>
+			)}
+			{menuOptions !== false && (
+				<React.Fragment>
+					<Button
+						className="event-card--actions"
+						data-test="event-header__context-menu-trigger"
+						px={2}
+						ml={1}
+						plain
+						onClick={toggleMenu}
+						icon={<Icon name="ellipsis-v" />}
+					/>
+
+					{showMenu && (
+						<ContextMenu position="bottom" onClose={toggleMenu}>
+							<React.Fragment>
+								{isOwnMessage && !card.pending && !updating && (
+									<ActionLink
+										data-test="event-header__link--edit-message"
+										onClick={onEditMessage}>
+										Edit message
+									</ActionLink>
+								)}
+
+								<ActionLink
+									data-test="event-header__link--copy-json"
+									onClick={copyJSON}
+									tooltip={{
+										text: 'JSON copied!',
+										trigger: 'click'
+									}}
+								>
+								Copy as JSON
+								</ActionLink>
+
+								{isMessage && (
+									<ActionLink
+										data-test="event-header__link--copy-raw"
+										onClick={copyRawMessage}
+										tooltip={{
+											text: 'Message copied!',
+											trigger: 'click'
+										}}
+									>
+									Copy raw message
+									</ActionLink>
+								)}
+
+								{menuOptions}
+							</React.Fragment>
+						</ContextMenu>
+					)}
+				</React.Fragment>
+			)}
+		</ContextWrapper>
+	)
+}

--- a/lib/ui-components/Event/EventHeader.jsx
+++ b/lib/ui-components/Event/EventHeader.jsx
@@ -5,24 +5,17 @@
  */
 
 import React from 'react'
-import copy from 'copy-to-clipboard'
 import _ from 'lodash'
 import styled from 'styled-components'
 import {
-	Theme, Flex, Txt, Button
+	Theme, Flex, Txt
 } from 'rendition'
-import {
-	ActionLink
-} from '../shame/ActionLink'
-import {
-	formatTimestamp
-} from '../services/helpers'
-import Icon from '../shame/Icon'
 import Link from '../Link'
-import ContextMenu from '../ContextMenu'
-import {
-	MirrorIcon
-} from '../MirrorIcon'
+import EventContext from './EventContext'
+
+const HeaderWrapper = styled(Flex) `
+	position: relative;
+`
 
 const ActorPlaceholder = styled.span `
 	width: 80px;
@@ -35,28 +28,6 @@ const ActorPlaceholder = styled.span `
 export default class EventHeader extends React.Component {
 	constructor (props) {
 		super(props)
-
-		this.state = {
-			showMenu: false
-		}
-
-		this.toggleMenu = () => {
-			this.setState({
-				showMenu: !this.state.showMenu
-			})
-		}
-
-		this.copyJSON = (event) => {
-			event.preventDefault()
-			event.stopPropagation()
-			copy(JSON.stringify(this.props.card, null, 2))
-		}
-
-		this.copyRawMessage = (event) => {
-			event.preventDefault()
-			event.stopPropagation()
-			copy(this.props.card.data.payload.message)
-		}
 
 		this.getTimelineElement = (card) => {
 			const targetCard = _.get(card, [ 'links', 'is attached to', '0' ], card)
@@ -96,12 +67,11 @@ export default class EventHeader extends React.Component {
 			onEditMessage,
 			squashTop
 		} = this.props
-		const timestamp = _.get(card, [ 'data', 'timestamp' ]) || card.created_at
 
 		const isOwnMessage = user.id === _.get(card, [ 'data', 'actor' ])
 
 		return (
-			<Flex justifyContent="space-between" mb={1} mt={squashTop ? 1 : 0}>
+			<HeaderWrapper justifyContent="space-between">
 				<Flex
 					mt={isMessage ? 0 : 1}
 					alignItems="center"
@@ -129,89 +99,18 @@ export default class EventHeader extends React.Component {
 					)}
 
 					{(!squashTop && !isMessage) && this.getTimelineElement(card)}
-
-					{Boolean(card.data) && Boolean(timestamp) && (
-						<Txt
-							className="event-card--timestamp"
-							color={Theme.colors.text.light}
-							fontSize={1}
-							ml="6px"
-						>
-							{formatTimestamp(timestamp, true)}
-						</Txt>
-					)}
-					{card.pending || updating ? (
-						<Txt color={Theme.colors.text.light} fontSize={1} ml="6px" data-test="event-header__status">
-							{ updating ? 'updating...' : 'sending...' }
-							<Icon
-								style={{
-									marginLeft: 6
-								}}
-								spin
-								name="cog"
-							/>
-						</Txt>
-					) : (
-						<MirrorIcon
-							mirrors={_.get(card, [ 'data', 'mirrors' ])}
-							threadIsMirrored={threadIsMirrored}
-						/>
-					)}
 				</Flex>
 
-				{menuOptions !== false && (
-					<span>
-						<Button
-							className="event-card--actions"
-							data-test="event-header__context-menu-trigger"
-							px={2}
-							plain
-							onClick={this.toggleMenu}
-							icon={<Icon name="ellipsis-v" />}
-						/>
-
-						{this.state.showMenu && (
-							<ContextMenu position="bottom" onClose={this.toggleMenu}>
-								<React.Fragment>
-									{isOwnMessage && !card.pending && !updating && (
-										<ActionLink
-											data-test="event-header__link--edit-message"
-											onClick={onEditMessage}>
-											Edit message
-										</ActionLink>
-									)}
-
-									<ActionLink
-										data-test="event-header__link--copy-json"
-										onClick={this.copyJSON}
-										tooltip={{
-											text: 'JSON copied!',
-											trigger: 'click'
-										}}
-									>
-										Copy as JSON
-									</ActionLink>
-
-									{isMessage && (
-										<ActionLink
-											data-test="event-header__link--copy-raw"
-											onClick={this.copyRawMessage}
-											tooltip={{
-												text: 'Message copied!',
-												trigger: 'click'
-											}}
-										>
-											Copy raw message
-										</ActionLink>
-									)}
-
-									{menuOptions}
-								</React.Fragment>
-							</ContextMenu>
-						)}
-					</span>
-				)}
-			</Flex>
+				<EventContext
+					card={card}
+					menuOptions={menuOptions}
+					onEditMessage={onEditMessage}
+					isOwnMessage={isOwnMessage}
+					isMessage={isMessage}
+					updating={updating}
+					threadIsMirrored={threadIsMirrored}
+				/>
+			</HeaderWrapper>
 		)
 	}
 }

--- a/lib/ui-components/Event/EventWrapper.jsx
+++ b/lib/ui-components/Event/EventWrapper.jsx
@@ -22,15 +22,6 @@ const EventWrapper = styled(Flex) `
 	}
 	min-width: 0;
 	word-break: break-word;
-	.event-card--actions {
-		opacity: 0;
-		transition: 150ms ease-in-out opacity;
-	}
-	&:hover {
-		.event-card--actions {
-			opacity: 1;
-		}
-	}
 	.rendition-tag--hl {
 		position: relative;
 		${tagStyle}
@@ -49,22 +40,6 @@ const EventWrapper = styled(Flex) `
     right: -4px;
     font-size: 10px;
 	}
-
-	${({
-		squashTop
-	}) => {
-		return squashTop ? `
-			.event-card--timestamp {
-				opacity: 0;
-				transition: 150ms ease-in-out opacity;
-			}
-			&:hover {
-				.event-card--timestamp {
-					opacity: 1;
-				}
-			}
-		` : ''
-	}}
 `
 
 export default EventWrapper

--- a/lib/ui-components/Event/EventWrapper.jsx
+++ b/lib/ui-components/Event/EventWrapper.jsx
@@ -15,6 +15,11 @@ import {
 // Min-width is used to stop text from overflowing the flex container, see
 // https://css-tricks.com/flexbox-truncated-text/ for a nice explanation
 const EventWrapper = styled(Flex) `
+	background: transparent;
+	transition: 150ms ease-in-out background;
+	&:hover {
+		background: #dde1f080;
+	}
 	min-width: 0;
 	word-break: break-word;
 	.event-card--actions {

--- a/lib/ui-components/Event/MessageContainer.jsx
+++ b/lib/ui-components/Event/MessageContainer.jsx
@@ -44,7 +44,11 @@ const MessageContainer = styled(Box) `
 		card, actor, theme, editing
 	}) => {
 		if (editing) {
-			return `
+			return (card.type === 'whisper' || card.type === 'whisper@1.0.0') ? `
+				border: solid 0.5px ${theme.colors.tertiary.light};
+				background: #2E587ADD;
+				color: white;
+			` : `
 				border: solid 0.5px ${theme.colors.gray.main};
 				background: ${theme.colors.gray.light};
 				color: ${theme.colors.text.main};

--- a/lib/ui-components/Event/MessageContainer.jsx
+++ b/lib/ui-components/Event/MessageContainer.jsx
@@ -54,7 +54,7 @@ const MessageContainer = styled(Box) `
 			return `
 				background: ${theme.colors.secondary.main};
 				color: white;
-
+				border: solid 0.5px ${theme.colors.tertiary.main};
 				blockquote {
 					color: lightgray;
 				}
@@ -92,6 +92,7 @@ const MessageContainer = styled(Box) `
 			? `
 				border-bottom-right-radius: 0;
 				border-bottom-left-radius: 0;
+				border-bottom-color: transparent;
 			` : ''
 	}
 }}

--- a/lib/ui-components/Event/tests/EventHeader.spec.jsx
+++ b/lib/ui-components/Event/tests/EventHeader.spec.jsx
@@ -4,17 +4,21 @@
  * Proprietary and confidential.
  */
 
-import '../../../../test/ui-setup'
+import {
+	getWrapper
+} from '../../../../test/ui-setup'
 import ava from 'ava'
 import sinon from 'sinon'
 import {
-	shallow
+	mount
 } from 'enzyme'
 import React from 'react'
 import EventHeader from '../EventHeader'
 import {
 	card
 } from './fixtures'
+
+const wrappingComponent = getWrapper().wrapper
 
 const sandbox = sinon.createSandbox()
 
@@ -37,57 +41,63 @@ ava.afterEach(() => {
 	sandbox.restore()
 })
 
-ava('\'updating...\' is displayed if card is updating', (test) => {
+ava('\'updating...\' is displayed if card is updating', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const eventHeader = shallow(
+	const eventHeader = await mount((
 		<EventHeader
 			{...commonProps}
 			updating
 		/>
-	)
-	const status = eventHeader.find('[data-test="event-header__status"]')
-	test.is(status.props().children[0], 'updating...')
+	), {
+		wrappingComponent
+	})
+	const status = eventHeader.find('Txt[data-test="event-header__status"]')
+	test.is(status.text(), 'updating...')
 })
 
-ava('\'Edit Message\' is not available if the user did not write the message', (test) => {
+ava('\'Edit Message\' is not available if the user did not write the message', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const eventHeader = shallow(
+	const eventHeader = await mount((
 		<EventHeader
 			{...commonProps}
 		/>
-	)
+	), {
+		wrappingComponent
+	})
 
-	const trigger = eventHeader.find('[data-test="event-header__context-menu-trigger"]')
+	const trigger = eventHeader.find('button[data-test="event-header__context-menu-trigger"]')
 	trigger.simulate('click')
 	eventHeader.update()
 
 	// The 'Copy JSON' link is now shown but the 'Edit Message' link is not
-	test.truthy(eventHeader.find('[data-test="event-header__link--copy-json"]').length)
-	test.falsy(eventHeader.find('[data-test="event-header__link--edit-message"]').length)
+	test.truthy(eventHeader.find('a[data-test="event-header__link--copy-json"]').length)
+	test.falsy(eventHeader.find('a[data-test="event-header__link--edit-message"]').length)
 })
 
-ava('Clicking \'Edit Message\' calls the onEditMessage prop callback', (test) => {
+ava('Clicking \'Edit Message\' calls the onEditMessage prop callback', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const eventHeader = shallow(
+	const eventHeader = await mount((
 		<EventHeader
 			{...commonProps}
 			user={{
 				id: card.data.actor
 			}}
 		/>
-	)
+	), {
+		wrappingComponent
+	})
 
-	const trigger = eventHeader.find('[data-test="event-header__context-menu-trigger"]')
+	const trigger = eventHeader.find('button[data-test="event-header__context-menu-trigger"]')
 	trigger.simulate('click')
 	eventHeader.update()
 
 	test.is(commonProps.onEditMessage.callCount, 0)
-	eventHeader.find('[data-test="event-header__link--edit-message"]').simulate('click')
+	eventHeader.find('a[data-test="event-header__link--edit-message"]').simulate('click')
 	test.is(commonProps.onEditMessage.callCount, 1)
 })

--- a/lib/ui-components/MirrorIcon.jsx
+++ b/lib/ui-components/MirrorIcon.jsx
@@ -88,11 +88,8 @@ const MirrorIconWrapper = styled(Flex) `
 `
 
 export const MirrorIcon = ({
-	threadIsMirrored, mirrors
+	mirrors
 }) => {
-	if (!threadIsMirrored) {
-		return null
-	}
 	const synced = !_.isEmpty(mirrors)
 	const handler = getMirrorHandler(mirrors)
 	const displayName = handler ? handler.name : ''

--- a/lib/ui-components/MirrorIcon.spec.jsx
+++ b/lib/ui-components/MirrorIcon.spec.jsx
@@ -37,7 +37,7 @@ ava('MirrorIcon identifies mirror source in tooltip', (test) => {
 	for (const {
 		name, mirrors
 	} of mirrorTests) {
-		const mirrorIcon = shallow(<MirrorIcon threadIsMirrored mirrors={mirrors} />)
+		const mirrorIcon = shallow(<MirrorIcon mirrors={mirrors} />)
 		const wrapper = mirrorIcon.find('[data-test="mirror-icon"]')
 
 		test.is(wrapper.props().className, 'synced')
@@ -58,18 +58,8 @@ ava('ThreadMirrorIcon identifies mirror source in tooltip and displays mirror ic
 })
 
 ava('MirrorIcon indicates if the mirror is not synced', (test) => {
-	const mirrorIcon = shallow(<MirrorIcon threadIsMirrored mirrors={[]} />)
+	const mirrorIcon = shallow(<MirrorIcon mirrors={[]} />)
 	const wrapper = mirrorIcon.find('[data-test="mirror-icon"]')
 	test.is(wrapper.props().className, 'unsynced')
 	test.is(wrapper.props().tooltip, 'Not yet synced')
-})
-
-ava('MirrorIcon is hidden if thread is not mirrored', (test) => {
-	const mirrorIcon = shallow(
-		<MirrorIcon
-			threadIsMirrored={false}
-			mirrors={[ 'https://github.com/balena-io/etcher/issues/2020' ]}
-		/>
-	)
-	test.falsy(mirrorIcon.get(0))
 })

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -555,7 +555,7 @@ class Timeline extends React.Component {
 				</Flex>
 
 				<EventsContainer
-					pt={2}
+					py={2}
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
 				>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2148,9 +2148,9 @@
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.10.tgz",
-      "integrity": "sha512-UGdpJiLBIqR/8xcLrCarf2pChqQFKjDTD02C7ZS/odpOVVl2YuHYRCLEOQ0GpfOk6jtYhmouSFOFoC8qNCe5cg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz",
+      "integrity": "sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==",
       "requires": {
         "prop-types": "^15.7.2"
       }
@@ -3173,9 +3173,9 @@
       }
     },
     "@types/sanitize-html": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-1.23.0.tgz",
-      "integrity": "sha512-yl0HvhWOZWzmkGEBQLKYf+BtotvbGLFhCejuBvwyM1Q23RliLXNfviuOMLQ/nCRFWR2yI0LRRiaH/Oz7CIpCGw==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-1.23.2.tgz",
+      "integrity": "sha512-s00omSXGjemcNGXChE44grxYLPCkxdp/rdxGCb4FcGyH0aOjFOacrnP0P394Ktp+IKeBk1Q7VsGJ+cOa2GZ5hw==",
       "requires": {
         "htmlparser2": "^4.1.0"
       },
@@ -4139,7 +4139,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "autosize": {
       "version": "4.0.2",
@@ -7256,17 +7257,6 @@
       "integrity": "sha512-8vPu5bsKaq2uKRy3OL7h1Oo7RayAWB8sYexLKAqvCXVib8SxgbmoF1IN4QMKjBv8uI8mp5gPPMbiRah25GMrVQ==",
       "requires": {
         "type-fest": "^0.8.1"
-      }
-    },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
       }
     },
     "css-b64-images": {
@@ -12409,40 +12399,16 @@
       "integrity": "sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q=="
     },
     "grommet": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.13.0.tgz",
-      "integrity": "sha512-C2asZEacDjr9stnVw2XoYVezPdbLM3qxQrxdLfnfdlj1pTb/JNfwqpQZatMW5G8NU3S596juVAnTPefmMXcwyQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.14.0.tgz",
+      "integrity": "sha512-G/LTkr+uFri4NUNQGJMx8TtWWe9+KSpIHCXC9WgRaICI73R3+BvhLSNSzWMQ6YIQC+7PJFtruebeWjdUqR3Ykw==",
       "requires": {
-        "css": "^2.2.3",
         "grommet-icons": "^4.2.0",
         "hoist-non-react-statics": "^3.2.0",
-        "markdown-to-jsx": "^6.9.1",
+        "markdown-to-jsx": "^6.11.4",
         "polished": "^3.4.1",
         "prop-types": "^15.7.2",
-        "react-desc": "^4.1.2",
-        "recompose": "^0.30.0"
-      },
-      "dependencies": {
-        "recompose": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-          "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-            }
-          }
-        }
+        "react-desc": "^4.1.2"
       }
     },
     "grommet-icons": {
@@ -12712,9 +12678,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
-      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
+      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg=="
     },
     "history": {
       "version": "4.10.1",
@@ -17105,9 +17071,9 @@
       "dev": true
     },
     "polished": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.4.tgz",
-      "integrity": "sha512-21moJXCm/7EvjeKQz5w89QDDKNPCoimc83CqwZZGJluFdMXsFlMQl9lPA/OMRkoceZ19kU0anKlMgZmY7LJSJw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.5.tgz",
+      "integrity": "sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       },
@@ -18466,9 +18432,9 @@
       }
     },
     "rendition": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-15.0.0.tgz",
-      "integrity": "sha512-fVJLfuo4ontLeLJna+gOQDpMcMUtZE61YQSo4OoYxSgQc2Vv6nU8ePKdWhO8AS4vHXXWVJkckjE0TB9YrtGhJA==",
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-15.1.4.tgz",
+      "integrity": "sha512-p0oeSS+K7+vt6Va38A7b7ENpb4Wu98FQjOrTfF9hT/eOu3O6/yY/6wFu/hKScGYwktSGQ0lniI6meSfFnAPs2Q==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.25",
         "@fortawesome/free-regular-svg-icons": "^5.11.2",
@@ -18493,7 +18459,7 @@
         "color": "^3.1.2",
         "color-hash": "^1.0.3",
         "copy-to-clipboard": "^3.0.8",
-        "grommet": "^2.13.0",
+        "grommet": "^2.14.0",
         "highlight.js": "^10.0.3",
         "jellyschema": "^0.11.9",
         "lodash": "^4.17.11",
@@ -18516,9 +18482,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.10.tgz",
-          "integrity": "sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q=="
+          "version": "13.13.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+          "integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw=="
         },
         "marked": {
           "version": "0.8.2",
@@ -18680,7 +18646,8 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
     },
     "response-time": {
       "version": "2.3.2",
@@ -19544,7 +19511,7 @@
       "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "smooth-dnd": {
-      "version": "git+https://github.com/rcdexta/smooth-dnd.git#f13924c67bf6ffe4613d97bb1ee83f11d364eb1e",
+      "version": "git+https://github.com/rcdexta/smooth-dnd.git#223f4672bea94f65b98af4fd28ab0db2c3b9c8a2",
       "from": "git+https://github.com/rcdexta/smooth-dnd.git"
     },
     "snake-case": {
@@ -19917,6 +19884,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -19937,7 +19905,8 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "sourcemap-codec": {
       "version": "1.4.8",
@@ -21657,7 +21626,8 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "redux": "^4.0.5",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.2.0",
-    "rendition": "^15.0.0",
+    "rendition": "^15.1.4",
     "request-promise": "^4.2.2",
     "response-time": "^2.3.2",
     "semver": "^7.3.2",


### PR DESCRIPTION
This PR focuses on reducing wasted vertical space by refactoring some of the `EventHeader` into a new `EventContext` component that is displayed when you hover over the event. 

The following event meta info is included in the `EventContext` panel that displays when you hover over an event:
* Updating/sending indication
* Timestamp
* Mirror sync icon
* Context menu button

![Event context](https://user-images.githubusercontent.com/2925657/84878051-7e21cb80-b0b3-11ea-9a9c-ff010e5a6f59.gif)

_Note: this change might fix [the OSX scrollbar issue](https://github.com/product-os/jellyfish/issues/4070)._

---

Along the way I've also fixed a number of small issues relating to messages (`Event` component) in the UI that would be tedious to do in their own PRs:
* Markdown formatting is fixed (by updating to the latest Rendition version which contains [the appropriate fix](https://github.com/balena-io-modules/rendition/pull/1135))
<a href="https://user-images.githubusercontent.com/2925657/84876904-0010f500-b0b2-11ea-98b9-351d38dac2bd.png" target="_blank"><img width="500" src="https://user-images.githubusercontent.com/2925657/84876904-0010f500-b0b2-11ea-98b9-351d38dac2bd.png"></a>

* #4106 better styling of message background and 'open thread' icon when hovering over the message.
![Event hover](https://user-images.githubusercontent.com/2925657/84877389-a230dd00-b0b2-11ea-9dd1-2b42b0950464.gif)

* #4067 Don't allow user save an empty edited message
![Empty message](https://user-images.githubusercontent.com/2925657/84877896-44e95b80-b0b3-11ea-888c-4d2690376b2c.gif)

* Don't show focused button outline or pointer cursor on the 'button' on the left side of the `Event` if it doesn't do anything (e.g. if it won't open a channel).
