### PR TITLE
Refactor timeline to make it a little easier to work with

### DIFF
--- a/lib/ui-components/Timeline/EventsList.jsx
+++ b/lib/ui-components/Timeline/EventsList.jsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Box
+} from 'rendition'
+import Icon from '../shame/Icon'
+import Update from '../Update'
+import Event from '../Event'
+
+const MESSAGE = 'message'
+const WHISPER = 'whisper'
+const UPDATE = 'update'
+
+const isNotMessage = (type) => {
+	return !_.includes([ MESSAGE, WHISPER ], type)
+}
+
+export default class EventsList extends React.Component {
+	render () {
+		const {
+			getActor,
+			hideWhispers,
+			sortedTail,
+			uploadingFiles,
+			handleCardVisible,
+			messagesOnly,
+			user,
+			page,
+			pageSize,
+			eventMenuOptions,
+			...eventProps
+		} = this.props
+		const pagedTail = (Boolean(sortedTail) && sortedTail.length > 0)
+			? sortedTail.slice(0 - (pageSize * page)) : null
+		if (pagedTail) {
+			return _.map(pagedTail, (event, index) => {
+				if (_.includes(uploadingFiles, event.slug)) {
+					return (
+						<Box key={event.slug} p={3}>
+							<Icon name="cog" spin /><em>{' '}Uploading file...</em>
+						</Box>
+					)
+				}
+
+				const pureType = event.type.split('@')[0]
+
+				if (messagesOnly && isNotMessage(pureType)) {
+					return null
+				}
+				if (hideWhispers && pureType === WHISPER) {
+					return null
+				}
+
+				if (pureType === UPDATE) {
+					return (
+						<Box
+							data-test={event.id}
+							key={event.id}>
+							<Update
+								onCardVisible={handleCardVisible}
+								card={event}
+								user={user}
+								getActor={getActor}
+							/>
+						</Box>
+					)
+				}
+
+				return (
+					<Box
+						data-test={event.id}
+						key={event.id}>
+						<Event
+							{...eventProps}
+							previousEvent={pagedTail[index - 1]}
+							nextEvent={pagedTail[index + 1]}
+							card={event}
+							user={user}
+						/>
+					</Box>
+				)
+			})
+		}
+		return null
+	}
+}

--- a/lib/ui-components/Timeline/Header.jsx
+++ b/lib/ui-components/Timeline/Header.jsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import moment from 'moment'
+import {
+	html
+} from 'common-tags'
+import {
+	saveAs
+} from 'file-saver'
+import {
+	Flex,
+	Box,
+	Button
+} from 'rendition'
+import {
+	getMessage
+} from '../Event'
+import {
+	generateJSONPatchDescription
+} from '../Update'
+import Icon from '../shame/Icon'
+import HeaderTitle from './HeaderTitle'
+
+const getEventContent = (typeBase, event) => {
+	switch (typeBase) {
+		case 'update':
+			if (_.some(event.data.payload, 'op')) {
+				return generateJSONPatchDescription(event.data.payload)
+			}
+			return event.name
+		case 'message':
+			return getMessage(event)
+		case 'whisper':
+			return `**whisper** ${getMessage(event)}`
+		default:
+			return ''
+	}
+}
+
+export default class Header extends React.Component {
+	constructor (props) {
+		super(props)
+
+		this.handleDownloadConversation = this.handleDownloadConversation.bind(this)
+	}
+
+	async handleDownloadConversation (events) {
+		const {
+			card,
+			getActor
+		} = this.props
+		let text = card.name
+		let activeDate = null
+
+		for (const event of events) {
+			const typeBase = event.type.split('@')[0]
+			const content = getEventContent(typeBase, event)
+			const actorCard = await getActor(event.data.actor)
+			const actorName = actorCard.name || ''
+			const timestamp = moment(_.get(event, [ 'data', 'timestamp' ]) || event.created_at)
+			const time = timestamp.format('HH:mm')
+			let date = ''
+
+			// Show message date if it's different from previous message date
+			if (!activeDate || !timestamp.isSame(activeDate, 'day')) {
+				date = timestamp.format('YYYY - MM - DD')
+				activeDate = timestamp
+			}
+
+			text += '\n\n'
+			text += html `
+                ${date}
+                ${time} ${actorName}
+
+                    ${content}
+			`
+		}
+
+		const blob = new Blob([ text ], {
+			type: 'text/plain'
+		})
+
+		saveAs(blob, `${card.name || card.slug}.txt`)
+	}
+
+	render () {
+		const {
+			headerOptions,
+			hideWhispers,
+			messagesOnly,
+			sortedTail,
+			handleJumpToTop,
+			handleWhisperToggle,
+			handleEventToggle
+		} = this.props
+		return (
+			<Flex m={2}>
+				<HeaderTitle title={_.get(headerOptions, [ 'title' ])} />
+				<Box style={{
+					marginLeft: 'auto'
+				}}>
+					<Button
+						plain
+						tooltip={{
+							placement: 'left',
+							text: 'Jump to first message'
+						}}
+						ml={2}
+						onClick={handleJumpToTop}
+						icon={<Icon name="chevron-circle-up"/>}
+					/>
+
+					{_.get(headerOptions, [ 'buttons', 'toggleWhispers' ]) !== false && (
+						<Button
+							plain
+							tooltip={{
+								placement: 'left',
+								text: `${hideWhispers ? 'Show' : 'Hide'} whispers`
+							}}
+							style={{
+								opacity: hideWhispers ? 0.5 : 1
+							}}
+							ml={2}
+							onClick={handleWhisperToggle}
+							icon={<Icon name="user-secret"/>}
+						/>
+					)}
+
+					{_.get(headerOptions, [ 'buttons', 'toggleEvents' ]) !== false && (
+						<Button
+							plain
+							tooltip={{
+								placement: 'left',
+								text: `${messagesOnly ? 'Show' : 'Hide'} create and update events`
+							}}
+							style={{
+								opacity: messagesOnly ? 0.5 : 1
+							}}
+							className="timeline__checkbox--additional-info"
+							ml={2}
+							onClick={handleEventToggle}
+							icon={<Icon name="stream"/>}
+						/>
+					)}
+
+					<Button
+						plain
+						tooltip={{
+							placement: 'left',
+							text: 'Download conversation'
+						}}
+						ml={2}
+						onClick={() => { return this.handleDownloadConversation(sortedTail) }}
+						icon={<Icon name="download"/>}
+					/>
+				</Box>
+			</Flex>
+		)
+	}
+}

--- a/lib/ui-components/Timeline/HeaderTitle.jsx
+++ b/lib/ui-components/Timeline/HeaderTitle.jsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Box,
+	Txt
+} from 'rendition'
+import styled from 'styled-components'
+
+const StyledBox = styled(Box) `
+	min-width: 0;
+	overflow: 'hidden';
+	text-overflow: 'ellipsis';
+	white-space: 'nowrap';
+`
+
+const HeaderTitle = ({
+	title
+}) => {
+	if (title) {
+		return (
+			<StyledBox flex={1} mr={2}>
+				<Txt.span tooltip={title}>{title}</Txt.span>
+			</StyledBox>
+		)
+	}
+	return null
+}
+
+export default HeaderTitle

--- a/lib/ui-components/Timeline/PendingMessages.jsx
+++ b/lib/ui-components/Timeline/PendingMessages.jsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Box
+} from 'rendition'
+import Event from '../Event'
+
+const PendingMessages = ({
+	pendingMessages,
+	...eventProps
+}) => {
+	return _.map(pendingMessages, (message) => {
+		return (
+			<Box key={message.slug}>
+				<Event
+					{...eventProps }
+					card={message}
+				/>
+			</Box>
+		)
+	})
+}
+
+export default PendingMessages

--- a/lib/ui-components/Timeline/TypingNotice.jsx
+++ b/lib/ui-components/Timeline/TypingNotice.jsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Box
+} from 'rendition'
+import styled from 'styled-components'
+import {
+	commaListsAnd
+} from 'common-tags'
+
+const StyledBox = styled.div `
+	background: white;
+	transform: translateY(-10px);
+	height: 0;
+	overflow: visible;
+	> * {
+		display: inline-block;
+		border-radius: 3px;
+		padding: 0 5px;
+		box-shadow: rgba(0,0,0,0.25) 0px 0px 3px;
+	}
+`
+
+const getTypingMessage = (usersTyping) => {
+	if (usersTyping.length === 1) {
+		return `${usersTyping[0].slice(5)} is typing...`
+	} else if (usersTyping.length > 1) {
+		const typing = usersTyping.map((slug) => {
+			return slug.slice(5)
+		})
+		return commaListsAnd `${typing} are typing...`
+	}
+	return null
+}
+
+const TypingNotice = ({
+	usersTyping
+}) => {
+	const typingMessage = getTypingMessage(usersTyping)
+	if (typingMessage) {
+		return (
+			<StyledBox data-test="typing-notice">
+				<Box bg="white" ml={3}>
+					<em>{typingMessage}</em>
+				</Box>
+			</StyledBox>
+		)
+	}
+	return null
+}
+
+export default TypingNotice

--- a/lib/ui-components/Timeline/tests/EventsList.spec.jsx
+++ b/lib/ui-components/Timeline/tests/EventsList.spec.jsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import React from 'react'
+import sinon from 'sinon'
+import {
+	mount
+} from 'enzyme'
+import {
+	createTestContext,
+	wrapperWithSetup
+} from './helpers'
+import EventsList from '../EventsList'
+
+const sandbox = sinon.createSandbox()
+
+ava.before((test) => {
+	test.context = createTestContext(test, sandbox)
+})
+
+ava('Only messages and whispers are displayed when the messagesOnly field is set', async (test) => {
+	const {
+		eventProps: {
+			tail,
+			...props
+		},
+		createEvent,
+		whisperEvent,
+		messageEvent,
+		updateEvent
+	} = test.context
+
+	const eventsList = await mount(
+		<EventsList
+			{...props}
+			messagesOnly
+			sortedTail={tail}
+		/>,
+		{
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: props.sdk
+			}
+		})
+	const messages = eventsList.find(`div[data-test="${messageEvent.id}"]`)
+	const whispers = eventsList.find(`div[data-test="${whisperEvent.id}"]`)
+	const update = eventsList.find(`div[data-test="${updateEvent.id}"]`)
+	const create = eventsList.find(`div[data-test="${createEvent.id}"]`)
+
+	test.is(messages.length, 1)
+	test.is(whispers.length, 1)
+	test.is(update.length, 0)
+	test.is(create.length, 0)
+})
+
+ava('Whispers are not shown if hideWhispers is set', async (test) => {
+	const {
+		eventProps: {
+			tail,
+			...props
+		},
+		whisperEvent,
+		messageEvent
+	} = test.context
+
+	const eventsList = await mount(
+		<EventsList
+			{...props}
+			hideWhispers
+			messagesOnly
+			sortedTail={tail}
+		/>,
+		{
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: props.sdk
+			}
+		})
+
+	const messages = eventsList.find(`div[data-test="${messageEvent.id}"]`)
+	const whispers = eventsList.find(`div[data-test="${whisperEvent.id}"]`)
+
+	test.is(messages.length, 1)
+	test.is(whispers.length, 0)
+})
+
+ava('All events are shown if messagesOnly and hideWhispers are not set', async (test) => {
+	const {
+		eventProps: {
+			tail,
+			...props
+		},
+		whisperEvent,
+		messageEvent,
+		updateEvent,
+		createEvent
+	} = test.context
+
+	const eventsList = await mount(
+		<EventsList
+			{...props}
+			sortedTail={tail}
+		/>,
+		{
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: props.sdk
+			}
+		})
+
+	const messages = eventsList.find(`div[data-test="${messageEvent.id}"]`)
+	const whispers = eventsList.find(`div[data-test="${whisperEvent.id}"]`)
+	const update = eventsList.find(`div[data-test="${updateEvent.id}"]`)
+	const create = eventsList.find(`div[data-test="${createEvent.id}"]`)
+
+	test.is(messages.length, 1)
+	test.is(whispers.length, 1)
+	test.is(update.length, 1)
+	test.is(create.length, 1)
+})

--- a/lib/ui-components/Timeline/tests/helpers.jsx
+++ b/lib/ui-components/Timeline/tests/helpers.jsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	getWrapper
+} from '../../../../test/ui-setup'
+import {
+	SetupProvider
+} from '../../SetupProvider'
+
+const {
+	wrapper: Wrapper
+} = getWrapper()
+
+const wrapperWithSetup = ({
+	children,
+	sdk
+}) => {
+	return (
+		<Wrapper>
+			<SetupProvider sdk={sdk}>
+				{ children }
+			</SetupProvider>
+		</Wrapper>
+	)
+}
+
+const createTestContext = (test, sandbox) => {
+	const getWithTimeline = sandbox.stub()
+	getWithTimeline.resolves([])
+
+	const createEvent = {
+		id: 'fake-create-id',
+		type: 'create@1.0.0'
+	}
+	const whisperEvent = {
+		id: 'fake-whisper-id',
+		type: 'whisper@1.0.0',
+		data: {
+			timestamp: new Date(),
+			message: 'I am a whisper'
+		}
+	}
+
+	const messageEvent = {
+		id: 'fake-message-id',
+		type: 'message@1.0.0',
+		data: {
+			timestamp: new Date(),
+			message: 'I am a message'
+		}
+	}
+
+	const updateEvent = {
+		id: 'fake-update-id',
+		type: 'update@1.0.0',
+		data: {
+			payload: {
+				op: 'add',
+				path: 'fake-path'
+			}
+		}
+	}
+
+	const user = {
+		id: 'fake-user-id'
+	}
+
+	const getActor = sandbox.stub()
+	getActor.resolves(user)
+
+	const tail = [ createEvent, messageEvent, whisperEvent, updateEvent ]
+
+	const eventProps = {
+		card: {
+			slug: 'fake-card'
+		},
+		selectCard: () => {
+			return sandbox.stub()
+		},
+		getCard: sandbox.stub(),
+		actions: {
+			addNotification: sandbox.stub()
+		},
+		usersTyping: [],
+		user,
+		getActor,
+		getWithTimeline,
+		tail,
+		sdk: {
+			card: {
+				getWithTimeline
+			}
+		}
+	}
+
+	return {
+		getWithTimeline,
+		eventProps,
+		tail,
+		createEvent,
+		whisperEvent,
+		messageEvent,
+		updateEvent
+	}
+}
+
+export {
+	createTestContext,
+	wrapperWithSetup
+}


### PR DESCRIPTION
Refactor of the Timeline component done in order to make pagination a little easier. Reviewing by commit should be the easiest approach.

Work includes:
- Moving header-related code into its own component (`Header`) - this could be broken-down further but I've left this for future work
- Moving pending-message-related code into its own component (`PendingMessages`)
- Moving userTyping code into its own component (`TypingNotice`)
- Refactoring how we figure out which events to display. Previously we were looping through the list to remove the updates/create events and then doing another loop to check to see if the whisper should be removed. I've moved all the event code into a component called `EventList` which does one loop and makes decisions about how to render the card within that loop. It also compartmentalises this code into one place. I've added some tests to make sure this is correct.

Also closes #4071