### PR TITLE
ui: Strip repo org from name in Home Channel menu

### DIFF
--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -286,7 +286,7 @@ export default class HomeChannel extends React.Component {
 			key: 'product-os',
 			children: (this.state.productOS || []).map((item) => {
 				return {
-					name: item.name,
+					name: item.name.replace(/^.*\//, ''),
 					key: item.slug,
 					card: item,
 					isStarred: false,

--- a/apps/ui/components/HomeChannel/TreeMenu.jsx
+++ b/apps/ui/components/HomeChannel/TreeMenu.jsx
@@ -38,6 +38,7 @@ const TreeMenu = (props) => {
 				actions={actions}
 				key={card.id}
 				card={card}
+				label={node.name}
 				isActive={isActive}
 				isStarred={node.isStarred}
 				activeSlice={activeSlice}

--- a/apps/ui/components/ViewLink/ViewLink.jsx
+++ b/apps/ui/components/ViewLink/ViewLink.jsx
@@ -90,6 +90,7 @@ export default class ViewLink extends React.Component {
 
 	render () {
 		const {
+			label,
 			isHomeView,
 			activeSlice,
 			card,
@@ -118,7 +119,7 @@ export default class ViewLink extends React.Component {
 						to={`/${card.slug || card.id}`}
 					>
 						<Flex justifyContent="space-between" alignItems="center">
-							{card.name}
+							{label || card.name}
 							{isHomeView && (
 								<Box fontSize="80%" color="gray.dark" mx={2} tooltip="Default view">
 									<Icon name="home" />


### PR DESCRIPTION
Instead of displaying 'product-os/jellyfish' we'll just display 'jellyfish'. The 'product-os' org is shown in the parent menu item so the context is clear and the item is still unique.

Closes #4075

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Note: A bigger refactor is needed to support arbitrary repos. [This comment](https://github.com/product-os/jellyfish/blob/bcb117fbe09e006b2a2abe7e9f5a91eb7ba2dcf8/apps/ui/components/HomeChannel/HomeChannel.jsx#L282-L283) explains that we'll tackle that when we move to a 'Loops-based' menu structure.

Before:
![image](https://user-images.githubusercontent.com/2925657/86696320-89737180-c037-11ea-95e5-9f2a36faf546.png)

After:
![image](https://user-images.githubusercontent.com/2925657/86695970-3994aa80-c037-11ea-837d-874759533699.png)

