### PR TITLE
Randomize metrics port number on collision

### DIFF
--- a/docs/developing/running-tests.markdown
+++ b/docs/developing/running-tests.markdown
@@ -425,9 +425,3 @@ make test-integration-core test-integration-queue test-integration-sync test-int
 		POSTGRES_DATABASE=$POSTGRES_DATABASE \
 		REDIS_HOST=localhost
 ```
-
-Please note that when running `test-integration-worker` and `test-integration-server` against an instance of Jellyfish running natively on your local machine, you will need to override default ports or tests will fail as necessary API/worker bootstraps will fail.
-```
-METRICS_PORT=9400 make test-integration-worker
-METRICS_PORT=9400 SOCKET_METRICS_PORT=9500 SERVER_PORT=8100 make test-integration-server
-```

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -18,6 +18,22 @@
  */
 const _ = require('lodash')
 
+/**
+ * @summary Set environment variable as integer, using fallback if necessary
+ * @function
+ *
+ * @param {String} rawValue - raw value as gotten by process.env
+ * @param {Number} fallback - number to fallback to
+ * @returns {Number} parsed value or fallback
+ *
+ * @example
+ * const val = setNumber(process.env.MY_VAR, 10)
+ */
+const setNumber = (rawValue, fallback) => {
+	const intValue = _.parseInt(rawValue)
+	return !_.isNaN(intValue) && intValue !== 0 ? intValue : fallback
+}
+
 exports.isProduction = () => {
 	return process.env.NODE_ENV === 'production'
 }
@@ -154,8 +170,8 @@ exports.mail = {
 exports.metrics = {
 	token: process.env.MONITOR_SECRET_TOKEN,
 	ports: {
-		app: process.env.METRICS_PORT,
-		socket: process.env.SOCKET_METRICS_PORT
+		app: setNumber(process.env.METRICS_PORT, 9000),
+		socket: setNumber(process.env.SOCKET_METRICS_PORT, 9001)
 	}
 }
 
@@ -197,8 +213,6 @@ exports.oauth = {
 	redirectBaseUrl: process.env.OAUTH_REDIRECT_BASE_URL
 }
 
-const concurrency = _.parseInt(process.env.QUEUE_CONCURRENCY)
-
 exports.queue = {
-	concurrency: !_.isNaN(concurrency) && concurrency !== 0 ? concurrency : 4
+	concurrency: setNumber(process.env.QUEUE_CONCURRENCY, 4)
 }

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -7,6 +7,7 @@
 const _ = require('lodash')
 const environment = require('../../lib/environment')
 const express = require('express')
+const http = require('http')
 const logger = require('../../lib/logger').getLogger(__filename)
 const {
 	metrics
@@ -215,7 +216,9 @@ exports.initExpress = (context) => {
 }
 
 /**
- * @summary Expose gathered metrics on /metrics
+ * Expose gathered metrics on /metrics
+ * Reassign port to random port number on collision
+ *
  * @function
  *
  * @param {Object} context - execution context
@@ -230,7 +233,19 @@ exports.startServer = (context, port) => {
 		return req.get('Authorization') === `Basic ${b64enc}`
 	}
 	logger.info(context, `Starting metrics server on ${port}`)
-	metrics.exportOn(port, '/metrics', metrics.requestHandler(isAuthorized))
+	const app = express()
+	const server = http.Server(app)
+	app.use('/metrics', metrics.requestHandler(isAuthorized))
+	server.on('listening', () => {
+		logger.info(context, `Metrics server listening on port ${server.address().port}`)
+	})
+	server.on('error', (err) => {
+		if (err.code === 'EADDRINUSE') {
+			logger.info(context, `Port ${port} is in use, starting metrics server on a random port`)
+			server.listen(0)
+		}
+	})
+	server.listen(port)
 }
 
 /**


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- randomizes the app metrics port to a random one when the default port is already in use
- confirms that `METRICS_PORT` and `SOCKET_METRICS_PORT` are numbers