### PR TITLE
metrics: add queue concurrency metric & label by worker id

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -198,6 +198,7 @@ const bootstrap = async (context, library, options) => {
 
 exports.worker = async (context, options) => {
 	metrics.startServer(context, options.metricsPort)
+	metrics.markQueueConcurrency()
 	return bootstrap(context, actionLibrary, {
 		enablePriorityBuffer: true,
 		onError: options.onError,

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -22,6 +22,7 @@ const metricNames = {
 	MIRROR_FAILURE_TOTAL: 'jf_mirror_failure_total',
 	WORKER_SATURATION: 'jf_worker_saturation',
 	WORKER_JOB_DURATION: 'jf_worker_job_duration_ms',
+	WORKER_CONCURRENCY: 'jf_worker_concurrency',
 	WORKER_ACTION_REQUEST_TOTAL: 'jf_worker_action_request_total',
 	BACK_SYNC_CARD_TOTAL: 'jf_back_sync_total',
 	TRANSLATE_TOTAL: 'jf_translate_total',
@@ -281,17 +282,30 @@ exports.markActionRequest = (action) => {
 }
 
 /**
+ * @summary Expose current queue concurrency setting
+ * @function
+ *
+ * @example
+ * metrics.markQueueConcurrency()
+ */
+exports.markQueueConcurrency = () => {
+	metrics.gauge(metricNames.WORKER_CONCURRENCY, environment.queue.concurrency)
+}
+
+/**
  * @summary Mark that a new job was added to the queue
  * @function
  *
  * @param {String} action - action name
+ * @param {String} id - id of the worker
  *
  * @example
- * metrics.markJobAdd('action-create-card')
+ * metrics.markJobAdd('action-create-card', context.id)
  */
-exports.markJobAdd = (action) => {
+exports.markJobAdd = (action, id) => {
 	metrics.inc(metricNames.WORKER_SATURATION, 1, {
-		type: action
+		type: action,
+		worker: id
 	})
 }
 
@@ -300,16 +314,18 @@ exports.markJobAdd = (action) => {
  * @function
  *
  * @param {String} action - action name
+ * @param {String} id - id of the worker
  * @param {String} timestamp - when action was completed
  *
  * @example
  * const action = 'action-create-card'
  * const timestamp = '2020-06-08T09:33:27.481Z'
- * metrics.markJobDone(action, timestamp)
+ * metrics.markJobDone(action, context.id, timestamp)
  */
-exports.markJobDone = (action, timestamp) => {
+exports.markJobDone = (action, id, timestamp) => {
 	const labels = {
-		type: action
+		type: action,
+		worker: id
 	}
 	const duration = new Date().getTime() - new Date(timestamp).getTime()
 	metrics.histogram(metricNames.WORKER_JOB_DURATION, duration, labels)

--- a/lib/queue/consumer.js
+++ b/lib/queue/consumer.js
@@ -77,13 +77,14 @@ module.exports = class Consumer {
 				}),
 				taskList: {
 					actionRequest: async (payload, helpers) => {
+						const action = payload.data.action.split('@')[0]
 						try {
 							this.messagesBeingHandled++
-							metrics.markJobAdd(payload.data.action.split('@')[0])
+							metrics.markJobAdd(action, context.id)
 							await onMessageEventHandler(payload)
 						} finally {
 							this.messagesBeingHandled--
-							metrics.markJobDone(payload.data.action.split('@')[0], payload.data.timestamp)
+							metrics.markJobDone(action, context.id, payload.data.timestamp)
 						}
 					}
 				}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: dt-rush <nickp@balena.io>

***

This PR exposes worker concurrency and unique worker IDs, both of which we will use in Prometheus to calculate when our production queues are almost completely saturated and send out an alert.
