### PR TITLE
Allow the webpack dev server to listen on all local interfaces.

### DIFF
--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -47,6 +47,7 @@ const config = mergeConfig(baseConfig, {
 
 	devServer: {
 		contentBase: outDir,
+		host: '0.0.0.0',
 		port: 9000
 	},
 


### PR DESCRIPTION
Telling the dev server to bind to all interfaces means that you can do UI development within a container that has it's ports bound to the host system.