### PR TITLE
Rename "balena-io/jellyfish" to "product-os/jellyfish"

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,25 +47,25 @@ services as needed using actions.
 
 ## Deployable Components
 
-### [`apps/action-server`](https://github.com/balena-io/jellyfish/tree/master/apps/action-server)
+### [`apps/action-server`](https://github.com/product-os/jellyfish/tree/master/apps/action-server)
 
 The action server worker, which dequeues action requests from the database
 and executes them with the configured action library.
 
-### [`apps/livechat`](https://github.com/balena-io/jellyfish/tree/master/apps/livechat)
+### [`apps/livechat`](https://github.com/product-os/jellyfish/tree/master/apps/livechat)
 
 This is the demo project for developing chat-widget.
 
-### [`apps/server`](https://github.com/balena-io/jellyfish/tree/master/apps/server)
+### [`apps/server`](https://github.com/product-os/jellyfish/tree/master/apps/server)
 
 The Jellyfish HTTP and WebSockets API.
 
-### [`apps/sidecar`](https://github.com/balena-io/jellyfish/tree/master/apps/sidecar)
+### [`apps/sidecar`](https://github.com/product-os/jellyfish/tree/master/apps/sidecar)
 
 A utility container to run tests against the other
 containers.
 
-### [`apps/ui`](https://github.com/balena-io/jellyfish/tree/master/apps/ui)
+### [`apps/ui`](https://github.com/product-os/jellyfish/tree/master/apps/ui)
 
 This is the main Jellyfish web user interface, and what most people will
 interact with.
@@ -74,12 +74,12 @@ interact with.
 
 A set of re-usable libraries that the top level components use.
 
-### [`lib/action-library`](https://github.com/balena-io/jellyfish/tree/master/lib/action-library)
+### [`lib/action-library`](https://github.com/product-os/jellyfish/tree/master/lib/action-library)
 
 The action library consists of a set of actions with which the system
 provisions workers.
 
-### [`lib/assert`](https://github.com/balena-io/jellyfish/tree/master/lib/assert)
+### [`lib/assert`](https://github.com/product-os/jellyfish/tree/master/lib/assert)
 
 The Jellyfish system distinguishes between two types of errors:
 
@@ -91,12 +91,12 @@ This module provides a handy set of functions to write concise assertions for
 both types of errors, and remove the amount of error handling `if` conditionals
 throughout the code
 
-### [`lib/chat-widget`](https://github.com/balena-io/jellyfish/tree/master/lib/chat-widget)
+### [`lib/chat-widget`](https://github.com/product-os/jellyfish/tree/master/lib/chat-widget)
 
 The chat widget is an embeddable component to allow external clients to send
 and receive messages using the Jellyfish system.
 
-### [`lib/core`](https://github.com/balena-io/jellyfish/tree/master/lib/core)
+### [`lib/core`](https://github.com/product-os/jellyfish/tree/master/lib/core)
 
 The Jellyfish core is a low-level internal SDK to interact with cards in the
 database, providing functions like `.getCardById()` or `.insertCard()`. The
@@ -134,7 +134,7 @@ of. Card type definitions are indicated by having a `type` of `type`, e.g.
 These "type" cards contain model definitions in the form of a JSON schema. The
 slug of a type card is the value used in the type property of instances of the
 type.
-As an example, you can look at the [type card for a "message"](https://github.com/balena-io/jellyfish/blob/master/apps/server/default-cards/contrib/message.json). You can see that under the `data` key, there is a `schema` value that defines the shape of a card of type "message".
+As an example, you can look at the [type card for a "message"](https://github.com/product-os/jellyfish/blob/master/apps/server/default-cards/contrib/message.json). You can see that under the `data` key, there is a `schema` value that defines the shape of a card of type "message".
 We follow the JSON schema spec, so if the schema allows, additional fields can
 be added to a card that are not defined in the type schema.
 
@@ -238,18 +238,18 @@ Cards can be linked together by creating a card of type "link" that references b
 Requests for individual cards by id or slug are cached, reducing DB load and
 improving query speed.
 
-### [`lib/environment`](https://github.com/balena-io/jellyfish/tree/master/lib/environment)
+### [`lib/environment`](https://github.com/product-os/jellyfish/tree/master/lib/environment)
 
 This module aims to be the startup system configuration hub, and it exposes any
 runtime settings to the remainingg of the system. Its the only place in the
 codebase that should ever read environment variables.
 
-### [`lib/jellyscript`](https://github.com/balena-io/jellyfish/tree/master/lib/jellyscript)
+### [`lib/jellyscript`](https://github.com/product-os/jellyfish/tree/master/lib/jellyscript)
 
 Jellyscript is a tiny embeddable language to define
 computed properties in Jellyfish card types.
 
-### [`lib/logger`](https://github.com/balena-io/jellyfish/tree/master/lib/logger)
+### [`lib/logger`](https://github.com/product-os/jellyfish/tree/master/lib/logger)
 
 The Jellyfish backend strongly discourages the use of `console.log()`. This
 module provides a set of functions that the backend uses for logging purposes.
@@ -264,15 +264,15 @@ module provides a set of functions that the backend uses for logging purposes.
 - The logger is able to pipe logs to a central location when running in
 	production
 
-### [`lib/mail`](https://github.com/balena-io/jellyfish/tree/master/lib/mail)
+### [`lib/mail`](https://github.com/product-os/jellyfish/tree/master/lib/mail)
 
 The mail library consists of a mailgun integration which can be used to send emails to jellyfish users
 
-### [`lib/metrics`](https://github.com/balena-io/jellyfish/tree/master/lib/metrics)
+### [`lib/metrics`](https://github.com/product-os/jellyfish/tree/master/lib/metrics)
 
 This library gathers Prometheus metrics and exposes them on `:8888/app_metrics`.
 
-### [`lib/queue`](https://github.com/balena-io/jellyfish/tree/master/lib/queue)
+### [`lib/queue`](https://github.com/product-os/jellyfish/tree/master/lib/queue)
 
 The Jellyfish system processes incoming action requests and adds them to a
 queue. The system can dequeue the next action request, execute it, and post the
@@ -290,17 +290,17 @@ this module.
 - The queue aims to be the source of truth of how action requests are marked as
 	executed and how action requests results are propagated back
 
-### [`lib/sync`](https://github.com/balena-io/jellyfish/tree/master/lib/sync)
+### [`lib/sync`](https://github.com/product-os/jellyfish/tree/master/lib/sync)
 
 This module contains an integration syncing engine built on top of Jellyfish,
 along with a set of integrations with third party services.
 
-### [`lib/ui-components`](https://github.com/balena-io/jellyfish/tree/master/lib/ui-components)
+### [`lib/ui-components`](https://github.com/product-os/jellyfish/tree/master/lib/ui-components)
 
 This module is a collection of re-usable React component that Jellyfish uses to
 build all its official user interfaces.
 
-### [`lib/worker`](https://github.com/balena-io/jellyfish/tree/master/lib/worker)
+### [`lib/worker`](https://github.com/product-os/jellyfish/tree/master/lib/worker)
 
 Jellyfish workers are in charge of consuming action requests from the queue,
 executing them, and reporting back the results. This module provides an lower

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ as a cross between Slack and Excel!
 ***
 
 - **Contributing**
-	- [**Architecture overview**](https://github.com/balena-io/jellyfish/blob/master/ARCHITECTURE.md)
-	- [**Working with the frontend**](https://github.com/balena-io/jellyfish/blob/master/docs/developing/frontend.markdown)
-	- [**Working with the backend**](https://github.com/balena-io/jellyfish/blob/master/docs/developing/backend.markdown)
-	- [**Adding a new type**](https://github.com/balena-io/jellyfish/blob/master/docs/developing/add-new-type.markdown)
+	- [**Architecture overview**](https://github.com/product-os/jellyfish/blob/master/ARCHITECTURE.md)
+	- [**Working with the frontend**](https://github.com/product-os/jellyfish/blob/master/docs/developing/frontend.markdown)
+	- [**Working with the backend**](https://github.com/product-os/jellyfish/blob/master/docs/developing/backend.markdown)
+	- [**Adding a new type**](https://github.com/product-os/jellyfish/blob/master/docs/developing/add-new-type.markdown)
 	- [**Developing locally**](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-on-balena.markdown)
 	- [**Adding metrics**](https://github.com/product-os/jellyfish/blob/master/docs/developing/adding-metrics.markdown)
 - **Links**
@@ -27,9 +27,9 @@ as a cross between Slack and Excel!
 	- [**New Relic**](https://synthetics.newrelic.com/accounts/2054842/monitors/8bf2b38d-7c2a-4d71-9629-7cbf05b6bd21)
 	- [**Metrics**](https://monitor.balena-cloud.com/d/jellyfish/jellyfish?orgId=1)
 - **Services**
-	- [**Using New Relic**](https://github.com/balena-io/jellyfish/blob/master/docs/newrelic.markdown)
-	- [**Using Balena CI**](https://github.com/balena-io/jellyfish/blob/master/docs/balenaci.markdown)
-	- [**Using Sentry**](https://github.com/balena-io/jellyfish/blob/master/docs/sentry.markdown)
+	- [**Using New Relic**](https://github.com/product-os/jellyfish/blob/master/docs/newrelic.markdown)
+	- [**Using Balena CI**](https://github.com/product-os/jellyfish/blob/master/docs/balenaci.markdown)
+	- [**Using Sentry**](https://github.com/product-os/jellyfish/blob/master/docs/sentry.markdown)
 
 Getting private package access
 ------------------------------
@@ -150,15 +150,15 @@ make test FILES=./test/unit/worker/utils.spec.js # Run a specific unit test file
 
 Some suites may provide or require various options. Consult the corresponding
 ["Developing"
-guides](https://github.com/balena-io/jellyfish/tree/master/docs/developing) or
-the [`Makefile`](https://github.com/balena-io/jellyfish/blob/master/Makefile)
+guides](https://github.com/product-os/jellyfish/tree/master/docs/developing) or
+the [`Makefile`](https://github.com/product-os/jellyfish/blob/master/Makefile)
 if unsure.
 
 Reporting problems
 ------------------
 
 If you're having any problem, please [raise an
-issue](https://github.com/balena-io/jellyfish/issues/new) on GitHub and the
+issue](https://github.com/product-os/jellyfish/issues/new) on GitHub and the
 Jellyfish team will be happy to help.
 
 License

--- a/apps/server/default-cards/balena/product-jellyfish.json
+++ b/apps/server/default-cards/balena/product-jellyfish.json
@@ -8,7 +8,7 @@
   "links": {},
   "active": true,
   "data": {
-      "url": "https://github.com/balena-io/jellyfish"
+    "url": "https://github.com/product-os/jellyfish"
   },
   "requires": [],
   "capabilities": []

--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -731,7 +731,7 @@ export default class HomeChannel extends React.Component {
 						<Link
 							p={2}
 							fontSize={1}
-							href='https://github.com/balena-io/jellyfish/blob/master/CHANGELOG.md'
+							href='https://github.com/product-os/jellyfish/blob/master/CHANGELOG.md'
 							blank
 						>
 							<Txt monospace>

--- a/docs/developing/add-new-type.markdown
+++ b/docs/developing/add-new-type.markdown
@@ -4,7 +4,7 @@ You can add a new type to Jellyfish by following these steps.
 
 ## Add a new type definition card
 
-New type cards should be added in the `default-cards` directory here https://github.com/balena-io/jellyfish/tree/master/apps/server/default-cards/contrib 
+New type cards should be added in the `default-cards` directory here https://github.com/product-os/jellyfish/tree/master/apps/server/default-cards/contrib
 
 A type card consists of the standard contract fields and a JSON schema that defines the shape of the new type. For example, a new type card that defines a Pokémon would look like this
 
@@ -90,7 +90,7 @@ For the sake of keeping things organised, the name of the file should match the
 ## Load the type card when the server starts
 
 Now that the card has been added, it needs to be loaded when the server starts.
-This is done by adding a line to this file https://github.com/balena-io/jellyfish/blob/master/apps/server/card-loader.js#L48
+This is done by adding a line to this file https://github.com/product-os/jellyfish/blob/master/apps/server/card-loader.js#L48
 
 Continuing with the Pokèmon card type example, the line would look like this:
 
@@ -103,7 +103,7 @@ await loadCard('contrib/pokemon.json')
 At this point, users with the `community` role will have CRUD access to the
 Pokèmon card type via the API but it will not show up in the web browser client.
 The easiest way to make this happen is to create a new view to list Pokèmon cards.
-As before, the new view card should be added in the `default-cards` directory here https://github.com/balena-io/jellyfish/tree/master/apps/server/default-cards/contrib
+As before, the new view card should be added in the `default-cards` directory here https://github.com/product-os/jellyfish/tree/master/apps/server/default-cards/contrib
 Here is an example view that displays all Pokèmon cards:
 
 ```
@@ -149,7 +149,7 @@ Here is an example view that displays all Pokèmon cards:
 }
 ```
 
-As before, this view needs to be loaded when the server starts, by adding a line to this file https://github.com/balena-io/jellyfish/blob/master/apps/server/card-loader.js#L48
+As before, this view needs to be loaded when the server starts, by adding a line to this file https://github.com/product-os/jellyfish/blob/master/apps/server/card-loader.js#L48
 
 The line would look like this:
 

--- a/lib/action-library/handlers/constants.js
+++ b/lib/action-library/handlers/constants.js
@@ -6,7 +6,7 @@
 
 const BCRYPT_SALT_ROUNDS = 12
 
-// See https://github.com/balena-io/jellyfish/issues/2011
+// See https://github.com/product-os/jellyfish/issues/2011
 const PASSWORDLESS_USER_HASH = 'PASSWORDLESS'
 
 module.exports = {

--- a/lib/core/DESCRIPTION.markdown
+++ b/lib/core/DESCRIPTION.markdown
@@ -34,7 +34,7 @@ of. Card type definitions are indicated by having a `type` of `type`, e.g.
 These "type" cards contain model definitions in the form of a JSON schema. The
 slug of a type card is the value used in the type property of instances of the
 type.
-As an example, you can look at the [type card for a "message"](https://github.com/balena-io/jellyfish/blob/master/apps/server/default-cards/contrib/message.json). You can see that under the `data` key, there is a `schema` value that defines the shape of a card of type "message".
+As an example, you can look at the [type card for a "message"](https://github.com/product-os/jellyfish/blob/master/apps/server/default-cards/contrib/message.json). You can see that under the `data` key, there is a `schema` value that defines the shape of a card of type "message".
 We follow the JSON schema spec, so if the schema allows, additional fields can
 be added to a card that are not defined in the type schema.
 

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -22,7 +22,7 @@ const markers = require('./markers')
 const metrics = require('../../../metrics')
 
 /*
- * See https://github.com/balena-io/jellyfish/issues/2401
+ * See https://github.com/product-os/jellyfish/issues/2401
  */
 const MAXIMUM_QUERY_LIMIT = 1000
 

--- a/lib/sync/instance.js
+++ b/lib/sync/instance.js
@@ -275,7 +275,7 @@ exports.run = async (integration, token, fn, options) => {
 
 				const data = {
 					// A hash that can never occur in the real-world
-					// See https://github.com/balena-io/jellyfish/issues/2011
+					// See https://github.com/product-os/jellyfish/issues/2011
 					hash: 'PASSWORDLESS',
 
 					roles: [],

--- a/lib/sync/integrations/balena-api.js
+++ b/lib/sync/integrations/balena-api.js
@@ -155,7 +155,7 @@ module.exports = class BalenaAPIIntegration {
 			data: {
 				roles: [ 'user-external-support' ],
 
-				// See  https://github.com/balena-io/jellyfish/issues/2011
+				// See  https://github.com/product-os/jellyfish/issues/2011
 				hash: 'PASSWORDLESS'
 			}
 		}

--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -259,7 +259,7 @@ const getMessageText = (payload) => {
 	 * as "\n" is meaningless on an HTML string.
 	 * The final result is that we lose double new lines.
 	 *
-	 * See https://github.com/balena-io/jellyfish/issues/1601
+	 * See https://github.com/product-os/jellyfish/issues/1601
 	 */
 	if (payload.body) {
 		return payload.body

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "codename": "cephea",
   "private": true,
   "description": "The Jellyfish Project",
-  "homepage": "https://github.com/balena-io/jellyfish",
+  "homepage": "https://github.com/product-os/jellyfish",
   "repository": {
     "type": "git",
-    "url": "git@github.com:balena-io/jellyfish.git"
+    "url": "git@github.com:product-os/jellyfish.git"
   },
   "engineStrict": true,
   "engines": {

--- a/scripts/architecture-summary.sh
+++ b/scripts/architecture-summary.sh
@@ -63,7 +63,7 @@ echo "## Deployable Components"
 echo ""
 for app in $APPS; do
 	echo "Processing app $app" 1>&2
-	URL="https://github.com/balena-io/jellyfish/tree/master/$app"
+	URL="https://github.com/product-os/jellyfish/tree/master/$app"
 	echo "### [\`$app\`]($URL)"
 	echo ""
 	cat "$CWD/$app/DESCRIPTION.markdown"
@@ -75,7 +75,7 @@ echo "A set of re-usable libraries that the top level components use."
 echo ""
 for module in $MODULES; do
 	echo "Processing module $module" 1>&2
-	URL="https://github.com/balena-io/jellyfish/tree/master/$module"
+	URL="https://github.com/product-os/jellyfish/tree/master/$module"
 	echo "### [\`$module\`]($URL)"
 	echo ""
 	cat "$CWD/$module/DESCRIPTION.markdown"


### PR DESCRIPTION
Change references to `balena-io/jellyfish` to `product-os/jellyfish` in documentation and links.

Does not change:

  * Existing items in `CHANGELOG.md`.
  * Anything in the `.versionbot` folder.
  * Anything in `deploy-templates`.

Change-type: patch
Signed-off-by: James Harton <jamesh@balena.io>