### PR TITLE
Add mentionsGroup and alertsGroup to withEvents card mixin

### DIFF
--- a/apps/server/default-cards/mixins/with-events.js
+++ b/apps/server/default-cards/mixins/with-events.js
@@ -31,6 +31,14 @@ module.exports = {
 						alertsUser: {
 							type: 'array',
 							$$formula: 'AGGREGATE($events, \'data.payload.alertsUser\')'
+						},
+						mentionsGroup: {
+							type: 'array',
+							$$formula: 'AGGREGATE($events, \'data.payload.mentionsGroup\')'
+						},
+						alertsGroup: {
+							type: 'array',
+							$$formula: 'AGGREGATE($events, \'data.payload.alertsGroup\')'
 						}
 					}
 				}


### PR DESCRIPTION
This allows us to query for group pings on any card with an associated timeline.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
