### PR TITLE
core: allow `$$links` to appear anywhere

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -51,6 +51,7 @@ const CARDS_SELECT = [
 
 // Functions cannot be created concurrently
 const CREATE_IMMUTABLE_ARRAY_TO_STRING_FUNCTION_LOCK = 3043989439426746
+const CREATE_MERGE_JSONB_VIEWS_FUNCTION_LOCK = 3043989439426747
 
 // Just a random fixed number used as the advisory lock ID for SQL
 // initialization scripts that modify the `cards` table
@@ -195,6 +196,33 @@ exports.setup = async (context, connection, database, options = {}) => {
 			CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text) RETURNS text AS $$
 				SELECT array_to_string(arr, sep);
 			$$ LANGUAGE SQL IMMUTABLE;
+
+			COMMIT;
+		`),
+
+		// Recursive function to merge JSONB objects. This function assumes both
+		// objects are just views into the same underlying object
+		connection.any(`
+			BEGIN;
+
+			SELECT pg_advisory_xact_lock(${CREATE_MERGE_JSONB_VIEWS_FUNCTION_LOCK});
+
+			CREATE OR REPLACE FUNCTION merge_jsonb_views(x jsonb, y jsonb) RETURNS jsonb AS $$
+				SELECT coalesce(merged.payload, '{}'::jsonb)
+				FROM (
+					SELECT jsonb_object_agg(
+						coalesce(x_key, y_key),
+						CASE
+							WHEN jsonb_typeof(x_value) = 'object' OR jsonb_typeof(x_value) = 'object' THEN
+								merge_jsonb_views(x_value, y_value)
+							ELSE coalesce(x_value, y_value)
+						END
+					) AS payload
+					FROM jsonb_each(x) AS f1(x_key, x_value)
+					FULL OUTER JOIN jsonb_each(y) AS f2(y_key, y_value)
+					ON x_key = y_key
+				) AS merged
+			$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 			COMMIT;
 		`)

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -72,7 +72,7 @@ const userBelongsToOrgOptimizationIsApplicable = (schema) => {
 		schema.$$links['has member'].properties.slug.const
 }
 
-const postProcessCard = (card, schema, errors) => {
+const postProcessCard = (card) => {
 	if ('links' in card) {
 		const cardLinks = card.links
 		for (const linkType of Object.keys(cardLinks)) {
@@ -80,10 +80,8 @@ const postProcessCard = (card, schema, errors) => {
 				Reflect.deleteProperty(cardLinks, linkType)
 			} else {
 				cardLinks[linkType] = cardLinks[linkType].map((linked) => {
-					return postProcessCard(linked, schema.$$links[linkType], errors)
+					return postProcessCard(linked)
 				})
-
-				utils.filter(schema.$$links[linkType], cardLinks[linkType], errors)
 			}
 		}
 	}
@@ -140,12 +138,11 @@ const runQuery = async (context, schema, query, connection, errors, values) => {
 	}
 }
 
-const postProcessResults = (results, schema, errors) => {
+const postProcessResults = (results) => {
 	const postProcessStart = performance.now()
 	const elements = results.map((wrapper) => {
-		return postProcessCard(wrapper.payload, schema, errors)
+		return postProcessCard(wrapper.payload)
 	})
-	utils.filter(schema, elements, errors)
 	const postProcessEnd = performance.now()
 
 	const postProcessTime = postProcessEnd - postProcessStart
@@ -185,7 +182,7 @@ const queryTable = async (context, backend, table, select, schema, options) => {
 	const {
 		elements,
 		postProcessTime
-	} = postProcessResults(results, schema, backend.errors)
+	} = postProcessResults(results)
 
 	logger[mode](context, 'Query database response', {
 		table,
@@ -874,7 +871,7 @@ module.exports = class PostgresBackend {
 			const {
 				elements,
 				postProcessTime
-			} = postProcessResults(results, schema, this.errors)
+			} = postProcessResults(results)
 
 			logger.debug(context, 'Prepared query database response', {
 				table: cards.TABLE,

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -76,11 +76,15 @@ const postProcessCard = (card, schema, errors) => {
 	if ('links' in card) {
 		const cardLinks = card.links
 		for (const linkType of Object.keys(cardLinks)) {
-			cardLinks[linkType] = cardLinks[linkType].map((linked) => {
-				return postProcessCard(linked, schema.$$links[linkType], errors)
-			})
+			if (cardLinks[linkType].length === 0) {
+				Reflect.deleteProperty(cardLinks, linkType)
+			} else {
+				cardLinks[linkType] = cardLinks[linkType].map((linked) => {
+					return postProcessCard(linked, schema.$$links[linkType], errors)
+				})
 
-			utils.filter(schema.$$links[linkType], cardLinks[linkType], errors)
+				utils.filter(schema.$$links[linkType], cardLinks[linkType], errors)
+			}
 		}
 	}
 

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -72,23 +72,6 @@ const userBelongsToOrgOptimizationIsApplicable = (schema) => {
 		schema.$$links['has member'].properties.slug.const
 }
 
-const postProcessCard = (card) => {
-	if ('links' in card) {
-		const cardLinks = card.links
-		for (const linkType of Object.keys(cardLinks)) {
-			if (cardLinks[linkType].length === 0) {
-				Reflect.deleteProperty(cardLinks, linkType)
-			} else {
-				cardLinks[linkType] = cardLinks[linkType].map((linked) => {
-					return postProcessCard(linked)
-				})
-			}
-		}
-	}
-
-	return utils.removeVersionFields(utils.convertDatesToISOString(card))
-}
-
 const compileSchema = (table, select, schema, options, errors) => {
 	const queryGenStart = performance.now()
 	let query = null
@@ -136,6 +119,28 @@ const runQuery = async (context, schema, query, connection, errors, values) => {
 		results,
 		queryTime
 	}
+}
+
+const postProcessCard = (card) => {
+	if ('links' in card) {
+		const cardLinks = card.links
+		for (const [ linkType, linked ] of Object.entries(cardLinks)) {
+			const linkedCards = linked.linkedcards
+
+			// `f1` and `f2` are how postgres denotes the first and second
+			// elements of an anonymous tuple, respectively
+			_.remove(linkedCards, [ 'f1', null ])
+			if (linkedCards.length === 0) {
+				Reflect.deleteProperty(cardLinks, linkType)
+			} else {
+				cardLinks[linkType] = linkedCards.map((tuple) => {
+					return postProcessCard(_.merge(tuple.f2[0], ...tuple.f2.slice(1)))
+				})
+			}
+		}
+	}
+
+	return utils.removeVersionFields(utils.convertDatesToISOString(card))
 }
 
 const postProcessResults = (results) => {

--- a/lib/core/backend/postgres/jsonschema2sql/array-contains-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/array-contains-filter.js
@@ -5,6 +5,7 @@
  */
 
 const SqlFilter = require('./sql-filter')
+const SqlFragmentBuilder = require('./fragment-builder')
 const SqlSelectBuilder = require('./select-builder')
 
 /**
@@ -17,24 +18,26 @@ module.exports = class ArrayContainsFilter extends SqlFilter {
 	 *
 	 * @param {SqlPath} path - Path to be tested.
 	 * @param {SqlFilter} filter - Filter to test elements against.
-	 * @param {String} alias - Name of the table `filter` refers to.
 	 */
-	constructor (path, filter, alias) {
+	constructor (path, filter) {
 		super()
 
-		this.field = path.toSql()
-		this.unnest = path.isProcessingJsonProperty ? 'jsonb_array_elements' : 'unnest'
-		this.alias = alias
+		this.path = path.cloned()
 		this.filter = filter
 	}
 
 	toSqlInto (builder) {
-		builder
+		const subBuilder = new SqlFragmentBuilder('items')
+		const field = this.path.toSql(builder.getTable())
+		const unnest = this.path.isProcessingJsonProperty ? 'jsonb_array_elements' : 'unnest'
+		subBuilder
 			.push('EXISTS ')
 			.extendParenthisedFrom(
 				new SqlSelectBuilder()
-					.pushFrom(`${this.unnest}(${this.field})`, this.alias)
+					.pushFrom(`${unnest}(${field})`, 'items')
 					.setFilter(this.filter)
 			)
+
+		builder.extendFrom(subBuilder)
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/array-contains-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/array-contains-filter.js
@@ -4,8 +4,8 @@
  * Proprietary and confidential.
  */
 
+const pgFormat = require('pg-format')
 const SqlFilter = require('./sql-filter')
-const SqlFragmentBuilder = require('./fragment-builder')
 const SqlSelectBuilder = require('./select-builder')
 
 /**
@@ -27,17 +27,19 @@ module.exports = class ArrayContainsFilter extends SqlFilter {
 	}
 
 	toSqlInto (builder) {
-		const subBuilder = new SqlFragmentBuilder('items')
+		const alias = pgFormat.ident(this.path.getLast())
 		const field = this.path.toSql(builder.getTable())
 		const unnest = this.path.isProcessingJsonProperty ? 'jsonb_array_elements' : 'unnest'
-		subBuilder
+
+		const context = builder.getContext()
+		context.pushTable(alias)
+		builder
 			.push('EXISTS ')
 			.extendParenthisedFrom(
 				new SqlSelectBuilder()
-					.pushFrom(`${unnest}(${field})`, 'items')
+					.pushFrom(`${unnest}(${field})`, alias)
 					.setFilter(this.filter)
 			)
-
-		builder.extendFrom(subBuilder)
+		context.popTable()
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/array-length-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/array-length-filter.js
@@ -23,15 +23,16 @@ module.exports = class ArrayLengthFilter extends SqlFilter {
 	constructor (path, operator, value) {
 		super()
 
-		this.cardinality = path.isProcessingJsonProperty ? 'jsonb_array_length' : 'cardinality'
-		this.field = path.toSql()
+		this.path = path.cloned()
 		this.operator = operator
 		this.value = value
 	}
 
 	toSqlInto (builder) {
+		const field = this.path.toSql(builder.getTable())
+		const cardinality = this.path.isProcessingJsonProperty ? 'jsonb_array_length' : 'cardinality'
 		builder
-			.pushInvoked(this.cardinality, this.field)
+			.pushInvoked(cardinality, field)
 			.pushSpaced(this.operator)
 			.push(this.value)
 	}

--- a/lib/core/backend/postgres/jsonschema2sql/builder-context.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder-context.js
@@ -12,6 +12,10 @@ const pgFormat = require('pg-format')
  * instance.
  */
 module.exports = class BuilderContext {
+	static lateralAliasFor (linkType) {
+		return pgFormat.ident(`linked@/${linkType}`)
+	}
+
 	/**
 	 * Constructor.
 	 *
@@ -104,7 +108,7 @@ module.exports = class BuilderContext {
 				linkName: pgFormat.literal(linkType),
 				linksAlias: pgFormat.ident(`links@/${stackString}`),
 				joinAlias,
-				lateralAlias: pgFormat.ident(`linked@/${linkType}`),
+				lateralAlias: BuilderContext.lateralAliasFor(linkType),
 
 				// This is a dummy value that is replaced when we have a value
 				// for it

--- a/lib/core/backend/postgres/jsonschema2sql/builder-context.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder-context.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const pgFormat = require('pg-format')
+
+/**
+ * Context for `SqlFragmentBuilder` that is shared between users of a builder
+ * instance.
+ */
+module.exports = class BuilderContext {
+	/**
+	 * Constructor.
+	 *
+	 * @param {String} table - Name or alias of the table we're currently
+	 *        referencing.
+	 */
+	constructor (table) {
+		this.tableStack = [ table ]
+
+		this.linkTypeStack = []
+		this.links = {}
+		this.linkCount = 0
+		this.hoistedFilters = []
+	}
+
+	/**
+	 * Push a new table to the top of the table stack.
+	 *
+	 * @param {String} table - Name or alias of the table to be pushed and used
+	 *        as current.
+	 */
+	pushTable (table) {
+		this.tableStack.push(table)
+	}
+
+	/**
+	 * Get the table at the top of the stack.
+	 *
+	 * @returns {String} Name or alias of the table at the top of the stack.
+	 */
+	getTable () {
+		return this.tableStack[this.tableStack.length - 1]
+	}
+
+	/**
+	 * Pop a table from the top of the stack.
+	 */
+	popTable () {
+		this.tableStack.pop()
+	}
+
+	/**
+	 * Add a link to this context. This will cause `filter` to be recursively
+	 * serialized into SQL and aggregated into a map (see {@link
+	 * BuilderContext#getLinks}). `filter` is always serialized with a new
+	 * `SqlFragmentBuilder` but the context (`this`) is always shared.
+	 *
+	 * @param {String} linkType - The link type.
+	 * @param {SqlFilter} filter - Filter for the link.
+	 * @returns {String} Name of the cards table joined by the link that was
+	 *          just added.
+	 */
+	addLink (linkType, filter) {
+		// The link type stack is usually very shallow, so following this path
+		// from the root is not an issue
+		let currentLinks = this.links
+		for (const [ stackLinkType, stackIdx ] of this.linkTypeStack) {
+			let next = _.get(currentLinks, [ stackLinkType, stackIdx, 'nested' ])
+			if (next) {
+				currentLinks = next
+			} else {
+				next = {}
+				_.set(currentLinks, [ stackLinkType, stackIdx, 'nested' ], next)
+				currentLinks = next
+			}
+		}
+
+		let variants = null
+		if (linkType in currentLinks) {
+			variants = currentLinks[linkType]
+		} else {
+			variants = []
+			currentLinks[linkType] = variants
+		}
+
+		const idx = variants.length
+		this.linkTypeStack.push([
+			linkType.replace('\\', '\\\\').replace('/', '\\/'),
+			idx
+		])
+
+		const stackString = this.linkTypeStack.map(([ stackLinkType, stackIdx ]) => {
+			return `${stackLinkType}.${stackIdx}`
+		}).join('/')
+		const joinAlias = pgFormat.ident(`join@/${stackString}`)
+
+		variants.push({
+			linked: {
+				linkType,
+				linkName: pgFormat.literal(linkType),
+				linksAlias: pgFormat.ident(`links@/${stackString}`),
+				joinAlias,
+				lateralAlias: pgFormat.ident(`linked@/${linkType}`),
+
+				// This is a dummy value that is replaced when we have a value
+				// for it
+				sqlFilter: null
+			}
+		})
+
+		// The `require` is here to break load-time circular dependencies
+		const SqlFragmentBuilder = require('./fragment-builder')
+		const linkCountStart = this.linkCount
+		this.pushTable(joinAlias)
+		const sqlFilter = new SqlFragmentBuilder(this)
+			.extendFrom(filter)
+			.toSql()
+		this.popTable()
+
+		if (linkCountStart < this.linkCount) {
+			this.hoistedFilters.push(sqlFilter)
+			variants[idx].linked.sqlFilter = 'true'
+		} else {
+			variants[idx].linked.sqlFilter = sqlFilter
+		}
+
+		this.linkTypeStack.pop()
+
+		this.linkCount += 1
+
+		return joinAlias
+	}
+
+	/**
+	 * Get all links stored in this context. The returned map has the following
+	 * (recursive) structure:
+	 *
+	 * ```
+	 * <links map> = {
+	 *   <link type>: [
+	 *     [
+	 *       {
+	 *         nested: <links map>,
+	 *         linked: {
+	 *             linkName: ...,
+	 *             linksAlias: ...,
+	 *             joinAlias: ...,
+	 *             lateralAlias: ...,
+	 *             sqlFilter: ...
+	 *         }
+	 *       },
+	 *       ...
+	 *     ],
+	 *     ...
+	 *   },
+	 *   ...
+	 * }
+	 * ```
+	 *
+	 * Where `nested` is optional.
+	 *
+	 * @returns {Object} A map of all links stored in this context.
+	 */
+	getLinks () {
+		return this.links
+	}
+
+	/**
+	 * In some cases, filters can only appear in the `WHERE` clause and not on
+	 * any specific join condition, or we risk emitting queries with circular
+	 * dependencies.
+	 *
+	 * @returns {String} Stringified version of all hoisted filters.
+	 */
+	getHoistedFilters () {
+		return this.hoistedFilters.join(' AND ')
+	}
+}

--- a/lib/core/backend/postgres/jsonschema2sql/builder-context.js
+++ b/lib/core/backend/postgres/jsonschema2sql/builder-context.js
@@ -12,10 +12,6 @@ const pgFormat = require('pg-format')
  * instance.
  */
 module.exports = class BuilderContext {
-	static lateralAliasFor (linkType) {
-		return pgFormat.ident(`linked@/${linkType}`)
-	}
-
 	/**
 	 * Constructor.
 	 *
@@ -108,7 +104,6 @@ module.exports = class BuilderContext {
 				linkName: pgFormat.literal(linkType),
 				linksAlias: pgFormat.ident(`links@/${stackString}`),
 				joinAlias,
-				lateralAlias: BuilderContext.lateralAliasFor(linkType),
 
 				// This is a dummy value that is replaced when we have a value
 				// for it

--- a/lib/core/backend/postgres/jsonschema2sql/equals-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/equals-filter.js
@@ -24,81 +24,86 @@ module.exports = class EqualsFilter extends SqlFilter {
 	constructor (path, values) {
 		super()
 
+		this.path = path.cloned()
+		this.values = values
+	}
+
+	toSqlInto (builder) {
 		let canBeSqlNull = false
 		const textValues = []
 		const nonTextValues = []
-		for (const value of values) {
-			if (value === null && !path.isProcessingJsonProperty) {
+		for (const value of this.values) {
+			if (value === null && !this.path.isProcessingJsonProperty) {
 				canBeSqlNull = true
 			} else if (_.isString(value)) {
 				textValues.push(pgFormat.literal(value))
 			} else {
-				nonTextValues.push(SqlFilter.maybeJsonLiteral(path, value))
+				nonTextValues.push(SqlFilter.maybeJsonLiteral(this.path, value))
 			}
 		}
 
-		this.filter = new ExpressionFilter(false)
+		const filter = new ExpressionFilter(false)
 		if (canBeSqlNull) {
-			this.filter.or(new IsNullFilter(path, true))
+			filter.or(new IsNullFilter(this.path, true))
 		}
 		if (textValues.length > 0) {
-			const field = path.toSql({
-				asText: true
-			})
-
-			let filter = null
+			let innerFilter = null
 			if (textValues.length === 1) {
-				filter = new IsEqualFilter(field, textValues[0])
+				innerFilter = new IsEqualFilter(this.path, true, textValues[0])
 			} else {
-				filter = new IsInFilter(field, textValues)
+				innerFilter = new IsInFilter(this.path, true, textValues)
 			}
-			this.filter.or(filter)
+			filter.or(innerFilter)
 		}
 		if (nonTextValues.length > 0) {
-			const field = path.toSql()
-
-			let filter = null
+			let innerFilter = null
 			if (nonTextValues.length === 1) {
-				filter = new IsEqualFilter(field, nonTextValues[0])
+				innerFilter = new IsEqualFilter(this.path, false, nonTextValues[0])
 			} else {
-				filter = new IsInFilter(field, nonTextValues)
+				innerFilter = new IsInFilter(this.path, false, nonTextValues)
 			}
-			this.filter.or(filter)
+			filter.or(innerFilter)
 		}
-	}
 
-	toSqlInto (builder) {
-		builder.extendFrom(this.filter)
+		builder.extendFrom(filter)
 	}
 }
 
 class IsEqualFilter extends SqlFilter {
-	constructor (field, value) {
+	constructor (path, asText, value) {
 		super()
 
-		this.field = field
+		this.path = path
+		this.asText = asText
 		this.value = value
 	}
 
 	toSqlInto (builder) {
+		const options = this.asText ? {
+			asText: true
+		} : {}
 		builder
-			.push(this.field)
+			.push(this.path.toSql(builder.getTable(), options))
 			.push(' = ')
 			.push(this.value)
 	}
 }
 
 class IsInFilter extends SqlFilter {
-	constructor (field, values) {
+	constructor (path, asText, values) {
 		super()
 
-		this.field = field
+		this.path = path
+		this.asText = asText
 		this.values = values
 	}
 
 	toSqlInto (builder) {
+		const options = this.asText ? {
+			asText: true
+		} : {}
 		builder
-			.push(this.field)
+			.push(this.path.toSql(builder.getTable(), options))
 			.push(' IN ')
 			.pushParenthisedList(this.values)
 	}

--- a/lib/core/backend/postgres/jsonschema2sql/fragment-builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/fragment-builder.js
@@ -8,8 +8,13 @@
  * Builder for any kind of SQL fragment.
  */
 module.exports = class SqlFragmentBuilder {
-	constructor () {
+	constructor (table) {
+		this.table = table
 		this.expr = ''
+	}
+
+	getTable () {
+		return this.table
 	}
 
 	push (fragment) {
@@ -75,7 +80,11 @@ module.exports = class SqlFragmentBuilder {
 		return this
 	}
 
-	build () {
+	toSql () {
 		return this.expr
+	}
+
+	toSqlInto (builder) {
+		builder.push(this.expr)
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/fragment-builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/fragment-builder.js
@@ -4,17 +4,25 @@
  * Proprietary and confidential.
  */
 
+const BuilderContext = require('./builder-context.js')
+
 /**
  * Builder for any kind of SQL fragment.
  */
 module.exports = class SqlFragmentBuilder {
-	constructor (table) {
-		this.table = table
+	constructor (tableOrContext) {
+		this.context = tableOrContext instanceof BuilderContext
+			? tableOrContext
+			: new BuilderContext(tableOrContext)
 		this.expr = ''
 	}
 
 	getTable () {
-		return this.table
+		return this.context.getTable()
+	}
+
+	getContext () {
+		return this.context
 	}
 
 	push (fragment) {

--- a/lib/core/backend/postgres/jsonschema2sql/full-text-search-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/full-text-search-filter.js
@@ -22,15 +22,19 @@ module.exports = class FullTextSearchFilter extends SqlFilter {
 	constructor (path, term, asArray = false) {
 		super()
 
-		const isRootArray = asArray && path.isProcessingColumn
-		this.tsVector = textSearch.toTSVector(path.getTable(), path.slice(1), isRootArray)
-		this.tsQuery = textSearch.toTSQuery(term)
+		this.path = path.cloned()
+		this.term = term
+		this.asArray = asArray
 	}
 
 	toSqlInto (builder) {
+		const isRootArray = this.asArray && this.path.isProcessingColumn
+		const tsVector = textSearch.toTSVector(
+			builder.getTable(), this.path.asArray(), isRootArray)
+		const tsQuery = textSearch.toTSQuery(this.term)
 		builder
-			.push(this.tsVector)
+			.push(tsVector)
 			.push(' @@ ')
-			.push(this.tsQuery)
+			.push(tsQuery)
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -5,11 +5,14 @@
  */
 
 const _ = require('lodash')
+const SelectMap = require('./select-map')
 const SqlQuery = require('./sql-query')
 
 module.exports = (table, select, schema, options = {}) => {
-	console.log(SqlQuery.fromSchema(null, _.cloneDeep(select), schema, options)
+	console.log(require('util').inspect(select, false, null, true))
+	console.log(require('util').inspect(schema, false, null, true))
+	console.log(SqlQuery.fromSchema(null, new SelectMap(select), schema, _.cloneDeep(options))
 		.toSqlSelect(table))
-	return SqlQuery.fromSchema(null, _.cloneDeep(select), schema, options)
+	return SqlQuery.fromSchema(null, new SelectMap(select), schema, _.cloneDeep(options))
 		.toSqlSelect(table)
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -8,6 +8,8 @@ const _ = require('lodash')
 const SqlQuery = require('./sql-query')
 
 module.exports = (table, select, schema, options = {}) => {
+	console.log(SqlQuery.fromSchema(null, _.cloneDeep(select), schema, options)
+		.toSqlSelect(table))
 	return SqlQuery.fromSchema(null, _.cloneDeep(select), schema, options)
 		.toSqlSelect(table)
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -8,5 +8,6 @@ const _ = require('lodash')
 const SqlQuery = require('./sql-query')
 
 module.exports = (table, select, schema, options = {}) => {
-	return SqlQuery.fromSchema(table, _.cloneDeep(select), schema, options).toSqlSelect()
+	return SqlQuery.fromSchema(null, _.cloneDeep(select), schema, options)
+		.toSqlSelect(table)
 }

--- a/lib/core/backend/postgres/jsonschema2sql/index.js
+++ b/lib/core/backend/postgres/jsonschema2sql/index.js
@@ -9,10 +9,6 @@ const SelectMap = require('./select-map')
 const SqlQuery = require('./sql-query')
 
 module.exports = (table, select, schema, options = {}) => {
-	console.log(require('util').inspect(select, false, null, true))
-	console.log(require('util').inspect(schema, false, null, true))
-	console.log(SqlQuery.fromSchema(null, new SelectMap(select), schema, _.cloneDeep(options))
-		.toSqlSelect(table))
 	return SqlQuery.fromSchema(null, new SelectMap(select), schema, _.cloneDeep(options))
 		.toSqlSelect(table)
 }

--- a/lib/core/backend/postgres/jsonschema2sql/is-null-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/is-null-filter.js
@@ -20,7 +20,7 @@ module.exports = class IsNullFilter extends SqlFilter {
 	constructor (path, isNull) {
 		super()
 
-		this.field = path.toSql()
+		this.path = path.cloned()
 		this.isNull = isNull
 	}
 
@@ -28,7 +28,7 @@ module.exports = class IsNullFilter extends SqlFilter {
 		const tail = this.isNull ? ' IS NULL' : ' IS NOT NULL'
 
 		builder
-			.push(this.field)
+			.extendFrom(this.path)
 			.push(tail)
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/is-of-json-types-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/is-of-json-types-filter.js
@@ -21,22 +21,25 @@ module.exports = class IsOfJsonTypesFilter extends SqlFilter {
 	constructor (path, types) {
 		super()
 
-		this.field = path.toSql()
-		this.types = types.map((type) => {
-			return pgFormat.literal(type)
-		})
+		this.path = path.cloned()
+		this.types = types
 	}
 
 	toSqlInto (builder) {
-		builder.pushInvoked('jsonb_typeof', this.field)
-		if (this.types.length === 1) {
+		const field = this.path.toSql(builder.getTable())
+		builder.pushInvoked('jsonb_typeof', field)
+
+		const types = this.types.map((type) => {
+			return pgFormat.literal(type)
+		})
+		if (types.length === 1) {
 			builder
 				.push(' = ')
-				.push(this.types[0])
+				.push(types[0])
 		} else {
 			builder
 				.push(' IN ')
-				.pushParenthisedList(this.types)
+				.pushParenthisedList(types)
 		}
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/json-map-property-count-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/json-map-property-count-filter.js
@@ -23,7 +23,7 @@ module.exports = class JsonMapPropertyCountFilter extends SqlFilter {
 	constructor (path, operator, value) {
 		super()
 
-		this.field = path.toSql()
+		this.path = path.cloned()
 		this.operator = operator
 		this.value = value
 	}
@@ -31,7 +31,7 @@ module.exports = class JsonMapPropertyCountFilter extends SqlFilter {
 	toSqlInto (builder) {
 		builder
 			.push('cardinality(array(SELECT jsonb_object_keys(')
-			.push(this.field)
+			.extendFrom(this.path)
 			.push(')))')
 			.pushSpaced(this.operator)
 			.push(this.value)

--- a/lib/core/backend/postgres/jsonschema2sql/link-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/link-filter.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const SqlFilter = require('./sql-filter')
+
+/**
+ * Filter asserting that there exists a linked card through a link type that
+ * passes a filter.
+ */
+module.exports = class LinkFilter extends SqlFilter {
+	/**
+	 * Constructor.
+	 *
+	 * @param {String} linkType - The link type.
+	 * @param {SqlFilter} filter - Filter for the link.
+	 */
+	constructor (linkType, filter) {
+		super()
+
+		this.linkType = linkType
+		this.filter = filter
+	}
+
+	toSqlInto (builder) {
+		const joinAlias = builder.getContext().addLink(this.linkType, this.filter)
+		builder.push(joinAlias)
+		builder.push('.id IS NOT NULL')
+	}
+}

--- a/lib/core/backend/postgres/jsonschema2sql/matches-regex-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/matches-regex-filter.js
@@ -24,17 +24,17 @@ module.exports = class MatchesRegexFilter extends SqlFilter {
 	constructor (path, regex, flags = {}) {
 		super()
 
-		this.field = path.toSql({
-			asText: true,
-			forceCast: true
-		})
+		this.path = path.cloned()
 		this.operator = flags.ignoreCase ? '~*' : '~'
 		this.regex = pgFormat.literal(regex)
 	}
 
 	toSqlInto (builder) {
+		this.path.toSqlInto(builder, {
+			asText: true,
+			forceCast: true
+		})
 		builder
-			.push(this.field)
 			.pushSpaced(this.operator)
 			.push(this.regex)
 	}

--- a/lib/core/backend/postgres/jsonschema2sql/multiple-of-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/multiple-of-filter.js
@@ -19,13 +19,13 @@ module.exports = class MultipleOfFilter extends SqlFilter {
 	constructor (path, multiple) {
 		super()
 
-		this.field = path.toSql()
+		this.path = path.cloned()
 		this.multiple = multiple
 	}
 
 	toSqlInto (builder) {
 		builder
-			.pushCasted(this.field, 'numeric')
+			.pushCasted(this.path.toSql(builder.getTable()), 'numeric')
 			.push(' % ')
 			.push(this.multiple)
 			.push(' = 0')

--- a/lib/core/backend/postgres/jsonschema2sql/select-builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/select-builder.js
@@ -94,11 +94,12 @@ module.exports = class SqlSelectBuilder {
 	/**
 	 * Add a path to `GROUP BY`.
 	 *
+	 * @param {String} table - The table that `path` references.
 	 * @param {SqlPath} path - The path to `GROUP BY`.
 	 * @returns {SqlSelectBuilder} `this`.
 	 */
-	pushGroupBy (path) {
-		this.groupBy.push(path)
+	pushGroupBy (table, path) {
+		this.groupBy.push([ table, path ])
 
 		return this
 	}
@@ -106,14 +107,15 @@ module.exports = class SqlSelectBuilder {
 	/**
 	 * Add a path to `ORDER BY`.
 	 *
+	 * @param {String} table - The table that `path` references.
 	 * @param {SqlPath} path - Path to `ORDER BY`.
 	 * @param {Boolean} isDescending - Whether the sort direction is in
 	 *        descending order. If false, the sort direction is ascending
 	 *        order. Optional, defaults to false (ascending).
 	 * @returns {SqlSelectBuilder} `this`.
 	 */
-	pushOrderBy (path, isDescending = false) {
-		this.orderBy.push([ path, isDescending ])
+	pushOrderBy (table, path, isDescending = false) {
+		this.orderBy.push([ table, path, isDescending ])
 
 		return this
 	}
@@ -188,22 +190,22 @@ module.exports = class SqlSelectBuilder {
 		}
 		if (this.groupBy.length > 0) {
 			builder.push('\nGROUP BY ')
-			for (const [ idx, path ] of this.groupBy.entries()) {
+			for (const [ idx, [ table, path ] ] of this.groupBy.entries()) {
 				if (idx > 0) {
 					builder.push(', ')
 				}
-				builder.push(path.toSql())
+				builder.push(path.toSql(table))
 			}
 		}
 		if (this.orderBy.length > 0) {
 			builder.push('\nORDER BY ')
-			for (const [ idx, [ path, isDescending ] ] of this.orderBy.entries()) {
+			for (const [ idx, [ table, path, isDescending ] ] of this.orderBy.entries()) {
 				if (idx > 0) {
 					builder.push(', ')
 				}
 
 				builder
-					.push(path.toSql())
+					.push(path.toSql(table))
 					.push(isDescending ? ' DESC' : ' ASC')
 					.push(' NULLS LAST')
 			}
@@ -245,8 +247,9 @@ class SqlJoin {
 				.push(' AS ')
 				.push(this.alias)
 		}
+
 		builder
 			.push('\nON ')
-			.extendFrom(this.filter)
+			.push(this.filter.toSql(this.alias || this.table))
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/select-builder.js
+++ b/lib/core/backend/postgres/jsonschema2sql/select-builder.js
@@ -9,6 +9,7 @@ const ExpressionFilter = require('./expression-filter')
 
 // Types of joins
 const INNER_JOIN = 0
+const LEFT_JOIN = 1
 
 /**
  * Builder for `SELECT` statements.
@@ -71,6 +72,23 @@ module.exports = class SqlSelectBuilder {
 	 */
 	pushInnerJoin (table, filter, alias) {
 		this.pushJoin(INNER_JOIN, table, filter, alias)
+
+		return this
+	}
+
+	/**
+	 * Add a `LEFT JOIN`.
+	 *
+	 * @param {String} table - The table to be joined. This can be the name of
+	 *        an actual table or anything recognized as one, such as
+	 *        subqueries.
+	 * @param {SqlFilter} filter - The join condition. Optional, defaults to
+	 *        true.
+	 * @param {String} alias - Table alias. Optional.
+	 * @returns {SqlSelectBuilder} `this`.
+	 */
+	pushLeftJoin (table, filter, alias) {
+		this.pushJoin(LEFT_JOIN, table, filter, alias)
 
 		return this
 	}
@@ -232,8 +250,11 @@ class SqlJoin {
 	}
 
 	toSqlInto (builder) {
-		// TODO: only inner joins are needed atm
-		builder.push('\nJOIN ')
+		if (this.type === LEFT_JOIN) {
+			builder.push('\nLEFT JOIN ')
+		} else {
+			builder.push('\nJOIN ')
+		}
 		if (_.isString(this.table)) {
 			builder.push(this.table)
 		} else {

--- a/lib/core/backend/postgres/jsonschema2sql/select-map.js
+++ b/lib/core/backend/postgres/jsonschema2sql/select-map.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash')
 const pgFormat = require('pg-format')
-const BuilderContext = require('./builder-context')
 const ExpressionFilter = require('./expression-filter')
 const SqlPath = require('./sql-path')
 
@@ -14,15 +13,30 @@ const SqlPath = require('./sql-path')
  * Map of properties to be selected, with support for conditional selects.
  */
 module.exports = class SelectMap {
+	static lateralAliasFor (linkType) {
+		return pgFormat.ident(`linked@/${linkType}`)
+	}
+
 	/**
 	 * Constructor.
 	 *
 	 * @param {Object} map - Recursive map of properties to be selected, where
 	 *        `x: {}` means "select `x`".
+	 * @param {Object} links - Internal.
+	 * @param {SqlPath} path - Internal.
 	 */
-	constructor (map) {
+	constructor (map, links = {}, path = new SqlPath()) {
 		// Save the pristine map to be used to create new `BranchMap`s
 		this.map = map
+
+		// Map of link types to the `SelectMap` of that link
+		this.links = links
+
+		// What column/property this `SelectMap` refers to
+		this.path = path
+
+		// Whether this `SelectMap` represents the `links` root property
+		this.isLinks = path.isProcessingColumn && path.getLast() === 'links'
 
 		// Common stuff for all branches
 		this.base = new BranchMap(map, this)
@@ -83,144 +97,284 @@ module.exports = class SelectMap {
 	}
 
 	/**
+	 * Get a `SelectMap` for a link.
+	 *
+	 * @param {String} linkType - The link's link type.
+	 * @returns {SelectMap} The `SelectMap` corresponding to the `linkType`
+	 *          link.
+	 */
+	getLink (linkType) {
+		if (linkType in this.links) {
+			return this.links[linkType]
+		}
+
+		const linkSelectMap = new SelectMap(this.map)
+		this.links[linkType] = linkSelectMap
+
+		return linkSelectMap
+	}
+
+	/**
 	 * Build an SQL expression yielding the JSONB card described by `this`.
 	 *
 	 * @param {String} table - The table the card is being selected from.
-	 * @param {SqlPath} path - Internal.
-	 * @param {ExpressionFilter} sunkFilter - Internal.
 	 * @returns {String} The SQL expression.
 	 */
-	toSql (table, path = new SqlPath(), sunkFilter = new ExpressionFilter(true)) {
-		// Start with the whole field if `additionalProperties` is true
-		const field = path.toSql(table)
-		const baseAdditionalProperties = this.base.getAdditionalProperties()
-		const build = []
-		if (baseAdditionalProperties) {
-			build.push(`to_jsonb(${field})`)
+	toSql (table) {
+		// The idea here is conceptually simple: the SQL expression this method
+		// returns will yield a JSONB object containing exactly the properties
+		// asked. The question is, what properties are those? There are three
+		// parameters that influence that:
+		//
+		// - `this.map`, given in the constructor, denoting explicitly selected
+		//   properties
+		// - The value of `additionalProperties`
+		// - The list of "seen" properties. These are the properties actually
+		//   present in the schema
+		//
+		// Every `SelectMap` is composed of a base `BranchMap`, and zero or
+		// more branching `BranchMap`. All of these have their own
+		// `additionalProperties` value and list of seen properties.
+		// `BranchMap`s also have an filter, although that is unused for the
+		// base. At a high level, the object that the SQL expression yields is:
+		//
+		// ```
+		// IF branch1.filter evaluates to true THEN
+		//   yield the union of base and branch1
+		// ELSE IF branch2.filter evaluates to true THEN
+		//   yield the union of base and branch1
+		// ...
+		// ELSE
+		//   yield base
+		// END
+		// ```
+		//
+		// The list properties implied by each `BranchMap` is as follows:
+		//
+		// - If `additionalProperties` is true or `this.map` is empty, then all
+		//   properties are selected
+		// - Otherwise, then:
+		//   - If base, all properties in `this.map`
+		//   - All properties seen by this `BranchMap`
+
+		// Build a list of all properties we need to select in the most general
+		// case. This can be `true` to denote that we want *all* properties
+		const explicitProperties = Object.keys(this.map)
+		let selectedProperties = true
+		if (!this.base.getAdditionalProperties()) {
+			if (explicitProperties.length > 0) {
+				selectedProperties = explicitProperties
+			} else {
+				selectedProperties = Array.from(this.base.seen)
+			}
 		}
 
-		// Find which properties we may need to explicitly add or replace. If
-		// `additionalProperties` is true we rely on what properties all
-		// branches have seen. Otherwise, it's just the properties that were
-		// explicitly selected
-		const allBranches = _.concat([ this.base ], this.branches)
-		let explicitProperties = Object.keys(this.map)
-		if (baseAdditionalProperties || explicitProperties.length === 0) {
-			const allSeen = new Set()
-			for (const branch of allBranches) {
-				for (const seen of branch.seen) {
-					allSeen.add(seen)
+		// Build a list of branches that are going to influence the final set
+		// of properties that are actually selected
+		const conditionalBranches = this.branches
+			.filter((branch) => {
+				// Branches that are unconditional do not influence what we
+				// select
+				return branch.isTransitivelyConditional()
+			})
+			.map((branch) => {
+				const properties = Array.from(branch.seen)
+
+				const transitivelyConditional = []
+				for (const [ property, selectMap ] of Object.entries(branch.all)) {
+					if (selectMap.isTransitivelyConditional()) {
+						transitivelyConditional.push(property)
+					}
+				}
+
+				return {
+					branch,
+					properties,
+					transitivelyConditional
+				}
+			})
+
+		// We start off with the greatest common set of properties we can
+		// return
+		let head = selectedProperties
+		for (const data of conditionalBranches) {
+			if (!data.branch.getAdditionalProperties()) {
+				if (head === true) {
+					head = data.properties
+				} else {
+					head = _.intersection(head, data.properties)
 				}
 			}
-
-			if (!baseAdditionalProperties && path.isProcessingTable && !('links' in this.map)) {
-				allSeen.delete('links')
-			}
-
-			explicitProperties = Array.from(allSeen)
 		}
 
-		// Create an object with all the properties that we need. For each
-		// property, we start with the JSONB object that `this.base` yields for
-		// that property, and then just replace with what the branches give us
-		const isSubLinks = path.isProcessingColumn && path.getLast() === 'links'
-		const args = []
-		path.push(null)
-		for (const name of explicitProperties) {
-			// TODO: conditional selects through links is complicated T_T
-			if (isSubLinks) {
-				args.push(pgFormat.literal(name))
-				args.push(`${BuilderContext.lateralAliasFor(name)}.linkedCards`)
-
-				continue
+		// Then for each branch we add all relevant properties conditioned to
+		// the branch's filter
+		const conditionalCases = []
+		for (const data of conditionalBranches) {
+			let addedProperties = []
+			if (head !== true) {
+				addedProperties = _.difference(data.properties, head)
 			}
-
-			path.setLast(name)
-
-			/* Const subTable = isSubLinks
-				? `${BuilderContext.lateralAliasFor(name)}.linkedCards`
-				: table
-			const subPath = isSubLinks ? new SqlPath() : path */
-
-			const isValidLinks =
-				path.isProcessingColumn &&
-				name === 'links' &&
-				(
-					baseAdditionalProperties ||
-					'links' in this.map
-				)
-
-			const force =
-
-				// If `additionalProperties` is false we have to be explicit
-				// about each selected field
-				!baseAdditionalProperties ||
-
-				// `<table>.links` always acts like
-				// `additionalProperties = false`
-				// isSubLinks ||
-
-				// Links come from joins, so we allways have to be explicit
-				// about them in SQL
-				isValidLinks
-
-			const alternatives = []
-			for (const branch of this.branches) {
-				const branchSql = branch.toSql(
-					table,
-					name,
-					path,
-					sunkFilter,
-					force
-				)
-				if (branchSql !== null) {
-					const filterSql = branch.filter.toSql(table)
-					alternatives.push(`WHEN ${filterSql} THEN ${branchSql}`)
-				}
-			}
-
-			const concat = []
-			const baseSql = this.base.toSql(
-				table,
-				name,
-				path,
-				sunkFilter,
-				force
+			const branchProperties = _.union(
+				addedProperties,
+				data.transitivelyConditional
 			)
-			if (baseSql !== null) {
-				concat.push(baseSql)
-			}
 
-			if (alternatives.length > 0) {
-				const defaultPayload = baseAdditionalProperties
-					? `to_jsonb(${path.toSql(table)})`
-					: '\'{}\'::jsonb'
-				concat.push(`CASE ${alternatives.join('\n')} ELSE ${defaultPayload} END`)
-			}
-
-			if (concat.length > 0) {
-				args.push(pgFormat.literal(name))
-				args.push(concat.join(' || '))
-			}
-		}
-		path.pop()
-		if (args.length > 0) {
-			build.push(`jsonb_build_object(${args.join(', ')})`)
+			conditionalCases.push(data.branch.toConditionalJsonbFragment(
+				table,
+				branchProperties
+			))
 		}
 
-		if (build.length === 0) {
-			return '\'{}\'::jsonb'
+		// Get the properties we need to include in the `ELSE` clause if it
+		// exists
+		let tail = []
+		if (conditionalCases.length > 0 && head !== true) {
+			if (selectedProperties === true) {
+				tail = true
+			} else {
+				tail = _.difference(selectedProperties, head)
+			}
+		}
+
+		// Also build a list of `this.base` properties that are conditional, as
+		// we need this in a couple of places
+		const baseConditionalProperties = []
+		for (const [ property, selectMap ] of Object.entries(this.base.all)) {
+			if (selectMap.isTransitivelyConditional()) {
+				baseConditionalProperties.push(property)
+			}
+		}
+
+		// We always treat the `version` and `links` columns as if they were
+		// conditional, so they will be built explicitly. Both are computed
+		// properties
+		if (this.path.isProcessingTable) {
+			if (
+				(selectedProperties === true || 'links' in selectedProperties) &&
+				!('links' in baseConditionalProperties) &&
+				!_.isEmpty(this.links)
+			) {
+				baseConditionalProperties.push('links')
+			}
+
+			if (
+				(selectedProperties === true || 'version' in selectedProperties) &&
+				!('version' in baseConditionalProperties)
+			) {
+				baseConditionalProperties.push('version')
+			}
+		}
+
+		// Finally, build the SQL expression
+
+		const build = []
+
+		if (head === true) {
+			build.push(`to_jsonb(${this.path.toSql(table)})`)
+
+			if (baseConditionalProperties.length > 0) {
+				build.push(this.sqlBuildJsonbFor(baseConditionalProperties, table))
+			}
+		} else {
+			build.push(this.sqlBuildJsonbFor(head, table))
+		}
+
+		if (conditionalCases.length > 0) {
+			let sqlTail = null
+			if (tail === true) {
+				sqlTail = [ `to_jsonb(${this.path.toSql(table)})` ]
+
+				if (baseConditionalProperties.length > 0) {
+					sqlTail.push(this.sqlBuildJsonbFor(baseConditionalProperties, table))
+				}
+
+				sqlTail = sqlTail.join(' || ')
+			} else if (tail.length > 0) {
+				sqlTail = this.sqlBuildJsonbFor(tail, table)
+			}
+
+			// Aggregate all conditional cases in a binary-tree-like structure
+			// so that they can be merged with the least amount of calls to
+			// `merge_jsonb_views`
+			let mergeTree = conditionalCases
+			while (mergeTree.length > 1) {
+				const newMergeTree = []
+				for (let idx = 0; idx < mergeTree.length; idx += 2) {
+					if (idx === mergeTree.length - 1) {
+						newMergeTree.push(mergeTree[idx])
+					} else {
+						newMergeTree.push(`merge_jsonb_views(${mergeTree[idx]}, ${mergeTree[idx + 1]})`)
+					}
+				}
+				mergeTree = newMergeTree
+			}
+
+			let body = mergeTree[0]
+			if (sqlTail !== null) {
+				const tailFilter = new ExpressionFilter(false)
+				for (const branch of this.branches) {
+					if (!branch.isTransitivelyConditional()) {
+						tailFilter.or(_.cloneDeep(branch.filter))
+					}
+				}
+				body = `
+					CASE
+						WHEN ${tailFilter.toSql(table)} THEN ${sqlTail}
+						ELSE ${body}
+					END
+				`
+			}
+
+			build.push(body)
 		}
 
 		return build.join(' || ')
 	}
 
-	isTransitivelyFiltered () {
-		if (this.base.isTransitivelyFiltered()) {
+	sqlBuildJsonbFor (properties, table) {
+		const args = []
+		const propertiesAsLiterals = []
+		this.path.push(null)
+		for (const property of properties) {
+			this.path.setLast(property)
+
+			const literal = pgFormat.literal(property)
+			propertiesAsLiterals.push(literal)
+			args.push(literal)
+
+			if (this.path.isProcessingColumn && property === 'links') {
+				const linkArgs = []
+				for (const linkType of Object.keys(this.links)) {
+					linkArgs.push(pgFormat.literal(linkType))
+					linkArgs.push(SelectMap.lateralAliasFor(linkType))
+				}
+				args.push(`jsonb_build_object(${linkArgs.join(', ')})`)
+			} else if (property in this.base.all) {
+				args.push(this.base.all[property].toSql(table))
+			} else {
+				args.push(this.path.toSql(table))
+			}
+		}
+		this.path.pop()
+
+		const jsonbObject = `jsonb_build_object(${args.join(', ')})`
+		if (this.path.isProcessingJsonProperty) {
+			return `${jsonbObject} - array(
+				SELECT key
+				FROM (VALUES (${propertiesAsLiterals.join('), (')})) AS f1(key)
+				WHERE key NOT IN (SELECT jsonb_object_keys(${this.path.toSql(table)}))
+			)`
+		}
+		return jsonbObject
+	}
+
+	isTransitivelyConditional () {
+		if (this.base.isTransitivelyConditional()) {
 			return true
 		}
 		for (const branch of this.branches) {
-			if (branch.isTransitivelyFiltered()) {
+			if (branch.isTransitivelyConditional()) {
 				return true
 			}
 		}
@@ -252,8 +406,16 @@ class BranchMap {
 		// `see()`
 		this.seen = new Set()
 
+		const path = this.parent.path
+		const links = this.parent.links
 		for (const [ key, value ] of Object.entries(map)) {
-			this.all[key] = new SelectMap(value)
+			if (this.parent.isLinks && !(key in links)) {
+				links[key] = new SelectMap(value)
+			} else {
+				const subPath = _.cloneDeep(path)
+				subPath.push(key)
+				this.all[key] = new SelectMap(value, links, subPath)
+			}
 		}
 	}
 
@@ -301,8 +463,16 @@ class BranchMap {
 	 */
 	see (name) {
 		this.seen.add(name)
-		if (!(name in this.all)) {
-			this.all[name] = new SelectMap({})
+
+		const links = this.parent.links
+		if (this.parent.isLinks) {
+			if (!(name in links)) {
+				links[name] = new SelectMap({})
+			}
+		} else if (!(name in this.all)) {
+			const subPath = _.cloneDeep(this.parent.path)
+			subPath.push(name)
+			this.all[name] = new SelectMap({}, links, subPath)
 		}
 	}
 
@@ -315,29 +485,32 @@ class BranchMap {
 	getProperty (name) {
 		this.see(name)
 
+		if (this.parent.isLinks) {
+			return this.parent.links[name]
+		}
+
 		return this.all[name]
 	}
 
-	getExcluded (from) {
-		if (this.additionalProperties) {
-			return []
-		}
-
-		const seen = this.seen
-
-		return _.filter(from, (name) => {
-			return !seen.has(name)
-		})
+	/**
+	 * Get a `SelectMap` for a link.
+	 *
+	 * @param {String} linkType - The link's link type.
+	 * @returns {SelectMap} The `SelectMap` corresponding to the `linkType`
+	 *          link.
+	 */
+	getLink (linkType) {
+		return this.parent.getLink(linkType)
 	}
 
 	// TODO: avoiding recursion with a cache would save some repeated
 	// calculations
-	isTransitivelyFiltered () {
+	isTransitivelyConditional () {
 		if (!this.additionalProperties) {
 			return true
 		}
 		for (const subProperty of Object.values(this.all)) {
-			if (subProperty.isTransitivelyFiltered()) {
+			if (subProperty.isTransitivelyConditional()) {
 				return true
 			}
 		}
@@ -345,20 +518,39 @@ class BranchMap {
 		return false
 	}
 
-	toSql (table, name, path, sunkFilter, force) {
-		if (!this.seen.has(name)) {
-			return null
+	toConditionalJsonbFragment (table, wantedProperties) {
+		const propertiesAsLiterals = []
+		const args = []
+		const path = this.parent.path
+		path.push(null)
+		for (const property of wantedProperties) {
+			const literal = pgFormat.literal(property)
+			propertiesAsLiterals.push(literal)
+			args.push(literal)
+
+			path.setLast(property)
+			if (property in this.all) {
+				args.push(this.all[property].toSql(table))
+			} else {
+				args.push(path.toSql(table))
+			}
+		}
+		path.pop()
+
+		let jsonbObject = `jsonb_build_object(${args.join(', ')})`
+		if (path.isProcessingJsonProperty) {
+			jsonbObject = `${jsonbObject} - array(
+				SELECT key
+				FROM (VALUES (${propertiesAsLiterals.join('), (')})) AS f1(key)
+				WHERE key NOT IN (SELECT jsonb_object_keys(${path.toSql(table)}))
+			)`
 		}
 
-		const subSelectMap = this.all[name]
-		if (!force && !subSelectMap.isTransitivelyFiltered()) {
-			return null
-		}
-
-		return subSelectMap.toSql(
-			table,
-			path,
-			_.cloneDeep(sunkFilter).and(_.cloneDeep(this.filter))
-		)
+		return `
+			CASE
+				WHEN ${this.filter.toSql(table)} THEN ${jsonbObject}
+				ELSE '{}'::jsonb
+			END
+		`
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/select-map.js
+++ b/lib/core/backend/postgres/jsonschema2sql/select-map.js
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const pgFormat = require('pg-format')
+const BuilderContext = require('./builder-context')
+const ExpressionFilter = require('./expression-filter')
+const SqlPath = require('./sql-path')
+
+/**
+ * Map of properties to be selected, with support for conditional selects.
+ */
+module.exports = class SelectMap {
+	/**
+	 * Constructor.
+	 *
+	 * @param {Object} map - Recursive map of properties to be selected, where
+	 *        `x: {}` means "select `x`".
+	 */
+	constructor (map) {
+		// Save the pristine map to be used to create new `BranchMap`s
+		this.map = map
+
+		// Common stuff for all branches
+		this.base = new BranchMap(map, this)
+
+		// A list of branches for the property that `this` represents
+		this.branches = []
+	}
+
+	/**
+	 * Create a new branch and return it.
+	 *
+	 * @returns {BranchMap} The new branch.
+	 */
+	newBranch () {
+		const branch = new BranchMap(this.map, this)
+		this.branches.push(branch)
+
+		return branch
+	}
+
+	/**
+	 * Get the unconditional `additionalProperties` setting for this map.
+	 *
+	 * @returns {Boolean} The unconditional `additionalProperties` setting.
+	 */
+	getAdditionalProperties () {
+		return this.base.getAdditionalProperties()
+	}
+
+	/**
+	 * Set the unconditional `additionalProperties` setting for this map.
+	 *
+	 * @param {Boolean} schema - The unconditional `additionalProperties`
+	 *        setting.
+	 */
+	setAdditionalProperties (schema) {
+		this.base.setAdditionalProperties(schema)
+	}
+
+	/**
+	 * Mark a property as seen. Unseen properties will be removed from the
+	 * final payload if `additionalProperties` is false.
+	 *
+	 * @param {String} name - The name of the property to be marked as seen.
+	 */
+	see (name) {
+		this.base.see(name)
+	}
+
+	/**
+	 * Get a `SelectMap` for a property. This also marks `name` as seen.
+	 *
+	 * @param {String} name - The name of the property.
+	 * @returns {SelectMap} The `SelectMap` corresponding for `name`.
+	 */
+	getProperty (name) {
+		return this.base.getProperty(name)
+	}
+
+	/**
+	 * Build an SQL expression yielding the JSONB card described by `this`.
+	 *
+	 * @param {String} table - The table the card is being selected from.
+	 * @param {SqlPath} path - Internal.
+	 * @param {ExpressionFilter} sunkFilter - Internal.
+	 * @returns {String} The SQL expression.
+	 */
+	toSql (table, path = new SqlPath(), sunkFilter = new ExpressionFilter(true)) {
+		// Start with the whole field if `additionalProperties` is true
+		const field = path.toSql(table)
+		const baseAdditionalProperties = this.base.getAdditionalProperties()
+		const build = []
+		if (baseAdditionalProperties) {
+			build.push(`to_jsonb(${field})`)
+		}
+
+		// Find which properties we may need to explicitly add or replace. If
+		// `additionalProperties` is true we rely on what properties all
+		// branches have seen. Otherwise, it's just the properties that were
+		// explicitly selected
+		const allBranches = _.concat([ this.base ], this.branches)
+		let explicitProperties = Object.keys(this.map)
+		if (baseAdditionalProperties || explicitProperties.length === 0) {
+			const allSeen = new Set()
+			for (const branch of allBranches) {
+				for (const seen of branch.seen) {
+					allSeen.add(seen)
+				}
+			}
+
+			if (!baseAdditionalProperties && path.isProcessingTable && !('links' in this.map)) {
+				allSeen.delete('links')
+			}
+
+			explicitProperties = Array.from(allSeen)
+		}
+
+		// Create an object with all the properties that we need. For each
+		// property, we start with the JSONB object that `this.base` yields for
+		// that property, and then just replace with what the branches give us
+		const isSubLinks = path.isProcessingColumn && path.getLast() === 'links'
+		const args = []
+		path.push(null)
+		for (const name of explicitProperties) {
+			// TODO: conditional selects through links is complicated T_T
+			if (isSubLinks) {
+				args.push(pgFormat.literal(name))
+				args.push(`${BuilderContext.lateralAliasFor(name)}.linkedCards`)
+
+				continue
+			}
+
+			path.setLast(name)
+
+			/* Const subTable = isSubLinks
+				? `${BuilderContext.lateralAliasFor(name)}.linkedCards`
+				: table
+			const subPath = isSubLinks ? new SqlPath() : path */
+
+			const isValidLinks =
+				path.isProcessingColumn &&
+				name === 'links' &&
+				(
+					baseAdditionalProperties ||
+					'links' in this.map
+				)
+
+			const force =
+
+				// If `additionalProperties` is false we have to be explicit
+				// about each selected field
+				!baseAdditionalProperties ||
+
+				// `<table>.links` always acts like
+				// `additionalProperties = false`
+				// isSubLinks ||
+
+				// Links come from joins, so we allways have to be explicit
+				// about them in SQL
+				isValidLinks
+
+			const alternatives = []
+			for (const branch of this.branches) {
+				const branchSql = branch.toSql(
+					table,
+					name,
+					path,
+					sunkFilter,
+					force
+				)
+				if (branchSql !== null) {
+					const filterSql = branch.filter.toSql(table)
+					alternatives.push(`WHEN ${filterSql} THEN ${branchSql}`)
+				}
+			}
+
+			const concat = []
+			const baseSql = this.base.toSql(
+				table,
+				name,
+				path,
+				sunkFilter,
+				force
+			)
+			if (baseSql !== null) {
+				concat.push(baseSql)
+			}
+
+			if (alternatives.length > 0) {
+				const defaultPayload = baseAdditionalProperties
+					? `to_jsonb(${path.toSql(table)})`
+					: '\'{}\'::jsonb'
+				concat.push(`CASE ${alternatives.join('\n')} ELSE ${defaultPayload} END`)
+			}
+
+			if (concat.length > 0) {
+				args.push(pgFormat.literal(name))
+				args.push(concat.join(' || '))
+			}
+		}
+		path.pop()
+		if (args.length > 0) {
+			build.push(`jsonb_build_object(${args.join(', ')})`)
+		}
+
+		if (build.length === 0) {
+			return '\'{}\'::jsonb'
+		}
+
+		return build.join(' || ')
+	}
+
+	isTransitivelyFiltered () {
+		if (this.base.isTransitivelyFiltered()) {
+			return true
+		}
+		for (const branch of this.branches) {
+			if (branch.isTransitivelyFiltered()) {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+const SelectMap = module.exports
+
+/**
+ * A single branch of a `SelectMap`.
+ */
+class BranchMap {
+	constructor (map, parent) {
+		// We need this for `this.newBranch()`
+		this.parent = parent
+
+		// Defaults to true as per the JSON schema spec
+		this.additionalProperties = true
+
+		// Map of all sub properties
+		this.all = {}
+
+		// The condition for all sub properties to be selected
+		this.filter = new ExpressionFilter(true)
+
+		// Set of sub properties we've seen, either from `getProperty()` or
+		// `see()`
+		this.seen = new Set()
+
+		for (const [ key, value ] of Object.entries(map)) {
+			this.all[key] = new SelectMap(value)
+		}
+	}
+
+	/**
+	 * Create a new branch from the parent `SelectMap` and return it.
+	 *
+	 * @returns {BranchMap} The new branch.
+	 */
+	newBranch () {
+		return this.parent.newBranch()
+	}
+
+	/**
+	 * Get this branch's `additionalProperties` setting.
+	 *
+	 * @returns {Boolean} This branch's `additionalProperties` setting.
+	 */
+	getAdditionalProperties () {
+		return this.additionalProperties
+	}
+
+	/**
+	 * Set this branch's `additionalProperties` setting for this map.
+	 *
+	 * @param {Boolean} schema - This branch's `additionalProperties` setting.
+	 */
+	setAdditionalProperties (schema) {
+		this.additionalProperties = schema
+	}
+
+	/**
+	 * Set the filter for this branch.
+	 *
+	 * @param {SqlFilter} filter - The filter.
+	 */
+	setFilter (filter) {
+		this.filter = _.cloneDeep(filter).intoExpression()
+	}
+
+	/**
+	 * Mark a property as seen. Unseen properties will be removed from the
+	 * final payload if `additionalProperties` is false.
+	 *
+	 * @param {String} name - The name of the property to be marked as seen.
+	 */
+	see (name) {
+		this.seen.add(name)
+		if (!(name in this.all)) {
+			this.all[name] = new SelectMap({})
+		}
+	}
+
+	/**
+	 * Get a `SelectMap` for a property. This also marks `name` as seen.
+	 *
+	 * @param {String} name - The name of the property.
+	 * @returns {SelectMap} The `SelectMap` corresponding for `name`.
+	 */
+	getProperty (name) {
+		this.see(name)
+
+		return this.all[name]
+	}
+
+	getExcluded (from) {
+		if (this.additionalProperties) {
+			return []
+		}
+
+		const seen = this.seen
+
+		return _.filter(from, (name) => {
+			return !seen.has(name)
+		})
+	}
+
+	// TODO: avoiding recursion with a cache would save some repeated
+	// calculations
+	isTransitivelyFiltered () {
+		if (!this.additionalProperties) {
+			return true
+		}
+		for (const subProperty of Object.values(this.all)) {
+			if (subProperty.isTransitivelyFiltered()) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	toSql (table, name, path, sunkFilter, force) {
+		if (!this.seen.has(name)) {
+			return null
+		}
+
+		const subSelectMap = this.all[name]
+		if (!force && !subSelectMap.isTransitivelyFiltered()) {
+			return null
+		}
+
+		return subSelectMap.toSql(
+			table,
+			path,
+			_.cloneDeep(sunkFilter).and(_.cloneDeep(this.filter))
+		)
+	}
+}

--- a/lib/core/backend/postgres/jsonschema2sql/sql-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-filter.js
@@ -7,6 +7,7 @@
 /* eslint-disable class-methods-use-this */
 
 const pgFormat = require('pg-format')
+const SqlFragmentBuilder = require('./fragment-builder')
 
 /**
  * Base class for SQL boolean expressions, aka filters, constraints, or
@@ -47,5 +48,18 @@ module.exports = class SqlFilter {
 	 */
 	toSqlInto (_builder) {
 		throw new Error()
+	}
+
+	/**
+     * Build an SQL filter expression from `this`.
+     *
+     * @param {String} table - The table the result will refer to.
+     * @returns {String} `this` as an SQL filter expression.
+     */
+	toSql (table) {
+		const builder = new SqlFragmentBuilder(table)
+		builder.extendFrom(this)
+
+		return builder.toSql()
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/sql-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-filter.js
@@ -57,9 +57,8 @@ module.exports = class SqlFilter {
      * @returns {String} `this` as an SQL filter expression.
      */
 	toSql (table) {
-		const builder = new SqlFragmentBuilder(table)
-		builder.extendFrom(this)
-
-		return builder.toSql()
+		return new SqlFragmentBuilder(table)
+			.extendFrom(this)
+			.toSql()
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/sql-path.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-path.js
@@ -6,6 +6,7 @@
 
 const _ = require('lodash')
 const pgFormat = require('pg-format')
+const SqlFragmentBuilder = require('./fragment-builder')
 
 /**
  * Abstraction for SQL field paths. Note that this implicitly depends on the
@@ -56,15 +57,13 @@ COALESCE(${table}.version_patch, '0')::text
 	/**
 	 * Constructor.
 	 *
-	 * @param {String} table - Table name or alias that this `SqlPath` will
-	 *        reference.
 	 * @param {SqlPath} parent - If this `SqlPath` denotes paths in a subquery,
 	 *        `parent` must be the `SqlPath` that points to the field that this
 	 *         subquery uses as table. Otherwise, `parent` must be `undefined`.
 	 */
-	constructor (table, parent) {
-		this.path = [ table ]
-		this.parent = parent ? parent.path : []
+	constructor (parent) {
+		this.path = []
+		this.parent = parent ? parent.flattened().path : []
 		this.recalculateIsProcessingState()
 		this.rootIsJson = this.isProcessingJsonProperty
 	}
@@ -78,14 +77,14 @@ COALESCE(${table}.version_patch, '0')::text
 		this.path.push(element)
 
 		const pathDepth = this.getDepth()
-		if (pathDepth === 2) {
+		if (pathDepth === 1) {
 			this.isProcessingTable = false
 			this.isProcessingColumn = true
-		} else if (pathDepth === 3) {
+		} else if (pathDepth === 2) {
 			this.isProcessingColumn = false
 			this.isProcessingSubColumn = this.getSecondToLast() !== 'data'
 			this.isProcessingJsonProperty = !this.isProcessingSubColumn
-		} else if (pathDepth === 4) {
+		} else if (pathDepth === 3) {
 			this.isProcessingSubColumn = false
 		}
 	}
@@ -99,30 +98,18 @@ COALESCE(${table}.version_patch, '0')::text
 	}
 
 	/**
-	 * Get the table `this` refers to.
-	 *
-	 * @returns {String} The table `this` refers to.
-	 */
-	getTable () {
-		return this.path[0]
-	}
-
-	/**
 	 * Get the second to last element.
 	 *
 	 * @returns {String} The second to last element.
 	 */
 	getSecondToLast () {
-		if (this.path.length > 2) {
-			return this.path[this.path.length - 2]
-		} else if (this.path.length === 2) {
-			if (this.parent.length === 0) {
-				return this.path[this.path.length - 2]
-			}
+		if (this.path.length === 0) {
+			return this.parent[this.parent.length - 2]
+		} else if (this.path.length === 1) {
 			return this.parent[this.parent.length - 1]
 		}
 
-		return this.parent[this.parent.length - 2]
+		return this.path[this.path.length - 2]
 	}
 
 	/**
@@ -131,9 +118,10 @@ COALESCE(${table}.version_patch, '0')::text
 	 * @returns {String} The last element.
 	 */
 	getLast () {
-		if (this.path.length === 1 && this.parent.length > 0) {
+		if (this.path.length === 0) {
 			return this.parent[this.parent.length - 1]
 		}
+
 		return this.path[this.path.length - 1]
 	}
 
@@ -146,39 +134,52 @@ COALESCE(${table}.version_patch, '0')::text
 		this.path[this.path.length - 1] = element
 
 		const pathDepth = this.getDepth()
-		if (pathDepth === 2) {
+		if (pathDepth === 1) {
 			this.isProcessingJsonProperty = element === 'data'
-		} else if (pathDepth === 3) {
+		} else if (pathDepth === 2) {
 			this.isProcessingSubColumn = this.getSecondToLast() !== 'data'
 			this.isProcessingJsonProperty = !this.isProcessingSubColumn
 		}
 	}
 
-	/**
-	 * Get a slice of path array, where each item is a path element.
-	 *
-	 * @param {Number} from - Where to slice from. Optional, defaults to the
-	 *        beginning.
-	 * @param {Number} to - Where to slice to. Optional, defaults to the end.
-	 * @returns {Array} The sliced path. This should not be modified.
-	 */
-	slice (from, to) {
-		return this.path.slice(from, to)
-	}
-
 	getDepth () {
-		return this.path.length + this.parent.length
+		const depth = this.path.length + this.parent.length
+		const adjustment = this.path.length === 0 && this.parent.length > 0 ? 1 : 0
+
+		return depth + adjustment
 	}
 
 	recalculateIsProcessingState () {
 		const pathDepth = this.getDepth()
-		this.isProcessingTable = pathDepth === 1
-		this.isProcessingColumn = pathDepth === 2
-		this.isProcessingSubColumn = pathDepth === 3 && this.getSecondToLast() !== 'data'
+		this.isProcessingTable = pathDepth === 0
+		this.isProcessingColumn = pathDepth === 1
+		this.isProcessingSubColumn = pathDepth === 2 && this.getSecondToLast() !== 'data'
 
-		const isData = pathDepth === 2 && this.getLast() === 'data'
-		const isDataProperty = pathDepth === 3 && !this.isProcessingSubColumn
-		this.isProcessingJsonProperty = isData || isDataProperty || pathDepth > 3
+		const isData = pathDepth === 1 && this.getLast() === 'data'
+		const isDataProperty = pathDepth === 2 && !this.isProcessingSubColumn
+		this.isProcessingJsonProperty = isData || isDataProperty || pathDepth > 2
+	}
+
+	/**
+	 * Return `this` as an array where each element is a path component.
+	 *
+	 * @returns {Array} `this` as an array.
+	 */
+	asArray () {
+		return this.path
+	}
+
+	/**
+	 * Return a clone of `this`.
+	 *
+	 * @returns {SqlPath} A clone of `this`.
+	 */
+	cloned () {
+		const clone = _.clone(this)
+		clone.path = _.clone(this.path)
+		clone.parent = _.clone(this.parent)
+
+		return clone
 	}
 
 	/**
@@ -188,23 +189,27 @@ COALESCE(${table}.version_patch, '0')::text
 	 */
 	flattened () {
 		if (this.parent.length > 0) {
-			return SqlPath.fromArray(_.concat(this.parent, this.slice(1)))
+			return SqlPath.fromArray(_.concat(this.parent, this.path))
 		}
+
 		return SqlPath.fromArray(_.clone(this.path))
 	}
 
 	/**
-	 * Build an SQL field from `this`.
+	 * Format this filter by pushing string fragments into `builder`.
 	 *
+	 * @param {SqlFragmentBuilder} builder - Builder for the final SQL string.
 	 * @param {Object} options - An optional object containing extra options.
 	 *        Accepted options are:
 	 *        - `asText`: return the field with the proper cast into text.
-	 * @returns {String} The SQL field.
+	 *        - `forceCast`: apply as cast (if requested) even for columns.
 	 */
-	toSql (options = {}) {
-		const table = this.getTable()
+	toSqlInto (builder, options = {}) {
+		const table = builder.getTable()
 		if (this.isProcessingColumn && this.getLast() === 'version') {
-			return SqlPath.getVersionComputedField(table)
+			builder.push(SqlPath.getVersionComputedField(table))
+
+			return
 		}
 
 		let operator = '#>'
@@ -218,20 +223,43 @@ COALESCE(${table}.version_patch, '0')::text
 			}
 		}
 
+		builder
+			.push(start)
+			.push(table)
+
 		if (this.rootIsJson) {
-			const selector = SqlPath.toJsonSelector(this.slice(1))
+			builder
+				.push(operator)
+				.push(SqlPath.toJsonSelector(this.path))
+		} else {
+			const column = pgFormat.ident(this.path[0] || table)
+			if (this.path.length > 0) {
+				builder
+					.push('.')
+					.push(column)
+			}
+			if (this.path.length > 1) {
+				builder
+					.push(operator)
+					.push(SqlPath.toJsonSelector(this.path.slice(1)))
+			}
+		}
 
-			return `${start}${table}${operator}${selector}${end}`
-		}
-		if (this.path.length === 1) {
-			return `${start}${table}${end}`
-		}
-		const column = pgFormat.ident(this.path[1])
-		if (this.path.length === 2) {
-			return `${start}${table}.${column}${end}`
-		}
-		const selector = SqlPath.toJsonSelector(this.slice(2))
+		builder.push(end)
+	}
 
-		return `${start}${table}.${column}${operator}${selector}${end}`
+	/**
+	 * Build an SQL field from `this`.
+	 *
+	 * @param {String} table - Table that `this` will refer to.
+	 * @param {Object} options - An optional object containing extra options.
+	 *        See {@link SqlPath#toSqlInto} for a list of accepted options.
+	 * @returns {String} The SQL field.
+	 */
+	toSql (table, options) {
+		const builder = new SqlFragmentBuilder(table)
+		this.toSqlInto(builder, options)
+
+		return builder.toSql()
 	}
 }

--- a/lib/core/backend/postgres/jsonschema2sql/sql-query.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-query.js
@@ -5,7 +5,6 @@
  */
 
 const _ = require('lodash')
-const pgFormat = require('pg-format')
 const assert = require('@balena/jellyfish-assert')
 const ArrayContainsFilter = require('./array-contains-filter')
 const ArrayLengthFilter = require('./array-length-filter')
@@ -98,77 +97,6 @@ const CARD_FIELDS = {
 	}
 }
 
-const CARD_ALL_NON_LINKS_SELECTED = {
-	id: {},
-	version: {},
-	slug: {},
-	name: {},
-	type: {},
-	tags: {},
-	markers: {},
-	created_at: {},
-	updated_at: {},
-	active: {},
-	requires: {},
-	capabilities: {},
-	data: {},
-	linked_at: {}
-}
-
-const CARD_ALL_NON_LINKS_KEYS = Object.keys(CARD_ALL_NON_LINKS_SELECTED)
-
-const getSelectPayloadFrom = (table, selectedProperties, path) => {
-	if (_.isEmpty(selectedProperties)) {
-		return path.toSql(table)
-	}
-
-	const args = []
-	path.push(null)
-	for (const [ name, contents ] of Object.entries(selectedProperties)) {
-		path.setLast(name)
-		args.push(pgFormat.literal(name))
-		args.push(getSelectPayloadFrom(table, contents, path))
-	}
-	path.pop()
-
-	return `jsonb_build_object(${args.join(', ')})`
-}
-
-const getSelectPayload = (table, select, linksBuildArgs = []) => {
-	const selectedNonLinks = _.pick(select, CARD_ALL_NON_LINKS_KEYS)
-	const selectsAllNonLinks = _.isEqual(selectedNonLinks, CARD_ALL_NON_LINKS_SELECTED)
-	const selectsLinks = 'links' in select
-	const fetchAll = selectsAllNonLinks && selectsLinks
-	const selectsOnlyLinks = _.isEmpty(selectedNonLinks) && selectsLinks
-
-	let links = ''
-	let mergeLinks = ''
-	if (selectsLinks) {
-		const selectedLinks = select.links
-		const filteredLinksBuildArgs = []
-		for (const [ linkType, linkName, field ] of linksBuildArgs) {
-			if (linkType in selectedLinks) {
-				filteredLinksBuildArgs.push(linkName)
-				filteredLinksBuildArgs.push(field)
-			}
-		}
-		links = `jsonb_build_object(${filteredLinksBuildArgs.join(', ')})`
-		links = `jsonb_build_object('links', ${links})`
-		mergeLinks = ` || ${links}`
-	}
-
-	if (fetchAll) {
-		return `to_jsonb(${table})${mergeLinks}`
-	} else if (selectsOnlyLinks) {
-		return links
-	}
-
-	const path = new SqlPath()
-	const main = getSelectPayloadFrom(table, select, path)
-
-	return `${main}${mergeLinks}`
-}
-
 const pathsForOrderBy = (table, sortBy) => {
 	const arrSortBy = _.castArray(sortBy)
 	if (arrSortBy.length === 1 && arrSortBy[0] === 'version') {
@@ -216,18 +144,9 @@ const pushLinkedJoins = (linked, innerSelect, parentTable, cardsTable) => {
 	innerSelect.pushLeftJoin(cardsTable, joinFilter, linked.joinAlias)
 }
 
-const pushLinkedBuildArgs = (linked, linksBuildArgs) => {
-	linksBuildArgs.push([
-		linked.linkType,
-		linked.linkName,
-		`${linked.lateralAlias}.linkedCards`
-	])
-}
-
 const pushLinkedLateral = (
 	select,
 	edgeIdx,
-	nestedLinksBuildArgs,
 	nestedLaterals,
 	lateralAlias,
 	options,
@@ -263,10 +182,9 @@ const pushLinkedLateral = (
 		.pushLeftJoin(cardsTable, new LiteralSql('linked.id = edges.sink'), 'linked')
 		.setFilter(new LiteralSql(`edges.idx = ${edgeIdx}`))
 
-	const payload = getSelectPayload('linked', select, nestedLinksBuildArgs)
 	const linkedSelect = new SqlSelectBuilder()
 		.pushSelect('edges.source')
-		.pushSelect(`array_agg(${payload}${orderBy})`, 'linkedCards')
+		.pushSelect(`array_agg(${select.toSql('linked')}${orderBy})`, 'linkedCards')
 		.pushSelect('array_agg(linked.id)', 'idList')
 		.pushFrom(edgesSelect, 'edges')
 		.pushLeftJoin(cardsTable, lateralJoinFilter, 'linked')
@@ -297,7 +215,6 @@ const linkedToSql = (
 	linked,
 	options,
 	innerSelect,
-	linksBuildArgs,
 	linkEdges,
 	laterals,
 	parentTable,
@@ -305,22 +222,19 @@ const linkedToSql = (
 	nested
 ) => {
 	pushLinkedJoins(linked, innerSelect, parentTable, cardsTable)
-	pushLinkedBuildArgs(linked, linksBuildArgs)
 
 	const edgeIdx = linkEdges.length
 	linkEdges.push(`row(${parentTable}.id, ${edgeIdx}, ${linked.joinAlias}.id)::linkEdge`)
 
-	const nestedLinksBuildArgs = []
 	const nestedLaterals = []
 	if (nested) {
 		for (const [ nestedLinkType, nestedVariants ] of Object.entries(nested)) {
 			for (const nestedNested of nestedVariants) {
 				linkedToSql(
-					_.get(select.links, [ nestedLinkType ], {}),
+					select.getProperty('links').getProperty(nestedLinkType),
 					nestedNested.linked,
 					_.get(options.links, [ nestedLinkType ], {}),
 					innerSelect,
-					nestedLinksBuildArgs,
 					linkEdges,
 					nestedLaterals,
 					linked.joinAlias,
@@ -334,7 +248,6 @@ const linkedToSql = (
 	pushLinkedLateral(
 		select,
 		edgeIdx,
-		nestedLinksBuildArgs,
 		nestedLaterals,
 		linked.lateralAlias,
 		options,
@@ -352,23 +265,15 @@ const linkedToSql = (
 module.exports = class SqlQuery {
 	static fromSchema (parent, select, schema, options) {
 		const query = new SqlQuery(parent, select, options)
+
 		if (schema === false) {
-			query.setAdditionalProperties(false)
 			query.filter.makeUnsatisfiable()
-		} else if (schema === true) {
-			// Defaults to `true` as per the JSON schema spec
-			query.setAdditionalProperties(true)
-		} else {
+		} else if (schema !== true) {
 			// Some keywords must be processed before the rest, for validation,
 			// correctness, or optimization
-
 			if ('additionalProperties' in schema) {
 				query.setAdditionalProperties(schema.additionalProperties)
-			} else {
-				// Defaults to `true` as per the JSON schema spec
-				query.setAdditionalProperties(true)
 			}
-
 			if ('type' in schema) {
 				query.setType(schema.type)
 			}
@@ -382,9 +287,9 @@ module.exports = class SqlQuery {
 			for (const [ key, value ] of Object.entries(schema)) {
 				query.visit(key, value)
 			}
-
-			query.finalize()
 		}
+
+		query.finalize()
 
 		return query
 	}
@@ -395,13 +300,7 @@ module.exports = class SqlQuery {
 	 *
 	 * @param {null|SqlQuery} parent - The parent SqlQuery if we're parsing a
 	 *        sub schema. Optional.
-	 * @param {Object} select - The properties to be selected. This should
-	 *        form a simple `<property>: <map of sub properties>` hierarchy.
-	 *        An empty `<map of sub properties>` means that `<property>` is the
-	 *        one being selected. The only exception is the `links` property of
-	 *        cards, where an empty `<map of sub properties>` means no links
-	 *        instead of all links. TODO: this is due to a quirk with `$$links`
-	 *        semantics. The constructor assumes ownership of this argument.
+	 * @param {SelectMap} select - The properties to be selected.
 	 * @param {Object} options - An optional map with taking anything accepted
 	 *        by {@link SqlQuery#fromSchema}, plus the following (for internal
 	 *        use only):
@@ -414,6 +313,8 @@ module.exports = class SqlQuery {
 	 *          SqlQuery#buildQueryFromCorrelatedSchema}.
 	 *        - extraFilter: a string that is used as the initial value for
 	 *          `this.filter`. Useful for constraints with placeholders.
+	 *        - linksSelectMap: the `SelectMap` of the `<table>.links`
+	 *          property.
 	 */
 	constructor (parent, select = {}, options = {}) {
 		// Set of properties that must exist
@@ -437,7 +338,7 @@ module.exports = class SqlQuery {
 		// until `finalize()` is called to apply some optimizations
 		this.propertiesFilter = null
 
-		// Format as specified by the `format` keyword
+		// Format, as specified by the `format` keyword
 		this.format = null
 
 		// See the constructor's docs
@@ -445,6 +346,9 @@ module.exports = class SqlQuery {
 		this.options = options
 		if (!('parentJsonPath' in this.options)) {
 			this.options.parentJsonPath = []
+		}
+		if (!('linksSelectMap' in this.options)) {
+			this.options.linksSelectMap = select.getProperty('links')
 		}
 
 		if (parent === null) {
@@ -486,28 +390,7 @@ module.exports = class SqlQuery {
 			return `value for '${this.formatJsonPath('additionalProperties')}' must be a boolean`
 		})
 
-		this.additionalProperties = schema
-
-		// If additionalProperties is true we just fetch everything. This is
-		// represented by a cleared `this.select` *except* at the root due to
-		// the whole `$$links` weirdness. In that case we just fill
-		// `this.select` with all columns. Also we don't touch
-		// `this.select` for `links` columns because, again, links are weird.
-		// Note that we modify `this.select` in place instead of reassigning
-		// it because it's a shared data structure
-		const isLinks = this.path.isProcessingColumn && this.path.getLast() === 'links'
-		if (schema === true && !isLinks) {
-			if (this.path.isProcessingTable) {
-				Object.assign(this.select, CARD_ALL_NON_LINKS_SELECTED)
-				if (!('links' in this.select)) {
-					this.select.links = {}
-				}
-			} else {
-				for (const key of Object.keys(this.select)) {
-					Reflect.deleteProperty(this.select, key)
-				}
-			}
-		}
+		this.select.setAdditionalProperties(schema)
 	}
 
 	setType (value) {
@@ -530,8 +413,11 @@ module.exports = class SqlQuery {
 			return `value for '${this.formatJsonPath('required')}' must be an array`
 		})
 
-		// We clone because other methods may modify `this.required`
+		// We clone here because other methods may modify `this.required`
 		this.required = _.clone(required)
+		for (const name of required) {
+			this.select.see(name)
+		}
 	}
 
 	setFormat (format) {
@@ -621,7 +507,11 @@ module.exports = class SqlQuery {
 		})
 
 		for (const [ idx, branchSchema ] of branches.entries()) {
-			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'allOf', idx ])
+			const branchQuery = this.buildQueryFromSubSchema(
+				branchSchema,
+				[ 'allOf', idx ]
+			)
+
 			this.filter.and(branchQuery.filter)
 			this.filterImpliesExists = this.filterImpliesExists || branchQuery.filterImpliesExists
 		}
@@ -635,7 +525,14 @@ module.exports = class SqlQuery {
 		let allFilterImpliesExists = true
 		const filter = new ExpressionFilter(false)
 		for (const [ idx, branchSchema ] of branches.entries()) {
-			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'anyOf', idx ])
+			const selectBranch = this.select.newBranch()
+			const branchQuery = this.buildQueryFromSubSchema(
+				branchSchema,
+				[ 'anyOf', idx ],
+				selectBranch
+			)
+			selectBranch.setFilter(branchQuery.filter)
+
 			filter.or(branchQuery.filter)
 			allFilterImpliesExists = allFilterImpliesExists && branchQuery.filterImpliesExists
 		}
@@ -770,7 +667,7 @@ module.exports = class SqlQuery {
 
 	tupleMustMatch (schemas) {
 		const filter = new ExpressionFilter(true)
-		if (!this.additionalProperties) {
+		if (!this.select.getAdditionalProperties()) {
 			filter.and(new ArrayLengthFilter(this.path, '<=', schemas.length))
 		}
 
@@ -870,6 +767,7 @@ module.exports = class SqlQuery {
 
 	notVisitor (schema) {
 		const subQuery = this.buildQueryFromSubSchema(schema, [ 'not' ])
+
 		this.filter.and(subQuery.filter.negate())
 	}
 
@@ -894,7 +792,7 @@ module.exports = class SqlQuery {
 			const propertyQuery = this.buildQueryFromSubSchema(
 				propertySchema,
 				[ 'properties', propertyName ],
-				this.select[propertyName]
+				this.select.getProperty(propertyName)
 			)
 
 			const isRequired = this.required.includes(propertyName)
@@ -1046,7 +944,7 @@ module.exports = class SqlQuery {
 	// purposes
 	buildQueryFromSubSchema (schema, suffix, select) {
 		this.options.parentJsonPath.push(...suffix)
-		const query = SqlQuery.fromSchema(this, select, schema, this.options)
+		const query = SqlQuery.fromSchema(this, select || this.select, schema, this.options)
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()
 		}
@@ -1066,9 +964,10 @@ module.exports = class SqlQuery {
 		}
 
 		this.options.parentJsonPath.push(...suffix)
-		const query = SqlQuery.fromSchema(null, {}, schema, {
+		const query = SqlQuery.fromSchema(null, this.select, schema, {
 			parentJsonPath: this.options.parentJsonPath,
-			parentPath
+			parentPath,
+			linksSelectMap: this.options.linksSelectMap
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()
@@ -1082,7 +981,7 @@ module.exports = class SqlQuery {
 	buildQueryFromLinkedSchema (linkType, schema, suffix) {
 		this.options.parentJsonPath.push(...suffix)
 
-		const select = _.get(this.select.links, [ linkType ])
+		const select = this.options.linksSelectMap.getProperty(linkType)
 		const query = SqlQuery.fromSchema(null, select, schema, {
 			parentJsonPath: this.options.parentJsonPath
 		})
@@ -1122,7 +1021,7 @@ module.exports = class SqlQuery {
 		if (_.isEmpty(links)) {
 			// Queries without links are fairly simple
 			select
-				.pushSelect(getSelectPayload(table, this.select), 'payload')
+				.pushSelect(this.select.toSql(table), 'payload')
 				.setFilter(rootFilter)
 		} else {
 			// Queries with links are more complex for performance reasons.
@@ -1145,7 +1044,6 @@ module.exports = class SqlQuery {
 			this.fillInnerOrderAndGroupBy(table, innerSelect)
 			this.setInnerLimit(innerSelect)
 
-			const linksBuildArgs = []
 			const linkEdges = []
 			const laterals = []
 			for (const [ linkType, variants ] of Object.entries(links)) {
@@ -1156,11 +1054,10 @@ module.exports = class SqlQuery {
 					} of variants
 				) {
 					linkedToSql(
-						_.get(this.select.links, [ linkType ], {}),
+						this.select.getProperty('links').getProperty(linkType),
 						linked,
 						_.get(this.options.links, [ linkType ], {}),
 						innerSelect,
-						linksBuildArgs,
 						linkEdges,
 						laterals,
 						table,
@@ -1189,7 +1086,7 @@ module.exports = class SqlQuery {
 			const fence = new SqlCteBuilder(FENCE_REWRAP)
 			fence.pushSubquery(innerSelect, 'fence', true)
 			select
-				.pushSelect(getSelectPayload(table, this.select, linksBuildArgs), 'payload')
+				.pushSelect(this.select.toSql(table), 'payload')
 				.pushFrom(fence, 'main')
 				.setFilter(new LiteralSql(`${table}.id = main.cardId`))
 

--- a/lib/core/backend/postgres/jsonschema2sql/sql-query.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-query.js
@@ -15,6 +15,7 @@ const FullTextSearchFilter = require('./full-text-search-filter')
 const IsNullFilter = require('./is-null-filter')
 const IsOfJsonTypesFilter = require('./is-of-json-types-filter')
 const JsonMapPropertyCountFilter = require('./json-map-property-count-filter')
+const LinkFilter = require('./link-filter')
 const LiteralSql = require('./literal-sql')
 const MatchesRegexFilter = require('./matches-regex-filter')
 const MultipleOfFilter = require('./multiple-of-filter')
@@ -116,6 +117,232 @@ const CARD_ALL_NON_LINKS_SELECTED = {
 
 const CARD_ALL_NON_LINKS_KEYS = Object.keys(CARD_ALL_NON_LINKS_SELECTED)
 
+const getSelectPayloadFrom = (table, selectedProperties, path) => {
+	if (_.isEmpty(selectedProperties)) {
+		return path.toSql(table)
+	}
+
+	const args = []
+	path.push(null)
+	for (const [ name, contents ] of Object.entries(selectedProperties)) {
+		path.setLast(name)
+		args.push(pgFormat.literal(name))
+		args.push(getSelectPayloadFrom(table, contents, path))
+	}
+	path.pop()
+
+	return `jsonb_build_object(${args.join(', ')})`
+}
+
+const getSelectPayload = (table, select, linksBuildArgs = []) => {
+	const selectedNonLinks = _.pick(select, CARD_ALL_NON_LINKS_KEYS)
+	const selectsAllNonLinks = _.isEqual(selectedNonLinks, CARD_ALL_NON_LINKS_SELECTED)
+	const selectsLinks = 'links' in select
+	const fetchAll = selectsAllNonLinks && selectsLinks
+	const selectsOnlyLinks = _.isEmpty(selectedNonLinks) && selectsLinks
+
+	let links = ''
+	let mergeLinks = ''
+	if (selectsLinks) {
+		const selectedLinks = select.links
+		const filteredLinksBuildArgs = []
+		for (const [ linkType, linkName, field ] of linksBuildArgs) {
+			if (linkType in selectedLinks) {
+				filteredLinksBuildArgs.push(linkName)
+				filteredLinksBuildArgs.push(field)
+			}
+		}
+		links = `jsonb_build_object(${filteredLinksBuildArgs.join(', ')})`
+		links = `jsonb_build_object('links', ${links})`
+		mergeLinks = ` || ${links}`
+	}
+
+	if (fetchAll) {
+		return `to_jsonb(${table})${mergeLinks}`
+	} else if (selectsOnlyLinks) {
+		return links
+	}
+
+	const path = new SqlPath()
+	const main = getSelectPayloadFrom(table, select, path)
+
+	return `${main}${mergeLinks}`
+}
+
+const pathsForOrderBy = (table, sortBy) => {
+	const arrSortBy = _.castArray(sortBy)
+	if (arrSortBy.length === 1 && arrSortBy[0] === 'version') {
+		return [
+			new LiteralSql(`${table}.version_major`),
+			new LiteralSql(`${table}.version_minor`),
+			new LiteralSql(`${table}.version_patch`)
+		]
+	}
+
+	return [ SqlPath.fromArray(arrSortBy) ]
+}
+
+const isDescendingSort = (dir) => {
+	return dir === 'desc'
+}
+
+const sortOrder = (dir) => {
+	return isDescendingSort(dir) ? 'DESC' : 'ASC'
+}
+
+const pushLinkedJoins = (linked, innerSelect, parentTable, cardsTable) => {
+	const linksFilter = new LiteralSql(`
+		(
+			${linked.linksAlias}.name = ${linked.linkName} AND
+			${linked.linksAlias}.fromId = ${parentTable}.id
+		) OR (
+			${linked.linksAlias}.inversename = ${linked.linkName} AND
+			${linked.linksAlias}.toId = ${parentTable}.id
+		)
+	`)
+	innerSelect.pushLeftJoin('links', linksFilter, linked.linksAlias)
+
+	const joinFilter = new LiteralSql(`(
+		(
+			${linked.linksAlias}.name = ${linked.linkName} AND
+			${linked.linksAlias}.toId = ${linked.joinAlias}.id
+		) OR (
+			${linked.linksAlias}.inversename = ${linked.linkName} AND
+			${linked.linksAlias}.fromId = ${linked.joinAlias}.id
+		)
+	) AND (
+		${linked.sqlFilter}
+	)`)
+	innerSelect.pushLeftJoin(cardsTable, joinFilter, linked.joinAlias)
+}
+
+const pushLinkedBuildArgs = (linked, linksBuildArgs) => {
+	linksBuildArgs.push([
+		linked.linkType,
+		linked.linkName,
+		`${linked.lateralAlias}.linkedCards`
+	])
+}
+
+const pushLinkedLateral = (
+	select,
+	edgeIdx,
+	nestedLinksBuildArgs,
+	nestedLaterals,
+	lateralAlias,
+	options,
+	laterals,
+	cardsTable
+) => {
+	const lateralJoinFilter = new ExpressionFilter(new LiteralSql('linked.id = edges.sink'))
+	let lowestSeq = 1
+	if ('skip' in options) {
+		lowestSeq = options.skip + 1
+		lateralJoinFilter.and(new LiteralSql(`edges.seq >= ${lowestSeq}`))
+	}
+	if ('limit' in options) {
+		const highestSeq = lowestSeq + options.limit - 1
+		lateralJoinFilter.and(new LiteralSql(`edges.seq <= ${highestSeq}`))
+	}
+
+	let orderBy = ''
+	if (options.sortBy) {
+		const formattedPaths = []
+		const order = sortOrder(options.sortDir)
+		for (const path of pathsForOrderBy('linked', options.sortBy)) {
+			formattedPaths.push(`${path.toSql('linked')} ${order} NULLS LAST`)
+		}
+		orderBy = ` ORDER BY ${formattedPaths.join(', ')}`
+	}
+
+	const edgesSelect = new SqlSelectBuilder()
+		.pushSelect(`row_number() OVER (PARTITION BY edges.source${orderBy})`, 'seq')
+		.pushSelect('edges.source')
+		.pushSelect('edges.sink')
+		.pushFrom('unnest(main.linkEdges)', 'edges')
+		.pushLeftJoin(cardsTable, new LiteralSql('linked.id = edges.sink'), 'linked')
+		.setFilter(new LiteralSql(`edges.idx = ${edgeIdx}`))
+
+	const payload = getSelectPayload('linked', select, nestedLinksBuildArgs)
+	const linkedSelect = new SqlSelectBuilder()
+		.pushSelect('edges.source')
+		.pushSelect(`array_agg(${payload}${orderBy})`, 'linkedCards')
+		.pushSelect('array_agg(linked.id)', 'idList')
+		.pushFrom(edgesSelect, 'edges')
+		.pushLeftJoin(cardsTable, lateralJoinFilter, 'linked')
+		.pushGroupBy('edges', SqlPath.fromArray([ 'source' ]))
+
+	for (const [ nestedLateral, nestedLateralAlias ] of nestedLaterals) {
+		linkedSelect.pushInnerJoin(
+			nestedLateral,
+			new LiteralSql(`${nestedLateralAlias}.source = linked.id`),
+			nestedLateralAlias
+		)
+	}
+
+	const lateral = new SqlSelectBuilder()
+		.pushSelect('unfilteredList.source')
+		.pushSelect(`array(
+			SELECT unnest.linkedCard
+			FROM unnest(unfilteredList.linkedCards, unfilteredList.idList) AS unnest(linkedCard, id)
+			WHERE unnest.id IS NOT NULL
+		)`, 'linkedCards')
+		.pushFrom(linkedSelect, 'unfilteredList')
+
+	laterals.push([ lateral, lateralAlias ])
+}
+
+const linkedToSql = (
+	select,
+	linked,
+	options,
+	innerSelect,
+	linksBuildArgs,
+	linkEdges,
+	laterals,
+	parentTable,
+	cardsTable,
+	nested
+) => {
+	pushLinkedJoins(linked, innerSelect, parentTable, cardsTable)
+	pushLinkedBuildArgs(linked, linksBuildArgs)
+
+	const edgeIdx = linkEdges.length
+	linkEdges.push(`row(${parentTable}.id, ${edgeIdx}, ${linked.joinAlias}.id)::linkEdge`)
+
+	const nestedLinksBuildArgs = []
+	const nestedLaterals = []
+	if (nested) {
+		for (const [ nestedLinkType, nestedVariants ] of Object.entries(nested)) {
+			for (const nestedNested of nestedVariants) {
+				linkedToSql(
+					_.get(select.links, [ nestedLinkType ], {}),
+					nestedNested.linked,
+					_.get(options.links, [ nestedLinkType ], {}),
+					innerSelect,
+					nestedLinksBuildArgs,
+					linkEdges,
+					nestedLaterals,
+					linked.joinAlias,
+					cardsTable,
+					nestedNested.nested
+				)
+			}
+		}
+	}
+
+	pushLinkedLateral(
+		select,
+		edgeIdx,
+		nestedLinksBuildArgs,
+		nestedLaterals,
+		linked.lateralAlias,
+		options,
+		laterals,
+		cardsTable
+	)
+}
+
 /**
  * Class encapsulating all data needed to create an SQL query from a JSON
  * schema. This class' constructor is supposed to be private. Use the static
@@ -162,23 +389,6 @@ module.exports = class SqlQuery {
 		return query
 	}
 
-	static getSelectPayloadFrom (selectedProperties, path) {
-		if (_.isEmpty(selectedProperties)) {
-			return path.toSql()
-		}
-
-		const args = []
-		path.push(null)
-		for (const [ name, contents ] of Object.entries(selectedProperties)) {
-			path.setLast(name)
-			args.push(pgFormat.literal(name))
-			args.push(SqlQuery.getSelectPayloadFrom(contents, path))
-		}
-		path.pop()
-
-		return `jsonb_build_object(${args.join(', ')})`
-	}
-
 	/**
 	 * Create a new, empty SqlQuery. {@link SqlQuery#fromSchema} should be
 	 * used instead of this constructor.
@@ -202,8 +412,6 @@ module.exports = class SqlQuery {
 	 *          field path. This is used when creating a child SqlQuery that
 	 *          refers to a different table. See {@link
 	 *          SqlQuery#buildQueryFromCorrelatedSchema}.
-	 *        - parentLinkTypes: an array of link types denoting `$$links`
-	 *          nesting.
 	 *        - extraFilter: a string that is used as the initial value for
 	 *          `this.filter`. Useful for constraints with placeholders.
 	 */
@@ -219,10 +427,6 @@ module.exports = class SqlQuery {
 			// Defaults to `true` as an empty schema matches anything
 			this.filter = new ExpressionFilter(true)
 		}
-
-		// Map of link types (i.e. the name of the relation between different
-		// cards) to the `SqlQuery` of the schema of that link type
-		this.links = {}
 
 		// True if, and only if `this.filter` implies that the property that
 		// this object represents must exist. This is used to elide needless
@@ -241,9 +445,6 @@ module.exports = class SqlQuery {
 		this.options = options
 		if (!('parentJsonPath' in this.options)) {
 			this.options.parentJsonPath = []
-		}
-		if (!('parentLinkTypes' in this.options)) {
-			this.options.parentLinkTypes = []
 		}
 
 		if (parent === null) {
@@ -396,8 +597,6 @@ module.exports = class SqlQuery {
 	}
 
 	$$linksVisitor (linkMap) {
-		assert.INTERNAL(null, this.path.isProcessingTable, InvalidSchema,
-			'a \'$$links\' key is only valid at the toplevel for the moment')
 		assert.INTERNAL(null, _.isPlainObject(linkMap), InvalidSchema, () => {
 			return `value for '${this.formatJsonPath('$$links')}' must be a map`
 		})
@@ -407,8 +606,12 @@ module.exports = class SqlQuery {
 				return `key for '${this.formatJsonPath([ '$$links', linkType ])}' must be a string`
 			})
 
-			this.links[linkType] = this.buildQueryFromLinkedSchema(
-				linkType, linkSchema, [ '$$links', linkType ])
+			const linkQuery = this.buildQueryFromLinkedSchema(
+				linkType,
+				linkSchema,
+				[ '$$links', linkType ]
+			)
+			this.filter.and(new LinkFilter(linkType, linkQuery.filter))
 		}
 	}
 
@@ -419,12 +622,8 @@ module.exports = class SqlQuery {
 
 		for (const [ idx, branchSchema ] of branches.entries()) {
 			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'allOf', idx ])
-
-			assert.INTERNAL(null, _.isEmpty(branchQuery.links), InvalidSchema,
-				'\'$$links\' is not supported inside an \'allOf\' declaration')
-
-			this.filterImpliesExists = this.filterImpliesExists || branchQuery.filterImpliesExists
 			this.filter.and(branchQuery.filter)
+			this.filterImpliesExists = this.filterImpliesExists || branchQuery.filterImpliesExists
 		}
 	}
 
@@ -437,12 +636,8 @@ module.exports = class SqlQuery {
 		const filter = new ExpressionFilter(false)
 		for (const [ idx, branchSchema ] of branches.entries()) {
 			const branchQuery = this.buildQueryFromSubSchema(branchSchema, [ 'anyOf', idx ])
-
-			assert.INTERNAL(null, _.isEmpty(branchQuery.links), InvalidSchema,
-				'\'$$links\' is not supported inside an \'anyOf\' declaration')
-
-			allFilterImpliesExists = allFilterImpliesExists && branchQuery.filterImpliesExists
 			filter.or(branchQuery.filter)
+			allFilterImpliesExists = allFilterImpliesExists && branchQuery.filterImpliesExists
 		}
 
 		this.filterImpliesExists = this.filterImpliesExists || allFilterImpliesExists
@@ -460,10 +655,6 @@ module.exports = class SqlQuery {
 		}
 
 		const containsQuery = this.buildQueryFromCorrelatedSchema(schema, [ 'contains' ])
-
-		assert.INTERNAL(null, _.isEmpty(containsQuery.links), InvalidSchema,
-			'\'$$links\' is not supported inside a \'contains\' declaration')
-
 		const filter = new ArrayContainsFilter(this.path, containsQuery.filter)
 		this.filter.and(this.ifTypeThen('array', filter))
 	}
@@ -573,10 +764,6 @@ module.exports = class SqlQuery {
 
 	arrayContentsMustMatch (schema) {
 		const itemsQuery = this.buildQueryFromCorrelatedSchema(schema, [ 'items' ])
-
-		assert.INTERNAL(null, _.isEmpty(itemsQuery.links), InvalidSchema,
-			'\'$$links\' is not supported inside an \'items\' declaration')
-
 		const filter = new ArrayContainsFilter(this.path, itemsQuery.filter.negate())
 		this.filter.and(this.ifTypeThen('array', new NotFilter(filter)))
 	}
@@ -591,9 +778,6 @@ module.exports = class SqlQuery {
 			this.path.push(idx)
 			const elementQuery = this.buildQueryFromSubSchema(schema, [ 'items', idx ])
 			this.path.pop()
-
-			assert.INTERNAL(null, _.isEmpty(elementQuery.links), InvalidSchema,
-				'\'$$links\' is not supported inside an \'items\' declaration')
 
 			const lengthFilter = new ArrayLengthFilter(this.path, '>', idx)
 				.intoExpression()
@@ -686,10 +870,6 @@ module.exports = class SqlQuery {
 
 	notVisitor (schema) {
 		const subQuery = this.buildQueryFromSubSchema(schema, [ 'not' ])
-
-		assert.INTERNAL(null, _.isEmpty(subQuery.links), InvalidSchema,
-			'\'$$links\' is not supported inside a \'not\' declaration')
-
 		this.filter.and(subQuery.filter.negate())
 	}
 
@@ -716,9 +896,6 @@ module.exports = class SqlQuery {
 				[ 'properties', propertyName ],
 				this.select[propertyName]
 			)
-
-			assert.INTERNAL(null, _.isEmpty(propertyQuery.links), InvalidSchema,
-				'\'$$links\' is not supported inside a \'properties\' declaration')
 
 			const isRequired = this.required.includes(propertyName)
 			if (isRequired) {
@@ -861,7 +1038,7 @@ module.exports = class SqlQuery {
 	}
 
 	formatJsonPath (suffix) {
-		return _.concat(this.options.parentJsonPath, _.castArray(suffix)).join('.')
+		return _.concat(this.options.parentJsonPath, _.castArray(suffix)).join('/')
 	}
 
 	// Subschemas are just what the name implies. They have the same context as
@@ -904,14 +1081,12 @@ module.exports = class SqlQuery {
 	// cards that are linked to the current schema
 	buildQueryFromLinkedSchema (linkType, schema, suffix) {
 		this.options.parentJsonPath.push(...suffix)
-		this.options.parentLinkTypes.push(linkType)
 
-		const query = SqlQuery.fromSchema(null, schema, Object.assign({
-			parentJsonPath: this.options.parentJsonPath,
-			parentLinkTypes: this.options.parentLinkTypes
-		}, _.get(this.options, [ 'links', linkType ])))
+		const select = _.get(this.select.links, [ linkType ])
+		const query = SqlQuery.fromSchema(null, select, schema, {
+			parentJsonPath: this.options.parentJsonPath
+		})
 
-		this.options.parentLinkTypes.pop()
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()
 		}
@@ -923,7 +1098,7 @@ module.exports = class SqlQuery {
 		// Set common stuff for our `SELECT`
 		const select = new SqlSelectBuilder()
 			.pushFrom(table)
-		this.fillOrderBy(select)
+		this.fillOrderBy(table, select)
 		if (this.options.skip) {
 			select.setOffset(this.options.skip)
 		}
@@ -931,11 +1106,24 @@ module.exports = class SqlQuery {
 			select.setLimit(this.options.limit)
 		}
 
-		if (_.isEmpty(this.links)) {
+		const filterBuilder = new SqlFragmentBuilder(table).extendFrom(this.filter)
+		const filterContext = filterBuilder.getContext()
+		const links = filterContext.getLinks()
+		const hoistedFilters = filterContext.getHoistedFilters()
+		const tableFilter = filterBuilder.toSql()
+		let rootFilter = null
+		if (hoistedFilters.length > 0) {
+			rootFilter = `(${tableFilter}) AND (${hoistedFilters})`
+		} else {
+			rootFilter = tableFilter
+		}
+		rootFilter = new LiteralSql(rootFilter)
+
+		if (_.isEmpty(links)) {
 			// Queries without links are fairly simple
 			select
-				.pushSelect(this.getSelectPayload(), 'payload')
-				.setFilter(this.filter)
+				.pushSelect(getSelectPayload(table, this.select), 'payload')
+				.setFilter(rootFilter)
 		} else {
 			// Queries with links are more complex for performance reasons.
 			// They have two parts separated by a `MATERIALIZED` CTE. The CTE
@@ -953,23 +1141,33 @@ module.exports = class SqlQuery {
 			// path.
 			const innerSelect = new SqlSelectBuilder()
 				.pushFrom(table)
-				.setFilter(this.filter)
+				.setFilter(rootFilter)
 			this.fillInnerOrderAndGroupBy(table, innerSelect)
 			this.setInnerLimit(innerSelect)
 
 			const linksBuildArgs = []
 			const linkEdges = []
 			const laterals = []
-			for (const [ linkType, linked ] of Object.entries(this.links)) {
-				linked.toJoin(
-					innerSelect,
-					linksBuildArgs,
-					linkEdges,
-					laterals,
-					[ linkType ],
-					table,
-					table
-				)
+			for (const [ linkType, variants ] of Object.entries(links)) {
+				for (
+					const {
+						nested,
+						linked
+					} of variants
+				) {
+					linkedToSql(
+						_.get(this.select.links, [ linkType ], {}),
+						linked,
+						_.get(this.options.links, [ linkType ], {}),
+						innerSelect,
+						linksBuildArgs,
+						linkEdges,
+						laterals,
+						table,
+						table,
+						nested
+					)
+				}
 			}
 
 			innerSelect.pushSelect(
@@ -991,7 +1189,7 @@ module.exports = class SqlQuery {
 			const fence = new SqlCteBuilder(FENCE_REWRAP)
 			fence.pushSubquery(innerSelect, 'fence', true)
 			select
-				.pushSelect(this.getSelectPayload(linksBuildArgs), 'payload')
+				.pushSelect(getSelectPayload(table, this.select, linksBuildArgs), 'payload')
 				.pushFrom(fence, 'main')
 				.setFilter(new LiteralSql(`${table}.id = main.cardId`))
 
@@ -1005,147 +1203,20 @@ module.exports = class SqlQuery {
 			.toSql()
 	}
 
-	toJoin (innerSelect, linksBuildArgs, linkEdges, laterals, linkTypeStack, parentTable, cardsTable) {
-		const idx = linkEdges.length
-		const linkType = linkTypeStack[linkTypeStack.length - 1]
-		const linkName = pgFormat.literal(linkType)
-		const stack = linkTypeStack.join('.')
-		const linksAlias = pgFormat.ident(`links.${stack}`)
-		const joinAlias = pgFormat.ident(`join.${stack}`)
-		const lateralAlias = pgFormat.ident(`linked.${linkType}`)
-
-		const linksFilter = new LiteralSql(`
-			(${linksAlias}.name = ${linkName} AND ${linksAlias}.fromId = ${parentTable}.id) OR
-			(${linksAlias}.inversename = ${linkName} AND ${linksAlias}.toId = ${parentTable}.id)
-		`)
-		innerSelect.pushInnerJoin('links', linksFilter, linksAlias)
-		const joinFilter = new LiteralSql(`(
-			(${linksAlias}.name = ${linkName} AND ${linksAlias}.toId = ${joinAlias}.id) OR
-			(${linksAlias}.inversename = ${linkName} AND ${linksAlias}.fromId = ${joinAlias}.id)
-		)`)
-
-		// TODO: maybe `cloneDeep()` isn't the best idea here......
-		innerSelect.pushInnerJoin(cardsTable, _.cloneDeep(this.filter).and(joinFilter), joinAlias)
-
-		linksBuildArgs.push([ linkType, `${lateralAlias}.linkedCards` ])
-		linkEdges.push(`row(${parentTable}.id, ${idx}, ${joinAlias}.id)::linkEdge`)
-
-		let orderByPaths = []
-		let orderBy = ''
-		if (this.options.sortBy) {
-			const formattedPaths = []
-			const order = this.isDescendingSort() ? 'DESC' : 'ASC'
-			orderByPaths = this.getPathsForOrderBy('linked')
-			for (const path of orderByPaths) {
-				formattedPaths.push(`${path.toSql('linked')} ${order} NULLS LAST`)
-			}
-			orderBy = ` ORDER BY ${formattedPaths.join(', ')}`
-		}
-
-		const lateralJoinFilter = new ExpressionFilter(new LiteralSql('linked.id = edges.sink'))
-		let lowestSeq = 1
-		if ('skip' in this.options) {
-			lowestSeq = this.options.skip + 1
-			lateralJoinFilter.and(new LiteralSql(`edges.seq >= ${lowestSeq}`))
-		}
-		if ('limit' in this.options) {
-			const highestSeq = lowestSeq + this.options.limit - 1
-			lateralJoinFilter.and(new LiteralSql(`edges.seq <= ${highestSeq}`))
-		}
-
-		const nestedLinksBuildArgs = []
-		const nestedLaterals = []
-		if (!_.isEmpty(this.links)) {
-			linkTypeStack.push(null)
-			for (const [ nestedLinkType, nestedLinked ] of Object.entries(this.links)) {
-				linkTypeStack[linkTypeStack.length - 1] = nestedLinkType
-				nestedLinked.toJoin(
-					innerSelect,
-					nestedLinksBuildArgs,
-					linkEdges,
-					nestedLaterals,
-					linkTypeStack,
-					joinAlias,
-					cardsTable
-				)
-			}
-			linkTypeStack.pop()
-		}
-
-		const edgesSelect = new SqlSelectBuilder()
-			.pushSelect(`row_number() OVER (PARTITION BY edges.source${orderBy})`, 'seq')
-			.pushSelect('edges.source')
-			.pushSelect('edges.sink')
-			.pushFrom('unnest(main.linkEdges)', 'edges')
-			.pushInnerJoin(cardsTable, new LiteralSql('linked.id = edges.sink'), 'linked')
-			.setFilter(new LiteralSql(`edges.idx = ${idx}`))
-		const payload = this.getSelectPayload(nestedLinksBuildArgs, 'linked')
-		const lateral = new SqlSelectBuilder()
-			.pushSelect('edges.source')
-			.pushSelect(`array_agg(${payload}${orderBy})`, 'linkedCards')
-			.pushFrom(edgesSelect, 'edges')
-			.pushInnerJoin(cardsTable, lateralJoinFilter, 'linked')
-			.pushGroupBy('edges', SqlPath.fromArray([ 'source' ]))
-		for (const [ nestedLateral, nestedLateralAlias ] of nestedLaterals) {
-			lateral.pushInnerJoin(
-				nestedLateral,
-				new LiteralSql(`${nestedLateralAlias}.source = linked.id`),
-				nestedLateralAlias
-			)
-		}
-		laterals.push([ lateral, lateralAlias ])
-	}
-
-	getSelectPayload (linksBuildArgs = [], tableOverride) {
-		const table = tableOverride || this.table
-		const selectedNonLinks = _.pick(this.select, CARD_ALL_NON_LINKS_KEYS)
-		const selectsAllNonLinks = _.isEqual(selectedNonLinks, CARD_ALL_NON_LINKS_SELECTED)
-		const selectsLinks = 'links' in this.select
-		const fetchAll = selectsAllNonLinks && selectsLinks
-		const selectsOnlyLinks = _.isEmpty(selectedNonLinks) && selectsLinks
-
-		let links = ''
-		let mergeLinks = ''
-		if (selectsLinks) {
-			const selectedLinks = this.select.links
-			const filteredLinksBuildArgs = []
-			for (const [ linkType, field ] of linksBuildArgs) {
-				if (linkType in selectedLinks) {
-					filteredLinksBuildArgs.push(pgFormat.literal(linkType))
-					filteredLinksBuildArgs.push(field)
-				}
-			}
-			links = `jsonb_build_object(${filteredLinksBuildArgs.join(', ')})`
-			links = `jsonb_build_object('links', ${links})`
-			mergeLinks = ` || ${links}`
-		}
-
-		if (fetchAll) {
-			return `to_jsonb(${table})${mergeLinks}`
-		} else if (selectsOnlyLinks) {
-			return links
-		}
-
-		const path = new SqlPath(table)
-		const main = SqlQuery.getSelectPayloadFrom(this.select, path)
-
-		return `${main}${mergeLinks}`
-	}
-
 	fillOrderBy (table, select) {
 		if (!this.options.sortBy) {
 			return
 		}
 
 		const isDescending = this.isDescendingSort()
-		for (const path of this.getPathsForOrderBy(table)) {
+		for (const path of pathsForOrderBy(table, this.options.sortBy)) {
 			select.pushOrderBy(table, path, isDescending)
 		}
 	}
 
 	fillInnerOrderAndGroupBy (table, innerSelect) {
 		if (this.options.sortBy) {
-			const paths = this.getPathsForOrderBy(table)
+			const paths = pathsForOrderBy(table, this.options.sortBy)
 			const isDescending = this.isDescendingSort()
 			for (const path of paths) {
 				innerSelect.pushGroupBy(table, path)
@@ -1156,21 +1227,8 @@ module.exports = class SqlQuery {
 		}
 	}
 
-	getPathsForOrderBy (table) {
-		const sortBy = _.castArray(this.options.sortBy)
-		if (sortBy.length === 1 && sortBy[0] === 'version') {
-			return [
-				new LiteralSql(`${table}.version_major`),
-				new LiteralSql(`${table}.version_minor`),
-				new LiteralSql(`${table}.version_patch`)
-			]
-		}
-
-		return [ SqlPath.fromArray(sortBy) ]
-	}
-
 	isDescendingSort () {
-		return this.options.sortDir === 'desc'
+		return isDescendingSort(this.options.sortDir)
 	}
 
 	setInnerLimit (innerSelect) {

--- a/lib/core/backend/postgres/jsonschema2sql/sql-query.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-query.js
@@ -123,8 +123,8 @@ const CARD_ALL_NON_LINKS_KEYS = Object.keys(CARD_ALL_NON_LINKS_SELECTED)
  * SqlQuery#toSqlSelect} to generate an SQL query for the parsed JSON schema.
  */
 module.exports = class SqlQuery {
-	static fromSchema (tableOrParent, select, schema, options) {
-		const query = new SqlQuery(tableOrParent, select, options)
+	static fromSchema (parent, select, schema, options) {
+		const query = new SqlQuery(parent, select, options)
 		if (schema === false) {
 			query.setAdditionalProperties(false)
 			query.filter.makeUnsatisfiable()
@@ -183,9 +183,8 @@ module.exports = class SqlQuery {
 	 * Create a new, empty SqlQuery. {@link SqlQuery#fromSchema} should be
 	 * used instead of this constructor.
 	 *
-	 * @param {String|SqlQuery} tableOrParent - Either the name of the table
-	 *        this SqlQuery will refer to, or the parent SqlQuery if we're
-	 *        parsing a sub schema.
+	 * @param {null|SqlQuery} parent - The parent SqlQuery if we're parsing a
+	 *        sub schema. Optional.
 	 * @param {Object} select - The properties to be selected. This should
 	 *        form a simple `<property>: <map of sub properties>` hierarchy.
 	 *        An empty `<map of sub properties>` means that `<property>` is the
@@ -208,7 +207,7 @@ module.exports = class SqlQuery {
 	 *        - extraFilter: a string that is used as the initial value for
 	 *          `this.filter`. Useful for constraints with placeholders.
 	 */
-	constructor (tableOrParent, select = {}, options = {}) {
+	constructor (parent, select = {}, options = {}) {
 		// Set of properties that must exist
 		this.required = []
 
@@ -247,15 +246,12 @@ module.exports = class SqlQuery {
 			this.options.parentLinkTypes = []
 		}
 
-		if (_.isString(tableOrParent)) {
-			// Table to `SELECT FROM`
-			this.table = tableOrParent
-
+		if (parent === null) {
 			// SQL field path that is currently being processed. This may refer
 			// to columns or JSONB properties
-			this.path = new SqlPath(this.table, this.options.parentPath)
+			this.path = new SqlPath(this.options.parentPath)
 		} else {
-			this.path = tableOrParent.path
+			this.path = parent.path
 		}
 
 		// Array of types this schema can be. Defaults to all accepted types
@@ -463,13 +459,12 @@ module.exports = class SqlQuery {
 			return
 		}
 
-		const alias = 'items'
-		const containsQuery = this.buildQueryFromCorrelatedSchema(alias, schema, [ 'contains' ])
+		const containsQuery = this.buildQueryFromCorrelatedSchema(schema, [ 'contains' ])
 
 		assert.INTERNAL(null, _.isEmpty(containsQuery.links), InvalidSchema,
 			'\'$$links\' is not supported inside a \'contains\' declaration')
 
-		const filter = new ArrayContainsFilter(this.path, containsQuery.filter, alias)
+		const filter = new ArrayContainsFilter(this.path, containsQuery.filter)
 		this.filter.and(this.ifTypeThen('array', filter))
 	}
 
@@ -577,13 +572,12 @@ module.exports = class SqlQuery {
 	}
 
 	arrayContentsMustMatch (schema) {
-		const alias = 'items'
-		const itemsQuery = this.buildQueryFromCorrelatedSchema(alias, schema, [ 'items' ])
+		const itemsQuery = this.buildQueryFromCorrelatedSchema(schema, [ 'items' ])
 
 		assert.INTERNAL(null, _.isEmpty(itemsQuery.links), InvalidSchema,
 			'\'$$links\' is not supported inside an \'items\' declaration')
 
-		const filter = new ArrayContainsFilter(this.path, itemsQuery.filter.negate(), alias)
+		const filter = new ArrayContainsFilter(this.path, itemsQuery.filter.negate())
 		this.filter.and(this.ifTypeThen('array', new NotFilter(filter)))
 	}
 
@@ -886,7 +880,7 @@ module.exports = class SqlQuery {
 	// Correlated schemas are subschemas that are implemented as subqueries at
 	// the SQL level, so the tables (or table aliases) they refer to are
 	// different, but they still rely on some shared context with `this`
-	buildQueryFromCorrelatedSchema (table, schema, suffix) {
+	buildQueryFromCorrelatedSchema (schema, suffix) {
 		let parentPath = null
 		if (_.isEmpty(this.options.parentPath)) {
 			parentPath = this.path
@@ -895,7 +889,7 @@ module.exports = class SqlQuery {
 		}
 
 		this.options.parentJsonPath.push(...suffix)
-		const query = SqlQuery.fromSchema(table, {}, schema, {
+		const query = SqlQuery.fromSchema(null, {}, schema, {
 			parentJsonPath: this.options.parentJsonPath,
 			parentPath
 		})
@@ -912,14 +906,10 @@ module.exports = class SqlQuery {
 		this.options.parentJsonPath.push(...suffix)
 		this.options.parentLinkTypes.push(linkType)
 
-		const options = Object.assign({
+		const query = SqlQuery.fromSchema(null, schema, Object.assign({
 			parentJsonPath: this.options.parentJsonPath,
 			parentLinkTypes: this.options.parentLinkTypes
-		}, _.get(this.options, [ 'links', linkType ]))
-
-		const table = pgFormat.ident(`join.${this.options.parentLinkTypes.join('.')}`)
-		const select = _.get(this.select.links, [ linkType ])
-		const query = SqlQuery.fromSchema(table, select, schema, options)
+		}, _.get(this.options, [ 'links', linkType ])))
 
 		this.options.parentLinkTypes.pop()
 		for (let idx = 0; idx < suffix.length; ++idx) {
@@ -929,10 +919,10 @@ module.exports = class SqlQuery {
 		return query
 	}
 
-	toSqlSelect () {
+	toSqlSelect (table) {
 		// Set common stuff for our `SELECT`
 		const select = new SqlSelectBuilder()
-			.pushFrom(this.table)
+			.pushFrom(table)
 		this.fillOrderBy(select)
 		if (this.options.skip) {
 			select.setOffset(this.options.skip)
@@ -962,9 +952,9 @@ module.exports = class SqlQuery {
 			// potential to send PG's query planner right out of the happy
 			// path.
 			const innerSelect = new SqlSelectBuilder()
-				.pushFrom(this.table)
+				.pushFrom(table)
 				.setFilter(this.filter)
-			this.fillInnerOrderAndGroupBy(innerSelect)
+			this.fillInnerOrderAndGroupBy(table, innerSelect)
 			this.setInnerLimit(innerSelect)
 
 			const linksBuildArgs = []
@@ -977,8 +967,8 @@ module.exports = class SqlQuery {
 					linkEdges,
 					laterals,
 					[ linkType ],
-					this.table,
-					this.table
+					table,
+					table
 				)
 			}
 
@@ -986,7 +976,7 @@ module.exports = class SqlQuery {
 				`
 				array_agg(
 					row(
-						${this.table}.id,
+						${table}.id,
 						array[
 							${linkEdges.join(', ')}
 						]
@@ -1003,16 +993,16 @@ module.exports = class SqlQuery {
 			select
 				.pushSelect(this.getSelectPayload(linksBuildArgs), 'payload')
 				.pushFrom(fence, 'main')
-				.setFilter(new LiteralSql(`${this.table}.id = main.cardId`))
+				.setFilter(new LiteralSql(`${table}.id = main.cardId`))
 
 			for (const [ lateral, alias ] of laterals) {
 				select.pushFrom(lateral, alias, true)
 			}
 		}
 
-		return new SqlFragmentBuilder()
+		return new SqlFragmentBuilder(table)
 			.extendFrom(select)
-			.build()
+			.toSql()
 	}
 
 	toJoin (innerSelect, linksBuildArgs, linkEdges, laterals, linkTypeStack, parentTable, cardsTable) {
@@ -1047,7 +1037,7 @@ module.exports = class SqlQuery {
 			const order = this.isDescendingSort() ? 'DESC' : 'ASC'
 			orderByPaths = this.getPathsForOrderBy('linked')
 			for (const path of orderByPaths) {
-				formattedPaths.push(`${path.toSql()} ${order} NULLS LAST`)
+				formattedPaths.push(`${path.toSql('linked')} ${order} NULLS LAST`)
 			}
 			orderBy = ` ORDER BY ${formattedPaths.join(', ')}`
 		}
@@ -1095,7 +1085,7 @@ module.exports = class SqlQuery {
 			.pushSelect(`array_agg(${payload}${orderBy})`, 'linkedCards')
 			.pushFrom(edgesSelect, 'edges')
 			.pushInnerJoin(cardsTable, lateralJoinFilter, 'linked')
-			.pushGroupBy(new LiteralSql('edges.source'))
+			.pushGroupBy('edges', SqlPath.fromArray([ 'source' ]))
 		for (const [ nestedLateral, nestedLateralAlias ] of nestedLaterals) {
 			lateral.pushInnerJoin(
 				nestedLateral,
@@ -1142,32 +1132,31 @@ module.exports = class SqlQuery {
 		return `${main}${mergeLinks}`
 	}
 
-	fillOrderBy (select, tableOverride) {
+	fillOrderBy (table, select) {
 		if (!this.options.sortBy) {
 			return
 		}
 
 		const isDescending = this.isDescendingSort()
-		for (const path of this.getPathsForOrderBy(tableOverride)) {
-			select.pushOrderBy(path, isDescending)
+		for (const path of this.getPathsForOrderBy(table)) {
+			select.pushOrderBy(table, path, isDescending)
 		}
 	}
 
-	fillInnerOrderAndGroupBy (innerSelect) {
+	fillInnerOrderAndGroupBy (table, innerSelect) {
 		if (this.options.sortBy) {
-			const paths = this.getPathsForOrderBy()
+			const paths = this.getPathsForOrderBy(table)
 			const isDescending = this.isDescendingSort()
 			for (const path of paths) {
-				innerSelect.pushGroupBy(path)
-				innerSelect.pushOrderBy(path, isDescending)
+				innerSelect.pushGroupBy(table, path)
+				innerSelect.pushOrderBy(table, path, isDescending)
 			}
 		} else {
-			innerSelect.pushGroupBy(SqlPath.fromArray([ this.table, 'id' ]))
+			innerSelect.pushGroupBy(table, SqlPath.fromArray([ 'id' ]))
 		}
 	}
 
-	getPathsForOrderBy (tableOverride) {
-		const table = tableOverride || this.table
+	getPathsForOrderBy (table) {
 		const sortBy = _.castArray(this.options.sortBy)
 		if (sortBy.length === 1 && sortBy[0] === 'version') {
 			return [
@@ -1177,7 +1166,7 @@ module.exports = class SqlQuery {
 			]
 		}
 
-		return [ SqlPath.fromArray(_.concat(table, sortBy)) ]
+		return [ SqlPath.fromArray(sortBy) ]
 	}
 
 	isDescendingSort () {

--- a/lib/core/backend/postgres/jsonschema2sql/sql-query.js
+++ b/lib/core/backend/postgres/jsonschema2sql/sql-query.js
@@ -19,6 +19,7 @@ const LiteralSql = require('./literal-sql')
 const MatchesRegexFilter = require('./matches-regex-filter')
 const MultipleOfFilter = require('./multiple-of-filter')
 const NotFilter = require('./not-filter')
+const SelectMap = require('./select-map')
 const SqlCteBuilder = require('./cte-builder')
 const SqlFragmentBuilder = require('./fragment-builder')
 const SqlPath = require('./sql-path')
@@ -32,13 +33,26 @@ const {
 
 const FENCE_REWRAP = new LiteralSql(`
 	SELECT
-		unwrapped.cardId,
-		array_agg(unwrapped.edges) AS linkEdges
+		unaggregated.cardId,
+		array(
+			SELECT row(
+				edges.source,
+				edges.sink,
+				array_agg(edges.idx)
+			)::polyLinkEdge
+			FROM unnest(unaggregated.edges) AS edges
+			GROUP BY edges.source, edges.sink
+		) AS linkEdges
 	FROM (
-		SELECT (unnest(fence.arr)).*
-		FROM fence
-	) AS unwrapped
-	GROUP BY unwrapped.cardId
+		SELECT
+			unwrapped.cardId,
+			array_agg(unwrapped.edges) AS edges
+		FROM (
+			SELECT (unnest(fence.arr)).*
+			FROM fence
+		) AS unwrapped
+		GROUP BY unwrapped.cardId
+	) AS unaggregated
 `)
 
 // Columns of the `cards` table
@@ -146,22 +160,25 @@ const pushLinkedJoins = (linked, innerSelect, parentTable, cardsTable) => {
 
 const pushLinkedLateral = (
 	select,
-	edgeIdx,
+	idxStart,
+	idxEnd,
 	nestedLaterals,
 	lateralAlias,
 	options,
-	laterals,
-	cardsTable
+	cardsTable,
+	laterals
 ) => {
-	const lateralJoinFilter = new ExpressionFilter(new LiteralSql('linked.id = edges.sink'))
+	const lateralJoinFilter = new ExpressionFilter(
+		new LiteralSql('linked.id = orderedEdges.sink')
+	)
 	let lowestSeq = 1
 	if ('skip' in options) {
 		lowestSeq = options.skip + 1
-		lateralJoinFilter.and(new LiteralSql(`edges.seq >= ${lowestSeq}`))
+		lateralJoinFilter.and(new LiteralSql(`orderedEdges.seq >= ${lowestSeq}`))
 	}
 	if ('limit' in options) {
 		const highestSeq = lowestSeq + options.limit - 1
-		lateralJoinFilter.and(new LiteralSql(`edges.seq <= ${highestSeq}`))
+		lateralJoinFilter.and(new LiteralSql(`orderedEdges.seq <= ${highestSeq}`))
 	}
 
 	let orderBy = ''
@@ -174,85 +191,102 @@ const pushLinkedLateral = (
 		orderBy = ` ORDER BY ${formattedPaths.join(', ')}`
 	}
 
-	const edgesSelect = new SqlSelectBuilder()
-		.pushSelect(`row_number() OVER (PARTITION BY edges.source${orderBy})`, 'seq')
+	const edgeIdxs = []
+	for (let idx = idxStart; idx < idxEnd; idx += 1) {
+		edgeIdxs.push(idx)
+	}
+
+	const orderedEdges = new SqlSelectBuilder()
 		.pushSelect('edges.source')
 		.pushSelect('edges.sink')
+		.pushSelect('edges.idxs')
+		.pushSelect(`row_number() OVER (PARTITION BY edges.source${orderBy})`, 'seq')
 		.pushFrom('unnest(main.linkEdges)', 'edges')
 		.pushLeftJoin(cardsTable, new LiteralSql('linked.id = edges.sink'), 'linked')
-		.setFilter(new LiteralSql(`edges.idx = ${edgeIdx}`))
+		.setFilter(new LiteralSql(`edges.idxs && ARRAY[${edgeIdxs.join(', ')}]`))
 
-	const linkedSelect = new SqlSelectBuilder()
-		.pushSelect('edges.source')
-		.pushSelect(`array_agg(${select.toSql('linked')}${orderBy})`, 'linkedCards')
-		.pushSelect('array_agg(linked.id)', 'idList')
-		.pushFrom(edgesSelect, 'edges')
+	// TODO: support differing views
+	const edgeViews = []
+	for (const idx of edgeIdxs) {
+		edgeViews.push(`WHEN idxs = ${idx} THEN ${select.toSql('linked')}`)
+	}
+
+	const lateral = new SqlSelectBuilder()
+		.pushSelect('orderedEdges.source')
+		.pushSelect(`
+			array_agg(
+				row(
+			        linked.id,
+			        array(
+			            SELECT CASE
+			                ${edgeViews.join('\n')}
+			            END
+			            FROM unnest(orderedEdges.idxs) AS idxs
+			        )
+			    )
+				ORDER BY orderedEdges.seq
+			)`,
+		'linkedCards'
+		)
+		.pushFrom(orderedEdges, 'orderedEdges')
 		.pushLeftJoin(cardsTable, lateralJoinFilter, 'linked')
-		.pushGroupBy('edges', SqlPath.fromArray([ 'source' ]))
+		.pushGroupBy('orderedEdges', SqlPath.fromArray([ 'source' ]))
 
 	for (const [ nestedLateral, nestedLateralAlias ] of nestedLaterals) {
-		linkedSelect.pushInnerJoin(
+		lateral.pushInnerJoin(
 			nestedLateral,
 			new LiteralSql(`${nestedLateralAlias}.source = linked.id`),
 			nestedLateralAlias
 		)
 	}
 
-	const lateral = new SqlSelectBuilder()
-		.pushSelect('unfilteredList.source')
-		.pushSelect(`array(
-			SELECT unnest.linkedCard
-			FROM unnest(unfilteredList.linkedCards, unfilteredList.idList) AS unnest(linkedCard, id)
-			WHERE unnest.id IS NOT NULL
-		)`, 'linkedCards')
-		.pushFrom(linkedSelect, 'unfilteredList')
-
 	laterals.push([ lateral, lateralAlias ])
 }
 
-const linkedToSql = (
-	select,
-	linked,
-	options,
-	innerSelect,
-	linkEdges,
-	laterals,
-	parentTable,
-	cardsTable,
-	nested
-) => {
-	pushLinkedJoins(linked, innerSelect, parentTable, cardsTable)
-
-	const edgeIdx = linkEdges.length
-	linkEdges.push(`row(${parentTable}.id, ${edgeIdx}, ${linked.joinAlias}.id)::linkEdge`)
-
+const linkedToSql = (data, state) => {
+	const idxStart = state.linkEdges.length
 	const nestedLaterals = []
-	if (nested) {
-		for (const [ nestedLinkType, nestedVariants ] of Object.entries(nested)) {
-			for (const nestedNested of nestedVariants) {
-				linkedToSql(
-					select.getProperty('links').getProperty(nestedLinkType),
-					nestedNested.linked,
-					_.get(options.links, [ nestedLinkType ], {}),
-					innerSelect,
-					linkEdges,
-					nestedLaterals,
-					linked.joinAlias,
-					cardsTable,
-					nestedNested.nested
-				)
-			}
+	for (
+		const {
+			nested,
+			linked
+		} of data.variants
+	) {
+		pushLinkedJoins(linked, state.innerSelect, data.parentTable, data.cardsTable)
+
+		const edgeIdx = state.linkEdges.length
+		const edge = `row(${data.parentTable}.id, ${edgeIdx}, ${linked.joinAlias}.id)::linkEdge`
+		state.linkEdges.push(edge)
+
+		for (const [ nestedLinkType, nestedVariants ] of Object.entries(nested || {})) {
+			linkedToSql(
+				{
+					select: data.select.getLink(nestedLinkType),
+					linkType: nestedLinkType,
+					variants: nestedVariants,
+					options: _.get(data.options.links, [ nestedLinkType ], {}),
+					parentTable: linked.joinAlias,
+					cardsTable: data.cardsTable
+				},
+				{
+					innerSelect: state.innerSelect,
+					linkEdges: state.linkEdges,
+					laterals: nestedLaterals
+				}
+			)
 		}
 	}
 
+	const lateralAlias = SelectMap.lateralAliasFor(data.linkType)
 	pushLinkedLateral(
-		select,
-		edgeIdx,
+		data.select,
+		idxStart,
+		state.linkEdges.length,
 		nestedLaterals,
-		linked.lateralAlias,
-		options,
-		laterals,
-		cardsTable
+		lateralAlias,
+		data.options,
+		data.cardsTable,
+		state.laterals
 	)
 }
 
@@ -313,8 +347,6 @@ module.exports = class SqlQuery {
 	 *          SqlQuery#buildQueryFromCorrelatedSchema}.
 	 *        - extraFilter: a string that is used as the initial value for
 	 *          `this.filter`. Useful for constraints with placeholders.
-	 *        - linksSelectMap: the `SelectMap` of the `<table>.links`
-	 *          property.
 	 */
 	constructor (parent, select = {}, options = {}) {
 		// Set of properties that must exist
@@ -346,9 +378,6 @@ module.exports = class SqlQuery {
 		this.options = options
 		if (!('parentJsonPath' in this.options)) {
 			this.options.parentJsonPath = []
-		}
-		if (!('linksSelectMap' in this.options)) {
-			this.options.linksSelectMap = select.getProperty('links')
 		}
 
 		if (parent === null) {
@@ -488,10 +517,6 @@ module.exports = class SqlQuery {
 		})
 
 		for (const [ linkType, linkSchema ] of Object.entries(linkMap)) {
-			assert.INTERNAL(null, _.isString(linkType), InvalidSchema, () => {
-				return `key for '${this.formatJsonPath([ '$$links', linkType ])}' must be a string`
-			})
-
 			const linkQuery = this.buildQueryFromLinkedSchema(
 				linkType,
 				linkSchema,
@@ -966,8 +991,7 @@ module.exports = class SqlQuery {
 		this.options.parentJsonPath.push(...suffix)
 		const query = SqlQuery.fromSchema(null, this.select, schema, {
 			parentJsonPath: this.options.parentJsonPath,
-			parentPath,
-			linksSelectMap: this.options.linksSelectMap
+			parentPath
 		})
 		for (let idx = 0; idx < suffix.length; ++idx) {
 			this.options.parentJsonPath.pop()
@@ -981,7 +1005,7 @@ module.exports = class SqlQuery {
 	buildQueryFromLinkedSchema (linkType, schema, suffix) {
 		this.options.parentJsonPath.push(...suffix)
 
-		const select = this.options.linksSelectMap.getProperty(linkType)
+		const select = this.select.getLink(linkType)
 		const query = SqlQuery.fromSchema(null, select, schema, {
 			parentJsonPath: this.options.parentJsonPath
 		})
@@ -1047,28 +1071,24 @@ module.exports = class SqlQuery {
 			const linkEdges = []
 			const laterals = []
 			for (const [ linkType, variants ] of Object.entries(links)) {
-				for (
-					const {
-						nested,
-						linked
-					} of variants
-				) {
-					linkedToSql(
-						this.select.getProperty('links').getProperty(linkType),
-						linked,
-						_.get(this.options.links, [ linkType ], {}),
+				linkedToSql(
+					{
+						select: this.select.getLink(linkType),
+						linkType,
+						variants,
+						options: _.get(this.options.links, [ linkType ], {}),
+						parentTable: table,
+						cardsTable: table
+					},
+					{
 						innerSelect,
 						linkEdges,
-						laterals,
-						table,
-						table,
-						nested
-					)
-				}
+						laterals
+					}
+				)
 			}
 
-			innerSelect.pushSelect(
-				`
+			innerSelect.pushSelect(`
 				array_agg(
 					row(
 						${table}.id,
@@ -1076,9 +1096,8 @@ module.exports = class SqlQuery {
 							${linkEdges.join(', ')}
 						]
 					)::cardAndLinkEdges
-				)
-				`,
-				'arr'
+				)`,
+			'arr'
 			)
 
 			// The outer `SELECT`, meanwhile, uses the IDs from the inner

--- a/lib/core/backend/postgres/jsonschema2sql/string-length-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/string-length-filter.js
@@ -23,16 +23,17 @@ module.exports = class StringLengthFilter extends SqlFilter {
 	constructor (path, operator, value) {
 		super()
 
-		this.field = path.toSql({
-			asText: true
-		})
+		this.path = path.cloned()
 		this.operator = operator
 		this.value = value
 	}
 
 	toSqlInto (builder) {
+		const field = this.path.toSql(builder.getTable(), {
+			asText: true
+		})
 		builder
-			.pushInvoked('char_length', this.field)
+			.pushInvoked('char_length', field)
 			.pushSpaced(this.operator)
 			.push(this.value)
 	}

--- a/lib/core/backend/postgres/jsonschema2sql/value-is-filter.js
+++ b/lib/core/backend/postgres/jsonschema2sql/value-is-filter.js
@@ -24,30 +24,26 @@ module.exports = class ValueIsFilter extends SqlFilter {
 	constructor (path, operator, value, cast) {
 		super()
 
-		if (cast) {
-			this.field = path.toSql({
-				asText: true
-			})
-			this.value = pgFormat.literal(value)
-			this.cast = cast
-		} else {
-			this.field = path.toSql()
-			this.value = SqlFilter.maybeJsonLiteral(path, value)
-		}
+		this.path = path.cloned()
 		this.operator = operator
+		this.value = value
+		this.cast = cast
 	}
 
 	toSqlInto (builder) {
 		if (this.cast) {
+			const field = this.path.toSql(builder.getTable(), {
+				asText: true
+			})
 			builder
-				.pushCasted(this.field, this.cast)
+				.pushCasted(field, this.cast)
 				.pushSpaced(this.operator)
-				.pushCasted(this.value, this.cast)
+				.pushCasted(pgFormat.literal(this.value), this.cast)
 		} else {
 			builder
-				.push(this.field)
+				.extendFrom(this.path)
 				.pushSpaced(this.operator)
-				.push(this.value)
+				.push(SqlFilter.maybeJsonLiteral(this.path, this.value))
 		}
 	}
 }

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -32,6 +32,10 @@ exports.setup = async (context, connection, database, options) => {
 				CREATE TYPE linkEdge AS (source UUID, idx INT, sink UUID);
 				CREATE TYPE cardAndLinkEdges AS (cardId UUID, edges linkEdge[]);
 			END IF;
+
+			IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'polylinkedge') THEN
+				CREATE TYPE polyLinkEdge AS (source UUID, sink UUID, idxs INT[]);
+			END IF;
 		END$$;
 
 		COMMIT;

--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -192,12 +192,6 @@ class Stream extends EventEmitter {
 			select.id = {}
 		}
 
-		// TODO: this shouldn't be necessary and won't be when we get SQL-side
-		// filtering
-		if (!_.get(schema, [ 'properties', 'id' ])) {
-			_.set(schema, [ 'properties', 'id' ], true)
-		}
-
 		const cards = await this.streamer.backend.query(
 			this.context,
 			select,
@@ -208,7 +202,7 @@ class Stream extends EventEmitter {
 			this.seenCardIds.add(card.id)
 		}
 
-		// Remove the ID if that wasn't requested
+		// Remove the ID if that wasn't requested in the first place
 		if (!selectsId && !_.get(schema, [ 'additionalProperties' ], true)) {
 			for (const card of cards) {
 				Reflect.deleteProperty(card, 'id')

--- a/lib/core/backend/postgres/utils.js
+++ b/lib/core/backend/postgres/utils.js
@@ -5,31 +5,12 @@
  */
 
 const _ = require('lodash')
-const skhema = require('skhema')
 
 // List of Postgres error codes we can safely ignore during initial db setup.
 // All error codes: https://www.postgresql.org/docs/12/errcodes-appendix.html
 // 23505: unique violation error
 // 42P07: duplicate table error
 const INIT_IGNORE_CODES = [ '23505', '42P07' ]
-
-exports.filter = (schema, elements, errors) => {
-	if (_.isNil(schema)) {
-		return
-	}
-
-	try {
-		skhema.filter(schema, elements)
-	} catch (error) {
-		if (error instanceof skhema.InvalidSchema) {
-			const newError = new errors.JellyfishInvalidSchema(error.message)
-			newError.expected = true
-			throw newError
-		}
-
-		throw error
-	}
-}
 
 // FIXME
 // this function is intended to make the transition between dates as

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -17,7 +17,7 @@ const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 
 const flattenSelected = (selected) => {
 	const flat = selected.properties
-	if (!_.isEmpty(selected.links)) {
+	if ('links' in flat && !_.isEmpty(selected.links)) {
 		flat.links = _.merge(flat.links, selected.links)
 	}
 

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -90,6 +90,16 @@ const getSelected = (schema) => {
 	}
 }
 
+const rectifySelected = (selected, filteredSelected) => {
+	for (const [ key, value ] of Object.entries(selected)) {
+		if (key in filteredSelected) {
+			rectifySelected(value, filteredSelected[key])
+		} else {
+			Reflect.deleteProperty(selected, key)
+		}
+	}
+}
+
 const getQueryFromSchema = async (context, backend, session, schema) => {
 	const finalSchema = schema.type === `${CARDS.view.slug}@${CARDS.view.version}`
 		? views.getSchema(schema)
@@ -101,6 +111,13 @@ const getQueryFromSchema = async (context, backend, session, schema) => {
 
 	const filteredQuery = await permissionFilter.getQuery(
 		context, backend, session, finalSchema)
+
+	// If a property is completely blacklisted by the permissions, it will be
+	// completely removed from `filteredQuery`. In that case we need to find
+	// all selected properties again from `filteredQuery` and then rectify
+	// `selected` by removing missing properties
+	const filteredSelected = flattenSelected(getSelected(filteredQuery))
+	rectifySelected(selected, filteredSelected)
 
 	return {
 		selected,

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -4276,6 +4276,778 @@ ava('.query() should be able to query $$links inside $$links', async (test) => {
 	test.deepEqual(results[0].links['is child of'][0].links['is child of'][0].links['believes in'][0].id, santa.id)
 })
 
+ava.skip('.query() should be able to query $$links inside an allOf', async (test) => {
+	const office = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: true
+			}
+		})
+
+	const worker2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: false
+			}
+		})
+
+	const worker3 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker1.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker1.id,
+					type: worker1.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker2.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker2.id,
+					type: worker2.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker3.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker3.id,
+					type: worker3.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context,
+		context.kernel.sessions.admin,
+		{
+			additionalProperties: false,
+			required: [ 'id', 'links' ],
+			allOf: [
+				{
+					$$links: {
+						'works at': {
+							additionalProperties: false,
+							properties: {
+								id: {
+									const: office.id
+								}
+							}
+						}
+					}
+				},
+				{
+					properties: {
+						data: {
+							properties: {
+								isStressed: {
+									const: true
+								}
+							}
+						}
+					}
+				}
+			]
+		}
+	)
+
+	test.deepEqual(results, [
+		{
+			id: worker1.id,
+			links: {
+				'works at': [
+					{
+						id: office.id
+					}
+				]
+			},
+			data: {
+				isStressed: true
+			}
+		}
+	])
+})
+
+ava('.query() should be able to query $$links inside an anyOf', async (test) => {
+	const office = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: false
+			}
+		})
+
+	const worker2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: true
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: false
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker1.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker1.id,
+					type: worker1.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context,
+		context.kernel.sessions.admin,
+		{
+			additionalProperties: false,
+			required: [ 'id', 'links' ],
+			anyOf: [
+				{
+					$$links: {
+						'works at': {
+							additionalProperties: false,
+							properties: {
+								id: {
+									const: office.id
+								}
+							}
+						}
+					}
+				},
+				{
+					required: [ 'data' ],
+					properties: {
+						data: {
+							required: [ 'isStressed' ],
+							properties: {
+								isStressed: {
+									const: true
+								}
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			sortBy: [ 'data', 'isStressed' ]
+		}
+	)
+
+	test.deepEqual(results, [
+		{
+			id: worker1.id,
+			links: {
+				'works at': [
+					{
+						id: office.id
+					}
+				]
+			},
+			data: {}
+		},
+		{
+			id: worker2.id,
+			links: {},
+			data: {
+				isStressed: true
+			}
+		}
+	])
+})
+
+ava('.query() should be able to query $$links inside a contains', async (test) => {
+	const office = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				stressedDays: [ 1, 3, 5 ]
+			}
+		})
+
+	const worker2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				stressedDays: [ 1, 2, 4 ]
+			}
+		})
+
+	const worker3 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker1.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker1.id,
+					type: worker1.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker2.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker2.id,
+					type: worker2.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker3.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker3.id,
+					type: worker3.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context,
+		context.kernel.sessions.admin,
+		{
+			additionalProperties: false,
+			required: [ 'id', 'links', 'data' ],
+			properties: {
+				data: {
+					required: [ 'stressedDays' ],
+					properties: {
+						stressedDays: {
+							type: 'array',
+							contains: {
+								$$links: {
+									'works at': {
+										additionalProperties: false,
+										properties: {
+											id: {
+												const: office.id
+											}
+										}
+									}
+								},
+								const: 5
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			sortBy: [ 'data', 'stressedDays' ]
+		}
+	)
+
+	test.deepEqual(results, [
+		{
+			id: worker1.id,
+			links: {
+				'works at': [
+					{
+						id: office.id
+					}
+				]
+			},
+			data: {
+				stressedDays: [ 1, 3, 5 ]
+			}
+		}
+	])
+})
+
+ava('.query() should be able to query $$links inside an items', async (test) => {
+	const office = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				stressedDays: [ 1, 3, 5 ]
+			}
+		})
+
+	const worker2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				stressedDays: [ 1, 'INVALID DAY', 4 ]
+			}
+		})
+
+	const worker3 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker1.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker1.id,
+					type: worker1.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker2.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker2.id,
+					type: worker2.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker3.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker3.id,
+					type: worker3.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context,
+		context.kernel.sessions.admin,
+		{
+			additionalProperties: false,
+			required: [ 'id', 'links', 'data' ],
+			properties: {
+				data: {
+					required: [ 'stressedDays' ],
+					properties: {
+						stressedDays: {
+							type: 'array',
+							items: {
+								$$links: {
+									'works at': {
+										additionalProperties: false,
+										properties: {
+											id: {
+												const: office.id
+											}
+										}
+									}
+								},
+								type: 'integer'
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			sortBy: [ 'data', 'stressedDays' ]
+		}
+	)
+
+	test.deepEqual(results, [
+		{
+			id: worker1.id,
+			links: {
+				'works at': [
+					{
+						id: office.id
+					}
+				]
+			},
+			data: {
+				stressedDays: [ 1, 3, 5 ]
+			}
+		}
+	])
+})
+
+ava('.query() should be able to query $$links inside a not', async (test) => {
+	const office = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker1.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker1.id,
+					type: worker1.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context,
+		context.kernel.sessions.admin,
+		{
+			additionalProperties: false,
+			required: [ 'links' ],
+			not: {
+				$$links: {
+					'works at': {
+						additionalProperties: false,
+						properties: {
+							id: {
+								const: office.id
+							}
+						}
+					}
+				}
+			},
+			properties: {
+				id: {
+					enum: [ worker1.id, worker2.id ]
+				}
+			}
+		}
+	)
+
+	test.deepEqual(results, [
+		{
+			id: worker2.id,
+			links: {}
+		}
+	])
+})
+
+ava('.query() should be able to query $$links inside a property', async (test) => {
+	const office = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	const worker1 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: true
+			}
+		})
+
+	const worker2 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0',
+			data: {
+				isStressed: false
+			}
+		})
+
+	const worker3 = await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: context.generateRandomSlug(),
+			type: 'card@1.0.0',
+			version: '1.0.0'
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker1.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker1.id,
+					type: worker1.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker2.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker2.id,
+					type: worker2.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	await context.kernel.insertCard(
+		context.context, context.kernel.sessions.admin, {
+			slug: `link-${worker3.slug}-works-at-${office.slug}`,
+			type: 'link@1.0.0',
+			version: '1.0.0',
+			name: 'works at',
+			data: {
+				inverseName: 'has worker',
+				from: {
+					id: worker3.id,
+					type: worker3.type
+				},
+				to: {
+					id: office.id,
+					type: office.type
+				}
+			}
+		})
+
+	const results = await context.kernel.query(
+		context.context,
+		context.kernel.sessions.admin,
+		{
+			additionalProperties: false,
+			required: [ 'id', 'links', 'data' ],
+			properties: {
+				data: {
+					required: [ 'isStressed' ],
+					properties: {
+						isStressed: {
+							$$links: {
+								'works at': {
+									additionalProperties: false,
+									properties: {
+										id: {
+											const: office.id
+										}
+									}
+								}
+							},
+							const: true
+						}
+					}
+				}
+			}
+		},
+		{
+			sortBy: ['data', 'isStressed']
+		}
+	)
+
+	test.deepEqual(results, [
+		{
+			id: worker1.id,
+			links: {
+				'works at': [
+					{
+						id: office.id
+					}
+				]
+			},
+			data: {
+				isStressed: true
+			}
+		}
+	])
+})
+
 ava.cb('.stream() should include data if additionalProperties true', (test) => {
 	const slug = context.generateRandomSlug({
 		prefix: 'card'

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -5027,7 +5027,7 @@ ava('.query() should be able to query $$links inside a property', async (test) =
 			}
 		},
 		{
-			sortBy: ['data', 'isStressed']
+			sortBy: [ 'data', 'isStressed' ]
 		}
 	)
 


### PR DESCRIPTION
Current blockers:

- [X] Remove part of post-query filtering by not selecting properties that are only relevant to permissions: PR #4250 
- [x] Adapt the streaming subsystem: PR #4434
- [x] Remove the need for post-query filtering by moving property hiding into SQL: this PR. Working as it should most of the time, but it has some rough edges that are not critical (i.e. can return a bit more data than it strictly should in some rare edge cases, but never returns (AFAIK) properties that are explicitly hidden). This is not a blocker for this PR and thus I'll fix it with another PR
- [X] Update the permission-merging code to a world where `$$links` can appear anywhere: PR #4577
- [X] ~Deal with the case where the same link type appear in multiple `$$links`~ Punted
- [X] ~Proper benchmarking and any necessary optimizations~ Punted

Description:

Allowed enclosing keywords (recursively):
- `$$links` (already allowed)
- ~`allOf`~ Not working due to a JSON schema merge issue
- `anyOf`
- `contains`
- `items`
- `not`
- `properties`

This works almost like any other keyword that you could put in the same place. That is, it constrains that specific schema. Inside `properties` for example:

```
{
  properties: {
    name: {
      $$links {
        'is part of': {
          properties: {
            slug: {
              const: 'org-balena'
            }
          }
        }
      },
      pattern: '^Balenista .*'
    }
  }
}
```

Cards returned through this query will meet the follwing two requirements at the same time:

- If `name` exists, the card has an `is part of` link to another card that has the `org-balena` slug
- If `name` exists, it must start with `Balenista `

Note that if `name` does not exist, this query may return *any* `is part of` links.