### PR TITLE
Use notification tag field to de-duplicate notifications

### DIFF
--- a/apps/ui/core/store/actioncreators/index.js
+++ b/apps/ui/core/store/actioncreators/index.js
@@ -298,6 +298,7 @@ export default class ActionCreator {
 					title,
 					body,
 					target,
+					tag: card.id,
 					historyPush: (path, pathState) => dispatch(push(path, pathState))
 				})
 			}

--- a/apps/ui/services/notifications.js
+++ b/apps/ui/services/notifications.js
@@ -34,6 +34,7 @@ export const registerForNotifications = () => {
 }
 
 export const createNotification = ({
+	tag,
 	historyPush,
 	title,
 	body,
@@ -44,6 +45,7 @@ export const createNotification = ({
 	}
 
 	const notice = new Notification(title, {
+		tag,
 		body,
 		icon: '/icons/jellyfish.png'
 	})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #3789 

As per [the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#Replacing_existing_notifications) we can use the `tag` option field on a `Notification` to ensure we don't create duplicate notifications for the same card.
