### PR TITLE
Fix codepath where private data could be leaked in an error message.

### DIFF
--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -457,6 +457,11 @@ module.exports = class Kernel {
 		} catch (error) {
 			if (error instanceof errors.JellyfishSchemaMismatch) {
 				error.expected = true
+
+				// Because the "full" unrestricted card is being validated there is
+				// potential for an error message to leak private data. To prevent this,
+				// override the detailed error message with a generic one.
+				error.message = 'The updated card is invalid'
 			}
 
 			throw error


### PR DESCRIPTION
Fixes #4144

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
