### PR TITLE
Use queries to paginate timeline

### DIFF
--- a/apps/ui/core/store/actioncreators/index.js
+++ b/apps/ui/core/store/actioncreators/index.js
@@ -526,7 +526,23 @@ export default class ActionCreator {
 				}
 
 				return this.sdk.card.getWithTimeline(target, {
-					type: cardType
+					schema: {
+						type: 'object',
+						properties: {
+							type: {
+								const: cardType
+							}
+						}
+					},
+					queryOptions: {
+						links: {
+							'has attached element': {
+								limit: 20,
+								sortBy: 'created_at',
+								sortDir: 'desc'
+							}
+						}
+					}
 				})
 					.then((result) => {
 						if (!result) {

--- a/apps/ui/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lens/full/SingleCard/SingleCard.jsx
@@ -26,10 +26,12 @@ import {
 } from '../../../../../lib/ui-components/services/helpers'
 
 const SingleCardTabs = styled(Tabs) `
-	flex: 1
-
+	flex: 1;
+	> [ role="tablist"]{
+	  height: 100%;
+	}
 	> [role="tabpanel"] {
-		flex: 1
+		flex: 1;
 	}
 `
 

--- a/lib/ui-components/InfiniteList.jsx
+++ b/lib/ui-components/InfiniteList.jsx
@@ -15,7 +15,6 @@ const ScrollArea = styled(Box) `
     height: 100%;
 `
 
-// ToDo: implement inverted list
 export class InfiniteList extends React.Component {
 	constructor (props, context) {
 		super(props, context)
@@ -23,37 +22,96 @@ export class InfiniteList extends React.Component {
 		this.processing = false
 		this.handleRef = this.handleRef.bind(this)
 		this.handleScroll = this.handleScroll.bind(this)
+		this.queryForMoreIfNecessary = this.queryForMoreIfNecessary.bind(this)
 	}
 
-	handleRef (scrollArea) {
-		this.scrollArea = scrollArea
+	componentDidMount () {
+		const {
+			fillMaxArea
+		} = this.props
+		if (fillMaxArea) {
+			this.queryForMoreIfNecessary()
+		}
+	}
+
+	componentDidUpdate () {
+		const {
+			fillMaxArea
+		} = this.props
+		if (fillMaxArea) {
+			this.queryForMoreIfNecessary()
+		}
+	}
+
+	queryForMoreIfNecessary () {
+		const {
+			onScrollBeginning,
+			onScrollEnding
+		} = this.props
+		const {
+			clientHeight,
+			scrollHeight
+		} = this.scrollArea
+		const noScrollBar = clientHeight === scrollHeight
+		if (noScrollBar) {
+			if (onScrollBeginning) {
+				onScrollBeginning()
+			}
+			if (onScrollEnding) {
+				onScrollEnding()
+			}
+		}
 	}
 
 	async handleScroll () {
-		if (this.processing ||
-            this.props.processing) {
+		const {
+			processing,
+			onScrollBeginning,
+			onScrollEnding,
+			triggerOffset
+		} = this.props
+		if (this.processing || processing) {
+			return
+		}
+		const {
+			scrollTop,
+			scrollHeight,
+			offsetHeight
+		} = this.scrollArea
+
+		if (scrollTop < triggerOffset && onScrollBeginning) {
+			this.processing = true
+			await onScrollBeginning()
+			this.processing = false
+		}
+
+		const scrollOffset = scrollHeight - (scrollTop + offsetHeight)
+
+		if (scrollOffset > triggerOffset) {
 			return
 		}
 
-		const scrollOffset = this.scrollArea.scrollHeight - (this.scrollArea.scrollTop + this.scrollArea.offsetHeight)
-
-		if (scrollOffset > this.props.triggerOffset) {
-			return
+		if (onScrollEnding) {
+			this.processing = true
+			await onScrollEnding()
+			this.processing = false
 		}
+	}
 
-		this.processing = true
-		await this.props.onScrollEnding()
-		this.processing = false
+	handleRef (ref) {
+		this.scrollArea = ref
 	}
 
 	render () {
 		const {
 			onScrollEnding,
+			onScrollBeginning,
 			...rest
 		} = this.props
 
 		return (
-			<ScrollArea {...rest}
+			<ScrollArea
+				{...rest}
 				ref={this.handleRef}
 				onScroll={this.handleScroll}
 			/>

--- a/lib/ui-components/Timeline/EventsList.jsx
+++ b/lib/ui-components/Timeline/EventsList.jsx
@@ -12,11 +12,12 @@ import {
 import Icon from '../shame/Icon'
 import Update from '../Update'
 import Event from '../Event'
-
-const MESSAGE = 'message'
-const WHISPER = 'whisper'
-const UPDATE = 'update'
-const SUMMARY = 'summary'
+import {
+	MESSAGE,
+	WHISPER,
+	UPDATE,
+	SUMMARY
+} from './constants'
 
 const isNotMessage = (type) => {
 	return !_.includes([ MESSAGE, WHISPER, SUMMARY ], type)
@@ -27,20 +28,17 @@ export default class EventsList extends React.Component {
 		const {
 			getActor,
 			hideWhispers,
-			sortedTail,
+			sortedEvents,
 			uploadingFiles,
 			handleCardVisible,
 			messagesOnly,
 			user,
-			page,
-			pageSize,
 			eventMenuOptions,
 			...eventProps
 		} = this.props
-		const pagedTail = (Boolean(sortedTail) && sortedTail.length > 0)
-			? sortedTail.slice(0 - (pageSize * page)) : null
-		if (pagedTail) {
-			return _.map(pagedTail, (event, index) => {
+
+		if (sortedEvents && sortedEvents.length > 0) {
+			return _.map(sortedEvents, (event, index) => {
 				if (_.includes(uploadingFiles, event.slug)) {
 					return (
 						<Box key={event.slug} p={3}>
@@ -79,8 +77,8 @@ export default class EventsList extends React.Component {
 						key={event.id}>
 						<Event
 							{...eventProps}
-							previousEvent={pagedTail[index - 1]}
-							nextEvent={pagedTail[index + 1]}
+							previousEvent={sortedEvents[index - 1]}
+							nextEvent={sortedEvents[index + 1]}
 							card={event}
 							user={user}
 						/>

--- a/lib/ui-components/Timeline/Header.jsx
+++ b/lib/ui-components/Timeline/Header.jsx
@@ -94,7 +94,7 @@ export default class Header extends React.Component {
 			headerOptions,
 			hideWhispers,
 			messagesOnly,
-			sortedTail,
+			sortedEvents,
 			handleJumpToTop,
 			handleWhisperToggle,
 			handleEventToggle
@@ -156,7 +156,7 @@ export default class Header extends React.Component {
 							text: 'Download conversation'
 						}}
 						ml={2}
-						onClick={() => { return this.handleDownloadConversation(sortedTail) }}
+						onClick={() => { return this.handleDownloadConversation(sortedEvents) }}
 						icon={<Icon name="download"/>}
 					/>
 				</Box>

--- a/lib/ui-components/Timeline/TimelineStart.jsx
+++ b/lib/ui-components/Timeline/TimelineStart.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Box,
+	Txt
+} from 'rendition'
+import styled from 'styled-components'
+
+const StyledBox = styled(Box)(({
+	primary
+}) => {
+	return {
+		width: '100%',
+		textAlign: 'center',
+		opacity: 0.8
+	}
+})
+
+const TimelineStart = () => {
+	return (
+		<StyledBox
+			pb={14}
+			pt={14}
+		>
+			<Txt
+				data-test='Timeline__TimelineStart'
+			>Beginning of Timeline</Txt>
+		</StyledBox>
+	)
+}
+
+export default TimelineStart

--- a/lib/ui-components/Timeline/constants.jsx
+++ b/lib/ui-components/Timeline/constants.jsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const MESSAGE = 'message'
+const WHISPER = 'whisper'
+const UPDATE = 'update'
+const CREATE = 'create'
+const SUMMARY = 'summary'
+
+export {
+	MESSAGE,
+	WHISPER,
+	UPDATE,
+	CREATE,
+	SUMMARY
+}

--- a/lib/ui-components/Timeline/tests/EventsList.spec.jsx
+++ b/lib/ui-components/Timeline/tests/EventsList.spec.jsx
@@ -38,7 +38,7 @@ ava('Only messages and whispers are displayed when the messagesOnly field is set
 		<EventsList
 			{...props}
 			messagesOnly
-			sortedTail={tail}
+			sortedEvents={tail}
 		/>,
 		{
 			wrappingComponent: wrapperWithSetup,
@@ -72,7 +72,7 @@ ava('Whispers are not shown if hideWhispers is set', async (test) => {
 			{...props}
 			hideWhispers
 			messagesOnly
-			sortedTail={tail}
+			sortedEvents={tail}
 		/>,
 		{
 			wrappingComponent: wrapperWithSetup,
@@ -103,7 +103,7 @@ ava('All events are shown if messagesOnly and hideWhispers are not set', async (
 	const eventsList = await mount(
 		<EventsList
 			{...props}
-			sortedTail={tail}
+			sortedEvents={tail}
 		/>,
 		{
 			wrappingComponent: wrapperWithSetup,

--- a/lib/ui-components/Timeline/tests/index.spec.jsx
+++ b/lib/ui-components/Timeline/tests/index.spec.jsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import _ from 'lodash'
+import React from 'react'
+import sinon from 'sinon'
+import {
+	mount
+} from 'enzyme'
+import {
+	createTestContext,
+	wrapperWithSetup
+} from './helpers'
+import Timeline from '../'
+
+const sandbox = sinon.createSandbox()
+
+ava.before((test) => {
+	test.context = createTestContext(test, sandbox)
+})
+
+ava('The TimelineStart component is rendered' +
+	' when all the events in the timeline have been returned and rendered', async (test) => {
+	const {
+		eventProps
+	} = test.context
+
+	const timeline = await mount(
+		<Timeline
+			{...eventProps}
+			tail={[]}
+		/>, {
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: eventProps.sdk
+			}
+		})
+
+	const timelineStart = timeline.find('div[data-test="Timeline__TimelineStart"]')
+	test.is(timelineStart.text(), 'Beginning of Timeline')
+})
+
+ava('Events are toggled when the event in the url is one of type UPDATE', async (test) => {
+	const {
+		eventProps
+	} = test.context
+
+	const eventId = 'fake-update-id'
+
+	// eslint-disable-next-line prefer-reflect
+	delete window.location
+
+	global.window.location = {
+		search: `?event=${eventId}`
+	}
+
+	const getWithTimeline = sandbox.stub()
+	getWithTimeline.resolves()
+
+	const timeline = await mount(
+		<Timeline
+			{...eventProps}
+			sdk={{
+				card: {
+					getWithTimeline
+				}
+			}}
+			tail={[ {
+				id: eventId,
+				type: 'update@1.0.0',
+				data: {
+					payload: []
+				}
+			} ]}
+		/>, {
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: eventProps.sdk
+			}
+		})
+	const updateEvent = timeline.find(`div[data-test="${eventId}"]`)
+	test.is(updateEvent.length, 1)
+})
+
+ava('Events are toggled when the event in the url is one of type CREATE', async (test) => {
+	const {
+		eventProps
+	} = test.context
+
+	const eventId = 'fake-create-id'
+
+	// eslint-disable-next-line prefer-reflect
+	delete window.location
+
+	global.window.location = {
+		search: `?event=${eventId}`
+	}
+
+	const getWithTimeline = sandbox.stub()
+	getWithTimeline.resolves()
+
+	const timeline = await mount(
+		<Timeline
+			{...eventProps}
+			sdk={{
+				card: {
+					getWithTimeline
+				}
+			}}
+			tail={[ {
+				id: eventId,
+				type: 'create@1,0,0'
+			} ]}
+		/>, {
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: eventProps.sdk
+			}
+		})
+	const createEvent = timeline.find(`div[data-test="${eventId}"]`)
+	test.is(createEvent.length, 1)
+})
+
+ava('getWithTimeline is used to get all the events for the timeline when' +
+	'the event in the url is not present in our first page of results', async (test) => {
+	const {
+		eventProps
+	} = test.context
+
+	const eventId = 'fake-message-id'
+
+	// eslint-disable-next-line prefer-reflect
+	delete window.location
+
+	global.window.location = {
+		search: `?event=${eventId}`
+	}
+
+	const tail = _.times(20, (index) => {
+		return {
+			id: `fake-event-${index}`,
+			type: 'message@1.0.0',
+			data: {
+				target: 'fake-target-id'
+			}
+		}
+	})
+
+	const getWithTimeline = sandbox.stub()
+	getWithTimeline.resolves({
+		links: {
+			'has attached element': [ {
+				id: eventId,
+				type: 'message@1.0.0',
+				data: {
+					target: {
+						id: 'fake-target-id'
+					}
+				}
+			} ]
+		}
+	})
+
+	await mount(
+		<Timeline
+			{...eventProps}
+			sdk={{
+				card: {
+					getWithTimeline
+				}
+			}}
+			tail={tail}
+		/>, {
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: eventProps.sdk
+			}
+		})
+
+	// GetWithTimeline should only be called once by JSDom is playing up and calling the handleScrollBeginning before the component is mounted
+	test.is(getWithTimeline.callCount, 2)
+	test.deepEqual(getWithTimeline.args[1], [ 'fake-card', {
+		queryOptions: {
+			links: {
+				'has attached element': {
+					sortBy: 'created_at',
+					sortDir: 'desc'
+				}
+			}
+		}
+	} ])
+})

--- a/test/ui-setup.jsx
+++ b/test/ui-setup.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react'
+import _ from 'lodash'
 import {
 	Provider
 } from 'rendition'
@@ -48,6 +49,9 @@ global.Sound = Sound
 
 class Location {}
 global.location = Location
+
+// eslint-disable-next-line no-undef
+window.HTMLElement.prototype.scrollIntoView = _.noop
 
 export const flushPromises = () => {
 	return new Promise((resolve) => {


### PR DESCRIPTION
When we load a single card at the moment, we query the entire timeline and then show slices of it using frontend pagination. This PR moves to paginating the timeline through queries rather than the UI.

**Basic behaviour**
When the single page is loaded, we query for the card alongside 20 of the latest items on the timeline. These items are displayed when the timeline loads. When the user scrolls upwards, a query is triggered for 20 more items until we reach the beginning of the timeline and render a "Timeline Beginning" message. I used the `InfiniteList` component to handle the scrolling triggers and updated it so that it can be used in reverse.

**Additional behaviour:**
A few other things have had to be updated as part of this behaviour change:

1. Most substantially, I have updated `InfiniteScroll` so that it can continue to query for data when the scroll area has not overflowed. This is necessary because of how the toggles work in the timeline. For example, in a case where you have 18 whispers and 2 messages in your first list of results, if you toggle the whispers off, then suddenly you only have two items on your timeline. This is not enough items for the container to overflow and so the user cannot scroll upwards to trigger more queries. From the user's perspective, it looks like they have reached the start of the timeline when we have actually got stuck at the end of the timeline (there is quite possibly more messages in the past but we can't query for them).

I toyed with the idea of making the container always scrollable but it was difficult to make a solution like this that wasn't unwieldy. In the end, it seemed more sensible to continue querying for more data until we have reached either the start of the timeline or we have filled the timeline container.

2. The handleJumpToTop now runs a query to retrieve all the data before jumping to the top

3. I implemented some code for scrolling to specific events (in the instance that the user puts a direct link into the url). First I checked that the event is present in our page of results. If it is not, I retrieve all the data and then scroll to the event. This may not be the best solution but I thought it was potentially better to do it this way than to load page after page of results for an event that could be right at the beginning of the timeline

4. I cleaned up how we are handling pending messages (specifically how we remove them from the state once they have been processed)