### PR TITLE
Add missing capabilities and requires to first-time-login and password-reset cards

### DIFF
--- a/apps/server/default-cards/contrib/first-time-login.json
+++ b/apps/server/default-cards/contrib/first-time-login.json
@@ -30,5 +30,7 @@
         }
       }
     }
-  }
+  },
+  "requires": [],
+  "capabilities": []
 }

--- a/apps/server/default-cards/contrib/password-reset.json
+++ b/apps/server/default-cards/contrib/password-reset.json
@@ -30,5 +30,7 @@
         }
       }
     }
-  }
+  },
+  "requires": [],
+  "capabilities": []
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add missing `capabilities` and `requires` to `first-time-login` and `password-reset` cards.
Found while working on https://github.com/product-os/jellyfish/pull/4280
