### PR TITLE
Add descriptions for each metric

### DIFF
--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -22,7 +22,7 @@ const metricNames = {
 	MIRROR_FAILURE_TOTAL: 'jf_mirror_failure_total',
 	WORKER_SATURATION: 'jf_worker_saturation',
 	WORKER_JOB_DURATION: 'jf_worker_job_duration_ms',
-	WORKER_CONCURRENCY: 'jf_worker_concurrency',
+	WORKER_CONCURRENCY: 'jf_worker_concurrency_total',
 	WORKER_ACTION_REQUEST_TOTAL: 'jf_worker_action_request_total',
 	BACK_SYNC_CARD_TOTAL: 'jf_back_sync_total',
 	TRANSLATE_TOTAL: 'jf_translate_total',
@@ -37,7 +37,7 @@ const metricNames = {
 
 	HTTP_QUERY_TOTAL: 'jf_http_api_query_total',
 	HTTP_TYPE_TOTAL: 'jf_http_api_type_total',
-	HTTP_ID_TOTAL: 'Jf_http_api_id_total',
+	HTTP_ID_TOTAL: 'jf_http_api_id_total',
 	HTTP_SLUG_TOTAL: 'jf_http_api_slug_total',
 	HTTP_ACTION_TOTAL: 'jf_http_api_action_total',
 	HTTP_WHOAMI_TOTAL: 'jf_http_whoami_query_total',
@@ -46,8 +46,8 @@ const metricNames = {
 	HTTP_TYPE_FAILURE_TOTAL: 'jf_http_api_type_failure_total',
 	HTTP_ID_FAILURE_TOTAL: 'jf_http_api_id_failure_total',
 	HTTP_SLUG_FAILURE_TOTAL: 'jf_http_api_slug_failure_total',
-	HTTP_ACTION_FAILURE_TOTAl: 'jf_http_api_action_failure_total',
-	HTTP_WHOAMI_FAILURE_TOTAl: 'jf_http_whoami_query_failure_total',
+	HTTP_ACTION_FAILURE_TOTAL: 'jf_http_api_action_failure_total',
+	HTTP_WHOAMI_FAILURE_TOTAL: 'jf_http_whoami_query_failure_total',
 
 	SQL_GEN_DURATION: 'jf_sql_gen_duration_ms',
 	QUERY_DURATION: 'jf_query_duration_ms',
@@ -57,8 +57,64 @@ const metricNames = {
 	STREAMS_ERROR_TOTAL: 'jf_streams_error_total'
 }
 
+// Describe each metric
 const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 29).map(Math.round)
 const queryLatencyBuckets = metrics.client.exponentialBuckets(1.1, Math.SQRT2, 30)
+
+metrics.describe.counter(metricNames.CARD_UPSERT_TOTAL, 'number of cards upserted')
+metrics.describe.counter(metricNames.CARD_INSERT_TOTAL, 'number of cards inserted')
+metrics.describe.counter(metricNames.CARD_READ_TOTAL, 'number of cards read from database/cache')
+metrics.describe.counter(metricNames.MIRROR_TOTAL, 'number of mirror calls')
+metrics.describe.counter(metricNames.MIRROR_FAILURE_TOTAL, 'number of mirror call failures')
+metrics.describe.counter(metricNames.WORKER_SATURATION, 'number of jobs being processed in worker queues')
+metrics.describe.gauge(metricNames.WORKER_CONCURRENCY, 'number of jobs worker queues can process concurrently')
+metrics.describe.counter(metricNames.WORKER_ACTION_REQUEST_TOTAL, 'number of received action requests')
+metrics.describe.counter(metricNames.TRANSLATE_TOTAL, 'number of translate calls')
+metrics.describe.counter(metricNames.HTTP_QUERY_TOTAL, 'number of /query requests')
+metrics.describe.counter(metricNames.HTTP_TYPE_TOTAL, 'number of /type requests')
+metrics.describe.counter(metricNames.HTTP_ID_TOTAL, 'number of /id requests')
+metrics.describe.counter(metricNames.HTTP_SLUG_TOTAL, 'number of /slug requests')
+metrics.describe.counter(metricNames.HTTP_ACTION_TOTAL, 'number of /action requests')
+metrics.describe.counter(metricNames.HTTP_WHOAMI_TOTAL, 'number of /whoami requests')
+metrics.describe.counter(metricNames.HTTP_QUERY_FAILURE_TOTAL, 'number of /query request failures')
+metrics.describe.counter(metricNames.HTTP_TYPE_FAILURE_TOTAL, 'number of /type request failures')
+metrics.describe.counter(metricNames.HTTP_ID_FAILURE_TOTAL, 'number of /id request failures')
+metrics.describe.counter(metricNames.HTTP_SLUG_FAILURE_TOTAL, 'number of /slug request failures')
+metrics.describe.counter(metricNames.HTTP_ACTION_FAILURE_TOTAL, 'number of /action request failures')
+metrics.describe.counter(metricNames.HTTP_WHOAMI_FAILURE_TOTAL, 'number of /whoami request failures')
+metrics.describe.counter(metricNames.STREAMS_SATURATION, 'number of streams open')
+metrics.describe.counter(metricNames.STREAMS_LINK_QUERY_TOTAL, 'number of times streams query links')
+metrics.describe.counter(metricNames.STREAMS_ERROR_TOTAL, 'number of stream errors')
+
+metrics.describe.histogram(metricNames.HTTP_QUERY_DURATION,
+	'histogram of durations taken to process /query requests in ms',
+	{
+		buckets: latencyBuckets
+	})
+
+metrics.describe.histogram(metricNames.HTTP_TYPE_DURATION,
+	'histogram of durations taken to process /type requests in ms',
+	{
+		buckets: latencyBuckets
+	})
+
+metrics.describe.histogram(metricNames.HTTP_ID_DURATION,
+	'histogram of durations taken to process /id requests in ms',
+	{
+		buckets: latencyBuckets
+	})
+
+metrics.describe.histogram(metricNames.HTTP_SLUG_DURATION,
+	'histogram of durations taken to process /slug requests in ms',
+	{
+		buckets: latencyBuckets
+	})
+
+metrics.describe.histogram(metricNames.HTTP_WHOAMI_DURATION,
+	'histogram of durations taken to process /whoami requests in ms',
+	{
+		buckets: latencyBuckets
+	})
 
 metrics.describe.histogram(metricNames.MIRROR_DURATION,
 	'histogram of durations taken to make mirror calls in ms',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add missing descriptions for each metric. This is particularly useful as these descriptions become tooltips in Grafana when creating graphs.
