### PR TITLE
ci: Randomize database name in setup for server integration tests

### DIFF
--- a/scripts/ci/tests/integration.spec.sh
+++ b/scripts/ci/tests/integration.spec.sh
@@ -19,6 +19,4 @@ run_test "Queue Integration Tests" test-integration-queue
 run_test "Worker Integration Tests" test-integration-worker
 
 # Run server integration tests.
-run_test "Server Integration Tests" test-integration-server \
-	SERVER_HOST=http://localhost \
-	POSTGRES_DATABASE=test_$(cat /proc/sys/kernel/random/uuid | cut -d - -f 1)
+run_test "Server Integration Tests" test-integration-server SERVER_HOST=http://localhost

--- a/test/integration/server/helpers.js
+++ b/test/integration/server/helpers.js
@@ -17,9 +17,11 @@ const actionServer = require('../../../apps/action-server/bootstrap')
 const utils = require('../utils')
 
 const workerOptions = {
-	metricsPort: 9100,
 	onError: (context, error) => {
 		throw error
+	},
+	database: {
+		database: `test_${uuid().replace(/-/g, '_')}`
 	}
 }
 
@@ -29,7 +31,9 @@ module.exports = {
 			id: `SERVER-TEST-${uuid()}`
 		}
 
-		test.context.server = await bootstrap(test.context.context)
+		test.context.server = await bootstrap(test.context.context, {
+			database: workerOptions.database
+		})
 		test.context.actionWorker = await actionServer.worker(
 			test.context.context, workerOptions)
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR sets the backend database name option to a randomly generated string in the server integration test helper. This is needed for the tests to pass in both balenaCI compose tests and local native tests. Until now, this random database name was set as an environment variable when calling `make test-integration-server`, but that will no longer be a viable option as we want to support running this test alongside others through a dotenv file.

Depends on https://github.com/product-os/jellyfish/pull/4255 and https://github.com/product-os/jellyfish/pull/4266