### PR TITLE
backend: Fix worker saturation description

### DIFF
--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -83,7 +83,7 @@ metrics.describe.counter(metricNames.HTTP_ID_FAILURE_TOTAL, 'number of /id reque
 metrics.describe.counter(metricNames.HTTP_SLUG_FAILURE_TOTAL, 'number of /slug request failures')
 metrics.describe.counter(metricNames.HTTP_ACTION_FAILURE_TOTAL, 'number of /action request failures')
 metrics.describe.counter(metricNames.HTTP_WHOAMI_FAILURE_TOTAL, 'number of /whoami request failures')
-metrics.describe.counter(metricNames.STREAMS_SATURATION, 'number of streams open')
+metrics.describe.gauge(metricNames.STREAMS_SATURATION, 'number of streams open')
 metrics.describe.counter(metricNames.STREAMS_LINK_QUERY_TOTAL, 'number of times streams query links')
 metrics.describe.counter(metricNames.STREAMS_ERROR_TOTAL, 'number of stream errors')
 

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -67,7 +67,7 @@ metrics.describe.counter(metricNames.CARD_INSERT_TOTAL, 'number of cards inserte
 metrics.describe.counter(metricNames.CARD_READ_TOTAL, 'number of cards read from database/cache')
 metrics.describe.counter(metricNames.MIRROR_TOTAL, 'number of mirror calls')
 metrics.describe.counter(metricNames.MIRROR_FAILURE_TOTAL, 'number of mirror call failures')
-metrics.describe.counter(metricNames.WORKER_SATURATION, 'number of jobs being processed in worker queues')
+metrics.describe.gauge(metricNames.WORKER_SATURATION, 'number of jobs being processed in worker queues')
 metrics.describe.gauge(metricNames.WORKER_CONCURRENCY, 'number of jobs worker queues can process concurrently')
 metrics.describe.counter(metricNames.WORKER_ACTION_REQUEST_TOTAL, 'number of received action requests')
 metrics.describe.counter(metricNames.TRANSLATE_TOTAL, 'number of translate calls')


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Fix `jf_worker_saturation` and `jf_stream_saturation` metric descriptions from `counter` to `gauge`