### PR TITLE
Optimize compose build pipeline

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,14 +2,13 @@ FROM balena/open-balena-base:v9.4.1
 
 WORKDIR /usr/src/jellyfish
 
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts
-COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
+COPY scripts/check_node_version.js scripts/check_node_version.js
+COPY package.json package-lock.json ./
 ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN cat ~/.npmrc
-RUN env
-RUN NODE_ENV=production npm ci
-RUN rm -f ~/.npmrc
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
+    cat ~/.npmrc && \
+    env && \
+    NODE_ENV=production npm ci && \
+    rm -f ~/.npmrc
 
 COPY Makefile .

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,15 @@
+FROM balena/open-balena-base:v9.4.1
+
+WORKDIR /usr/src/jellyfish
+
+COPY package.json package-lock.json /usr/src/jellyfish/
+RUN mkdir -p scripts
+COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
+ARG NPM_TOKEN
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+RUN cat ~/.npmrc
+RUN env
+RUN NODE_ENV=production npm ci
+RUN rm -f ~/.npmrc
+
+COPY Makefile .

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,19 +6,18 @@ FROM resinci/jellyfish-test:v1.3.11
 
 WORKDIR /usr/src/jellyfish
 
-COPY webpack.config.base.js /usr/src/jellyfish/
-COPY ./scripts ./scripts
-COPY package.json package-lock.json /usr/src/jellyfish/
+COPY scripts scripts
+COPY package.json package-lock.json webpack.config.base.js ./
 ARG NPM_TOKEN
 RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci && \
     rm -f ~/.npmrc
 
-COPY ./apps ./apps
-COPY ./lib ./lib
-COPY ./test ./test
-COPY ./Makefile ./Makefile
-COPY ./.git ./.git
+COPY apps apps
+COPY lib lib
+COPY test test
+COPY Makefile Makefile
+COPY .git .git
 
 # Run set test script
 CMD /bin/bash -c "source ~/.bashrc && /usr/src/jellyfish/scripts/ci/tests/init.js"

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,19 +1,19 @@
 FROM scratch AS preface
 
-COPY ./lib/action-library ./lib/action-library
-COPY ./lib/assert ./lib/assert
-COPY ./lib/core ./lib/core
-COPY ./lib/environment ./lib/environment
-COPY ./lib/logger ./lib/logger
-COPY ./lib/jellyscript ./lib/jellyscript
-COPY ./lib/sync ./lib/sync
-COPY ./lib/queue ./lib/queue
-COPY ./lib/worker ./lib/worker
-COPY ./lib/mail ./lib/mail
-COPY ./lib/metrics ./lib/metrics
+COPY lib/action-library lib/action-library
+COPY lib/assert lib/assert
+COPY lib/core lib/core
+COPY lib/environment lib/environment
+COPY lib/logger lib/logger
+COPY lib/jellyscript lib/jellyscript
+COPY lib/sync lib/sync
+COPY lib/queue lib/queue
+COPY lib/worker lib/worker
+COPY lib/mail lib/mail
+COPY lib/metrics lib/metrics
 
 # Production debugging scripts
-COPY ./scripts/production ./scripts/production
+COPY scripts/production scripts/production
 
 FROM jellyfish-base
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM jellyfish-base
+FROM scratch AS preface
 
 COPY ./lib/action-library ./lib/action-library
 COPY ./lib/assert ./lib/assert
@@ -14,5 +14,9 @@ COPY ./lib/metrics ./lib/metrics
 
 # Production debugging scripts
 COPY ./scripts/production ./scripts/production
+
+FROM jellyfish-base
+
+COPY --from=preface . .
 
 ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,18 @@
+FROM jellyfish-base
+
+COPY ./lib/action-library ./lib/action-library
+COPY ./lib/assert ./lib/assert
+COPY ./lib/core ./lib/core
+COPY ./lib/environment ./lib/environment
+COPY ./lib/logger ./lib/logger
+COPY ./lib/jellyscript ./lib/jellyscript
+COPY ./lib/sync ./lib/sync
+COPY ./lib/queue ./lib/queue
+COPY ./lib/worker ./lib/worker
+COPY ./lib/mail ./lib/mail
+COPY ./lib/metrics ./lib/metrics
+
+# Production debugging scripts
+COPY ./scripts/production ./scripts/production
+
+ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,14 +1,12 @@
 FROM scratch AS preface
 
 COPY webpack.config.base.js .
-COPY lib/chat-widget ./lib/chat-widget
-COPY lib/ui-components ./lib/ui-components
+COPY lib/chat-widget lib/chat-widget
+COPY lib/ui-components lib/ui-components
 
 FROM jellyfish-base
 
 COPY --from=preface . .
 
-RUN mkdir -p scripts/template
-COPY scripts/template/package*.json \
-       /usr/src/jellyfish/scripts/template/
+COPY scripts/template/package*.json scripts/template/
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i --no-package-lock

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -6,11 +6,9 @@ COPY lib/ui-components ./lib/ui-components
 
 FROM jellyfish-base
 
+COPY --from=preface . .
+
 RUN mkdir -p scripts/template
 COPY scripts/template/package*.json \
        /usr/src/jellyfish/scripts/template/
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i --no-package-lock
-
-COPY webpack.config.base.js .
-COPY lib/chat-widget ./lib/chat-widget
-COPY lib/ui-components ./lib/ui-components

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,16 @@
+FROM scratch AS preface
+
+COPY webpack.config.base.js .
+COPY lib/chat-widget ./lib/chat-widget
+COPY lib/ui-components ./lib/ui-components
+
+FROM jellyfish-base
+
+RUN mkdir -p scripts/template
+COPY scripts/template/package*.json \
+       /usr/src/jellyfish/scripts/template/
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i --no-package-lock
+
+COPY webpack.config.base.js .
+COPY lib/chat-widget ./lib/chat-widget
+COPY lib/ui-components ./lib/ui-components

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ compose-build: docker-compose.yml
 	docker build . --build-arg NPM_TOKEN="${NPM_TOKEN}" -f Dockerfile.base -t jellyfish-base
 	echo server ui | \
 		xargs -n 1 -P 2 bash -c 'docker build . -t jellyfish-$$0-base -f Dockerfile.$$0'
-	docker-compose $(DOCKER_COMPOSE_OPTIONS) build \
+	docker-compose $(DOCKER_COMPOSE_OPTIONS) build --parallel \
 		$(DOCKER_COMPOSE_COMMAND_OPTIONS)
 
 compose-exec-%: docker-compose.yml

--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,13 @@ build-livechat:
 docker-exec-%:
 	docker exec $(subst docker-exec-,,$@) $(COMMAND) $(ARGS)
 
+compose-build: docker-compose.yml
+	docker build . --build-arg NPM_TOKEN="${NPM_TOKEN}" -f Dockerfile.base -t jellyfish-base
+	echo server ui | \
+		xargs -n 1 -P 2 bash -c 'docker build . -t jellyfish-$$0-base -f Dockerfile.$$0'
+	docker-compose $(DOCKER_COMPOSE_OPTIONS) build \
+		$(DOCKER_COMPOSE_COMMAND_OPTIONS)
+
 compose-exec-%: docker-compose.yml
 	docker-compose $(DOCKER_COMPOSE_OPTIONS) \
 		exec $(subst compose-exec-,,$@) $(COMMAND) $(ARGS) \

--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -1,6 +1,6 @@
 FROM scratch AS preface
 
-COPY ./apps/action-server ./apps/action-server
+COPY apps/action-server apps/action-server
 
 FROM jellyfish-server-base
 

--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -1,36 +1,6 @@
-FROM balena/open-balena-base:v9.4.1
-
-WORKDIR /usr/src/jellyfish
-
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts
-COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN cat ~/.npmrc
-RUN env
-RUN NODE_ENV=production npm ci
-RUN rm -f ~/.npmrc
-
-COPY ./lib/action-library ./lib/action-library
-COPY ./lib/assert ./lib/assert
-COPY ./lib/core ./lib/core
-COPY ./lib/environment ./lib/environment
-COPY ./lib/logger ./lib/logger
-COPY ./lib/jellyscript ./lib/jellyscript
-COPY ./lib/sync ./lib/sync
-COPY ./lib/queue ./lib/queue
-COPY ./lib/worker ./lib/worker
-COPY ./lib/mail ./lib/mail
-COPY ./lib/metrics ./lib/metrics
+FROM jellyfish-server-base
 
 COPY ./apps/action-server ./apps/action-server
-COPY Makefile .
-
-# Production debugging scripts
-COPY ./scripts/production ./scripts/production
-
-ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-tick >> run.sh && \

--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -1,6 +1,10 @@
-FROM jellyfish-server-base
+FROM scratch AS preface
 
 COPY ./apps/action-server ./apps/action-server
+
+FROM jellyfish-server-base
+
+COPY --from=preface . .
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-tick >> run.sh && \

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -1,6 +1,6 @@
 FROM scratch AS preface
 
-COPY ./apps/action-server ./apps/action-server
+COPY apps/action-server apps/action-server
 
 FROM jellyfish-server-base
 

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -1,34 +1,6 @@
-FROM balena/open-balena-base:v9.4.1
-
-WORKDIR /usr/src/jellyfish
-
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts
-COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN NODE_ENV=production npm ci
-RUN rm -f ~/.npmrc
-
-COPY ./lib/action-library ./lib/action-library
-COPY ./lib/assert ./lib/assert
-COPY ./lib/core ./lib/core
-COPY ./lib/environment ./lib/environment
-COPY ./lib/logger ./lib/logger
-COPY ./lib/jellyscript ./lib/jellyscript
-COPY ./lib/sync ./lib/sync
-COPY ./lib/queue ./lib/queue
-COPY ./lib/worker ./lib/worker
-COPY ./lib/mail ./lib/mail
-COPY ./lib/metrics ./lib/metrics
+FROM jellyfish-server-base
 
 COPY ./apps/action-server ./apps/action-server
-COPY Makefile .
-
-# Production debugging scripts
-COPY ./scripts/production ./scripts/production
-
-ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-worker >> run.sh && \

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -1,6 +1,10 @@
-FROM jellyfish-server-base
+FROM scratch AS preface
 
 COPY ./apps/action-server ./apps/action-server
+
+FROM jellyfish-server-base
+
+COPY --from=preface . .
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-worker >> run.sh && \

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,25 +2,9 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.4.1 as base
+FROM jellyfish-ui-base AS base
 
-WORKDIR /usr/src/jellyfish
-
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts/template
-COPY scripts/template/package*.json \
-	/usr/src/jellyfish/scripts/template/
-COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-RUN rm -f ~/.npmrc
-
-COPY webpack.config.base.js .
 COPY apps/livechat ./apps/livechat
-COPY lib/ui-components ./lib/ui-components
-COPY lib/chat-widget ./lib/chat-widget
-COPY Makefile .
 
 ARG SERVER_HOST=https://api.ly.fish
 ARG SERVER_PORT=443

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,9 +2,13 @@
 # Base
 ###########################################################
 
-FROM jellyfish-ui-base AS base
+FROM scratch AS preface
 
 COPY apps/livechat ./apps/livechat
+
+FROM jellyfish-ui-base AS base
+
+COPY --from=preface . .
 
 ARG SERVER_HOST=https://api.ly.fish
 ARG SERVER_PORT=443

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM scratch AS preface
 
-COPY apps/livechat ./apps/livechat
+COPY apps/livechat apps/livechat
 
 FROM jellyfish-ui-base AS base
 
@@ -23,6 +23,8 @@ RUN make build-livechat \
 ###########################################################
 
 FROM nginx:1.15
+
 WORKDIR /usr/src/jellyfish
+
 COPY --from=base /usr/src/jellyfish/dist/livechat /usr/share/nginx/html
 COPY apps/livechat/conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,6 +1,10 @@
-FROM jellyfish-server-base
+FROM scratch AS preface
 
 COPY ./apps/server ./apps/server
+
+FROM jellyfish-server-base
+
+COPY --from=preface . .
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-server >> run.sh && \

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM scratch AS preface
 
-COPY ./apps/server ./apps/server
+COPY apps/server apps/server
 
 FROM jellyfish-server-base
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,34 +1,6 @@
-FROM balena/open-balena-base:v9.4.1
-
-WORKDIR /usr/src/jellyfish
-
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts
-COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN NODE_ENV=production npm ci
-RUN rm -f ~/.npmrc
-
-COPY ./lib/action-library ./lib/action-library
-COPY ./lib/assert ./lib/assert
-COPY ./lib/core ./lib/core
-COPY ./lib/environment ./lib/environment
-COPY ./lib/logger ./lib/logger
-COPY ./lib/jellyscript ./lib/jellyscript
-COPY ./lib/sync ./lib/sync
-COPY ./lib/queue ./lib/queue
-COPY ./lib/worker ./lib/worker
-COPY ./lib/mail ./lib/mail
-COPY ./lib/metrics ./lib/metrics
+FROM jellyfish-server-base
 
 COPY ./apps/server ./apps/server
-COPY Makefile .
-
-# Production debugging scripts
-COPY ./scripts/production ./scripts/production
-
-ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
 
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-server >> run.sh && \

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -4,28 +4,29 @@
 
 FROM scratch AS preface
 
-COPY ./scripts ./scripts
+COPY scripts scripts
 
-COPY ./lib/core ./lib/core
-COPY ./lib/environment ./lib/environment
-COPY ./lib/sync ./lib/sync
-COPY ./lib/mail ./lib/mail
+COPY lib/core lib/core
+COPY lib/environment lib/environment
+COPY lib/sync lib/sync
+COPY lib/mail lib/mail
 
-COPY ./test ./test
+COPY test test
 
 FROM jellyfish-ui-base AS base
 FROM resinci/jellyfish-sidecar:v1.3.11
 
 WORKDIR /usr/src/jellyfish
 
-COPY --from=base /usr/src/jellyfish/lib/uuid ./lib/uuid
-COPY --from=base /usr/src/jellyfish/lib/chat-widget ./lib/chat-widget
-COPY --from=base /usr/src/jellyfish/node_modules ./node_modules
+COPY --from=base /usr/src/jellyfish/lib/uuid lib/uuid
+COPY --from=base /usr/src/jellyfish/lib/chat-widget lib/chat-widget
+COPY --from=base /usr/src/jellyfish/node_modules node_modules
 COPY --from=base \
     /usr/src/jellyfish/Makefile \
     /usr/src/jellyfish/package-lock.json \
     /usr/src/jellyfish/package.json \
     ./
+
 COPY --from=preface . .
 
 # Sleep forever

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -2,25 +2,31 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-sidecar:v1.3.11
-
-WORKDIR /usr/src/jellyfish
+FROM scratch AS preface
 
 COPY ./scripts ./scripts
-COPY package.json package-lock.json /usr/src/jellyfish/
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-RUN rm -f ~/.npmrc
 
 COPY ./lib/core ./lib/core
-COPY ./lib/chat-widget ./lib/chat-widget
 COPY ./lib/environment ./lib/environment
 COPY ./lib/sync ./lib/sync
 COPY ./lib/mail ./lib/mail
 
 COPY ./test ./test
-COPY ./Makefile ./Makefile
+
+FROM jellyfish-ui-base AS base
+FROM resinci/jellyfish-sidecar:v1.3.11
+
+WORKDIR /usr/src/jellyfish
+
+COPY --from=base /usr/src/jellyfish/lib/uuid ./lib/uuid
+COPY --from=base /usr/src/jellyfish/lib/chat-widget ./lib/chat-widget
+COPY --from=base /usr/src/jellyfish/node_modules ./node_modules
+COPY --from=base \
+    /usr/src/jellyfish/Makefile \
+    /usr/src/jellyfish/package-lock.json \
+    /usr/src/jellyfish/package.json \
+    ./
+COPY --from=preface . .
 
 # Sleep forever
 # See: https://stackoverflow.com/a/35770783

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,25 +2,9 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.4.1 as base
+FROM jellyfish-ui-base AS base
 
-WORKDIR /usr/src/jellyfish
-
-COPY package.json package-lock.json /usr/src/jellyfish/
-RUN mkdir -p scripts/template
-COPY scripts/template/package*.json \
-	/usr/src/jellyfish/scripts/template/
-COPY scripts/check_node_version.js /usr/src/jellyfish/scripts
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
-RUN rm -f ~/.npmrc
-
-COPY webpack.config.base.js .
 COPY apps/ui ./apps/ui
-COPY lib/ui-components ./lib/ui-components
-COPY lib/chat-widget ./lib/chat-widget
-COPY Makefile .
 
 ARG SERVER_HOST=https://api.ly.fish
 ARG SERVER_PORT=443

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,9 +2,13 @@
 # Base
 ###########################################################
 
-FROM jellyfish-ui-base AS base
+FROM scratch AS preface
 
 COPY apps/ui ./apps/ui
+
+FROM jellyfish-ui-base AS base
+
+COPY --from=preface . .
 
 ARG SERVER_HOST=https://api.ly.fish
 ARG SERVER_PORT=443

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM scratch AS preface
 
-COPY apps/ui ./apps/ui
+COPY apps/ui apps/ui
 
 FROM jellyfish-ui-base AS base
 
@@ -26,6 +26,8 @@ RUN make build-ui \
 ###########################################################
 
 FROM nginx:1.15
+
 WORKDIR /usr/src/jellyfish
+
 COPY --from=base /usr/src/jellyfish/dist/ui /usr/share/nginx/html
 COPY apps/ui/conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.nobase.yml
+++ b/docker-compose.nobase.yml
@@ -1,23 +1,6 @@
 version: '2.1'
 
 services:
-  base:
-    image: jellyfish-base
-    build:
-      context: .
-      dockerfile: Dockerfile.base
-      args:
-        - NPM_TOKEN
-  server-base:
-    image: jellyfish-server-base
-    build:
-      context: .
-      dockerfile: Dockerfile.server
-  ui-base:
-    image: jellyfish-ui-base
-    build:
-      context: .
-      dockerfile: Dockerfile.ui
   api:
     image: balena/jellyfish
     build:
@@ -124,6 +107,41 @@ services:
     restart: always
     networks:
       - internal
+  sidecar:
+    build:
+      context: .
+      dockerfile: apps/sidecar/Dockerfile
+    depends_on:
+      - api
+      - livechat
+      - postgres
+      - ui
+      - balena-mdns-publisher
+    environment:
+      DATABASE: postgres
+      LIVECHAT_HOST: http://livechat
+      LIVECHAT_PORT: 80
+      NODE_ENV: test
+      POSTGRES_DATABASE: jellyfish
+      POSTGRES_HOST: postgres
+      POSTGRES_PASSWORD: docker
+      POSTGRES_USER: docker
+      SERVER_HOST: http://api
+      SERVER_PORT: 8000
+      UI_HOST: http://ui
+      UI_PORT: 80
+    networks:
+      - internal
+    healthcheck:
+      interval: 10s
+      retries: 10
+      test:
+        - CMD
+        - curl
+        - --fail
+        - http://api:8000/ping
+      timeout: 10s
+    restart: always
   tick:
     image: balena/jellyfish-tick-server
     build:
@@ -398,6 +416,7 @@ services:
       - worker_3
       - ui
       - tick
+      - sidecar
       - livechat
       - api
       - balena-mdns-publisher
@@ -421,3 +440,4 @@ services:
 
 networks:
   internal: {}
+

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -6,8 +6,6 @@ services:
     build:
       context: .
       dockerfile: apps/server/Dockerfile
-      args:
-        - NPM_TOKEN
     networks:
       - internal
     depends_on:
@@ -89,7 +87,6 @@ services:
       args:
         - SERVER_HOST=http://api.ly.fish.local
         - SERVER_PORT=80
-        - NPM_TOKEN
       context: .
       dockerfile: apps/livechat/Dockerfile
     depends_on:
@@ -115,8 +112,6 @@ services:
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.tick
-      args:
-        - NPM_TOKEN
     depends_on:
       - postgres
       - redis
@@ -172,7 +167,6 @@ services:
         - SENTRY_DSN_UI='0'
         - SERVER_HOST=http://api.ly.fish.local
         - SERVER_PORT=80
-        - NPM_TOKEN
       context: .
       dockerfile: apps/ui/Dockerfile
     depends_on:
@@ -189,8 +183,6 @@ services:
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker
-      args:
-        - NPM_TOKEN
     depends_on:
       - postgres
       - redis

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -1,6 +1,25 @@
 version: '2.1'
 
 services:
+  {{#BASE_IMAGES}}
+  base:
+    image: jellyfish-base
+    build:
+      context: .
+      dockerfile: Dockerfile.base
+      args:
+        - NPM_TOKEN
+  server-base:
+    image: jellyfish-server-base
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+  ui-base:
+    image: jellyfish-ui-base
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+  {{/BASE_IMAGES}}
   api:
     image: balena/jellyfish
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     build:
       context: .
       dockerfile: apps/server/Dockerfile
-      args:
-        - NPM_TOKEN
     networks:
       - internal
     depends_on:
@@ -89,7 +87,6 @@ services:
       args:
         - SERVER_HOST=http://api.ly.fish.local
         - SERVER_PORT=80
-        - NPM_TOKEN
       context: .
       dockerfile: apps/livechat/Dockerfile
     depends_on:
@@ -115,8 +112,6 @@ services:
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.tick
-      args:
-        - NPM_TOKEN
     depends_on:
       - postgres
       - redis
@@ -172,7 +167,6 @@ services:
         - SENTRY_DSN_UI='0'
         - SERVER_HOST=http://api.ly.fish.local
         - SERVER_PORT=80
-        - NPM_TOKEN
       context: .
       dockerfile: apps/ui/Dockerfile
     depends_on:
@@ -188,8 +182,6 @@ services:
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker
-      args:
-        - NPM_TOKEN
     depends_on:
       - postgres
       - redis
@@ -246,8 +238,6 @@ services:
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker
-      args:
-        - NPM_TOKEN
     depends_on:
       - postgres
       - redis
@@ -304,8 +294,6 @@ services:
     build:
       context: .
       dockerfile: apps/action-server/Dockerfile.worker
-      args:
-        - NPM_TOKEN
     depends_on:
       - postgres
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -404,4 +404,3 @@ services:
 
 networks:
   internal: {}
-


### PR DESCRIPTION
This PR is composed of 3 optimizations that each build on previous ones. **Note that the numbers presented here will be even lower in the final PR as I haven't touched the `sidecar`'s dockerfile at all in this draft PR**.

- Times from `master` are (see the end of this comment for an explanation of what each item means, although they are pretty self-descriptive):
  - From scratch: 15m43s
  - Cached rebuild: 15s
  - Modifying `package.json`: 9m26s
  - Modifying `lib/core/index.js`: 2m56s

- Optimization 1: factor out the dockerfiles into common base images. The three base images are: `jellyfish-base` for stuff every service needs, particularly `npm ci`, `jellyfish-server-base` for backend services, and `jellyfish-ui-base` for frontend services. These are build using *plain docker and not compose* to avoid creating empty services. So this optimization as-is prevents `balena push` from working, but that can be fixed so it's not a blocker. Times are:
  - From scratch: 11m45s
  - Cached rebuild: 16s
  - Modifying `package.json`: 10m19s
  - Modifying `lib/core/index.js`: 2m4s

- Optimization 2: enable parallel compose builds. Times are:
  - From scratch: 7m27s
  - Cached rebuild: 16s
  - Modifying `package.json`: 6m51s
  - Modifying `lib/core/index.js`: 1m53s

- Optimization 3: join base images as late as possible to break false dependencies. The linear nature of a dockerfile means that some statements invalidate the latter parts of the dockerfile even if they don't depend on what happened previously. In special, most `COPY` commands are uncorrelated with the contents of base images and thus neither should invalidate the other's cache. Times are:
  - From scratch: 7m12s
  - Cached rebuild: 18s
  - Modifying `package.json`: 6m26s (this is going to be much lower when I adapt the `sidecar`'s dockerfile too)
  - Modifying `lib/core/index.js`: 1m33s

As for what each benchmark variant means:
- From scratch: build from a completely clean docker. This means remote images are downloaded too, but with my connection the time docker spent blocked waiting for a download is insignificant. This benchmark condition is meant to replicate what happens in the CI.
- Cached rebuild: time to build when cache hit rate is 100%
- Modifying `package.json`: time to build with a cache when `package.json` is updated. This should trigger basically a full rebuild *except* with optimization 3. This is a common occurence in JF as `versionbot` touches `package.json` and `package-lock.json` with every PR merged.
- Modifying `lib/core/index.js`: time to build with a cache when `lib/core/index.js` is updated. The `core` module is used by all backend services, so this modification triggers a significant but partial rebuild.