### PR TITLE
backend: Add optional options parameter to server bootstrap

### DIFF
--- a/apps/server/bootstrap.js
+++ b/apps/server/bootstrap.js
@@ -19,7 +19,7 @@ const http = require('./http')
 const socket = require('./socket')
 const graphql = require('./graphql')
 
-module.exports = async (context) => {
+module.exports = async (context, options) => {
 	logger.info(context, 'Configuring HTTP server')
 	const webServer = await http(context, {
 		port: environment.http.port,
@@ -39,8 +39,10 @@ module.exports = async (context) => {
 	}
 
 	logger.info(context, 'Instantiating core library')
+	const backendOptions = (options && options.database) ? Object.assign({}, environment.database.options, options.database)
+		: environment.database.options
 	const jellyfish = await core.create(context, cache, {
-		backend: environment.database.options
+		backend: backendOptions
 	})
 
 	metrics.startServer(context, environment.metrics.ports.app)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This allows for setting custom options, specifically backend constructor options, when setting up a server instance.

Normally environment variables will suffice, but there are times, especially with tests, in which we need to customize parameters on a case-by-case basis in the code.
