### PR TITLE
Use common styling for all events container elements

### DIFF
--- a/apps/ui/components/Inbox/MessageList.jsx
+++ b/apps/ui/components/Inbox/MessageList.jsx
@@ -32,6 +32,7 @@ import Event from '../../../../lib/ui-components/Event'
 import {
 	withDefaultGetActorHref
 } from '../../../../lib/ui-components/HOC/with-default-get-actor-href'
+import EventsContainer from '../../../../lib/ui-components/EventsContainer'
 
 class MessageList extends React.Component {
 	constructor (props) {
@@ -127,16 +128,10 @@ class MessageList extends React.Component {
 					position: 'relative'
 				}}
 			>
-				<Box
-					py={2}
+				<EventsContainer
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
 					data-test={'messageList-ListWrapper'}
-					style={{
-						flex: 1,
-						overflowY: 'auto',
-						borderTop: '1px solid #eee'
-					}}
 				>
 					{(Boolean(tail) && tail.length > 0) && _.map(tail, (card) => {
 						return (
@@ -168,7 +163,7 @@ class MessageList extends React.Component {
 							</Box>
 						)
 					})}
-				</Box>
+				</EventsContainer>
 			</Column>
 		)
 	}

--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -38,6 +38,7 @@ import Icon from '../../../../lib/ui-components/shame/Icon'
 import {
 	withDefaultGetActorHref
 } from '../../../../lib/ui-components/HOC/with-default-get-actor-href'
+import EventsContainer from '../../../../lib/ui-components/EventsContainer'
 import BaseLens from '../common/BaseLens'
 
 const NONE_MESSAGE_TIMELINE_TYPES = [
@@ -256,15 +257,9 @@ export class Interleaved extends BaseLens {
 				}}
 			>
 				<ReactResizeObserver onResize={this.scrollToBottom}/>
-				<Box
-					py={2}
+				<EventsContainer
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
-					style={{
-						flex: 1,
-						overflowY: 'auto',
-						borderTop: '1px solid #eee'
-					}}
 				>
 					{this.props.totalPages > this.props.page + 1 && (
 						<Box p={3}>
@@ -294,7 +289,7 @@ export class Interleaved extends BaseLens {
 							</Box>
 						)
 					})}
-				</Box>
+				</EventsContainer>
 
 				{head && head.slug !== 'view-my-alerts' && head.slug !== 'view-my-mentions' && (
 					<Flex

--- a/lib/ui-components/EventsContainer.jsx
+++ b/lib/ui-components/EventsContainer.jsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import styled from 'styled-components'
+import {
+	Box
+} from 'rendition'
+import {
+	px
+} from './services/helpers'
+
+export default styled(Box) `
+	padding: ${(props) => { return px(props.theme.space[2]) }} 0;
+	flex: 1;
+	overflow-y: auto;
+	border-top: 1px solid ${(props) => { return props.theme.colors.border }};
+	background-color: ${(props) => { return props.theme.colors.quartenary.light }};
+`

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -40,6 +40,7 @@ import MessageInput from './MessageInput'
 import {
 	withSetup
 } from '../SetupProvider'
+import EventsContainer from '../EventsContainer'
 
 const messageSymbolRE = /^\s*%\s*/
 
@@ -61,13 +62,6 @@ const TypingNotice = styled.div `
 		padding: 0 5px;
 		box-shadow: rgba(0,0,0,0.25) 0px 0px 3px;
 	}
-`
-
-const EventsContainer = styled(Box) `
-	flex: 1;
-	overflow-y: auto;
-	border-top: 1px solid #eee;
-	background-color: ${(props) => { return props.theme.colors.quartenary.light }}
 `
 
 const getSendCommand = (user) => {
@@ -557,7 +551,6 @@ class Timeline extends React.Component {
 				</Flex>
 
 				<EventsContainer
-					py={2}
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
 				>


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

A simple PR to use a common component for the various places that contain a list of `Event` components.

Note: As part of this refactor, a non-white background is used for the events container. This is the same background color already used within the `Timeline` component. It makes the messages stand-out a bit and makes our UI _slightly_ less WHITE!
