### PR TITLE
backend: Skip card loader upserts when possible

### DIFF
--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+const _ = require('lodash')
 const Bluebird = require('bluebird')
 const path = require('path')
 const $RefParser = require('json-schema-ref-parser')
@@ -150,6 +151,15 @@ module.exports = async (context, jellyfish, worker, session) => {
 		await loadCard('balena/view-workflows.json')
 	], async (card) => {
 		if (!card) {
+			return
+		}
+
+		// Skip cards that already exist and do not need updating
+		// Need to update omitted list if any similar fields are added to the schema
+		card.name = (card.name) ? card.name : null
+		const currentCard = await jellyfish.getCardBySlug(context, session, `${card.slug}@${card.version}`)
+		if (currentCard && _.isEqual(card,
+			_.omit(currentCard, [ 'id', 'created_at', 'updated_at', 'linked_at', 'new_created_at', 'new_updated_at' ]))) {
 			return
 		}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR skips card upserts when possible in `apps/server/card-loader.js`, reducing the overall number of database operations executed on system init. This should help with the problem described in https://github.com/product-os/jellyfish/issues/4109

With the logic added in this PR I was able to reduce the number of upserts from 275 to 55 when initializing against a populated database. This number is compounded by the number of api instances we have running in production, which from what I can tell from Grafana charts is 16. 

Estimated number of upserts on production deploy: 275 cards x 16 instances = **4400**
After adding skip logic: 55 cards x 16 instances = **880**

## Mismatches
I thought that I would be able to skip all cards that already exist in the database, but there are still some stragglers that I'm not sure what to do with.

### Card Definition
For this example, `apps/server/default-cards/balena/view-support-threads-to-audit.json`:
```
{
  slug: 'view-support-threads-to-audit',
  name: 'To audit',
  version: '1.0.0',
  type: 'view@1.0.0',
  markers: [ 'org-balena' ],
  tags: [],
  links: {},
  active: true,
  data: {
    namespace: 'Support',
    allOf: [ [Object] ],
    lenses: [
      'lens-support-threads-to-audit',
      'lens-kanban',
      'lens-support-audit-chart'
    ]
  },
  requires: [],
  capabilities: []
}
```

### Card Already in Database
```
{
  id: 'f92e9c65-8875-4840-9d75-81a8d844a526',
  slug: 'view-support-threads-to-audit',
  type: 'view@1.0.0',
  active: true,
  version: '1.0.0',
  name: 'Users Pending Update',
  tags: [],
  markers: [ 'org-balena' ],
  created_at: '2020-06-30T03:16:37.884Z',
  requires: [],
  capabilities: [],
  data: {
    allOf: [ [Object] ],
    lenses: [ 'lens-support-threads', 'lens-kanban' ]
  },
  updated_at: '2020-06-30T03:22:31.846Z',
  linked_at: {},
  links: {}
}
```

As you can see, `data.namespace` and `data.lenses` differ, causing the upsert to occur.