### PR TITLE
Remove unnecessary handling of links in Markdown

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -203,11 +203,6 @@ export default class Event extends React.Component {
 			return
 		}
 
-		// Modify all links in the message to open in a new tab
-		// TODO: Make this an option in the rendition <Markdown /> component.
-		Array.from(this.messageElement.querySelectorAll('a')).forEach((node) => {
-			node.setAttribute('target', '_blank')
-		})
 		const instance = new Mark(this.messageElement)
 		instance.unmark()
 


### PR DESCRIPTION
Rendition already sets all links to be `target="_blank"` so this code is unnecessary.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

See [this function in Rendition](https://github.com/balena-io-modules/rendition/blob/8d7b067c2b9b969bc26d3c0b220a5a324f7804f4/src/extra/utils.ts#L6-L9).
