### PR TITLE
Typeform signature bug

### DIFF
--- a/apps/server/default-cards/balena/view-typeform-responses.json
+++ b/apps/server/default-cards/balena/view-typeform-responses.json
@@ -16,7 +16,7 @@
           "type": "object",
           "properties": {
             "type": {
-              "const": "form-response"
+              "const": "form-response@1.0.0"
             }
           },
           "required": [

--- a/lib/sync/integrations/typeform.js
+++ b/lib/sync/integrations/typeform.js
@@ -97,13 +97,13 @@ module.exports = class TypeformIntegration {
 }
 
 module.exports.isEventValid = (token, rawEvent, headers) => {
-	const signature = headers['Typeform-Signature']
+	const signature = headers['typeform-signature']
 	if (!signature || !token || !token.signature) {
 		return false
 	}
 
 	const hash = crypto.createHmac('sha256', token.signature)
 		.update(rawEvent)
-		.digest('hex')
+		.digest('base64')
 	return signature === `sha256=${hash}`
 }


### PR DESCRIPTION
The signature failures were due to the digest algorithm when creating the HMAC signatures, it needs to be base64.