### PR TITLE
Fix CSS issue with Support filters and Safari.

### DIFF
--- a/apps/ui/lens/full/View.jsx
+++ b/apps/ui/lens/full/View.jsx
@@ -651,7 +651,9 @@ class ViewRenderer extends React.Component {
 				}}
 			>
 				{Boolean(head) && (
-					<Flex alignItems="flex-start" mx={3} mt={3}>
+					<Flex alignItems="flex-start" mx={3} mt={3} style={{
+						flexShrink: 0
+					}}>
 						<Collapsible
 							title="Filters and Lenses"
 							maxContentHeight="70vh"


### PR DESCRIPTION
For some reason in Safari it's possible for a flex element to shrink smaller than it's child contents, unless you specify `flex-shrink: 0`.  This PR resolves this issue so that the selection tabs are no longer behind the filters dialog.

Closes #3844.