### PR TITLE
ui: Prevent video link button opening two tabs

### DIFF
--- a/apps/ui/components/VideoLink/VideoLink.jsx
+++ b/apps/ui/components/VideoLink/VideoLink.jsx
@@ -68,7 +68,7 @@ export default function VideoLink ({
 		<Link
 			{...rest}
 			color={conferenceUrl ? theme.colors.text.main : theme.colors.gray.dark}
-			onClick={openGoogleMeet}
+			onClick={conferenceUrl ? null : openGoogleMeet }
 			href={conferenceUrl}
 			blank
 			tooltip={{


### PR DESCRIPTION
The `return false` on the onclick handler seems to be ignored, so just don't call the onclick handler at all if the conferenceUrl is set.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Previously if the video link already existed, clicking on the video button would open two tabs (in Chrome). Now we ensure only the `href` attribute is defined if the Google Meet URL already exists - so we don't open a second tab.