### PR TITLE
test: wait for thread sync whisper after creating support-thread

### DIFF
--- a/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
+++ b/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
@@ -65,11 +65,10 @@
       "$eval": "source.links['is attached to'][0].id"
     },
     "arguments": {
-      "reason": null,
       "payload": {
         "message": "[This thread is synced to Jellyfish](https://jel.ly.fish/${source.links['is attached to'][0].id})"
       },
-      "type": "whisper@1.0.0"
+      "type": "whisper"
     }
   },
   "requires": [],

--- a/test/e2e/server/helpers.js
+++ b/test/e2e/server/helpers.js
@@ -14,7 +14,7 @@ const environment = require('@balena/jellyfish-environment')
 
 const waitForServer = async (test, retries = 50) => {
 	try {
-		await test.context.http('GET', '/ping')
+		await test.context.http('GET', '/readiness')
 	} catch (error) {
 		if (retries > 0 &&
 			(error.code === 'ECONNREFUSED' || error.code === 'ECONNRESET')) {

--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -229,6 +229,8 @@ ava.serial.before(async (test) => {
 			}
 		})
 
+		await test.context.waitForThreadSyncWhisper(result.id)
+
 		return test.context.sdk.getById(result.id, {
 			type: 'support-thread'
 		})

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -209,7 +209,7 @@ ava.serial.before(async (test) => {
 			prefix: 'support-thread'
 		})
 
-		return test.context.executeThenWait(async () => {
+		const supportThread = await test.context.executeThenWait(async () => {
 			return test.context.sdk.card.create({
 				name: title,
 				slug,
@@ -227,6 +227,10 @@ ava.serial.before(async (test) => {
 				}
 			})
 		}, getMirrorWaitSchema(slug))
+
+		await test.context.waitForThreadSyncWhisper(supportThread.id)
+
+		return supportThread
 	}
 
 	const listResourceUntil = async (fn, id, predicate, retries = 10) => {

--- a/test/e2e/sync/helpers.js
+++ b/test/e2e/sync/helpers.js
@@ -12,6 +12,46 @@ const helpers = require('../sdk/helpers')
 exports.mirror = {
 	before: async (test) => {
 		await helpers.before(test)
+
+		test.context.waitForThreadSyncWhisper = async (threadId) => {
+			return test.context.waitForMatch({
+				type: 'object',
+				required: [ 'type', 'data' ],
+				properties: {
+					data: {
+						type: 'object',
+						required: [ 'target', 'payload' ],
+						additionalProperties: false,
+						properties: {
+							target: {
+								const: threadId
+							},
+							mirrors: {
+								type: 'array',
+								items: {
+									type: 'string',
+									pattern: '^https:\\/\\/forums\\.balena\\.io'
+								}
+							},
+							payload: {
+								type: 'object',
+								required: [ 'message' ],
+								additionalProperties: false,
+								properties: {
+									message: {
+										type: 'string',
+										pattern: 'This thread is synced to Jellyfish'
+									}
+								}
+							}
+						}
+					},
+					type: {
+						const: 'whisper@1.0.0'
+					}
+				}
+			})
+		}
 	},
 	after: async (test) => {
 		await helpers.after(test)


### PR DESCRIPTION
This should fix the race condition seen where sometimes the first 'test' message in a thread is saved before the 'sync whisper' that is created by the asynchronous triggered action. This makes it hard to determine which event will be the 'last' in the list of events. Hopefully by waiting for the sync whisper before posting any test message to the thread, we ensure the sync message will always be the first one in the thread.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

An example of the type of test failure this PR should fix can be found **[here](https://app.circleci.com/pipelines/github/product-os/jellyfish/44842/workflows/cf57e1f1-7ef2-4011-a08d-213aeecc678d/jobs/135858/steps)**
