### PR TITLE
Correctly handle Front API rate limiting errors in try...catch blocks

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -619,7 +619,7 @@ const getThread = async (context, front, event, inbox, threadType) => {
 
 const handleRateLimit = async (context, fn, times = 100) => {
 	try {
-		return fn()
+		return await fn()
 	} catch (error) {
 		if (error.name === 'FrontError' && error.status === 429 && times > 0) {
 			// The error message suggest how many milliseconds to retry,

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -31,7 +31,7 @@ const retryWhile404 = async (fn, times = 5) => {
 
 const retryWhile429 = async (fn, times = 100) => {
 	try {
-		return fn()
+		return await fn()
 	} catch (error) {
 		if (error.name === 'FrontError' && error.status === 429 && times > 0) {
 			const delay = _.parseInt(_.first(error.message.match(/(\d+)/))) || 2000


### PR DESCRIPTION
Previously, because the API call was not awaited, the promis would be
returned immediately and any resulting error would not be caught in
a try catch block.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
