### PR TITLE
Derive explicit select

### DIFF
--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -60,8 +60,9 @@ const postProcessCard = (card, schema, errors) => {
 		const cardLinks = card.links
 		for (const linkType of Object.keys(cardLinks)) {
 			cardLinks[linkType] = cardLinks[linkType].map((linked) => {
-				return postProcessCard(linked, schema.$$links[linkType])
+				return postProcessCard(linked, schema.$$links[linkType], errors)
 			})
+
 			utils.filter(schema.$$links[linkType], cardLinks[linkType], errors)
 		}
 	}
@@ -85,7 +86,6 @@ const queryTable = async (context, backend, table, schema, options) => {
 		return []
 	}
 
-	const preProcessingStartDate = new Date()
 	const queryGenStart = performance.now()
 	let query = null
 	try {
@@ -99,7 +99,6 @@ const queryTable = async (context, backend, table, schema, options) => {
 	}
 	const queryGenEnd = performance.now()
 
-	const queryStartDate = new Date()
 	const queryStart = performance.now()
 	const results = await backend.connection.any(query).catch((error) => {
 		assert.USER(context, !error.message.includes('statement timeout'),
@@ -115,24 +114,28 @@ const queryTable = async (context, backend, table, schema, options) => {
 		throw error
 	})
 	const queryEnd = performance.now()
-	const queryEndDate = new Date()
 
-	metrics.markSqlGenTime(queryGenEnd - queryGenStart)
-	metrics.markQueryTime(queryEnd - queryStart)
-
+	const postProcessStart = performance.now()
 	const elements = results.map((card) => {
 		return postProcessCard(card, schema, backend.errors)
 	})
 	utils.filter(schema, elements, backend.errors)
-	const postProcessingEndDate = new Date()
+	const postProcessEnd = performance.now()
+
+	const queryGenTime = queryGenEnd - queryGenStart
+	const queryTime = queryEnd - queryStart
+	const postProcessTime = postProcessEnd - postProcessStart
+
+	metrics.markSqlGenTime(queryGenTime)
+	metrics.markQueryTime(queryTime)
 
 	logger[mode](context, 'Query database response', {
 		table,
 		database: backend.database,
 		count: elements.length,
-		queryTime: queryEndDate.getTime() - queryStartDate.getTime(),
-		preProcessingTime: queryStartDate.getTime() - preProcessingStartDate.getTime(),
-		postProcessingTime: postProcessingEndDate.getTime() - queryEndDate.getTime()
+		preProcessingTime: queryGenTime,
+		queryTime: queryTime,
+		postProcessingTime: postProcessTime
 	})
 
 	return elements

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -70,7 +70,7 @@ const postProcessCard = (card, schema, errors) => {
 	return utils.removeVersionFields(utils.convertDatesToISOString(card))
 }
 
-const queryTable = async (context, backend, table, schema, options) => {
+const queryTable = async (context, backend, table, select, schema, options) => {
 	const mode = options.profile ? 'info' : 'debug'
 
 	logger[mode](context, 'Querying from table', {
@@ -89,7 +89,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 	const queryGenStart = performance.now()
 	let query = null
 	try {
-		query = jsonschema2sql(table, schema, options)
+		query = jsonschema2sql(table, select, schema, options)
 	} catch (error) {
 		if (error.name === 'InvalidSchema') {
 			throw new backend.errors.JellyfishInvalidSchema(error.message)
@@ -116,8 +116,8 @@ const queryTable = async (context, backend, table, schema, options) => {
 	const queryEnd = performance.now()
 
 	const postProcessStart = performance.now()
-	const elements = results.map((card) => {
-		return postProcessCard(card, schema, backend.errors)
+	const elements = results.map((wrapper) => {
+		return postProcessCard(wrapper.payload, schema, backend.errors)
 	})
 	utils.filter(schema, elements, backend.errors)
 	const postProcessEnd = performance.now()
@@ -134,7 +134,7 @@ const queryTable = async (context, backend, table, schema, options) => {
 		database: backend.database,
 		count: elements.length,
 		preProcessingTime: queryGenTime,
-		queryTime: queryTime,
+		queryTime,
 		postProcessingTime: postProcessTime
 	})
 
@@ -713,7 +713,7 @@ module.exports = class PostgresBackend {
 	 *   they are about and construct more customised queries for
 	 *   them for performance reasons
 	 */
-	async query (context, schema, options = {}) {
+	async query (context, select, schema, options = {}) {
 		// Apply a maximum for safety reasons
 		if (typeof options.limit === 'undefined') {
 			options.limit = MAXIMUM_QUERY_LIMIT
@@ -759,7 +759,7 @@ module.exports = class PostgresBackend {
 		}
 
 		const results = await queryTable(
-			context, this, cards.TABLE, schema, options)
+			context, this, cards.TABLE, select, schema, options)
 
 		// Mark card read metric.
 		_.forEach(results, (result) => {
@@ -791,7 +791,7 @@ module.exports = class PostgresBackend {
 	 * In order to implement this feature, we will tap into the master
 	 * stream and resolve links and JSON Schema filtering client side.
 	 */
-	async stream (context, schema) {
+	async stream (context, select, schema) {
 		/*
 		 * We first make sure that the schema is valid.
 		 */
@@ -804,7 +804,7 @@ module.exports = class PostgresBackend {
 			// queries and links injections passed to the streams
 			// module shouldn't happen.
 			query: (query, options) => {
-				return this.query(context, query, options)
+				return this.query(context, select, query, options)
 			}
 		})
 	}

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -4,8 +4,9 @@
  * Proprietary and confidential.
  */
 
+const _ = require('lodash')
 const SqlQuery = require('./sql-query')
 
-module.exports = (table, schema, options = {}) => {
-	return SqlQuery.fromSchema(table, schema, options).toSqlSelect()
+module.exports = (table, select, schema, options = {}) => {
+	return SqlQuery.fromSchema(table, _.cloneDeep(select), schema, options).toSqlSelect()
 }

--- a/lib/core/backend/postgres/jsonschema2sql/sql-query.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-query.js
@@ -97,6 +97,25 @@ const CARD_FIELDS = {
 	}
 }
 
+const CARD_ALL_NON_LINKS_SELECTED = {
+	id: {},
+	version: {},
+	slug: {},
+	name: {},
+	type: {},
+	tags: {},
+	markers: {},
+	created_at: {},
+	updated_at: {},
+	active: {},
+	requires: {},
+	capabilities: {},
+	data: {},
+	linked_at: {}
+}
+
+const CARD_ALL_NON_LINKS_KEYS = Object.keys(CARD_ALL_NON_LINKS_SELECTED)
+
 /**
  * Class encapsulating all data needed to create an SQL query from a JSON
  * schema. This class' constructor is supposed to be private. Use the static
@@ -104,16 +123,25 @@ const CARD_FIELDS = {
  * SqlQuery#toSqlSelect} to generate an SQL query for the parsed JSON schema.
  */
 module.exports = class SqlQuery {
-	static fromSchema (tableOrParent, schema, options) {
-		const query = new SqlQuery(tableOrParent, options)
+	static fromSchema (tableOrParent, select, schema, options) {
+		const query = new SqlQuery(tableOrParent, select, options)
 		if (schema === false) {
+			query.setAdditionalProperties(false)
 			query.filter.makeUnsatisfiable()
-		} else if (schema !== true) {
+		} else if (schema === true) {
+			// Defaults to `true` as per the JSON schema spec
+			query.setAdditionalProperties(true)
+		} else {
 			// Some keywords must be processed before the rest, for validation,
 			// correctness, or optimization
+
 			if ('additionalProperties' in schema) {
 				query.setAdditionalProperties(schema.additionalProperties)
+			} else {
+				// Defaults to `true` as per the JSON schema spec
+				query.setAdditionalProperties(true)
 			}
+
 			if ('type' in schema) {
 				query.setType(schema.type)
 			}
@@ -134,6 +162,23 @@ module.exports = class SqlQuery {
 		return query
 	}
 
+	static getSelectPayloadFrom (selectedProperties, path) {
+		if (_.isEmpty(selectedProperties)) {
+			return path.toSql()
+		}
+
+		const args = []
+		path.push(null)
+		for (const [ name, contents ] of Object.entries(selectedProperties)) {
+			path.setLast(name)
+			args.push(pgFormat.literal(name))
+			args.push(SqlQuery.getSelectPayloadFrom(contents, path))
+		}
+		path.pop()
+
+		return `jsonb_build_object(${args.join(', ')})`
+	}
+
 	/**
 	 * Create a new, empty SqlQuery. {@link SqlQuery#fromSchema} should be
 	 * used instead of this constructor.
@@ -141,6 +186,13 @@ module.exports = class SqlQuery {
 	 * @param {String|SqlQuery} tableOrParent - Either the name of the table
 	 *        this SqlQuery will refer to, or the parent SqlQuery if we're
 	 *        parsing a sub schema.
+	 * @param {Object} select - The properties to be selected. This should
+	 *        form a simple `<property>: <map of sub properties>` hierarchy.
+	 *        An empty `<map of sub properties>` means that `<property>` is the
+	 *        one being selected. The only exception is the `links` property of
+	 *        cards, where an empty `<map of sub properties>` means no links
+	 *        instead of all links. TODO: this is due to a quirk with `$$links`
+	 *        semantics. The constructor assumes ownership of this argument.
 	 * @param {Object} options - An optional map with taking anything accepted
 	 *        by {@link SqlQuery#fromSchema}, plus the following (for internal
 	 *        use only):
@@ -154,16 +206,12 @@ module.exports = class SqlQuery {
 	 *        - parentLinkTypes: an array of link types denoting `$$links`
 	 *          nesting
 	 */
-	constructor (tableOrParent, options = {}) {
+	constructor (tableOrParent, select = {}, options = {}) {
 		// Set of properties that must exist
 		this.required = []
 
 		// Query filter. Defaults to `true` as an empty schema matches anything
 		this.filter = new ExpressionFilter(true)
-
-		// `additionalProperties` value for the schema to be parsed. Defaults
-		// to `true` as per the JSON schema spec
-		this.additionalProperties = true
 
 		// Map of link types (i.e. the name of the relation between different
 		// cards) to the `SqlQuery` of the schema of that link type
@@ -182,6 +230,7 @@ module.exports = class SqlQuery {
 		this.format = null
 
 		// See the constructor's docs
+		this.select = select
 		this.options = options
 		if (!('parentJsonPath' in this.options)) {
 			this.options.parentJsonPath = []
@@ -191,9 +240,6 @@ module.exports = class SqlQuery {
 		}
 
 		if (_.isString(tableOrParent)) {
-			// Set of columns we are selecting
-			this.columns = new Set()
-
 			// Table to `SELECT FROM`
 			this.table = tableOrParent
 
@@ -201,7 +247,6 @@ module.exports = class SqlQuery {
 			// to columns or JSONB properties
 			this.path = new SqlPath(this.table, this.options.parentPath)
 		} else {
-			this.columns = tableOrParent.columns
 			this.path = tableOrParent.path
 		}
 
@@ -237,6 +282,27 @@ module.exports = class SqlQuery {
 		})
 
 		this.additionalProperties = schema
+
+		// If additionalProperties is true we just fetch everything. This is
+		// represented by a cleared `this.select` *except* at the root due to
+		// the whole `$$links` weirdness. In that case we just fill
+		// `this.select` with all columns. Also we don't touch
+		// `this.select` for `links` columns because, again, links are weird.
+		// Note that we modify `this.select` in place instead of reassigning
+		// it because it's a shared data structure
+		const isLinks = this.path.isProcessingColumn && this.path.getLast() === 'links'
+		if (schema === true && !isLinks) {
+			if (this.path.isProcessingTable) {
+				Object.assign(this.select, CARD_ALL_NON_LINKS_SELECTED)
+				if (!('links' in this.select)) {
+					this.select.links = {}
+				}
+			} else {
+				for (const key of Object.keys(this.select)) {
+					Reflect.deleteProperty(this.select, key)
+				}
+			}
+		}
 	}
 
 	setType (value) {
@@ -261,11 +327,6 @@ module.exports = class SqlQuery {
 
 		// We clone because other methods may modify `this.required`
 		this.required = _.clone(required)
-		if (this.path.isProcessingTable) {
-			for (const key of required) {
-				this.columns.add(key)
-			}
-		}
 	}
 
 	setFormat (format) {
@@ -648,12 +709,11 @@ module.exports = class SqlQuery {
 		this.path.push(null)
 		for (const [ propertyName, propertySchema ] of Object.entries(propertiesMap)) {
 			this.path.setLast(propertyName)
-			if (this.path.isProcessingColumn) {
-				this.columns.add(propertyName)
-			}
-
 			const propertyQuery = this.buildQueryFromSubSchema(
-				propertySchema, [ 'properties', propertyName ])
+				propertySchema,
+				[ 'properties', propertyName ],
+				this.select[propertyName]
+			)
 
 			assert.INTERNAL(null, _.isEmpty(propertyQuery.links), InvalidSchema,
 				'\'$$links\' is not supported inside a \'properties\' declaration')
@@ -805,9 +865,9 @@ module.exports = class SqlQuery {
 	// Subschemas are just what the name implies. They have the same context as
 	// `this` and are just build as a separate object for organizational
 	// purposes
-	buildQueryFromSubSchema (schema, suffix) {
+	buildQueryFromSubSchema (schema, suffix, select) {
 		this.options.parentJsonPath.push(...suffix)
-		const query = SqlQuery.fromSchema(this, schema, this.options)
+		const query = SqlQuery.fromSchema(this, select, schema, this.options)
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()
 		}
@@ -827,7 +887,7 @@ module.exports = class SqlQuery {
 		}
 
 		this.options.parentJsonPath.push(...suffix)
-		const query = SqlQuery.fromSchema(table, schema, {
+		const query = SqlQuery.fromSchema(table, {}, schema, {
 			parentJsonPath: this.options.parentJsonPath,
 			parentPath
 		})
@@ -850,7 +910,8 @@ module.exports = class SqlQuery {
 		}, _.get(this.options, [ 'links', linkType ]))
 
 		const table = pgFormat.ident(`join.${this.options.parentLinkTypes.join('.')}`)
-		const query = SqlQuery.fromSchema(table, schema, options)
+		const select = _.get(this.select.links, [ linkType ])
+		const query = SqlQuery.fromSchema(table, select, schema, options)
 
 		this.options.parentLinkTypes.pop()
 		for (let idx = 0; idx < suffix.length; ++idx) {
@@ -863,8 +924,7 @@ module.exports = class SqlQuery {
 	toSqlSelect () {
 		// Set common stuff for our `SELECT`
 		const select = new SqlSelectBuilder()
-		this.fillNonLinkColumns(select)
-		select.pushFrom(this.table)
+			.pushFrom(this.table)
 		this.fillOrderBy(select)
 		if (this.options.skip) {
 			select.setOffset(this.options.skip)
@@ -875,10 +935,9 @@ module.exports = class SqlQuery {
 
 		if (_.isEmpty(this.links)) {
 			// Queries without links are fairly simple
-			select.setFilter(this.filter)
-			if (this.additionalProperties || this.columns.has('links')) {
-				select.pushSelect(`${this.table}.links`)
-			}
+			select
+				.pushSelect(this.getSelectPayload(), 'payload')
+				.setFilter(this.filter)
 		} else {
 			// Queries with links are more complex for performance reasons.
 			// They have two parts separated by a `MATERIALIZED` CTE. The CTE
@@ -933,7 +992,8 @@ module.exports = class SqlQuery {
 			// `SELECT` to fetch the actual data and build the `links` map.
 			const fence = new SqlCteBuilder(FENCE_REWRAP)
 			fence.pushSubquery(innerSelect, 'fence', true)
-			select.pushSelect(`${this.table}.links || jsonb_build_object(${linksBuildArgs.join(', ')})`, 'links')
+			select
+				.pushSelect(this.getSelectPayload(linksBuildArgs), 'payload')
 				.pushFrom(fence, 'main')
 				.setFilter(new LiteralSql(`${this.table}.id = main.cardId`))
 
@@ -969,8 +1029,7 @@ module.exports = class SqlQuery {
 		// TODO: maybe `cloneDeep()` isn't the best idea here......
 		innerSelect.pushInnerJoin(cardsTable, _.cloneDeep(this.filter).and(joinFilter), joinAlias)
 
-		linksBuildArgs.push(pgFormat.literal(linkType))
-		linksBuildArgs.push(`${lateralAlias}.linkedCards`)
+		linksBuildArgs.push([ linkType, `${lateralAlias}.linkedCards` ])
 		linkEdges.push(`row(${parentTable}.id, ${idx}, ${joinAlias}.id)::linkEdge`)
 
 		let orderByPaths = []
@@ -996,10 +1055,9 @@ module.exports = class SqlQuery {
 			lateralJoinFilter.and(new LiteralSql(`edges.seq <= ${highestSeq}`))
 		}
 
-		let buildNestedLinks = ''
+		const nestedLinksBuildArgs = []
 		const nestedLaterals = []
 		if (!_.isEmpty(this.links)) {
-			const nestedLinksBuildArgs = []
 			linkTypeStack.push(null)
 			for (const [ nestedLinkType, nestedLinked ] of Object.entries(this.links)) {
 				linkTypeStack[linkTypeStack.length - 1] = nestedLinkType
@@ -1014,8 +1072,6 @@ module.exports = class SqlQuery {
 				)
 			}
 			linkTypeStack.pop()
-
-			buildNestedLinks = ` || jsonb_build_object('links', jsonb_build_object(${nestedLinksBuildArgs.join(', ')}))`
 		}
 
 		const edgesSelect = new SqlSelectBuilder()
@@ -1025,9 +1081,10 @@ module.exports = class SqlQuery {
 			.pushFrom('unnest(main.linkEdges)', 'edges')
 			.pushInnerJoin(cardsTable, new LiteralSql('linked.id = edges.sink'), 'linked')
 			.setFilter(new LiteralSql(`edges.idx = ${idx}`))
+		const payload = this.getSelectPayload(nestedLinksBuildArgs, 'linked')
 		const lateral = new SqlSelectBuilder()
 			.pushSelect('edges.source')
-			.pushSelect(`array_agg(to_jsonb(linked)${buildNestedLinks}${orderBy})`, 'linkedCards')
+			.pushSelect(`array_agg(${payload}${orderBy})`, 'linkedCards')
 			.pushFrom(edgesSelect, 'edges')
 			.pushInnerJoin(cardsTable, lateralJoinFilter, 'linked')
 			.pushGroupBy(new LiteralSql('edges.source'))
@@ -1041,31 +1098,40 @@ module.exports = class SqlQuery {
 		laterals.push([ lateral, lateralAlias ])
 	}
 
-	fillNonLinkColumns (select) {
-		if (this.additionalProperties) {
-			select.pushSelect(`${this.table}.id`)
-			select.pushSelect(`${this.table}.slug`)
-			select.pushSelect(`${this.table}.type`)
-			select.pushSelect(`${this.table}.active`)
-			select.pushSelect(SqlPath.getVersionComputedField(this.table), 'version')
-			select.pushSelect(`${this.table}.name`)
-			select.pushSelect(`${this.table}.tags`)
-			select.pushSelect(`${this.table}.markers`)
-			select.pushSelect(`${this.table}.created_at`)
-			select.pushSelect(`${this.table}.requires`)
-			select.pushSelect(`${this.table}.capabilities`)
-			select.pushSelect(`${this.table}.data`)
-			select.pushSelect(`${this.table}.updated_at`)
-			select.pushSelect(`${this.table}.linked_at`)
-		} else {
-			for (const column of this.columns) {
-				if (column === 'version') {
-					select.pushSelect(SqlPath.getVersionComputedField(this.table), 'version')
-				} else {
-					select.pushSelect(`${this.table}.${pgFormat.ident(column)}`)
+	getSelectPayload (linksBuildArgs = [], tableOverride) {
+		const table = tableOverride || this.table
+		const selectedNonLinks = _.pick(this.select, CARD_ALL_NON_LINKS_KEYS)
+		const selectsAllNonLinks = _.isEqual(selectedNonLinks, CARD_ALL_NON_LINKS_SELECTED)
+		const selectsLinks = 'links' in this.select
+		const fetchAll = selectsAllNonLinks && selectsLinks
+		const selectsOnlyLinks = _.isEmpty(selectedNonLinks) && selectsLinks
+
+		let links = ''
+		let mergeLinks = ''
+		if (selectsLinks) {
+			const selectedLinks = this.select.links
+			const filteredLinksBuildArgs = []
+			for (const [ linkType, field ] of linksBuildArgs) {
+				if (linkType in selectedLinks) {
+					filteredLinksBuildArgs.push(pgFormat.literal(linkType))
+					filteredLinksBuildArgs.push(field)
 				}
 			}
+			links = `jsonb_build_object(${filteredLinksBuildArgs.join(', ')})`
+			links = `jsonb_build_object('links', ${links})`
+			mergeLinks = ` || ${links}`
 		}
+
+		if (fetchAll) {
+			return `to_jsonb(${table})${mergeLinks}`
+		} else if (selectsOnlyLinks) {
+			return links
+		}
+
+		const path = new SqlPath(table)
+		const main = SqlQuery.getSelectPayloadFrom(this.select, path)
+
+		return `${main}${mergeLinks}`
 	}
 
 	fillOrderBy (select, tableOverride) {

--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -33,25 +33,7 @@ const filter = (schema, element) => {
 	}
 
 	const elementCopy = _.cloneDeep(element)
-	const result = skhema.filter(schema, elementCopy)
-
-	// If additionalProperties is false, remove properties that haven't been
-	// explicitly selected. This is done because the Skhema module will merge
-	// anyOf branches into the top level properties before applying the filter
-	// (which is correct) however, due to the Jellyfish permissions system,
-	// properties may be added to the result that the initial query did not
-	// specify, depending on which permission views are merged in.
-	if (schema.additionalProperties === false) {
-		for (const item of _.castArray(elementCopy)) {
-			for (const key in item) {
-				if (!schema.properties[key]) {
-					Reflect.deleteProperty(item, key)
-				}
-			}
-		}
-	}
-
-	return result
+	return skhema.filter(schema, elementCopy)
 }
 
 exports.setup = async (context, connection, table, columns) => {

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -13,39 +13,22 @@ const skhema = require('skhema')
 // 42P07: duplicate table error
 const INIT_IGNORE_CODES = [ '23505', '42P07' ]
 
-exports.filter = (schema, element, errors) => {
+exports.filter = (schema, elements, errors) => {
 	if (_.isNil(schema)) {
-		return element
+		return
 	}
 
-	const result = _.attempt(skhema.filter, schema, element)
-	if (_.isError(result)) {
-		if (result instanceof skhema.InvalidSchema) {
-			const error = new errors.JellyfishInvalidSchema(result.message)
-			error.expected = true
-			throw error
+	try {
+		skhema.filter(schema, elements)
+	} catch (error) {
+		if (error instanceof skhema.InvalidSchema) {
+			const newError = new errors.JellyfishInvalidSchema(error.message)
+			newError.expected = true
+			throw newError
 		}
 
-		throw result
+		throw error
 	}
-
-	// If additionalProperties is false, remove properties that haven't been
-	// explicitly selected. This is done because the Skhema module will merge
-	// anyOf branches into the top level properties before applying the filter
-	// (which is correct) however, due to the Jellyfish permissions system,
-	// properties may be added to the result that the initial query did not
-	// specify, depending on which permission views are merged in.
-	if (schema.additionalProperties === false) {
-		for (const item of _.castArray(element)) {
-			for (const key in item) {
-				if (!schema.properties[key]) {
-					Reflect.deleteProperty(item, key)
-				}
-			}
-		}
-	}
-
-	return result
 }
 
 // FIXME

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -15,6 +15,81 @@ const CARDS = require('./cards')
 const permissionFilter = require('./permission-filter')
 const logger = require('../logger').getLogger(__filename)
 
+const flattenSelected = (selected) => {
+	const flat = selected.properties
+	if (!_.isEmpty(selected.links)) {
+		flat.links = _.merge(flat.links, selected.links)
+	}
+
+	return flat
+}
+
+const mergeSelectedMaps = (base, extras) => {
+	return _.mergeWith(base, ...extras, (objA, objB) => {
+		if (!_.isEmpty(objA)) {
+			return objA
+		} else if (!_.isEmpty(objB)) {
+			return objB
+		}
+
+		/* eslint-disable no-undefined */
+		return undefined
+	})
+}
+
+const getSelected = (schema) => {
+	if (_.isBoolean(schema)) {
+		return {
+			links: {},
+			properties: {}
+		}
+	}
+
+	const links = {}
+	if ('$$links' in schema) {
+		for (const [ linkType, linked ] of Object.entries(schema.$$links)) {
+			links[linkType] = flattenSelected(getSelected(linked))
+		}
+	}
+
+	const extraLinks = []
+	const properties = {}
+	if ('required' in schema) {
+		for (const required of schema.required) {
+			properties[required] = {}
+		}
+	}
+	if ('properties' in schema) {
+		for (const [ name, subSchema ] of Object.entries(schema.properties)) {
+			const subSelected = getSelected(subSchema)
+			extraLinks.push(subSelected.links)
+			properties[name] = subSelected.properties
+		}
+	}
+
+	const extraProperties = []
+	for (const combinator of [ 'allOf', 'anyOf' ]) {
+		if (combinator in schema) {
+			for (const branch of schema[combinator]) {
+				const subSelected = getSelected(branch)
+				extraLinks.push(subSelected.links)
+				extraProperties.push(subSelected.properties)
+			}
+		}
+	}
+
+	if ('not' in schema) {
+		const subSelected = getSelected(schema.not)
+		extraLinks.push(subSelected.links)
+		extraProperties.push(subSelected.properties)
+	}
+
+	return {
+		links: mergeSelectedMaps(links, extraLinks),
+		properties: mergeSelectedMaps(properties, extraProperties)
+	}
+}
+
 const patchCard = (card, patch, options = {}) => {
 	return patch.reduce((accumulator, operation) => {
 		if (!operation.path) {
@@ -493,6 +568,7 @@ module.exports = class Kernel {
 	 * @param {String | String[]} [options.sortBy] - Key or key path as an array to
 	 *   a value that the query should be sorted by
 	 * @param {'asc' | 'desc'} [options.sortDir] - Set sort direction,
+	 * @param {Object} selectOverride - Internal use
    * @returns {Object[]} results
    *
    * @example
@@ -510,14 +586,20 @@ module.exports = class Kernel {
    *   required: [ 'slug' ]
    * })
    */
-	async query (context, session, schema, options = {}) {
+	async query (context, session, schema, options = {}, selectOverride) {
 		const finalSchema = schema.type === `${CARDS.view.slug}@${CARDS.view.version}`
 			? views.getSchema(schema)
 			: schema
+
+		// TODO: this is probably going to be given in the schema itself.
+		// `selectOverride` is just a workaround for `this.stream()` to ask
+		// this method what it wants
+		const selected = selectOverride || flattenSelected(getSelected(finalSchema))
+
 		const filteredQuery = await permissionFilter.getQuery(
 			context, this.backend, session, finalSchema)
 
-		return this.backend.query(context, filteredQuery, {
+		return this.backend.query(context, selected, filteredQuery, {
 			limit: options.limit,
 			skip: options.skip,
 			sortBy: options.sortBy,
@@ -590,9 +672,10 @@ module.exports = class Kernel {
 			: schema
 		const filteredQuery = await permissionFilter.getQuery(
 			context, this.backend, session, finalSchema)
+		const selected = flattenSelected(getSelected(finalSchema))
 
 		logger.debug(context, 'Opening stream')
-		return this.backend.stream(context, filteredQuery)
+		return this.backend.stream(context, selected, filteredQuery)
 	}
 
 	/**

--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -29,6 +29,8 @@ const applyMarkers = async (context, backend, user, schema) => {
 	 * and execute it really fast.
 	 */
 	const orgs = await backend.query(context, {
+		slug: {}
+	}, {
 		type: 'object',
 		$$links: {
 			'has member': {

--- a/test/e2e/server/full-text-search.spec.js
+++ b/test/e2e/server/full-text-search.spec.js
@@ -212,11 +212,11 @@ ava.serial('full-text search should match queries for card data->object->string 
 							'payload'
 						],
 						properties: {
-							type: 'object',
-							required: [
-								'message'
-							],
 							payload: {
+								type: 'object',
+								required: [
+									'message'
+								],
 								properties: {
 									message: {
 										type: 'string',
@@ -364,11 +364,11 @@ ava.serial('full-text search should not match on card data->object->string field
 							'payload'
 						],
 						properties: {
-							type: 'object',
-							required: [
-								'message'
-							],
 							payload: {
+								type: 'object',
+								required: [
+									'message'
+								],
 								properties: {
 									message: {
 										type: 'string',

--- a/test/integration/core/backend/index.spec.js
+++ b/test/integration/core/backend/index.spec.js
@@ -60,7 +60,7 @@ ava('.disconnect() should gracefully close streams', async (test) => {
 	}
 	await helpers.before(local)
 	await test.notThrowsAsync(async () => {
-		await local.context.backend.stream(local.context.context, {
+		await local.context.backend.stream(local.context.context, {}, {
 			type: 'object'
 		})
 		await local.context.backend.disconnect(local.context.context)
@@ -943,7 +943,7 @@ ava('.upsertElement() should not insert an element with a non-matching id nor sl
 
 ava('.query() should correctly take string contraints on the uuid', async (test) => {
 	const results = await test.context.backend.query(
-		test.context.context, {
+		test.context.context, {}, {
 			type: 'object',
 			additionalProperties: true,
 			required: [ 'id' ],
@@ -1016,7 +1016,7 @@ ava('.query() should query the database using JSON schema', async (test) => {
 		active: true
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1052,6 +1052,12 @@ ava('.query() should query the database using JSON schema', async (test) => {
 ava('.query() should escape malicious query keys', async (test) => {
 	await test.notThrowsAsync(async () => {
 		await test.context.backend.query(test.context.context, {
+			data: {
+				'Robert\'); DROP TABLE cards; --': {
+					'Robert\'); DROP TABLE cards; --': {}
+				}
+			}
+		}, {
 			type: 'object',
 			properties: {
 				data: {
@@ -1078,6 +1084,8 @@ ava('.query() should escape malicious query values', async (test) => {
 	const injection = 'id FROM cards; DROP TABLE cards; COMMIT; SELECT *'
 	const error = await test.throwsAsync(() => {
 		return test.context.backend.query(test.context.context, {
+			[injection]: {}
+		}, {
 			type: 'object',
 			properties: {
 				[injection]: {
@@ -1093,6 +1101,8 @@ ava('.query() should escape malicious query values', async (test) => {
 
 	await test.notThrowsAsync(async () => {
 		await test.context.backend.query(test.context.context, {
+			slug: {}
+		}, {
 			type: 'object',
 			properties: {
 				slug: {
@@ -1106,6 +1116,8 @@ ava('.query() should escape malicious query values', async (test) => {
 
 	await test.notThrowsAsync(async () => {
 		await test.context.backend.query(test.context.context, {
+			name: {}
+		}, {
 			type: 'object',
 			properties: {
 				name: {
@@ -1147,10 +1159,10 @@ ava('.query() should survive a deep schema', async (test) => {
 		}
 	}
 
-	const results1 = await test.context.backend.query(test.context.context, generate(50, [ 'foo', 'bar' ]))
+	const results1 = await test.context.backend.query(test.context.context, {}, generate(50, [ 'foo', 'bar' ]))
 	test.deepEqual(results1, [])
 
-	const results2 = await test.context.backend.query(test.context.context, generate(80, [ 'foo', 'bar' ]))
+	const results2 = await test.context.backend.query(test.context.context, {}, generate(80, [ 'foo', 'bar' ]))
 	test.deepEqual(results2, [])
 })
 
@@ -1173,7 +1185,7 @@ ava('.query() should query an element by its id', async (test) => {
 		active: true
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -1207,7 +1219,7 @@ ava('.query() should fail to query an element by its id', async (test) => {
 	const otherId = test.context.generateRandomID()
 	test.not(result.id, otherId)
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -1240,7 +1252,7 @@ ava('.query() should query an element by its slug', async (test) => {
 		active: true
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			slug: {
@@ -1275,6 +1287,8 @@ ava('.query() should fail to query an element by its slug', async (test) => {
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		slug: {}
+	}, {
 		type: 'object',
 		properties: {
 			slug: {
@@ -1310,7 +1324,7 @@ ava('.query() should handle integer float limits', async (test) => {
 		})
 	}
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1328,7 +1342,7 @@ ava('.query() should handle integer float limits', async (test) => {
 })
 
 ava('.query() should throw given float limits', async (test) => {
-	await test.throwsAsync(test.context.backend.query(test.context.context, {
+	await test.throwsAsync(test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1367,7 +1381,7 @@ ava('.query() should apply a maximum limit by default', async (test) => {
 		})
 	}
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1404,7 +1418,7 @@ ava('.query() return nothing given a zero limit', async (test) => {
 		})
 	}
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1443,7 +1457,7 @@ ava('.query() should apply a maximum limit by default given sortBy', async (test
 		})
 	}
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1461,7 +1475,7 @@ ava('.query() should apply a maximum limit by default given sortBy', async (test
 })
 
 ava('.query() should throw if limit is negative', async (test) => {
-	await test.throwsAsync(test.context.backend.query(test.context.context, {
+	await test.throwsAsync(test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1479,7 +1493,7 @@ ava('.query() should throw if limit is negative', async (test) => {
 })
 
 ava('.query() should throw if limit is too large', async (test) => {
-	await test.throwsAsync(test.context.backend.query(test.context.context, {
+	await test.throwsAsync(test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1497,7 +1511,7 @@ ava('.query() should throw if limit is too large', async (test) => {
 })
 
 ava('.query() should throw if limit is Infinity', async (test) => {
-	await test.throwsAsync(test.context.backend.query(test.context.context, {
+	await test.throwsAsync(test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1515,7 +1529,7 @@ ava('.query() should throw if limit is Infinity', async (test) => {
 })
 
 ava('.query() should throw if limit is -Infinity', async (test) => {
-	await test.throwsAsync(test.context.backend.query(test.context.context, {
+	await test.throwsAsync(test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1533,7 +1547,7 @@ ava('.query() should throw if limit is -Infinity', async (test) => {
 })
 
 ava('.query() should throw if limit is NaN', async (test) => {
-	await test.throwsAsync(test.context.backend.query(test.context.context, {
+	await test.throwsAsync(test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1614,7 +1628,7 @@ ava('.query() should be able to limit the results', async (test) => {
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1700,7 +1714,7 @@ ava('.query() should be able to skip the results', async (test) => {
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -1743,6 +1757,8 @@ ava('.query() should be able to skip the results of a one-element query', async 
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		id: {}
+	}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -1779,6 +1795,8 @@ ava('.query() should not skip the results of a one-element query if skip is set 
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		id: {}
+	}, {
 		type: 'object',
 		additionalProperties: false,
 		properties: {
@@ -1820,6 +1838,8 @@ ava('.query() should be able to limit the results of a one-element query to 0', 
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		id: {}
+	}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -1856,6 +1876,8 @@ ava('.query() should not omit the results of a one-element query if limit is set
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		id: {}
+	}, {
 		type: 'object',
 		additionalProperties: false,
 		properties: {
@@ -1940,7 +1962,7 @@ ava('.query() should be able to limit and skip the results', async (test) => {
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -2041,7 +2063,7 @@ ava('.query() should be able to sort the query using a key', async (test) => {
 		data: {}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -2131,7 +2153,7 @@ ava('.query() should be able to sort the query in descending order', async (test
 		data: {}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -2226,7 +2248,7 @@ ava('.query() should be able to sort the query using an array of keys', async (t
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -2316,7 +2338,7 @@ ava('.query() should apply sort before skip', async (test) => {
 		data: {}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -2407,7 +2429,7 @@ ava('.query() should apply sort before limit', async (test) => {
 		data: {}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		properties: {
@@ -2432,7 +2454,7 @@ ava('.query() should apply sort before limit', async (test) => {
 ava('.query() should escape malicious sortBy statements', async (test) => {
 	const injection = 'created_at; DROP TABLE cards; --'
 	const error = await test.throwsAsync(() => {
-		return test.context.backend.query(test.context.context, {
+		return test.context.backend.query(test.context.context, {}, {
 			type: 'object',
 			additionalProperties: true,
 			properties: {
@@ -2488,6 +2510,9 @@ ava('.query() should correctly honour top level additionalProperties: true', asy
 	})
 
 	const results1 = await test.context.backend.query(test.context.context, {
+		slug: {},
+		type: {}
+	}, {
 		type: 'object',
 		anyOf: [
 			{
@@ -2511,6 +2536,9 @@ ava('.query() should correctly honour top level additionalProperties: true', asy
 	})
 
 	const results2 = await test.context.backend.query(test.context.context, {
+		type: {},
+		slug: {}
+	}, {
 		type: 'object',
 		anyOf: [
 			{
@@ -2534,6 +2562,9 @@ ava('.query() should correctly honour top level additionalProperties: true', asy
 	})
 
 	const results3 = await test.context.backend.query(test.context.context, {
+		type: {},
+		slug: {}
+	}, {
 		type: 'object',
 		anyOf: [
 			{
@@ -2558,6 +2589,9 @@ ava('.query() should correctly honour top level additionalProperties: true', asy
 	})
 
 	const results4 = await test.context.backend.query(test.context.context, {
+		type: {},
+		slug: {}
+	}, {
 		type: 'object',
 		anyOf: [
 			{
@@ -2583,9 +2617,11 @@ ava('.query() should correctly honour top level additionalProperties: true', asy
 
 	test.deepEqual(_.sortBy(results1, 'slug'), [
 		{
+			slug: user2.slug,
 			type: 'user@1.0.0'
 		},
 		{
+			slug: user1.slug,
 			type: 'user@1.0.0'
 		}
 	])
@@ -2600,9 +2636,11 @@ ava('.query() should correctly honour top level additionalProperties: true', asy
 	])
 	test.deepEqual(_.sortBy(results4, 'slug'), [
 		{
+			slug: user2.slug,
 			type: 'user@1.0.0'
 		},
 		{
+			slug: user1.slug,
 			type: 'user@1.0.0'
 		}
 	])
@@ -2687,7 +2725,7 @@ ava('.query() should resolve "limit" after resolving links', async (test) => {
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		additionalProperties: true,
 		required: [ 'type', 'slug' ],
@@ -2794,7 +2832,7 @@ ava('adding a link should update the linked_at field', async (test) => {
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -2825,7 +2863,7 @@ ava('adding a link should update the linked_at field', async (test) => {
 		version: '1.0.0'
 	})
 
-	const results2 = await test.context.backend.query(test.context.context, {
+	const results2 = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -2960,7 +2998,7 @@ ava('adding a link should augment an existing linked_at field', async (test) => 
 		}
 	})
 
-	const results = await test.context.backend.query(test.context.context, {
+	const results = await test.context.backend.query(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			id: {
@@ -3181,6 +3219,16 @@ ava('.query() should be able to query using links', async (test) => {
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		type: {},
+		links: {
+			'is attached to': {
+				id: {},
+				type: {},
+				slug: {}
+			}
+		},
+		data: {}
+	}, {
 		type: 'object',
 		required: [ 'type', 'links', 'data' ],
 		$$links: {
@@ -3347,6 +3395,13 @@ ava('.query() should be able to query using links when getting an element by id'
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		links: {
+			'is attached to': {}
+		},
+		id: {},
+		data: {},
+		type: {}
+	}, {
 		type: 'object',
 		required: [ 'type', 'links', 'data' ],
 		$$links: {
@@ -3476,6 +3531,13 @@ ava('.query() should be able to query using links when getting an element by slu
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		slug: {},
+		type: {},
+		links: {
+			'is attached to': {}
+		},
+		data: {}
+	}, {
 		type: 'object',
 		required: [ 'type', 'links', 'data' ],
 		$$links: {
@@ -3654,6 +3716,13 @@ ava('.query() should be able to query using links and an inverse name', async (t
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		id: {},
+		type: {},
+		links: {
+			'has attached element': {}
+		},
+		data: {}
+	}, {
 		type: 'object',
 		required: [ 'type', 'links', 'data' ],
 		$$links: {
@@ -3872,6 +3941,12 @@ ava('.query() should omit a result if a link does not match', async (test) => {
 	})
 
 	const results = await test.context.backend.query(test.context.context, {
+		type: {},
+		data: {},
+		links: {
+			'is attached to': {}
+		}
+	}, {
 		type: 'object',
 		required: [ 'type', 'links', 'data' ],
 		$$links: {
@@ -3947,6 +4022,9 @@ ava('.query() should omit a result if a link does not match', async (test) => {
 
 ava.cb('.stream() should report back new elements that match a certain type', (test) => {
 	test.context.backend.stream(test.context.context, {
+		type: {},
+		data: {}
+	}, {
 		type: 'object',
 		additionalProperties: false,
 		properties: {
@@ -4071,6 +4149,10 @@ ava.cb('.stream() should report back changes to certain elements', (test) => {
 		})
 	}).then(() => {
 		return test.context.backend.stream(test.context.context, {
+			slug: {},
+			type: {},
+			data: {}
+		}, {
 			type: 'object',
 			additionalProperties: false,
 			properties: {
@@ -4192,6 +4274,10 @@ ava.cb('.stream() should report back changes to large elements', (test) => {
 		}
 	}).then(() => {
 		return test.context.backend.stream(test.context.context, {
+			slug: {},
+			type: {},
+			data: {}
+		}, {
 			type: 'object',
 			additionalProperties: false,
 			properties: {
@@ -4282,6 +4368,8 @@ ava.cb('.stream() should report back changes to large elements', (test) => {
 
 ava.cb('.stream() should close without finding anything', (test) => {
 	test.context.backend.stream(test.context.context, {
+		slug: {}
+	}, {
 		type: 'object',
 		properties: {
 			slug: {
@@ -4317,6 +4405,10 @@ ava.cb('.stream() should set "before" to null if it previously did not match the
 		}
 	}).then((emitter) => {
 		return test.context.backend.stream(test.context.context, {
+			slug: {},
+			type: {},
+			data: {}
+		}, {
 			type: 'object',
 			additionalProperties: false,
 			properties: {
@@ -4409,6 +4501,10 @@ ava.cb('.stream() should filter the "before" section of a change', (test) => {
 		}
 	}).then(() => {
 		return test.context.backend.stream(test.context.context, {
+			slug: {},
+			type: {},
+			data: {}
+		}, {
 			type: 'object',
 			additionalProperties: false,
 			properties: {
@@ -4507,7 +4603,7 @@ ava.cb('.stream() should filter the "before" section of a change', (test) => {
 })
 
 ava('.stream() should throw if the schema is invalid', async (test) => {
-	await test.throwsAsync(test.context.backend.stream(test.context.context, {
+	await test.throwsAsync(test.context.backend.stream(test.context.context, {}, {
 		type: 'object',
 		properties: {
 			type: {
@@ -4554,7 +4650,7 @@ ava('.upsertElement() should handle multiple parallel insertions on the same slu
 			test.true(error instanceof errors.JellyfishElementAlreadyExists)
 		}
 
-		const results = await test.context.backend.query(test.context.context, {
+		const results = await test.context.backend.query(test.context.context, {}, {
 			type: 'object',
 			required: [ 'type' ],
 			properties: {
@@ -4601,7 +4697,7 @@ ava('.insertElement() should handle multiple parallel insertions on the same slu
 			test.true(error instanceof errors.JellyfishElementAlreadyExists)
 		}
 
-		const results = await test.context.backend.query(test.context.context, {
+		const results = await test.context.backend.query(test.context.context, {}, {
 			type: 'object',
 			required: [ 'type', 'slug' ],
 			properties: {

--- a/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/integration/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -121,12 +121,15 @@ const runner = async ({
 	/*
 	 * 3. Query the elements back using our translator.
 	 */
-	const query = jsonschema2sql(table, schema, options)
+	const query = jsonschema2sql(table, {}, schema, options)
 
 	/*
 	 * 4. Return the results.
 	 */
-	return connection.any(query)
+	const results = await connection.any(query)
+	return results.map((wrapper) => {
+		return wrapper.payload
+	})
 }
 
 ava.serial.before(async (test) => {

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -3133,8 +3133,7 @@ ava('.query() should ignore queries to properties not whitelisted by a role', as
 	test.deepEqual(results, [
 		{
 			type: 'type@1.0.0',
-			slug: 'user',
-			markers: []
+			slug: 'user'
 		}
 	])
 })
@@ -3208,7 +3207,6 @@ ava('.query() should ignore $id properties in roles', async (test) => {
 	test.deepEqual(results, [
 		{
 			type: 'type@1.0.0',
-			markers: [],
 			slug: 'user'
 		}
 	])
@@ -3277,7 +3275,6 @@ ava('.query() should ignore queries to disallowed properties with additionalProp
 
 	test.deepEqual(results, [
 		{
-			markers: [],
 			type: 'type@1.0.0',
 			slug: 'user'
 		}

--- a/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
+++ b/test/unit/core/backend/postgres/jsonschema2sql/index.spec.js
@@ -37,7 +37,7 @@ ava('when performing full-text searches we use to_tsvector and to_tsquery functi
 		}
 	}
 
-	const query = jsonschema2sql('cards', payload.query, payload.options)
+	const query = jsonschema2sql('cards', {}, payload.query, payload.options)
 	test.truthy(query.includes('to_tsvector'))
 	test.truthy(query.includes('to_tsquery'))
 })


### PR DESCRIPTION
Only fetch from the database what is being asked by the unfiltered JSON schema query. This has an obvious performance benefit and avoids some some bad cases when `$$links` starts being usable in other parts of the schema.

This also unlocks the possibility of having an explicit select list instead of tying that with filtering.