### PR TITLE
Format group mentions in message body

### DIFF
--- a/apps/ui/components/Inbox/InboxTab.jsx
+++ b/apps/ui/components/Inbox/InboxTab.jsx
@@ -5,6 +5,7 @@
  */
 
 import * as Bluebird from 'bluebird'
+import _ from 'lodash'
 import React, {
 	useCallback,
 	useEffect,
@@ -57,6 +58,8 @@ const DebouncedSearch = (props) => {
 export default (props) => {
 	const user = useSelector(selectors.getCurrentUser)
 
+	const groups = useSelector(selectors.getGroups)
+
 	// State controller for managing canonical data from the API
 	const [ results, setResults ] = useState([])
 
@@ -88,7 +91,7 @@ export default (props) => {
 		setIsMarkingAllAsRead(true)
 
 		await Bluebird.map(results, (card) => {
-			return sdk.card.markAsRead(user.slug, card)
+			return sdk.card.markAsRead(user.slug, card, _.map(_.filter(groups, 'isMine'), 'name'))
 		}, {
 			concurrency: 10
 		})

--- a/apps/ui/components/Inbox/MessageList.jsx
+++ b/apps/ui/components/Inbox/MessageList.jsx
@@ -64,7 +64,7 @@ class MessageList extends React.Component {
 			id
 		})
 
-		sdk.card.markAsRead(this.props.user.slug, card)
+		sdk.card.markAsRead(this.props.user.slug, card, _.map(_.filter(this.props.groups, 'isMine'), 'name'))
 			.catch((error) => {
 				console.error(error)
 			})

--- a/apps/ui/components/Inbox/MessageList.jsx
+++ b/apps/ui/components/Inbox/MessageList.jsx
@@ -138,6 +138,7 @@ class MessageList extends React.Component {
 							<Box key={card.id}>
 								<Event
 									user={this.props.user}
+									groups={this.props.groups}
 									openChannel={this.openChannel}
 									card={card}
 									selectCard={selectors.getCard}
@@ -171,6 +172,7 @@ class MessageList extends React.Component {
 
 const mapStateToProps = (state) => {
 	return {
+		groups: selectors.getGroups(state),
 		user: selectors.getCurrentUser(state)
 	}
 }

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -470,6 +470,7 @@ class SupportThreadBase extends React.Component {
 												key={statusEvent.id}
 												card={statusEvent}
 												user={this.props.user}
+												groups={this.props.groups}
 												selectCard={selectors.getCard}
 												getCard={this.props.actions.getCard}
 												actions={eventActions}
@@ -525,6 +526,7 @@ const mapStateToProps = (state) => {
 	return {
 		accounts: selectors.getAccounts(state),
 		types: selectors.getTypes(state),
+		groups: selectors.getGroups(state),
 		user: selectors.getCurrentUser(state)
 	}
 }

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -279,6 +279,7 @@ export class Interleaved extends BaseLens {
 									onCardVisible={this.handleCardVisible}
 									openChannel={this.openChannel}
 									user={this.props.user}
+									groups={this.props.groups}
 									card={card}
 									firstInThread={isFirstInThread(card, firstMessagesByThreads)}
 									selectCard={selectors.getCard}
@@ -317,6 +318,7 @@ export class Interleaved extends BaseLens {
 
 const mapStateToProps = (state) => {
 	return {
+		groups: selectors.getGroups(state),
 		user: selectors.getCurrentUser(state)
 	}
 }

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -202,7 +202,7 @@ export class Interleaved extends BaseLens {
 	}
 
 	handleCardVisible (card) {
-		sdk.card.markAsRead(this.props.user.slug, card)
+		sdk.card.markAsRead(this.props.user.slug, card, _.map(_.filter(this.props.groups, 'isMine'), 'name'))
 			.catch((error) => {
 				console.error(error)
 			})

--- a/apps/ui/lens/list/Timeline.jsx
+++ b/apps/ui/lens/list/Timeline.jsx
@@ -35,6 +35,7 @@ const mapStateToProps = (state, ownProps) => {
 		enableAutocomplete: !environment.isTest(),
 		sdk,
 		types: selectors.getTypes(state),
+		groups: selectors.getGroups(state),
 		user: selectors.getCurrentUser(state),
 		usersTyping: selectors.getUsersTypingOnCard(state, card.id),
 		timelineMessage: selectors.getTimelineMessage(state, card.id)

--- a/lib/chat-widget/routes/ChatRoute.jsx
+++ b/lib/chat-widget/routes/ChatRoute.jsx
@@ -91,6 +91,9 @@ export const ChatRoute = () => {
 								enableAutocomplete={!environment.isTest()}
 								sdk={sdk}
 								types={types}
+
+								// TODO: #4229 add support for correctly identifying and formatting group mentions in the chat widget
+								groups={null}
 								wide={false}
 								allowWhispers={false}
 								card={thread}

--- a/lib/ui-components/Event/EventWrapper.jsx
+++ b/lib/ui-components/Event/EventWrapper.jsx
@@ -40,6 +40,13 @@ const EventWrapper = styled(Flex) `
     right: -4px;
     font-size: 10px;
 	}
+	.rendition-tag--read-by:after {
+		content: attr(data-read-by-count);
+		position: absolute;
+    top: -4px;
+    right: -4px;
+    font-size: 10px;
+	}
 `
 
 export default EventWrapper

--- a/lib/ui-components/Event/MessageContainer.jsx
+++ b/lib/ui-components/Event/MessageContainer.jsx
@@ -21,11 +21,16 @@ const MessageContainer = styled(Box) `
 	.rendition-tag--personal {
 		background: #FFF1C2;
 		color: #333;
-		&.rendition-tag--read:after {
+		&.rendition-tag--read:after,
+		&.rendition-tag--read-by:after {
 			background: #FFC19B;
-			border-radius: 5px;
+			width: 1.5em;
+			height: 1.5em;
+			border-radius: 50%;
+			line-height: 1.5em;
+			vertical-align: middle;
+			text-align: center;
 			font-size: 8px;
-			padding: 2px;
 		}
 	}
 	img {

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -413,6 +413,7 @@ class Timeline extends React.Component {
 			addNotification,
 			sdk,
 			types,
+			groups,
 			allowWhispers,
 			tail,
 			usersTyping,
@@ -464,6 +465,7 @@ class Timeline extends React.Component {
 
 		const eventProps = {
 			types,
+			groups,
 			enableAutocomplete,
 			sendCommand,
 			onCardVisible: this.handleCardVisible,

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -317,7 +317,7 @@ class Timeline extends React.Component {
 	}
 
 	handleCardVisible (card) {
-		this.props.sdk.card.markAsRead(this.props.user.slug, card)
+		this.props.sdk.card.markAsRead(this.props.user.slug, card, _.map(_.filter(this.props.groups, 'isMine'), 'name'))
 			.catch((error) => {
 				console.error(error)
 			})

--- a/package-lock.json
+++ b/package-lock.json
@@ -3963,9 +3963,9 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-0.5.0.tgz",
-      "integrity": "sha512-p8Ufc1qZeVXHD+d5k4d6eaIiA8KnDN+oRerhlXEEv3zzl+ux31DMpSogDZI8FaTwP09yBsvnfjRQ7nqcpZInSg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-1.1.0.tgz",
+      "integrity": "sha512-CvkZ1+YD1mGx/YBmgOjLCxxwvAJ1E7t/hZjWv4Q6ChZizzUgt4x/ozoqtyr3FpVaY740WqVug1aXue8p3/+wpA==",
       "requires": {
         "axios": "^0.19.2",
         "bluebird": "^3.7.2",
@@ -3978,11 +3978,6 @@
         "uuid": "^7.0.2"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-        },
         "fast-json-patch": {
           "version": "3.0.0-1",
           "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.10.1",
-    "@balena/jellyfish-client-sdk": "^0.5.0",
+    "@balena/jellyfish-client-sdk": "^1.1.0",
     "@balena/node-metrics-gatherer": "^5.7.0",
     "@octokit/auth-app": "^2.4.7",
     "@octokit/plugin-retry": "^3.0.3",


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

When a message mentions or alerts a group, this is now identified in the rendering of the message text. See screenshot below:
![image](https://user-images.githubusercontent.com/2925657/85105152-252d7100-b234-11ea-88c7-9ba9dbaec696.png)

Note that we also display a count of the number of users in the group who have read the message (aside from the message author, who is never included in the `readBy`).
