### PR TITLE
ci: Move sidecar to separate compose config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,13 +78,13 @@ jobs:
           command: cd scripts/template && npm install
       - run:
           name: Compose Build
-          command: make compose-build
+          command: make compose-build SIDECAR=1
       - run:
           name: Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_GITHUB_PRIVATE_KEY=$GITHUB_PRIVATE_KEY INTEGRATION_GITHUB_APP_ID=$GITHUB_APP_ID
+          command: make compose-up SIDECAR=1 DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_GITHUB_PRIVATE_KEY=$GITHUB_PRIVATE_KEY INTEGRATION_GITHUB_APP_ID=$GITHUB_APP_ID
       - run:
           name: Sync Tests
-          command: make compose-exec-sidecar COMMAND="make" ARGS="test FILES=./test/e2e/sync/github-mirror.spec.js SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_GITHUB_PRIVATE_KEY=$GITHUB_PRIVATE_KEY INTEGRATION_GITHUB_APP_ID=$GITHUB_APP_ID"
+          command: make docker-exec-jellyfish_sidecar_1 COMMAND="make" ARGS="test FILES=./test/e2e/sync/github-mirror.spec.js SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_GITHUB_PRIVATE_KEY=$GITHUB_PRIVATE_KEY INTEGRATION_GITHUB_APP_ID=$GITHUB_APP_ID"
       - run:
           name: Compose Down
           command: make compose-stop
@@ -142,13 +142,13 @@ jobs:
           command: cd scripts/template && npm install
       - run:
           name: Compose Build
-          command: make compose-build
+          command: make compose-build SIDECAR=1
       - run:
           name: Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN
+          command: make compose-up SIDECAR=1 DETACH=1 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN
       - run:
           name: Sync Tests
-          command: make compose-exec-sidecar COMMAND="make" ARGS="test FILES=./test/e2e/sync/front-mirror.spec.js SCRUB=0 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN"
+          command: make docker-exec-jellyfish_sidecar_1 COMMAND="make" ARGS="test FILES=./test/e2e/sync/front-mirror.spec.js SCRUB=0 INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN"
       - run:
           name: Compose Down
           command: make compose-stop
@@ -169,13 +169,13 @@ jobs:
           command: cd scripts/template && npm install
       - run:
           name: Compose Build
-          command: make compose-build
+          command: make compose-build SIDECAR=1
       - run:
           name: Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME
+          command: make compose-up SIDECAR=1 DETACH=1 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME
       - run:
           name: Sync Tests
-          command: make compose-exec-sidecar COMMAND="make" ARGS="test FILES=./test/e2e/sync/discourse-mirror.spec.js SCRUB=0 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME"
+          command: make docker-exec-jellyfish_sidecar_1 COMMAND="make" ARGS="test FILES=./test/e2e/sync/discourse-mirror.spec.js SCRUB=0 INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME"
       - run:
           name: Compose Down
           command: make compose-stop
@@ -233,13 +233,13 @@ jobs:
           command: cd scripts/template && npm install
       - run:
           name: Compose Build
-          command: make compose-build
+          command: make compose-build SIDECAR=1
       - run:
           name: Docker Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY INTEGRATION_TYPEFORM_SIGNATURE_KEY=$TYPEFORM_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
+          command: make compose-up SIDECAR=1 DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY INTEGRATION_TYPEFORM_SIGNATURE_KEY=$TYPEFORM_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
       - run:
           name: End To End Tests (Server)
-          command: make compose-exec-sidecar COMMAND="make" ARGS="test-e2e-server SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY INTEGRATION_TYPEFORM_SIGNATURE_KEY=$TYPEFORM_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
+          command: make docker-exec-jellyfish_sidecar_1 COMMAND="make" ARGS="test-e2e-server SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY INTEGRATION_TYPEFORM_SIGNATURE_KEY=$TYPEFORM_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
       - run:
           name: Postgres Dump
           command: docker exec jellyfish_postgres_1 bash -c 'PGPASSWORD="${POSTGRES_PASSWORD}" pg_dump --username="${POSTGRES_USER}" jellyfish' | gzip -9 > dump-server.gz
@@ -272,19 +272,19 @@ jobs:
           command: cd scripts/template && npm install
       - run:
           name: Compose Build
-          command: make compose-build
+          command: make compose-build SIDECAR=1
       - run:
           name: Docker Compose Up
-          command: make compose-up DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
+          command: make compose-up SIDECAR=1 DETACH=1 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
       - run:
           name: Fetch Old Postgres Dump
           command: ./scripts/ci/postgres-get-previous-dump.sh server && ls -l && gunzip dump.gz
       - run:
           name: Import Postgres Dump
-          command: docker cp dump jellyfish_sidecar_1:/usr/src/jellyfish/dump && make compose-exec-sidecar COMMAND="./scripts/ci/postgres-import-snapshot.sh" ARGS="/usr/src/jellyfish/dump"
+          command: docker cp dump jellyfish_sidecar_1:/usr/src/jellyfish/dump && make docker-exec-jellyfish_sidecar_1 COMMAND="./scripts/ci/postgres-import-snapshot.sh" ARGS="/usr/src/jellyfish/dump"
       - run:
           name: End To End Tests (Server)
-          command: make compose-exec-sidecar COMMAND="make" ARGS="test-e2e-server SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
+          command: make docker-exec-jellyfish_sidecar_1 COMMAND="make" ARGS="test-e2e-server SCRUB=0 INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish"
       - run:
           name: Docker Compose Down
           command: make compose-stop
@@ -309,13 +309,13 @@ jobs:
           command: cd scripts/template && npm install
       - run:
           name: Compose Build
-          command: make compose-build
+          command: make compose-build SIDECAR=1
       - run:
           name: Docker Compose Up
-          command: make compose-up DETACH=1 FS_DRIVER=s3FS
+          command: make compose-up SIDECAR=1 DETACH=1 FS_DRIVER=s3FS
       - run:
           name: S3 File Upload Tests
-          command: make compose-exec-sidecar COMMAND="/bin/bash -c \". /root/.bashrc && make test FILES=./test/e2e/ui/file-upload.spec.js\""
+          command: make docker-exec-jellyfish_sidecar_1 COMMAND="/bin/bash -c \". /root/.bashrc && make test FILES=./test/e2e/ui/file-upload.spec.js\""
       - run:
           name: Docker Compose Down
           command: make compose-stop

--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,9 @@ DOCKER_COMPOSE_FILES = --file docker-compose.yml
 ifdef MONITOR
 DOCKER_COMPOSE_FILES += --file docker-compose.monitor.yml
 endif
+ifdef SIDECAR
+DOCKER_COMPOSE_FILES += --file docker-compose.sidecar.yml
+endif
 
 DOCKER_COMPOSE_OPTIONS = \
 	$(DOCKER_COMPOSE_FILES) \
@@ -436,6 +439,9 @@ build-livechat:
 # -----------------------------------------------
 # Development
 # -----------------------------------------------
+
+docker-exec-%:
+	docker exec $(subst docker-exec-,,$@) $(COMMAND) $(ARGS)
 
 compose-exec-%: docker-compose.yml
 	docker-compose $(DOCKER_COMPOSE_OPTIONS) \

--- a/docker-compose.sidecar.yml
+++ b/docker-compose.sidecar.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+
+services:
+  sidecar:
+    build:
+      context: .
+      dockerfile: apps/sidecar/Dockerfile
+      args:
+        - NPM_TOKEN
+    depends_on:
+      - api
+      - livechat
+      - postgres
+      - ui
+      - balena-mdns-publisher
+    environment:
+      DATABASE: postgres
+      LIVECHAT_HOST: http://livechat
+      LIVECHAT_PORT: 80
+      NODE_ENV: test
+      POSTGRES_DATABASE: jellyfish
+      POSTGRES_HOST: postgres
+      POSTGRES_PASSWORD: docker
+      POSTGRES_USER: docker
+      SERVER_HOST: http://api
+      SERVER_PORT: 8000
+      UI_HOST: http://ui
+      UI_PORT: 80
+    networks:
+      - internal
+    healthcheck:
+      interval: 10s
+      retries: 10
+      test:
+        - CMD
+        - curl
+        - --fail
+        - http://api:8000/ping
+      timeout: 10s
+    restart: always

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -110,43 +110,6 @@ services:
     restart: always
     networks:
       - internal
-  sidecar:
-    build:
-      context: .
-      dockerfile: apps/sidecar/Dockerfile
-      args:
-        - NPM_TOKEN
-    depends_on:
-      - api
-      - livechat
-      - postgres
-      - ui
-      - balena-mdns-publisher
-    environment:
-      DATABASE: {{DATABASE}}
-      LIVECHAT_HOST: http://livechat
-      LIVECHAT_PORT: 80
-      NODE_ENV: {{NODE_ENV}}
-      POSTGRES_DATABASE: {{POSTGRES_DATABASE}}
-      POSTGRES_HOST: postgres
-      POSTGRES_PASSWORD: docker
-      POSTGRES_USER: docker
-      SERVER_HOST: http://api
-      SERVER_PORT: {{SERVER_PORT}}
-      UI_HOST: http://ui
-      UI_PORT: 80
-    networks:
-      - internal
-    healthcheck:
-      interval: 10s
-      retries: 10
-      test:
-        - CMD
-        - curl
-        - --fail
-        - http://api:8000/ping
-      timeout: 10s
-    restart: always
   tick:
     image: balena/jellyfish-tick-server
     build:
@@ -316,7 +279,6 @@ services:
       {{/workers}}
       - ui
       - tick
-      - sidecar
       - livechat
       - api
       - balena-mdns-publisher

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,43 +110,6 @@ services:
     restart: always
     networks:
       - internal
-  sidecar:
-    build:
-      context: .
-      dockerfile: apps/sidecar/Dockerfile
-      args:
-        - NPM_TOKEN
-    depends_on:
-      - api
-      - livechat
-      - postgres
-      - ui
-      - balena-mdns-publisher
-    environment:
-      DATABASE: postgres
-      LIVECHAT_HOST: http://livechat
-      LIVECHAT_PORT: 80
-      NODE_ENV: test
-      POSTGRES_DATABASE: jellyfish
-      POSTGRES_HOST: postgres
-      POSTGRES_PASSWORD: docker
-      POSTGRES_USER: docker
-      SERVER_HOST: http://api
-      SERVER_PORT: 8000
-      UI_HOST: http://ui
-      UI_PORT: 80
-    networks:
-      - internal
-    healthcheck:
-      interval: 10s
-      retries: 10
-      test:
-        - CMD
-        - curl
-        - --fail
-        - http://api:8000/ping
-      timeout: 10s
-    restart: always
   tick:
     image: balena/jellyfish-tick-server
     build:
@@ -430,7 +393,6 @@ services:
       - worker_3
       - ui
       - tick
-      - sidecar
       - livechat
       - api
       - balena-mdns-publisher


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move `sidecar` to a separate compose config that is used only when `SIDECAR=1` is set.

`sidecar` is only used in CircleCI and therefore wastes precious time and resources when unnecessarily built and ran in balenaCI.
We are also planning on doing away with `sidecar` once all tests are moved to balenaCI, so this will make that change quite easy.
