### PR TITLE
More searchable fields

### DIFF
--- a/apps/server/default-cards/contrib/faq.json
+++ b/apps/server/default-cards/contrib/faq.json
@@ -12,17 +12,20 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "fullTextSearch": true
         },
         "data": {
           "type": "object",
           "properties": {
             "topic": {
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             },
             "answer": {
               "type": "string",
-              "format": "markdown"
+              "format": "markdown",
+              "fullTextSearch": true
             }
           }
         }

--- a/apps/server/default-cards/contrib/support-issue.json
+++ b/apps/server/default-cards/contrib/support-issue.json
@@ -12,7 +12,8 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "fullTextSearch": true
         },
         "tags": {
           "type": "array",
@@ -67,7 +68,8 @@
             },
             "category": {
               "title": "Category",
-              "type": "string"
+              "type": "string",
+              "fullTextSearch": true
             },
             "shareable": {
               "title": "Shareable",
@@ -76,11 +78,13 @@
             },
             "Problem": {
               "type": "string",
-              "format": "markdown"
+              "format": "markdown",
+              "fullTextSearch": true
             },
             "Solution": {
               "type": "string",
-              "format": "markdown"
+              "format": "markdown",
+              "fullTextSearch": true
             }
           }
         }

--- a/apps/server/default-cards/contrib/support-issue.json
+++ b/apps/server/default-cards/contrib/support-issue.json
@@ -93,9 +93,6 @@
         "name"
       ]
     },
-    "slices": [
-      "properties.data.properties.severity"
-    ],
     "fieldOrder": [
       "name",
       "tags",


### PR DESCRIPTION
### Add full text search fields to support issues

### Add full text search fields to FAQ card type

### Remove "slices" definition from support issues

The current implementation of the "slices" functionality impedes the
usefulness of the support issues, as it preselects high severity issues,
which is not what is wanted by support agents. The "slices" concept most
likely needs to be rethought, but for the time being, removing the
annotation from the support issue card type will provide a good
quality-of-life improvement for support agents looking through support
issues.