### PR TITLE
ui: Ensure full message text is always sent

### DIFF
--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -249,9 +249,7 @@ class Timeline extends React.Component {
 
 	addMessage (event) {
 		event.preventDefault()
-		const {
-			newMessage
-		} = this.state
+		const newMessage = event.target.value || this.state.newMessage
 		const {
 			allowWhispers
 		} = this.props


### PR DESCRIPTION
The `newMessage` state is set on a 100ms debounced callback. If the user enters the 'Send Command' within 100ms of typing the last characters of their message, those characters were not getting sent. This change uses the current value of the DOM input element rather than the value cached in the `Timeline`'s state.

Closes #3896

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Note: The `Timeline` component is being refactored in PR #4322 - it will be easier to add a unit test for this once that work has been completed.