### PR TITLE
Ensure group names contain only certain characters

### DIFF
--- a/apps/server/default-cards/contrib/group.json
+++ b/apps/server/default-cards/contrib/group.json
@@ -12,7 +12,8 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-_]+$"
         },
         "data": {
           "type": "object",


### PR DESCRIPTION
We want to ensure that group names don't contain any spaces or other odd characters. 

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Note: We don't currently have any groups defined so it shouldn't cause any problems to add this restriction.

Ideally we also want to make group names unique. I can't see a way to do this at the moment with JSON schema?