### PR TITLE
ci: Speed up translate tests by using shared backend

### DIFF
--- a/scripts/ci/skip_tests_if_only.sh
+++ b/scripts/ci/skip_tests_if_only.sh
@@ -8,7 +8,6 @@
 
 set -e
 MODULES="$*"
-set -u
 
 if [ -z "$MODULES" ]; then
 	echo "Usage: $0 <modules...>" 1>&2
@@ -21,9 +20,15 @@ fi
 
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
+# Check if specified file, if set, is in the list of modified files
+MODIFIED_FILES="$(git diff --name-only master..."$CURRENT_BRANCH")"
+if [[ "$CHECK_FOR" && "$MODIFIED_FILES" == *"$CHECK_FOR"* ]]; then
+	exit 1
+fi
+
 # A list of the affected modules from lib/ and apps/
 # that the current branch is modifying
-AFFECTED_MODULES="$(git diff --name-only master..."$CURRENT_BRANCH" \
+AFFECTED_MODULES="$(echo "$MODIFIED_FILES" \
 	| grep -E "^(lib|apps)" \
 	| cut -d / -f 2 \
 	| sort \

--- a/scripts/ci/tests/translate.spec.sh
+++ b/scripts/ci/tests/translate.spec.sh
@@ -10,17 +10,17 @@ set -e
 source "$(dirname $0)/helpers.sh"
 
 # Run Outreach translate tests.
-./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+CHECK_FOR=outreach-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
 	run_test "Outreach Translate Tests" test FILES=./test/integration/sync/outreach-translate.spec.js
 
 # Run Balena API translate tests.
-./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+CHECK_FOR=balena-api-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
 	run_test "Balena API Translate Tests" test FILES=./test/integration/sync/balena-api-translate.spec.js
 
 # Run GitHub translate tests.
-./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+CHECK_FOR=github-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
 	run_test "GitHub Translate Tests" test FILES=./test/integration/sync/github-translate.spec.js
 
 # Run Flowdock translate tests.
-./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+CHECK_FOR=flowdock-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
 	run_test "Flowdock Translate Tests" test FILES=./test/integration/sync/flowdock-translate.spec.js

--- a/test/integration/sync/balena-api-translate.spec.js
+++ b/test/integration/sync/balena-api-translate.spec.js
@@ -14,8 +14,14 @@ const uuid = require('uuid/v4')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration['balena-api']
+const helpers = require('./helpers')
 
-ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.before(async (test) => {
+	await scenario.before(test)
+	await helpers.save(test)
+})
+
+ava.serial.after.always(scenario.after)
 ava.serial.afterEach.always(scenario.afterEach)
 
 const prepareEvent = async (event) => {

--- a/test/integration/sync/discourse-translate.spec.js
+++ b/test/integration/sync/discourse-translate.spec.js
@@ -10,8 +10,14 @@ const uuid = require('uuid/v4')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.discourse
+const helpers = require('./helpers')
 
-ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.before(async (test) => {
+	await scenario.before(test)
+	await helpers.save(test)
+})
+
+ava.serial.after.always(scenario.after)
 ava.serial.afterEach.always(scenario.afterEach)
 
 ava('should not change the same user email', async (test) => {

--- a/test/integration/sync/flowdock-translate.spec.js
+++ b/test/integration/sync/flowdock-translate.spec.js
@@ -8,8 +8,14 @@ const ava = require('ava')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.flowdock
+const helpers = require('./helpers')
 
-ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.before(async (test) => {
+	await scenario.before(test)
+	await helpers.save(test)
+})
+
+ava.serial.after.always(scenario.after)
 ava.serial.afterEach.always(scenario.afterEach)
 
 scenario.run(ava, {

--- a/test/integration/sync/front-translate.spec.js
+++ b/test/integration/sync/front-translate.spec.js
@@ -9,8 +9,14 @@ const _ = require('lodash')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.front
+const helpers = require('./helpers')
 
-ava.serial.beforeEach(scenario.beforeEach)
+ava.serial.before(async (test) => {
+	await scenario.before(test)
+	await helpers.save(test)
+})
+
+ava.serial.after.always(scenario.after)
 ava.serial.afterEach.always(scenario.afterEach)
 
 scenario.run(ava, {

--- a/test/integration/sync/github-translate.spec.js
+++ b/test/integration/sync/github-translate.spec.js
@@ -10,10 +10,13 @@ const jwt = require('jsonwebtoken')
 const scenario = require('./scenario')
 const environment = require('../../../lib/environment')
 const TOKEN = environment.integration.github
+const helpers = require('./helpers')
 
+ava.serial.before(async (test) => {
+	await scenario.before(test)
+	await helpers.save(test)
+})
 ava.serial.beforeEach(async (test) => {
-	await scenario.beforeEach(test)
-
 	if (TOKEN.api && TOKEN.key) {
 		await nock('https://api.github.com')
 			.persist()
@@ -44,6 +47,7 @@ ava.serial.beforeEach(async (test) => {
 	}
 })
 
+ava.serial.after.always(scenario.after)
 ava.serial.afterEach.always(scenario.afterEach)
 
 scenario.run(ava, {

--- a/test/integration/sync/helpers.js
+++ b/test/integration/sync/helpers.js
@@ -19,5 +19,13 @@ module.exports = {
 	},
 	afterEach: async (test) => {
 		await helpers.worker.after(test)
+	},
+	save: async (test) => {
+		await test.context.jellyfish.backend.connection.any('CREATE TABLE cards_copy AS TABLE cards')
+	},
+	restore: async (test) => {
+		await test.context.jellyfish.backend.connection.any('DELETE FROM links')
+		await test.context.jellyfish.backend.connection.any('DELETE FROM cards')
+		await test.context.jellyfish.backend.connection.any('INSERT INTO cards SELECT * FROM cards_copy')
 	}
 }

--- a/test/integration/sync/pipeline.spec.js
+++ b/test/integration/sync/pipeline.spec.js
@@ -6,14 +6,20 @@
 
 const ava = require('ava')
 const _ = require('lodash')
-const helpers = require('./helpers')
 const typedErrors = require('typed-errors')
 const pipeline = require('../../../lib/sync/pipeline')
 const errors = require('../../../lib/sync/errors')
 const NoOpIntegration = require('./noop-integration')
+const scenario = require('./scenario')
+const helpers = require('./helpers')
 
-ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.before(async (test) => {
+	await scenario.before(test)
+	await helpers.save(test)
+})
+
+ava.serial.after.always(scenario.after)
+ava.serial.afterEach.always(scenario.afterEach)
 
 ava('.importCards() should import no card', async (test) => {
 	const result = await pipeline.importCards(test.context.syncContext, [])

--- a/test/integration/sync/scenario.js
+++ b/test/integration/sync/scenario.js
@@ -11,6 +11,7 @@ const uuid = require('uuid/v4')
 const path = require('path')
 const _ = require('lodash')
 const syncHelpers = require('../../integration/sync/helpers')
+const helpers = require('./helpers')
 
 const TRANSLATE_PREFIX = uuid()
 
@@ -336,7 +337,7 @@ const getObjDifference = (expected, obtained) => {
 }
 
 module.exports = {
-	beforeEach: async (test) => {
+	before: async (test) => {
 		await syncHelpers.beforeEach(test, {
 			suffix: TRANSLATE_PREFIX
 		})
@@ -367,10 +368,12 @@ module.exports = {
 		nock.cleanAll()
 		nock.disableNetConnect()
 	},
-	afterEach: async (test) => {
+	after: async (test) => {
 		await syncHelpers.afterEach(test)
-
+	},
+	afterEach: async (test) => {
 		nock.cleanAll()
+		await helpers.restore(test)
 	},
 
 	run: async (ava, suite) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- speeds up translate tests
- modifies the skip check script to look for specified file using the `CHECK_FOR` env var

Translate tests are sped up by using a shared backend instance + db for each set of tests instead of creating a new instance + db for each individual test. This works by creating a copy of the initial data in the db after backend initialization is complete and before any tests are ran. Then, this data set is restored after each test. This allows us to emulate a new instance + db for a fraction of the cost and not have to modify test logic/cases.

The ideal situation would be to run all tests in parallel against a shared backend, but this is at least a step in the right direction that provides big returns with small changes. Here are the speed boosts found on my local machine:

### Front
- Before: 08:19:00-09:12:11 => ~53m
- After:  16:43:58-17:04:24 => ~21m

### Discourse
- Before: 14:08:20-14:59:52 => ~51m
- After:  16:21:10-16:42:43 => ~21m

### GitHub
- Before: 17:34:26-17:35:14 => 48s
- After:  17:33:29-17:33:51 => 22s

### Flowdock
- Before: 05:37:24-05:37:52 => 28s
- After:  05:39:57-05:40:08 => 11s

### Pipeline
- Before: 05:48:41-05:48:54 => 13s
- After:  05:52:02-05:52:07 => 7s

### Balena API
- Before: 05:45:39-05:46:19 => 40s
- After:  05:47:22-05:47:37 => 15s

### Outreach
- Before: 09:17:37-09:18:26 => 49s
- After:  09:15:43-09:15:59 => 16s