### PR TITLE
ui: Enable file uploads as messages

### DIFF
--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -127,7 +127,7 @@ class Timeline extends React.Component {
 	}
 
 	handleFileChange (files) {
-		const type = this.props.allowWhispers ? 'whisper' : 'message'
+		const type = this.state.whisper ? 'whisper' : 'message'
 		const file = _.first(files)
 		const message = {
 			target: this.props.card,


### PR DESCRIPTION
Previously file uploads would always be saved as whispers if whispers were allowed on a thread.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***