### PR TITLE
Friday hack: Automate the daily standup

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -114,6 +114,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('balena/os-test-result.json'),
 		await loadCard('balena/product-balena-cloud.json'),
 		await loadCard('balena/product-jellyfish.json'),
+		await loadCard('balena/standup.json'),
 		await loadCard('balena/view-all-agendas.json'),
 		await loadCard('balena/view-all-blog-posts.json'),
 		await loadCard('balena/view-typeform-responses.json'),

--- a/apps/server/default-cards/balena/standup.json
+++ b/apps/server/default-cards/balena/standup.json
@@ -1,0 +1,43 @@
+{
+  "slug": "standup",
+  "name": "Standup for a person on a particular day",
+  "type": "type@1.0.0",
+  "version": "1.0.0",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "string",
+							"pattern": "^user-[a-z0-9-]+$",
+              "fullTextSearch": true
+            },
+            "date": {
+              "type": "string",
+							"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+					  "message": {
+							"type": "string",
+							"format": "markdown"
+							},
+							"respository":{
+								"type": "string"
+							}
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/lib/action-library/actions/action-run-standup.js
+++ b/lib/action-library/actions/action-run-standup.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'action-run-standup',
+	type: 'action@1.0.0',
+	version: '1.0.0',
+	name: 'Run the daily standup',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {
+		filter: {
+			type: 'object'
+		},
+		arguments: {
+			repository: {
+				type: 'string'
+			},
+			users: {
+				type: 'array',
+				items: {
+					type: 'string'
+				}
+			}
+		}
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/action-library/handlers/action-run-standup.js
+++ b/lib/action-library/handlers/action-run-standup.js
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const moment = require('moment')
+const uuid = require('../../uuid')
+const actionCreateEventHandler = require('./action-create-event').handler
+
+const questions = [ '**Time for your daily standup** \n **What will be your primary focus for today?**',
+	'**Are you facing any blockers requiring action from others?**',
+	'**Any personal tidbits you\'d like to share?**' ]
+
+const getMessageText = (messages) => {
+	return _.map(messages, (message) => {
+		return _.get(message, [ 'data', 'payload', 'message' ])
+	})
+}
+
+const getQuestionsAsked = ({
+	messages,
+	bot
+}) => {
+	const botMessages = _.filter(messages, [ 'data.actor', bot.id ])
+	return getMessageText(botMessages)
+}
+
+const getNextQuestion = ({
+	messages,
+	bot
+}) => {
+	if (!messages) {
+		return questions[0]
+	}
+	const questionsAsked = getQuestionsAsked({
+		messages,
+		bot
+	})
+	const remainingQuestions = _.difference(questions, questionsAsked)
+	if (remainingQuestions.length > 0) {
+		return remainingQuestions[0]
+	}
+	return null
+}
+
+const getThread = async ({
+	context,
+	marker,
+	session,
+	request,
+	date
+}) => {
+	const [ existingThread ] = await context.query(context.privilegedSession, {
+		type: 'object',
+		properties: {
+			type: {
+				const: 'thread@1.0.0'
+			},
+			links: {
+				type: 'object',
+				additionalProperties: true
+			},
+			markers: {
+				type: 'array',
+				minItems: 1,
+				items: {
+					const: marker
+				}
+			}
+		},
+		$$links: {
+			'has attached element': {
+				type: 'object',
+				properties: {
+					type: {
+						const: 'message@1.0.0'
+					},
+					created_at: {
+						type: 'string',
+						pattern: `${date}.+`
+					}
+				}
+			}
+		}
+	}, {
+		links: {
+			'has attached element': {
+				sortBy: 'created_at'
+			}
+		}
+	})
+	if (existingThread) {
+		return existingThread
+	}
+	const typeCard = await context.getCardBySlug(session, 'thread@latest')
+	return context.insertCard(context.privilegedSession, typeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachedEvents: true
+	}, {
+		version: typeCard.version,
+		slug: await context.getEventSlug('thread'),
+		markers: [ marker ]
+	})
+}
+
+const sendQuestion = async ({
+	context,
+	question,
+	request,
+	session,
+	thread,
+	user,
+	bot
+}) => {
+	const eventRequest = {
+		timestamp: request.timestamp,
+		actor: bot.id,
+		originator: request.originator,
+		arguments: {
+			slug: `message-${await uuid.random()}`,
+			type: 'message',
+			payload: {
+				mentionsUser: [],
+				alertsUser: [],
+				mentionsGroup: [],
+				message: question,
+				markers: `user-bot+${user}`
+			}
+		}
+	}
+	await actionCreateEventHandler(
+		session, context, thread, eventRequest)
+}
+
+const createStandup = async ({
+	messages,
+	context,
+	user,
+	repository,
+	date,
+	request,
+	bot
+}) => {
+	const typeCard = await context.getCardBySlug(context.privilegedSession, 'standup@latest')
+	const messageStrings = getMessageText(messages)
+	const standup = await context.insertCard(context.privilegedSession, typeCard, {
+		timestamp: request.timestamp,
+		actor: bot.id,
+		originator: request.originator,
+		attachedEvents: false
+	}, {
+		version: '1.0.0',
+		slug: await context.getEventSlug('standup'),
+		data: {
+			user,
+			repository,
+			date,
+			message: messageStrings.join('/n')
+		}
+	})
+}
+
+const handler = async (session, context, card, request) => {
+	const {
+		users,
+		repository
+	} = request.arguments
+	const date = moment().format('YYYY-MM-DD')
+	const bot = await context.getCardBySlug(session, 'user-bot@1.0.0')
+	for (const user of users) {
+		const marker = `user-bot+${user}`
+		const thread = await getThread({
+			context,
+			date,
+			marker,
+			session,
+			request
+		})
+		const messages = _.get(thread, [ 'links', 'has attached element' ])
+
+		const question = getNextQuestion({
+			messages, bot
+		})
+
+		if (question) {
+			await sendQuestion({
+				context,
+				question,
+				request,
+				session,
+				thread,
+				user,
+				bot
+			})
+		} else {
+			await createStandup({
+				messages,
+				context,
+				user,
+				repository,
+				date,
+				request,
+				bot
+			})
+		}
+	}
+
+	return {
+		id: card.id,
+		type: card.type,
+		version: card.version,
+		slug: card.slug
+	}
+}
+
+module.exports = {
+	handler
+}

--- a/lib/action-library/index.js
+++ b/lib/action-library/index.js
@@ -155,5 +155,10 @@ module.exports = {
 		card: require('./actions/action-google-meet'),
 		pre: _.noop,
 		handler: require('./handlers/action-google-meet').handler
+	},
+	'action-run-standup': {
+		card: require('./actions/action-run-standup'),
+		pre: _.noop,
+		handler: require('./handlers/action-run-standup').handler
 	}
 }

--- a/lib/core/cards/index.js
+++ b/lib/core/cards/index.js
@@ -17,5 +17,6 @@ module.exports = {
 	'user-admin': require('./user-admin'),
 	user: require('./user'),
 	'role-user-admin': require('./role-user-admin'),
-	view: require('./view')
+	view: require('./view'),
+	'user-bot': require('./user-bot')
 }

--- a/lib/core/cards/user-bot.js
+++ b/lib/core/cards/user-bot.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'user-bot',
+	type: 'user@1.0.0',
+	version: '1.0.0',
+	name: 'The bot user',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {
+		email: 'accounts+jellyfish@resin.io',
+		hash: 'PASSWORDLESS',
+		roles: []
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -203,8 +203,18 @@ module.exports = class Kernel {
 			}
 		})
 
+		const botUser = await unsafeUpsert(CARDS['user-bot'])
+		const botSession = await unsafeUpsert({
+			slug: 'session-bot',
+			type: `${CARDS.session.slug}@${CARDS.session.version}`,
+			data: {
+				actor: botUser.id
+			}
+		})
+
 		this.sessions = {
-			admin: adminSession.id
+			admin: adminSession.id,
+			bot: botSession.id
 		}
 
 		await Promise.all([


### PR DESCRIPTION
I wanted to see if I could create a bot for automating the standup.

The idea is that each day this bot will message us and ask us a series of questions. After we answer each question it will ask the next one until we have finished all the questions.

Once we have finished the questions, it will post a formatted standup message to the repo thread.

So far I have made a bot and a `action-run-standup` action. Each time this is run, it evaluates which questions the user has answered and asks the next one. Once all the questions are answered, it creates a standup card.

https://www.loom.com/share/8b9e51076f1a463dbfa1f3864ea0976e

Next I need to get this working with triggers