### PR TITLE
Exclude messages in inactive threads in repository lens

### DIFF
--- a/apps/ui/lens/index.js
+++ b/apps/ui/lens/index.js
@@ -113,8 +113,12 @@ export const getContextualThreadsQuery = (id) => {
 					}
 				},
 				type: 'object',
-				required: [ 'type' ],
+				required: [ 'type', 'active' ],
 				properties: {
+					active: {
+						type: 'boolean',
+						const: true
+					},
 					type: {
 						type: 'string',
 						const: 'thread@1.0.0'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes: #4141 

TBD: cc @Ereski @LucianBuzzo have we broken something in the backend? I would have thought that you shouldn't have to specify `active: true` on `$$links`. (I'm assuming we'll fix the issue in the backend and throw away this PR. But I've created it to demonstrate the problem if nothing else!)
