### PR TITLE
Switch to third-party library for UUID validation

### DIFF
--- a/apps/ui/core/store/actioncreators/index.js
+++ b/apps/ui/core/store/actioncreators/index.js
@@ -18,8 +18,8 @@ import {
 	v4 as uuid
 } from 'uuid'
 import {
-	isUUID
-} from '../../../../../lib/uuid'
+	v4 as isUUID
+} from 'is-uuid'
 import actions from '../actions'
 import * as helpers from '../../../../../lib/ui-components/services/helpers'
 import {

--- a/lib/action-library/handlers/action-create-session.js
+++ b/lib/action-library/handlers/action-create-session.js
@@ -7,9 +7,10 @@
 const bcrypt = require('bcrypt')
 const uuid = require('../../uuid')
 const assert = require('../../assert')
+const isUUID = require('is-uuid').v4
 
 const pre = async (session, context, request) => {
-	const userCard = uuid.isUUID(request.card)
+	const userCard = isUUID(request.card)
 		? await context.getCardById(session, request.card)
 		: await context.getCardBySlug(session, `${request.card}@latest`)
 

--- a/lib/action-library/handlers/action-maintain-contact.js
+++ b/lib/action-library/handlers/action-maintain-contact.js
@@ -7,7 +7,7 @@
 const _ = require('lodash')
 const logger = require('../../logger').getLogger(__filename)
 const assert = require('../../assert')
-const uuid = require('../../uuid')
+const isUUID = require('is-uuid').v4
 
 const handler = async (session, context, card, request) => {
 	logger.info(request.context, 'Maintaining contact', {
@@ -28,7 +28,7 @@ const handler = async (session, context, card, request) => {
 	assert.INTERNAL(request.context, typeCard,
 		context.errors.WorkerNoElement, 'No such type: contact')
 
-	const originCard = card.data.origin && (uuid.isUUID(card.data.origin)
+	const originCard = card.data.origin && (isUUID(card.data.origin)
 		? await context.getCardById(session, card.data.origin)
 		: await context.getCardBySlug(session, card.data.origin))
 

--- a/lib/queue/producer.js
+++ b/lib/queue/producer.js
@@ -11,6 +11,7 @@ const assert = require('../assert')
 const errors = require('./errors')
 const events = require('./events')
 const CARDS = require('./cards')
+const isUUID = require('is-uuid').v4
 
 module.exports = class Producer {
 	constructor (jellyfish, session) {
@@ -46,7 +47,7 @@ module.exports = class Producer {
 		// Use the request session to retrieve the various cards, this ensures that
 		// the action cannot be run if the session doesn't have access to the cards.
 		const cards = await Bluebird.props({
-			target: uuid.isUUID(options.card) ? {
+			target: isUUID(options.card) ? {
 				id: options.card
 
 				// TODO: Require users to be explicit on the card version

--- a/lib/sync/integrations/outreach.js
+++ b/lib/sync/integrations/outreach.js
@@ -8,7 +8,7 @@ const _ = require('lodash')
 const crypto = require('crypto')
 const Bluebird = require('bluebird')
 const assert = require('../../assert')
-const uuid = require('../../uuid')
+const isUUID = require('is-uuid').v4
 
 const MAX_NAME_LENGTH = 50
 
@@ -135,7 +135,7 @@ const getProspectByEmail = async (context, actor, errors, baseUrl, emails) => {
 }
 
 const getByIdOrSlug = async (context, idOrSlug) => {
-	return (uuid.isUUID(idOrSlug) && await context.getElementById(idOrSlug)) ||
+	return (isUUID(idOrSlug) && await context.getElementById(idOrSlug)) ||
 		context.getElementBySlug(`${idOrSlug}@latest`)
 }
 

--- a/lib/uuid/index.js
+++ b/lib/uuid/index.js
@@ -28,6 +28,3 @@ const UUID_V4_REGEX =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 exports.REGEX = UUID_V4_REGEX
-exports.isUUID = (string) => {
-	return UUID_V4_REGEX.test(string)
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15703,6 +15703,11 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "is-uuid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-uuid/-/is-uuid-1.0.2.tgz",
+      "integrity": "sha1-rRiY3fFUlHwlyOVJZvSGBOnK7MQ="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "howler": "^2.2.0",
     "immutability-helper": "^3.1.1",
     "intercom-client": "^2.10.4",
+    "is-uuid": "^1.0.2",
     "json-e": "^2.6.0",
     "json-schema-ref-parser": "^9.0.1",
     "jsonwebtoken": "^8.5.1",

--- a/test/unit/uuid/index.spec.js
+++ b/test/unit/uuid/index.spec.js
@@ -8,14 +8,6 @@ const ava = require('ava')
 const _ = require('lodash')
 const uuid = require('../../../lib/uuid')
 
-ava('.isUUID() should return true for a uuid', async (test) => {
-	test.true(uuid.isUUID(await uuid.random()))
-})
-
-ava('.isUUID() should return false if input is not a complete uuid', async (test) => {
-	test.false(uuid.isUUID((await uuid.random()).slice(0, 10)))
-})
-
 ava('REGEX should be a regular expression', (test) => {
 	test.true(_.isRegExp(uuid.REGEX))
 })


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR switches to using [`is-uuid`](https://www.npmjs.com/package/is-uuid) for UUID validation. 
This is a part of a series of PRs to break apart our monorepo.
