### PR TITLE
Display support thread status in thread header

### DIFF
--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -291,6 +291,8 @@ class SupportThreadBase extends React.Component {
 
 		const eventActions = _.pick(this.props.actions, [ 'addNotification' ])
 
+		const statusDescription = _.get(card, [ 'data', 'statusDescription' ])
+
 		return (
 			<CardLayout
 				card={card}
@@ -437,67 +439,85 @@ class SupportThreadBase extends React.Component {
 						})}
 					</Flex>
 
-					<Flex alignItems="center" mb={1} >
-						<ThreadMirrorIcon mirrors={mirrors} mr={2}/>
-						{Boolean(actor) && (
-							<Txt tooltip={actor.email}>
-								Conversation with <strong>{actor.name}</strong>
+					<Collapsible
+						mt={1}
+						maxContentHeight='50vh'
+						title={(
+							<Flex alignItems="center" flexWrap="wrap" >
+								<ThreadMirrorIcon mirrors={mirrors} mr={2}/>
+								{Boolean(actor) && (
+									<Txt.span tooltip={actor.email}>
+										Conversation with <Txt.span bold>{actor.name}</Txt.span>
+										{Boolean(card.name) && <Txt.span mr={2}>:</Txt.span>}
+									</Txt.span>
+								)}
+								{Boolean(card.name) && <Txt.span bold>{card.name}</Txt.span>}
+							</Flex>
+						)}
+						defaultCollapsed={false}
+						data-test="support-thread__collapse-status"
+					>
+						{statusDescription && (
+							<Txt color="text.light" data-test="support-thread__status-description">
+								{statusDescription}
 							</Txt>
 						)}
-					</Flex>
+						<Collapsible
+							mt={1}
+							title="Details"
+							maxContentHeight='50vh'
+							lazyLoadContent
+							data-test="support-thread-details"
+						>
+							<Flex mt={1} justifyContent="space-between">
+								<Txt><em>Created {helpers.formatTimestamp(card.created_at)}</em></Txt>
+								<Txt>
+									<em>
+										Updated {helpers.timeAgo(_.get(helpers.getLastUpdate(card), [ 'data', 'timestamp' ]))}
+									</em>
+								</Txt>
+							</Flex>
 
-					{Boolean(card.name) && (
-						<Box mb={1}>
-							<Txt bold>{card.name}</Txt>
-						</Box>
-					)}
+							{highlights.length > 0 && (
+								<Collapsible mt={1} title="Highlights" lazyLoadContent data-test="support-thread-highlights">
+									<Extract py={2}>
+										{_.map(highlights, (statusEvent) => {
+											return (
+												<Event
+													key={statusEvent.id}
+													card={statusEvent}
+													user={this.props.user}
+													groups={this.props.groups}
+													selectCard={selectors.getCard}
+													getCard={this.props.actions.getCard}
+													actions={eventActions}
+													mb={1}
+													threadIsMirrored={isMirrored}
+													getActorHref={getActorHref}
+												/>
+											)
+										})}
+									</Extract>
+								</Collapsible>
+							)}
 
-					<Collapsible title="Details" maxContentHeight='50vh' lazyLoadContent data-test="support-thread-details">
-						<Flex mt={1} justifyContent="space-between">
-							<Txt><em>Created {helpers.formatTimestamp(card.created_at)}</em></Txt>
-
-							<Txt>
-								<em>Updated {helpers.timeAgo(_.get(helpers.getLastUpdate(card), [ 'data', 'timestamp' ]))}</em>
-							</Txt>
-						</Flex>
-
-						{highlights.length > 0 && (
-							<Collapsible mt={1} title="Highlights" lazyLoadContent data-test="support-thread-highlights">
-								<Extract py={2}>
-									{_.map(highlights, (statusEvent) => {
-										return (
-											<Event
-												key={statusEvent.id}
-												card={statusEvent}
-												user={this.props.user}
-												groups={this.props.groups}
-												selectCard={selectors.getCard}
-												getCard={this.props.actions.getCard}
-												actions={eventActions}
-												mb={1}
-												threadIsMirrored={isMirrored}
-												getActorHref={getActorHref}
-											/>
-										)
-									})}
-								</Extract>
-							</Collapsible>
-						)}
-
-						<CardFields
-							card={card}
-							fieldOrder={fieldOrder}
-							type={typeCard}
-							omit={[
-								'category',
-								'status',
-								'inbox',
-								'origin',
-								'environment',
-								'translateDate'
-							]}
-						/>
+							<CardFields
+								card={card}
+								fieldOrder={fieldOrder}
+								type={typeCard}
+								omit={[
+									'statusDescription',
+									'category',
+									'status',
+									'inbox',
+									'origin',
+									'environment',
+									'translateDate'
+								]}
+							/>
+						</Collapsible>
 					</Collapsible>
+
 				</Box>
 				<Box flex="1" style={{
 					minHeight: 0

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -28,7 +28,7 @@ const context = {
 }
 
 const selectors = {
-	threadMoreButton: '[data-test="support-thread-details__header"]',
+	statusDescription: '[data-test="support-thread__status-description"]',
 	rbTeam: 'label[for="rb-ghf-team"]',
 	rbUnassign: 'label[for="rb-ghf-unassign"]',
 	ddAssignToMe: '[data-test="card-owner-menu__assign-to-me"]',
@@ -73,7 +73,7 @@ const getWhisperText = async (page) => {
 }
 
 const verifyThreadStatus = async (test, page, expectedStatus) => {
-	const statusDescription = await macros.getElementText(page, '[data-test="card-field__value--statusdescription"]')
+	const statusDescription = await macros.getElementText(page, selectors.statusDescription)
 	test.is(statusDescription.trim(), expectedStatus)
 }
 
@@ -110,7 +110,6 @@ ava.serial('You can assign an unassigned thread to yourself', async (test) => {
 
 	// Create a new support thread
 	await createSupportThreadAndNavigate(page)
-	await macros.waitForThenClickSelector(page, selectors.threadMoreButton)
 
 	// Verify its currently unassigned
 	await verifyCardOwner(test, page, false, unassignedButtonText)
@@ -135,7 +134,6 @@ ava.serial('You can assign an unassigned thread to another user', async (test) =
 
 	// Create a new support thread
 	await createSupportThreadAndNavigate(page)
-	await macros.waitForThenClickSelector(page, selectors.threadMoreButton)
 
 	// Verify its currently unassigned
 	await verifyCardOwner(test, page, false, unassignedButtonText)
@@ -187,7 +185,6 @@ ava.serial('You can unassign a thread that was assigned to you', async (test) =>
 
 	// Create a new support thread (assigned to ourselves)
 	await createSupportThreadAndNavigate(page, currentUser)
-	await macros.waitForThenClickSelector(page, selectors.threadMoreButton)
 
 	// Verify its currently assigned to us
 	await verifyCardOwner(test, page, true, currentUserSlug)
@@ -235,7 +232,6 @@ ava.serial('You can unassign a thread that was assigned to another user', async 
 
 	// Create a new support thread (assigned to the other user)
 	await createSupportThreadAndNavigate(page, otherCommunityUser)
-	await macros.waitForThenClickSelector(page, selectors.threadMoreButton)
 
 	// Verify its currently assigned to the other user
 	await verifyCardOwner(test, page, true, otherCommunityUserSlug)
@@ -285,7 +281,6 @@ ava.serial('You can reassign a thread from yourself to another user', async (tes
 
 	// Create a new support thread (assigned to ourselves)
 	await createSupportThreadAndNavigate(page, currentUser)
-	await macros.waitForThenClickSelector(page, selectors.threadMoreButton)
 
 	// Verify its currently assigned to us
 	await verifyCardOwner(test, page, true, currentUserSlug)


### PR DESCRIPTION
Refactored header elements a bit to help reduce wasted vertical space. Thread name is now displayed on the same line as the 'Conversation with...' text and this acts as the title of the (default open) collapsible section containing the status description and the (collapsed) 'Details' section.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3886 

TBD: I've refactored the support thread header details a bit to try and ensure we don't take up too much vertical space. Would be interested in feedback on whether this is an improvement or not. I'm not overly-attached to any particular way of displaying the info!

![image](https://user-images.githubusercontent.com/2925657/85977240-6b3dbe00-ba06-11ea-93c0-e360a4be2f1a.png)
