### PR TITLE
ui: Consolidate auth UI components

### DIFF
--- a/apps/ui/components/Auth/AuthUtil.jsx
+++ b/apps/ui/components/Auth/AuthUtil.jsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import styled from 'styled-components'
+import {
+	Flex, Heading, Input, Button, Img
+} from 'rendition'
+import Link from '../../../../lib/ui-components/Link'
+
+const Label = styled.label `
+	font-size: 1;
+`
+const Form = styled.form `
+	align-self: stretch;
+`
+
+const FlexCard = styled(Flex) `
+	background: white;
+	border-radius: 2px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+`
+
+const HeadingFlex = styled(Flex) `
+	text-align: center;
+`
+
+export const AuthCard = ({
+	children,
+	...props
+}) => {
+	return (
+		<FlexCard
+			p={4}
+			flex={[ '1 auto', '0 auto' ]}
+			width={[ '100%', '470px' ]}
+			flexDirection="column"
+			alignItems="center"
+			{...props}
+		>
+			<Img
+				width="70px"
+				height="70px"
+				src="/icons/jellyfish-icon.svg"
+			/>
+			{children}
+		</FlexCard>
+	)
+}
+
+export const AuthForm = ({
+	children,
+	...props
+}) => {
+	return (
+		<Form {...props}>{children}</Form>
+	)
+}
+
+export const AuthHeading = ({
+	title, subtitle
+}) => {
+	return (
+		<HeadingFlex mb={3} alignItems="center" flexDirection="column">
+			{title && <Heading.h2 mb={1}>{title}</Heading.h2>}
+			{subtitle && <Heading.h5>{subtitle}</Heading.h5>}
+		</HeadingFlex>
+	)
+}
+
+export const AuthField = ({
+	name,
+	label,
+	...props
+}) => {
+	return (
+		<React.Fragment>
+			<Label mb={1} htmlFor={name}>{label}</Label>
+			<Input
+				name={name}
+				mb={3}
+				width="100%"
+				emphasized={true}
+				{...props}
+			/>
+		</React.Fragment>
+	)
+}
+
+export const AuthButton = (props) => {
+	return (
+		<Button
+			mt={2}
+			width="100%"
+			primary={true}
+			emphasized={true}
+			type="submit"
+			{...props}
+		/>
+	)
+}
+
+export const AuthLink = ({
+	children, ...props
+}) => {
+	return <Link mt={3} {...props}>{children}</Link>
+}

--- a/apps/ui/components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
+++ b/apps/ui/components/Auth/CompleteFirstTimeLogin/CompleteFirstTimeLogin.jsx
@@ -7,16 +7,14 @@
 import React from 'react'
 import _ from 'lodash'
 import {
-	Box,
-	Button,
-	Divider,
-	Heading,
-	Input,
-	Txt
+	Input
 } from 'rendition'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
+import {
+	AuthCard, AuthHeading, AuthForm, AuthField, AuthButton
+} from '../AuthUtil'
 
-class CompleteFirstTimeLogin extends React.Component {
+export default class CompleteFirstTimeLogin extends React.Component {
 	constructor (props) {
 		super(props)
 
@@ -70,62 +68,44 @@ class CompleteFirstTimeLogin extends React.Component {
 		const username = _.get(this.props, [ 'match', 'params', 'username' ], '')
 
 		return (
-			<React.Fragment>
-				<Txt align="center" mb={4}>
-					<Heading.h2 mb={2}>Set Password</Heading.h2>
-					<span>{'Enter your password below'}</span>
-				</Txt>
-
-				<Divider color="#eee" mb={4}/>
-
-				<form
+			<AuthCard>
+				<AuthHeading title="Set Password" subtitle="Enter your password below" />
+				<AuthForm
 					data-test="completeFirstTimeLogin-page__form"
-					onSubmit={this.completeFirstTimeLogin}>
-
+					onSubmit={this.completeFirstTimeLogin}
+				>
 					<Input display="none" name="username" autoComplete="username" value={username} />
-
-					<Txt fontSize={1} mb={1}>Password</Txt>
-					<Input
-						data-test="completeFirstTimeLogin-page__password"
-						mb={5}
-						width="100%"
-						emphasized={true}
+					<AuthField
 						name="password"
+						label="Password"
+						data-test="completeFirstTimeLogin-page__password"
+						tabIndex={1}
 						placeholder="New Password"
 						type="password"
 						autoComplete="new-password"
 						value={password}
 						onChange={this.handleInputChange}
 					/>
-					<Txt fontSize={1} mb={1}>Password Confirmation</Txt>
-					<Input
-						data-test="completeFirstTimeLogin-page__password-confirmation"
-						mb={5}
-						width="100%"
-						emphasized={true}
+					<AuthField
 						name="passwordConfirmation"
+						label="Password Confirmation"
+						data-test="completeFirstTimeLogin-page__password-confirmation"
+						tabIndex={2}
 						placeholder="Password Confirmation"
 						type="password"
 						autoComplete="new-password"
 						value={passwordConfirmation}
 						onChange={this.handleInputChange}
 					/>
-					<Box>
-						<Button
-							data-test="completeFirstTimeLogin-page__submit"
-							width="100%"
-							primary={true}
-							emphasized={true}
-							type="submit"
-							disabled={!password || passwordConfirmation !== password || completingFirstTimeLogin}
-						>
-							{completingFirstTimeLogin ? <Icon spin name="cog"/> : 'Set password'}
-						</Button>
-					</Box>
-				</form>
-			</React.Fragment>
+					<AuthButton
+						tabIndex={3}
+						data-test="completeFirstTimeLogin-page__submit"
+						disabled={!password || passwordConfirmation !== password || completingFirstTimeLogin}
+					>
+						{completingFirstTimeLogin ? <Icon spin name="cog"/> : 'Set password'}
+					</AuthButton>
+				</AuthForm>
+			</AuthCard>
 		)
 	}
 }
-
-export default CompleteFirstTimeLogin

--- a/apps/ui/components/Auth/CompletePasswordReset/CompletePasswordReset.jsx
+++ b/apps/ui/components/Auth/CompletePasswordReset/CompletePasswordReset.jsx
@@ -7,16 +7,14 @@
 import React from 'react'
 import _ from 'lodash'
 import {
-	Box,
-	Button,
-	Divider,
-	Heading,
-	Input,
-	Txt
+	Input
 } from 'rendition'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
+import {
+	AuthCard, AuthHeading, AuthForm, AuthField, AuthButton
+} from '../AuthUtil'
 
-class CompletePasswordReset extends React.Component {
+export default class CompletePasswordReset extends React.Component {
 	constructor (props) {
 		super(props)
 
@@ -70,62 +68,44 @@ class CompletePasswordReset extends React.Component {
 		const username = _.get(this.props, [ 'match', 'params', 'username' ], '')
 
 		return (
-			<React.Fragment>
-				<Txt align="center" mb={4}>
-					<Heading.h2 mb={2}>Reset Password</Heading.h2>
-					<span>{'Enter your new password below'}</span>
-				</Txt>
-
-				<Divider color="#eee" mb={4}/>
-
-				<form
+			<AuthCard>
+				<AuthHeading title="Reset Password" subtitle="Enter your new password below" />
+				<AuthForm
 					data-test="completePasswordReset-page__form"
-					onSubmit={this.completePasswordReset}>
-
+					onSubmit={this.completePasswordReset}
+				>
 					<Input display="none" name="username" autoComplete="username" value={username} />
-
-					<Txt fontSize={1} mb={1}>Password</Txt>
-					<Input
-						data-test="completePasswordReset-page__password"
-						mb={5}
-						width="100%"
-						emphasized={true}
+					<AuthField
 						name="password"
+						label="Password"
+						data-test="completePasswordReset-page__password"
+						tabIndex={1}
 						placeholder="New Password"
 						type="password"
 						autoComplete="new-password"
 						value={password}
 						onChange={this.handleInputChange}
 					/>
-					<Txt fontSize={1} mb={1}>Password Confirmation</Txt>
-					<Input
-						data-test="completePasswordReset-page__password-confirmation"
-						mb={5}
-						width="100%"
-						emphasized={true}
+					<AuthField
 						name="passwordConfirmation"
+						label="Password Confirmation"
+						data-test="completePasswordReset-page__password-confirmation"
+						tabIndex={2}
 						placeholder="Password Confirmation"
 						type="password"
 						autoComplete="new-password"
 						value={passwordConfirmation}
 						onChange={this.handleInputChange}
 					/>
-					<Box>
-						<Button
-							data-test="completePasswordReset-page__submit"
-							width="100%"
-							primary={true}
-							emphasized={true}
-							type="submit"
-							disabled={!password || passwordConfirmation !== password || completingPasswordReset}
-						>
-							{completingPasswordReset ? <Icon spin name="cog"/> : 'Reset password'}
-						</Button>
-					</Box>
-				</form>
-			</React.Fragment>
+					<AuthButton
+						tabIndex={3}
+						data-test="completePasswordReset-page__submit"
+						disabled={!password || passwordConfirmation !== password || completingPasswordReset}
+					>
+						{completingPasswordReset ? <Icon spin name="cog"/> : 'Reset password'}
+					</AuthButton>
+				</AuthForm>
+			</AuthCard>
 		)
 	}
 }
-
-export default CompletePasswordReset

--- a/apps/ui/components/Auth/Login/Login.jsx
+++ b/apps/ui/components/Auth/Login/Login.jsx
@@ -5,21 +5,10 @@
  */
 
 import React from 'react'
-import styled from 'styled-components'
-import {
-	Box,
-	Button,
-	Divider,
-	Heading,
-	Input,
-	Txt
-} from 'rendition'
-import Link from '../../../../../lib/ui-components/Link'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
-
-const StyledLink = styled(Link) `
-	float: right;
-`
+import {
+	AuthCard, AuthHeading, AuthForm, AuthField, AuthButton, AuthLink
+} from '../AuthUtil'
 
 export default class Login extends React.Component {
 	constructor (props) {
@@ -76,60 +65,40 @@ export default class Login extends React.Component {
 		} = this.state
 
 		return (
-			<div className='login-page'>
-				<Txt align="center" mb={4}>
-					<Heading.h2 mb={2}>Login to Jellyfish</Heading.h2>
-					<span>Enter your details below</span>
-				</Txt>
-
-				<Divider color="#eee" mb={4}/>
-
-				<form onSubmit={this.login}>
-					<Txt fontSize={1} mb={1}>Username</Txt>
-					<Input
+			<AuthCard className='login-page'>
+				<AuthHeading title="Login to Jellyfish" subtitle="Enter your details below" />
+				<AuthForm onSubmit={this.login}>
+					<AuthField
+						tabIndex={1}
+						name="username"
+						label="Username"
 						className="login-page__input--username"
-						mb={5}
-						width="100%"
-						emphasized={true}
 						placeholder="Username"
 						autoComplete="username"
 						value={username}
 						onChange={this.handleUsernameChange}
 					/>
-
-					<Txt fontSize={1} mb={1}>Password</Txt>
-					<Input
+					<AuthField
+						tabIndex={2}
+						name="password"
+						label="Password"
 						className="login-page__input--password"
-						mb={5}
-						width="100%"
-						emphasized={true}
 						placeholder="Password"
 						type="password"
 						autoComplete="current-password"
 						value={password}
 						onChange={this.handlePasswordChange}
 					/>
-
-					<Box>
-						<Button
-							className="login-page__submit--login"
-							width="100%"
-							primary={true}
-							emphasized={true}
-							type="submit"
-							disabled={!username || !password || loggingIn}
-						>
-							{loggingIn ? <Icon spin name="cog"/> : 'Log in'}
-						</Button>
-					</Box>
-				</form>
-				<StyledLink
-					mt={3}
-					to="/request_password_reset"
-				>
-					Forgot Password?
-				</StyledLink>
-			</div>
+					<AuthButton
+						tabIndex={3}
+						className="login-page__submit--login"
+						disabled={!username || !password || loggingIn}
+					>
+						{loggingIn ? <Icon spin name="cog"/> : 'Log in'}
+					</AuthButton>
+				</AuthForm>
+				<AuthLink to="/request_password_reset" tabIndex={4}>Forgot Password?</AuthLink>
+			</AuthCard>
 		)
 	}
 }

--- a/apps/ui/components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
+++ b/apps/ui/components/Auth/RequestPasswordReset/RequestPasswordReset.jsx
@@ -5,21 +5,10 @@
  */
 
 import React from 'react'
-import styled from 'styled-components'
-import {
-	Box,
-	Button,
-	Divider,
-	Heading,
-	Input,
-	Txt
-} from 'rendition'
-import Link from '../../../../../lib/ui-components/Link'
 import Icon from '../../../../../lib/ui-components/shame/Icon'
-
-const StyledLink = styled(Link) `
-	float: right;
-`
+import {
+	AuthCard, AuthHeading, AuthForm, AuthField, AuthButton, AuthLink
+} from '../AuthUtil'
 
 export default class RequestPasswordReset extends React.Component {
 	constructor (props) {
@@ -74,49 +63,32 @@ export default class RequestPasswordReset extends React.Component {
 		} = this.state
 
 		return (
-			<React.Fragment>
-				<Txt align="center" mb={4}>
-					<Heading.h2 mb={2}>Request a password reset</Heading.h2>
-					<span>Enter your username below</span>
-				</Txt>
-
-				<Divider color="#eee" mb={4}/>
-
-				<form
+			<AuthCard>
+				<AuthHeading title="Request a password reset" subtitle="Enter your username below" />
+				<AuthForm
 					onSubmit={this.requestPasswordReset}
 					data-test="requestPasswordReset-page__form"
 				>
-					<Txt fontSize={1} mb={1}>Username</Txt>
-					<Input
+					<AuthField
+						name="username"
+						label="Username"
+						tabIndex={1}
 						data-test="requestPasswordReset-page__username"
-						mb={5}
-						width="100%"
-						emphasized={true}
 						placeholder="Username"
 						autoComplete="username"
 						value={username}
 						onChange={this.handleUsernameChange}
 					/>
-					<Box>
-						<Button
-							data-test="requestPasswordReset-page__submit"
-							width="100%"
-							primary={true}
-							emphasized={true}
-							type="submit"
-							disabled={!username || requestingPasswordReset}
-						>
-							{requestingPasswordReset ? <Icon spin name="cog"/> : 'Submit'}
-						</Button>
-					</Box>
-				</form>
-				<StyledLink
-					mt={3}
-					href="/"
-				>
-					Return to login?
-				</StyledLink>
-			</React.Fragment>
+					<AuthButton
+						tabIndex={2}
+						data-test="requestPasswordReset-page__submit"
+						disabled={!username || requestingPasswordReset}
+					>
+						{requestingPasswordReset ? <Icon spin name="cog"/> : 'Submit'}
+					</AuthButton>
+				</AuthForm>
+				<AuthLink to="/" tabIndex={3}>Return to login</AuthLink>
+			</AuthCard>
 		)
 	}
 }

--- a/apps/ui/components/Auth/index.js
+++ b/apps/ui/components/Auth/index.js
@@ -7,21 +7,12 @@
 import React from 'react'
 import styled from 'styled-components'
 import {
-	Container,
-	Box,
-	Flex,
-	Img
+	Flex
 } from 'rendition'
 
-const AuthBox = styled(Box) `
-	max-width: 470px;
-`
-const ShadowBox = styled(Flex) `
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-`
-
-const Icon = styled(Img) `
-  height: 70;
+const AuthWrapper = styled(Flex) `
+	height: 100%;
+	background: ${(props) => { return props.theme.colors.tertiary.main }};
 `
 
 const AuthContainer = (props) => {
@@ -29,26 +20,12 @@ const AuthContainer = (props) => {
 		children
 	} = props
 	return (
-		<React.Fragment>
-			<ShadowBox
-				justifyContent="space-between"
-				align="center"
-			>
-				<Box>
-					<Icon
-						width={70}
-						pl={2}
-						p={10}
-						src="/icons/jellyfish-icon.svg"
-					/>
-				</Box>
-			</ShadowBox>
-			<Container mt={4}>
-				<AuthBox mx="auto">
-					{ children }
-				</AuthBox>
-			</Container>
-		</React.Fragment>
+		<AuthWrapper
+			justifyContent={[ 'stretch', 'center' ]}
+			alignItems={[ 'stretch', 'center' ]}
+		>
+			{ children }
+		</AuthWrapper>
 	)
 }
 


### PR DESCRIPTION
Better responsive layout, refreshed the style with a card effect for desktop views.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR tidies up the four 'Auth' components to re-use common building-block components. 

I've also changed the style a bit to create a cleaner, more responsive look.

### Before

| Mobile | Desktop |
| :------- | :-------- |
|  <a href="https://user-images.githubusercontent.com/2925657/86436871-61c99400-bd2d-11ea-9986-241a697fe1e3.png"><img width="300" src="https://user-images.githubusercontent.com/2925657/86436871-61c99400-bd2d-11ea-9986-241a697fe1e3.png"></a>  |  <a href="https://user-images.githubusercontent.com/2925657/86437012-c1c03a80-bd2d-11ea-86f2-955f3554bb95.png"><img width="500" src="https://user-images.githubusercontent.com/2925657/86437012-c1c03a80-bd2d-11ea-86f2-955f3554bb95.png"></a> | 


### After

| Mobile | Desktop |
| :------- | :-------- |
|  <a href="https://user-images.githubusercontent.com/2925657/86437114-fa601400-bd2d-11ea-8d68-b7b56d99cd92.png"><img width="300" src="https://user-images.githubusercontent.com/2925657/86437114-fa601400-bd2d-11ea-8d68-b7b56d99cd92.png"></a>  |  <a href="https://user-images.githubusercontent.com/2925657/86437130-0a77f380-bd2e-11ea-80bf-f5e31074657e.png"><img width="500" src="https://user-images.githubusercontent.com/2925657/86437130-0a77f380-bd2e-11ea-80bf-f5e31074657e.png"></a> | 
