### PR TITLE
Move ChatWidgetSidebar into apps/ui

### DIFF
--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -26,7 +26,7 @@ import {
 } from 'file-saver'
 import {
 	ChatWidgetSidebar
-} from '../../lib/ui-components/ChatWidgetSidebar'
+} from './components/ChatWidgetSidebar'
 import HomeChannel from './components/HomeChannel'
 import Notifications from './components/HOC/Notifications'
 import RouteHandler from './components/RouteHandler'

--- a/apps/ui/components/ChatWidgetSidebar.jsx
+++ b/apps/ui/components/ChatWidgetSidebar.jsx
@@ -11,10 +11,10 @@ import {
 } from 'rendition'
 import {
 	App
-} from '../../lib/chat-widget'
+} from '../../../lib/chat-widget'
 import {
-	useSetup
-} from './SetupProvider'
+	sdk
+} from '../core'
 
 const Container = styled(Box) `
     display: flex;
@@ -36,10 +36,6 @@ const Container = styled(Box) `
 export const ChatWidgetSidebar = ({
 	onClose
 }) => {
-	const {
-		sdk
-	} = useSetup()
-
 	return (
 		<Container
 			width={[ 'calc(100% - 20px)', 'calc(100% - 20px)', '376px' ]}


### PR DESCRIPTION
Removes a dependency violation (from lib/ui-components to lib/chat-widget)

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Nothing in `lib/ui-components` should import from `lib/chat-widget` (as `lib/ui-components` is a dependency of `lib/chat-widget`)!