### PR TITLE
backend: Conform metric names to Prometheus naming conventions

### DIFF
--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -19,15 +19,15 @@ const metricNames = {
 	CARD_INSERT_TOTAL: 'jf_card_insert_total',
 	CARD_READ_TOTAL: 'jf_card_read_total',
 	MIRROR_TOTAL: 'jf_mirror_total',
-	MIRROR_DURATION: 'jf_mirror_duration_ms',
+	MIRROR_DURATION: 'jf_mirror_duration_seconds',
 	MIRROR_FAILURE_TOTAL: 'jf_mirror_failure_total',
 	WORKER_SATURATION: 'jf_worker_saturation',
-	WORKER_JOB_DURATION: 'jf_worker_job_duration_ms',
-	WORKER_CONCURRENCY: 'jf_worker_concurrency_total',
+	WORKER_JOB_DURATION: 'jf_worker_job_duration_seconds',
+	WORKER_CONCURRENCY: 'jf_worker_concurrency',
 	WORKER_ACTION_REQUEST_TOTAL: 'jf_worker_action_request_total',
 	BACK_SYNC_CARD_TOTAL: 'jf_back_sync_total',
 	TRANSLATE_TOTAL: 'jf_translate_total',
-	TRANSLATE_DURATION: 'jf_translate_duration_ms',
+	TRANSLATE_DURATION: 'jf_translate_duration_seconds',
 
 	HTTP_QUERY_DURATION: 'jf_http_api_query_duration',
 	HTTP_TYPE_DURATION: 'jf_http_api_type_duration',
@@ -50,8 +50,8 @@ const metricNames = {
 	HTTP_ACTION_FAILURE_TOTAL: 'jf_http_api_action_failure_total',
 	HTTP_WHOAMI_FAILURE_TOTAL: 'jf_http_whoami_query_failure_total',
 
-	SQL_GEN_DURATION: 'jf_sql_gen_duration_ms',
-	QUERY_DURATION: 'jf_query_duration_ms',
+	SQL_GEN_DURATION: 'jf_sql_gen_duration_seconds',
+	QUERY_DURATION: 'jf_query_duration_seconds',
 
 	STREAMS_SATURATION: 'jf_streams_saturation',
 	STREAMS_LINK_QUERY_TOTAL: 'jf_streams_link_query_total',
@@ -59,8 +59,13 @@ const metricNames = {
 }
 
 // Describe each metric
-const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 29).map(Math.round)
-const queryLatencyBuckets = metrics.client.exponentialBuckets(1.1, Math.SQRT2, 30)
+const latencyBuckets = metrics.client.exponentialBuckets(0.004, Math.SQRT2, 29).map((bucket) => {
+	return bucket.toFixed(3)
+})
+
+const queryLatencyBuckets = metrics.client.exponentialBuckets(0.0011, Math.SQRT2, 30).map((bucket) => {
+	return bucket.toFixed(4)
+})
 
 metrics.describe.counter(metricNames.CARD_UPSERT_TOTAL, 'number of cards upserted')
 metrics.describe.counter(metricNames.CARD_INSERT_TOTAL, 'number of cards inserted')


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- updates metrics names to conform with [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/#metric-names)
- changes duration metrics from milliseconds to seconds, which is [also recommended](https://prometheus.io/docs/practices/naming/#metric-names)

Will update the [volatile Jellyfish dashboard](https://monitor.balena-cloud.com/d/w3y8wAmGk/jellyfish-test?orgId=1&refresh=1m) and open a PR on `balena-monitor` to update the [standard dashboard](https://monitor.balena-cloud.com/d/jellyfish/jellyfish?orgId=1&refresh=1m) once I get the okay from @dt-rush on these changes. 

**Millisecond metrics output example**
```
  jf_sql_gen_duration_ms_bucket{le="1.1"} 8262         
  jf_sql_gen_duration_ms_bucket{le="1.5556349186104048"} 8278
  jf_sql_gen_duration_ms_bucket{le="2.2000000000000006"} 8314
  jf_sql_gen_duration_ms_bucket{le="3.11126983722081"} 8330
  jf_sql_gen_duration_ms_bucket{le="4.400000000000001"} 8338
  jf_sql_gen_duration_ms_bucket{le="6.22253967444162"} 8339
  jf_sql_gen_duration_ms_bucket{le="8.800000000000002"} 8339
  jf_sql_gen_duration_ms_bucket{le="12.44507934888324"} 8339
  jf_sql_gen_duration_ms_bucket{le="17.600000000000005"} 8339
  jf_sql_gen_duration_ms_bucket{le="24.89015869776648"} 8339
  jf_sql_gen_duration_ms_bucket{le="35.20000000000001"} 8339
  jf_sql_gen_duration_ms_bucket{le="49.78031739553296"} 8339
  jf_sql_gen_duration_ms_bucket{le="70.40000000000002"} 8339
  jf_sql_gen_duration_ms_bucket{le="99.56063479106592"} 8339
  jf_sql_gen_duration_ms_bucket{le="140.80000000000004"} 8339
  jf_sql_gen_duration_ms_bucket{le="199.12126958213184"} 8339
  jf_sql_gen_duration_ms_bucket{le="281.6000000000001"} 8339
  jf_sql_gen_duration_ms_bucket{le="398.2425391642637"} 8339
  jf_sql_gen_duration_ms_bucket{le="563.2000000000002"} 8339
  jf_sql_gen_duration_ms_bucket{le="796.4850783285274"} 8339
  jf_sql_gen_duration_ms_bucket{le="1126.4000000000003"} 8339
  jf_sql_gen_duration_ms_bucket{le="1592.9701566570548"} 8339
  jf_sql_gen_duration_ms_bucket{le="2252.8000000000006"} 8339
  jf_sql_gen_duration_ms_bucket{le="3185.9403133141095"} 8339
  jf_sql_gen_duration_ms_bucket{le="4505.600000000001"} 8339
  jf_sql_gen_duration_ms_bucket{le="6371.880626628219"} 8339
  jf_sql_gen_duration_ms_bucket{le="9011.200000000003"} 8339
  jf_sql_gen_duration_ms_bucket{le="12743.761253256438"} 8339                            
  jf_sql_gen_duration_ms_bucket{le="18022.400000000005"} 8339
  jf_sql_gen_duration_ms_bucket{le="25487.522506512876"} 8339                                                                            
  jf_sql_gen_duration_ms_bucket{le="+Inf"} 8339                                                                                          
  jf_sql_gen_duration_ms_sum 2233.6991810370237                                                                                          
  jf_sql_gen_duration_ms_count 8339
```

**Second metrics output example**
```
  jf_sql_gen_duration_seconds_bucket{le="0.0011"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0016"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0022"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0031"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0044"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0062"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0088"} 0    
  jf_sql_gen_duration_seconds_bucket{le="0.0124"} 1    
  jf_sql_gen_duration_seconds_bucket{le="0.0176"} 2    
  jf_sql_gen_duration_seconds_bucket{le="0.0249"} 8    
  jf_sql_gen_duration_seconds_bucket{le="0.0352"} 35    
  jf_sql_gen_duration_seconds_bucket{le="0.0498"} 182    
  jf_sql_gen_duration_seconds_bucket{le="0.0704"} 974    
  jf_sql_gen_duration_seconds_bucket{le="0.0996"} 1827    
  jf_sql_gen_duration_seconds_bucket{le="0.1408"} 2287    
  jf_sql_gen_duration_seconds_bucket{le="0.1991"} 3548    
  jf_sql_gen_duration_seconds_bucket{le="0.2816"} 5844    
  jf_sql_gen_duration_seconds_bucket{le="0.3982"} 8018    
  jf_sql_gen_duration_seconds_bucket{le="0.5632"} 9075    
  jf_sql_gen_duration_seconds_bucket{le="0.7965"} 9238    
  jf_sql_gen_duration_seconds_bucket{le="1.1264"} 9271    
  jf_sql_gen_duration_seconds_bucket{le="1.5930"} 9301    
  jf_sql_gen_duration_seconds_bucket{le="2.2528"} 9336    
  jf_sql_gen_duration_seconds_bucket{le="3.1859"} 9354    
  jf_sql_gen_duration_seconds_bucket{le="4.5056"} 9360    
  jf_sql_gen_duration_seconds_bucket{le="6.3719"} 9364    
  jf_sql_gen_duration_seconds_bucket{le="9.0112"} 9365    
  jf_sql_gen_duration_seconds_bucket{le="12.7438"} 9365    
  jf_sql_gen_duration_seconds_bucket{le="18.0224"} 9365    
  jf_sql_gen_duration_seconds_bucket{le="25.4875"} 9365    
  jf_sql_gen_duration_seconds_bucket{le="+Inf"} 9365    
  jf_sql_gen_duration_seconds_sum 2528.1120259780437    
  jf_sql_gen_duration_seconds_count 9365
```