### PR TITLE
backend: Add optional database to worker options

### DIFF
--- a/apps/action-server/bootstrap.js
+++ b/apps/action-server/bootstrap.js
@@ -104,8 +104,10 @@ const bootstrap = async (context, library, options) => {
 	}
 
 	logger.info(context, 'Instantiating core library')
+	const backendOptions = (options && options.database) ? Object.assign({}, environment.database.options, options.database)
+		: environment.database.options
 	const jellyfish = await core.create(context, cache, {
-		backend: environment.database.options
+		backend: backendOptions
 	})
 
 	const session = jellyfish.sessions.admin
@@ -217,7 +219,8 @@ exports.worker = async (context, options) => {
 					return worker.execute(key.id, actionRequest)
 				})
 				.catch(errorHandler)
-		}
+		},
+		database: options.database
 	})
 }
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Related to https://github.com/product-os/jellyfish/pull/4255

Adds support for an optional `database` object passed in `options` when bootstrapping a worker.
Needed for the same reasons as the above linked PR, sometimes we need to set custom database settings when bootstrapping a worker when running tests instead of depending on environment variables. Shouldn't break anything as this is an optional child of the already existing `options` parameter passed to worker bootstrap.
