### PR TITLE
Ensure ProductOS menu items (repositories) are listed alphabetically

### DIFF
--- a/apps/server/default-cards/contrib/repository.json
+++ b/apps/server/default-cards/contrib/repository.json
@@ -32,7 +32,10 @@
       "required": [
         "data"
       ]
-    }
+    },
+    "indexed_fields": [
+      [ "data.name" ]
+    ]
   },
   "requires": [],
   "capabilities": []

--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -418,6 +418,8 @@ export default class HomeChannel extends React.Component {
 					pattern: '^product-os'
 				}
 			}
+		}, {
+			sortBy: [ 'data', 'name' ]
 		})
 			.then((results) => {
 				this.setState({
@@ -458,6 +460,7 @@ export default class HomeChannel extends React.Component {
 	isExpanded (name) {
 		return _.includes(_.get(this.props.uiState, [ 'sidebar', 'expanded' ], []), name)
 	}
+
 	render () {
 		const {
 			isMobile,


### PR DESCRIPTION
This ensures we display them in the same order each time on the Home Channel menu.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before the Home Channel was displaying ProductOS repositories in a random order that would change from time to time when you re-loaded Jellyfish. Now we ensure we always display them in alphabetical order.

Closes #4265 

Note: I've added an index on the `data.name` field to ensure we can still filter and sort repository cards efficiently by name.