### PR TITLE
Add names to cards, fix triggered action card slug

### DIFF
--- a/apps/server/default-cards/contrib/external-event.json
+++ b/apps/server/default-cards/contrib/external-event.json
@@ -2,6 +2,7 @@
   "slug": "external-event",
   "type": "type@1.0.0",
   "version": "1.0.0",
+  "name": "External event",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-github-issue-link.json
+++ b/apps/server/default-cards/contrib/triggered-action-github-issue-link.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-github-issue-link",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for broadcasting links from a support thread to GitHub issue or pull request",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-hangouts-link.json
+++ b/apps/server/default-cards/contrib/triggered-action-hangouts-link.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-hangouts-link",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for creating messages with Hangouts link",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-increment-tag.json
+++ b/apps/server/default-cards/contrib/triggered-action-increment-tag.json
@@ -1,5 +1,5 @@
 {
-  "slug": "triggered-action-hangouts-link",
+  "slug": "triggered-action-increment-tag",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
   "name": "Triggered action for incrementing count value of a tag",

--- a/apps/server/default-cards/contrib/triggered-action-increment-tag.json
+++ b/apps/server/default-cards/contrib/triggered-action-increment-tag.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-hangouts-link",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for incrementing count value of a tag",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-integration-discourse-mirror-event",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for Discourse mirrors",
   "tags": [],
   "markers": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-integration-front-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-front-mirror-event.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-integration-front-mirror-event",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for Front mirrors",
   "tags": [],
   "markers": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-integration-github-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-github-mirror-event.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-integration-github-mirror-event",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for GitHub mirrors",
   "tags": [],
   "markers": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-integration-import-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-import-event.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-integration-import-event",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for external service import events",
   "tags": [],
   "markers": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-integration-outreach-mirror-event",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for Outreach mirrors",
   "tags": [],
   "markers": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-set-user-avatar.json
+++ b/apps/server/default-cards/contrib/triggered-action-set-user-avatar.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-set-user-avatar",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for user avatars",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-support-closed-issue-reopen",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for reopening support threads when issues are closed",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-reopen.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-support-reopen",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for reopening support threads because of activity",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-summary.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-support-summary",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for support summaries",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
+++ b/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-sync-thread-post-link-whisper",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for creating a whisper with link on thread sync",
   "markers": [],
   "tags": [],
   "links": {},

--- a/apps/server/default-cards/contrib/triggered-action-user-contact.json
+++ b/apps/server/default-cards/contrib/triggered-action-user-contact.json
@@ -2,6 +2,7 @@
   "slug": "triggered-action-user-contact",
   "type": "triggered-action@1.0.0",
   "version": "1.0.0",
+  "name": "Triggered action for maintaining user contact information",
   "markers": [],
   "tags": [],
   "links": {},


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling josh@balena.io

***

- Add `name` to cards that are currently missing it
- Fix `slug` for `triggered-action-increment-tag.json`
