### PR TITLE
Improve message editing

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -342,7 +342,10 @@ export default class Event extends React.Component {
 							menuOptions={menuOptions}
 							isMessage={isMessage}
 							onEditMessage={this.onStartEditing}
+							onCommitEdit={this.saveEditedMessage}
+							onCancelEdit={this.onStopEditing}
 							updating={updating}
+							editing={editedMessage !== null}
 							user={user}
 							squashTop={squashTop}
 							getActorHref={getActorHref}

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -125,6 +125,8 @@ export default class Event extends React.Component {
 
 		this.saveEditedMessage = () => {
 			const {
+				sdk,
+				user,
 				card,
 				onUpdateCard
 			} = this.props
@@ -155,8 +157,13 @@ export default class Event extends React.Component {
 						}
 					}, this.props.card))
 					onUpdateCard(this.props.card, patch)
-						.then(() => {
+						.then(async () => {
 							this.onStopEditing()
+
+							// If the edit happens to add a mention of the current user,
+							// we need to mark this message as read!
+							const updatedCard = await sdk.card.get(card.id)
+							sdk.card.markAsRead(user.slug, updatedCard)
 						})
 						.catch(() => {
 							this.setState({

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -114,6 +114,8 @@ export default class Event extends React.Component {
 			this.setState({
 				editedMessage: null,
 				updating: false
+			}, () => {
+				this.processText()
 			})
 		}
 
@@ -155,7 +157,9 @@ export default class Event extends React.Component {
 						}
 					}, this.props.card))
 					onUpdateCard(this.props.card, patch)
-						.then(this.onStopEditing)
+						.then(() => {
+							this.onStopEditing()
+						})
 						.catch(() => {
 							this.setState({
 								updating: false

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -114,8 +114,6 @@ export default class Event extends React.Component {
 			this.setState({
 				editedMessage: null,
 				updating: false
-			}, () => {
-				this.processText()
 			})
 		}
 
@@ -187,6 +185,12 @@ export default class Event extends React.Component {
 		this.processText()
 	}
 
+	componentDidUpdate (prevProps) {
+		if (prevProps.card !== this.props.card) {
+			this.processText()
+		}
+	}
+
 	processText () {
 		if (!this.messageElement) {
 			return
@@ -198,6 +202,7 @@ export default class Event extends React.Component {
 			node.setAttribute('target', '_blank')
 		})
 		const instance = new Mark(this.messageElement)
+		instance.unmark()
 
 		const readBy = this.props.card.data.readBy || []
 		const userSlug = this.props.user.slug

--- a/lib/ui-components/Event/EventBody.jsx
+++ b/lib/ui-components/Event/EventBody.jsx
@@ -187,7 +187,6 @@ export default class EventBody extends React.Component {
 									value={editedMessage}
 									onChange={onUpdateDraft}
 									onSubmit={onSaveEditedMessage}
-									onClickOutside={onSaveEditedMessage}
 								/>
 							) : (
 								<StyledMarkdown

--- a/lib/ui-components/Event/EventHeader.jsx
+++ b/lib/ui-components/Event/EventHeader.jsx
@@ -59,15 +59,12 @@ export default class EventHeader extends React.Component {
 	render () {
 		const {
 			isMessage,
+			user,
 			actor,
 			card,
-			threadIsMirrored,
-			menuOptions,
-			user,
-			updating,
-			onEditMessage,
 			squashTop,
-			getActorHref
+			getActorHref,
+			...contextProps
 		} = this.props
 
 		const isOwnMessage = user.id === _.get(card, [ 'data', 'actor' ])
@@ -111,12 +108,9 @@ export default class EventHeader extends React.Component {
 
 				<EventContext
 					card={card}
-					menuOptions={menuOptions}
-					onEditMessage={onEditMessage}
+					{...contextProps}
 					isOwnMessage={isOwnMessage}
 					isMessage={isMessage}
-					updating={updating}
-					threadIsMirrored={threadIsMirrored}
 				/>
 			</HeaderWrapper>
 		)

--- a/lib/ui-components/Event/tests/EventHeader.spec.jsx
+++ b/lib/ui-components/Event/tests/EventHeader.spec.jsx
@@ -41,7 +41,7 @@ ava.afterEach(() => {
 	sandbox.restore()
 })
 
-ava('\'updating...\' is displayed if card is updating', async (test) => {
+ava('\'updating...\' is displayed if card is updating and editing', async (test) => {
 	const {
 		commonProps
 	} = test.context
@@ -49,6 +49,7 @@ ava('\'updating...\' is displayed if card is updating', async (test) => {
 		<EventHeader
 			{...commonProps}
 			updating
+			editing
 		/>
 	), {
 		wrappingComponent

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -718,8 +718,7 @@ ava.serial('A user can edit their own message', async (test) => {
 	await page.waitForSelector(`${eventSelector} textarea`)
 	await page.type(`${eventSelector} textarea`, messageSuffix)
 
-	// Click anywhere outside the textarea to save the edited message
-	await macros.waitForThenClickSelector(page, '.column--support-thread')
+	await macros.waitForThenClickSelector(page, '[data-test="event-header__btn--save-edit"]')
 
 	// Wait for the message to be updated and verify the message text
 	const newMessageText = await macros.getElementText(page, `${eventSelector} [data-test="event-card__message"]`)


### PR DESCRIPTION
This PR fixes various small issues relating to editing a message:

* Closes #4197 - you can now use the auto-complete functionality as expected when editing a message.
* Closes #4196 - formatting of usernames, tags etc is re-applied after editing a message
* Closes #4068 - the 'click-outside to save changes' functionality has been replaced by having a 'Save changes' button and a 'Cancel changes' button on the message popup. 

See gif demo below:

![edit message](https://user-images.githubusercontent.com/2925657/85250564-22738b80-b481-11ea-9919-37af055d5f15.gif)

