### PR TITLE
Fixup flaky e2e tests

### DIFF
--- a/apps/ui/components/HomeChannel/TreeMenu.jsx
+++ b/apps/ui/components/HomeChannel/TreeMenu.jsx
@@ -59,6 +59,7 @@ const TreeMenu = (props) => {
 					px={3}
 					my={2}
 					data-groupname={node.name}
+					data-expanded={isExpanded}
 					data-test={`home-channel__group-toggle--${node.key}`}
 					onClick={props.toggleExpandGroup}
 				>

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -111,7 +111,7 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 	await page.type('.jellyfish-async-select__input input', productImprovement1Name)
 	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
 	await page.keyboard.press('Enter')
-	await page.click('[data-test="card-linker--existing__submit"]')
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__submit"]:not(:disabled)')
 
 	const pi1CardChatSummary = `[data-test-component="card-chat-summary"][data-test-id="${productImprovement1.id}"]`
 	await page.waitForSelector(`[data-test="segment-card--product-improvements"] ${pi1CardChatSummary}`)

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -265,7 +265,7 @@ ava.serial.skip('card actions: should let users delete a card', async (test) => 
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	test.pass()
 })
@@ -303,7 +303,7 @@ ava.serial('card actions: should let users add a custom field to a card', async 
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	// Check that the card now has the expected value
 	const updatedCard = await context.sdk.card.get(card.id)
@@ -456,7 +456,7 @@ ava.serial('user profile: You should be able to change the send command to "ente
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	await page.waitForSelector('[data-test="lens-my-user__send-command-select"][value="enter"]')
 
@@ -503,7 +503,7 @@ ava.serial('user profile: You should be able to change the send command to "ctrl
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	// Unfortunately puppeteer Control+Enter doesn't seem to work at all
 	// TODO: Fix this test so it works

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -100,9 +100,12 @@ ava.serial('core: should stop users from seeing messages attached to cards they 
 
 	await ensureCommunityLogin(page)
 
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--org-balena"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--Support"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-support-issues"]')
+	await macros.navigateToHomeChannelItem(page, [
+		'[data-test="home-channel__group-toggle--org-balena"]',
+		'[data-test="home-channel__group-toggle--Support"]',
+		'[data-test="home-channel__item--view-all-support-issues"]'
+	])
+
 	await page.waitForSelector('.column--view-all-support-issues')
 	await macros.waitForThenClickSelector(page, '.btn--add-support-issue')
 
@@ -318,9 +321,11 @@ ava.serial('lens: A lens selection should be remembered', async (test) => {
 
 	await ensureCommunityLogin(page)
 
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--org-balena"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--Support"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-support-threads"]')
+	await macros.navigateToHomeChannelItem(page, [
+		'[data-test="home-channel__group-toggle--org-balena"]',
+		'[data-test="home-channel__group-toggle--Support"]',
+		'[data-test="home-channel__item--view-all-support-threads"]'
+	])
 
 	await page.waitForSelector('.column--view-all-support-threads')
 

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -192,3 +192,22 @@ exports.waitForSelectorToDisappear = async (page, selector, retryCount = 30) => 
 exports.waitForThenDismissAlert = async (page, alertType) => {
 	await exports.waitForThenClickSelector(page, `[data-test="alert--${alertType}"] button`)
 }
+
+exports.navigateToHomeChannelItem = async (page, menuStack) => {
+	while (menuStack.length) {
+		const itemSelector = menuStack.shift()
+		const menuItem = await page.waitForSelector(itemSelector)
+		const isExpanded = await page.evaluate(
+			(item) => { return item.getAttribute('data-expanded') },
+			menuItem
+		)
+		if (isExpanded === 'false') {
+			// Need to expand this item
+			await exports.waitForThenClickSelector(page, itemSelector)
+		} else if (menuStack.length === 0) {
+			// We've reached the end of the menu stack.
+			// Click the final item to navigate to the view
+			await exports.waitForThenClickSelector(page, itemSelector)
+		}
+	}
+}

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -44,9 +44,12 @@ ava.serial('should let users create new accounts', async (test) => {
 		page
 	} = context
 
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--org-balena"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--Sales"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-customers"]')
+	await macros.navigateToHomeChannelItem(page, [
+		'[data-test="home-channel__group-toggle--org-balena"]',
+		'[data-test="home-channel__group-toggle--Sales"]',
+		'[data-test="home-channel__item--view-all-customers"]'
+	])
+
 	await macros.waitForThenClickSelector(page, '.btn--add-account')
 
 	const name = `test account ${uuid()}`

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -81,7 +81,7 @@ ava.serial('should let users create new contacts attached to accounts', async (t
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	const results = await page.evaluate((nameParam) => {
 		return window.sdk.query({
@@ -182,7 +182,7 @@ ava.serial('should let users create new opportunities and directly link existing
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	// We wait for the db to catch up on the linking
 	await Bluebird.delay(1000)

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -173,7 +173,7 @@ ava.serial('should let users create new opportunities and directly link existing
 	await page.type('.jellyfish-async-select__input input', 'test')
 	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
 	await page.keyboard.press('Enter')
-	await page.click('[data-test="card-linker--existing__submit"]')
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__submit"]:not(:disabled)')
 
 	await page.waitForSelector('[data-test="segment-card--account"] [data-test-component="card-chat-summary"]')
 

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -45,9 +45,11 @@ ava.serial('Updates to support threads should be reflected in the support thread
 		page
 	} = context
 
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--org-balena"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__group-toggle--Support"]')
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-support-threads"]')
+	await macros.navigateToHomeChannelItem(page, [
+		'[data-test="home-channel__group-toggle--org-balena"]',
+		'[data-test="home-channel__group-toggle--Support"]',
+		'[data-test="home-channel__item--view-all-support-threads"]'
+	])
 
 	await page.waitForSelector('.column--view-all-support-threads')
 

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -498,7 +498,7 @@ ava.serial.skip('Users should be able to audit a support thread', async (test) =
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 
 	// Add a small delay to allow for the link creation to occur
 	// TODO: Add a "wait" method to the SDK that will resolve once a matching
@@ -528,7 +528,7 @@ ava.serial.skip('Users should be able to audit a support thread', async (test) =
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
-	await page.waitForSelector('[data-test="alert--success"]')
+	await macros.waitForThenDismissAlert(page, 'success')
 	await Bluebird.delay(2000)
 	const archivedThread = await page.evaluate((id) => {
 		return window.sdk.card.get(id)

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -244,7 +244,7 @@ ava.serial('You should be able to link support threads to existing support issue
 
 	await page.keyboard.press('Enter')
 
-	await page.click('[data-test="card-linker--existing__submit"]')
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__submit"]:not(:disabled)')
 
 	await macros.waitForThenClickSelector(page, '[data-test="support-thread-details__header"]')
 

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -226,23 +226,11 @@ ava.serial('You should be able to link support threads to existing support issue
 	)
 	supportIssueOption.click()
 
-	// TODO: this is a hack, because waiting for the async-select option is really
-	// flakey for some reason
-	await macros.retry(5, async () => {
-		await Bluebird.delay(1000)
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"] input')
 
-		// Clicking the type input here will ensure that the target input gets cleared if this
-		// is executing in a retry loop
-		await macros.waitForThenClickSelector(page, '[data-test="card-linker--type__input"]')
+	await page.type('.jellyfish-async-select__input input', name)
 
-		await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"]')
-
-		await page.type('.jellyfish-async-select__input input', name)
-
-		await page.waitForSelector('.jellyfish-async-select__option--is-focused')
-	})
-
-	await page.keyboard.press('Enter')
+	await macros.waitForThenClickSelector(page, '.jellyfish-async-select__option--is-focused')
 
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__submit"]:not(:disabled)')
 


### PR DESCRIPTION
**test: improve home channel navigation logic**
Use a helper method to ensure that expandable menu items are only clicked on if they are not expanded.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---
**test: Ensure toast notification is dismissed as part of test step**
This mitigates the situation where the notification blocks the item we are trying to click on next.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---
**test: only click Link Modal submit button once enabled**
Avoid the situation where we click on the Submit button before it is enabled.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---
**test: Fix flaky LinkModal test code**
Click on the Select option rather than clicking 'Enter' to select the Select option.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

A small combination of improvements to tighten up flaky e2e UI tests.

Relates to #3341
