### PR TITLE
Set Dependabot config to live updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,8 +5,3 @@ update_configs:
     update_schedule: "live"
     commit_message:
       prefix: "patch"
-    automerged_updates:
-          # Automerge any @balena/ prefixed dependency that is a minor or patch update
-          - match:
-              dependency_name: "@balena/*"
-              update_type: "semver:minor"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "live"
     commit_message:
       prefix: "patch"
     automerged_updates:


### PR DESCRIPTION
This PR does two things:

1. It updates the Dependabot config for live updates. After Dependabot has worked through the initial updates, it will send bump PRs as soon as the dependency gets updated.

2. Remove the auto-merge settings for balena repos. Because Dependabot PRs still require approval we can use Versionbot instead still behavior.