### PR TITLE
Add support for linking to a specific message within a thread.

### DIFF
--- a/lib/ui-components/Event/Attachments/AttachmentButton.jsx
+++ b/lib/ui-components/Event/Attachments/AttachmentButton.jsx
@@ -25,7 +25,7 @@ const AttachmentButton = ({
 			secondary={card.type.split('@')[0] === 'whisper'}
 			data-test="event-card__file"
 			mr={2}
-			mb={2}
+			my={1}
 		>
 			<Icon name="file-download" />
 			<Txt monospace ml={2}>

--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -7,7 +7,9 @@
 import {
 	circularDeepEqual
 } from 'fast-equals'
+import classnames from 'classnames'
 import _ from 'lodash'
+import queryString from 'query-string'
 import * as jsonpatch from 'fast-json-patch'
 import Mark from 'mark.js'
 import React from 'react'
@@ -314,9 +316,20 @@ export default class Event extends React.Component {
 			nextEvent.data.target === card.data.target &&
 			nextEvent.data.actor === card.data.actor
 
+		const {
+			event: focusedEvent
+		} = queryString.parse(_.get(location, [ 'search' ], ''))
+
 		return (
 			<VisibilitySensor onChange={this.handleVisibilityChange}>
-				<EventWrapper {...rest} squashTop={squashTop} className={`event-card event-card--${typeBase}`}>
+				<EventWrapper
+					{...rest}
+					squashTop={squashTop}
+					className={classnames(`event-card event-card--${typeBase}`, {
+						'event--focused': focusedEvent === card.id
+					})}
+					id={`event-${card.id}`}
+				>
 					<EventButton
 						openChannel={openChannel}
 						onClick={this.openChannel}

--- a/lib/ui-components/Event/EventContext.jsx
+++ b/lib/ui-components/Event/EventContext.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react'
 import _ from 'lodash'
+import queryString from 'query-string'
 import copy from 'copy-to-clipboard'
 import styled from 'styled-components'
 import {
@@ -24,6 +25,7 @@ import {
 import ContextMenu from '../ContextMenu'
 
 const ContextWrapper = styled(Flex) `
+	z-index: 2;
 	padding: 2px 4px 2px 2px;
  	border-radius: 6px;
 	box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
@@ -68,6 +70,16 @@ export default function EventContext ({
 		event.preventDefault()
 		event.stopPropagation()
 		copy(card.data.payload.message)
+	}
+
+	const copyLink = (event) => {
+		event.preventDefault()
+		event.stopPropagation()
+		const urlParams = queryString.stringify({
+			...queryString.parse(_.get(location, [ 'search' ], '')),
+			event: card.id
+		})
+		copy(`${_.get(location, [ 'origin' ])}/${card.data.target}?${urlParams}`)
 	}
 
 	const wrapperProps = {
@@ -189,6 +201,17 @@ export default function EventContext ({
 									Copy raw message
 									</ActionLink>
 								)}
+
+								<ActionLink
+									data-test="event-header__link--copy-link"
+									onClick={copyLink}
+									tooltip={{
+										text: 'Link copied!',
+										trigger: 'click'
+									}}
+								>
+									{`Copy link to this ${card.type.split('@')[0]}`}
+								</ActionLink>
 
 								{menuOptions}
 							</React.Fragment>

--- a/lib/ui-components/Event/EventWrapper.jsx
+++ b/lib/ui-components/Event/EventWrapper.jsx
@@ -15,6 +15,31 @@ import {
 // Min-width is used to stop text from overflowing the flex container, see
 // https://css-tricks.com/flexbox-truncated-text/ for a nice explanation
 const EventWrapper = styled(Flex) `
+	@keyframes pulse {
+		0% {
+			opacity: 0;
+			outline-color: transparent;
+		}
+		100% {
+			opacity: 0.5;
+			outline-color: ${(props) => { return props.theme.colors.info.dark }};
+		}
+	}
+	&.event--focused::after {
+		content: '';
+		opacity: 0;
+		outline-offset: -4px;
+		outline-width: 3px;
+		outline-style: solid;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		z-index: 1;
+		animation: pulse 0.7s 6;
+		animation-direction: alternate;
+	}
+	position: relative;
+
 	background: transparent;
 	transition: 150ms ease-in-out background;
 	&:hover {

--- a/lib/ui-components/Event/tests/Event.spec.jsx
+++ b/lib/ui-components/Event/tests/Event.spec.jsx
@@ -137,6 +137,20 @@ ava('It should render', (test) => {
 	})
 })
 
+ava('The event is marked as \'focused\' if the card\'s ID matches the \'event\' url param', (test) => {
+	global.location.search = `?event=${card.id}`
+	const event = mount(
+		<Event
+			{...commonProps}
+			card={card}
+		/>, {
+			wrappingComponent: wrapper
+		}
+	)
+	const eventWrapper = event.find(`div#event-${card.id}`)
+	test.true(eventWrapper.hasClass('event--focused'))
+})
+
 ava('It should display the actor\'s details', (test) => {
 	const event = mount(
 		<Event

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -7,6 +7,7 @@
 import {
 	circularDeepEqual
 } from 'fast-equals'
+import queryString from 'query-string'
 import _ from 'lodash'
 import React from 'react'
 import {
@@ -49,6 +50,7 @@ class Timeline extends React.Component {
 		this.shouldScroll = true
 
 		this.state = {
+			scrollToEvent: null,
 			page: 1,
 			hideWhispers: false,
 			messageSymbol: false,
@@ -168,6 +170,14 @@ class Timeline extends React.Component {
 	componentDidMount () {
 		this.shouldScroll = true
 		this.scrollToBottom()
+		const {
+			event
+		} = queryString.parse(window.location.search)
+		if (event) {
+			this.setState({
+				scrollToEvent: event
+			})
+		}
 	}
 
 	getSnapshotBeforeUpdate (nextProps, nextState) {
@@ -197,8 +207,22 @@ class Timeline extends React.Component {
 	}
 
 	componentDidUpdate (prevProps, prevState, snapshot) {
-		// Scroll to bottom if the component has been updated with new items
-		this.scrollToBottom()
+		if (this.state.scrollToEvent && _.find(this.props.tail, {
+			id: this.state.scrollToEvent
+		})) {
+			const messageElement = document.getElementById(`event-${this.state.scrollToEvent}`)
+			if (messageElement) {
+				messageElement.scrollIntoView({
+					behavior: 'smooth'
+				})
+				this.setState({
+					scrollToEvent: null
+				})
+			}
+		} else {
+			// Scroll to bottom if the component has been updated with new items
+			this.scrollToBottom()
+		}
 		if (
 			this.scrollArea &&
 			this.scrollBottomOffset &&

--- a/test/ui-setup.jsx
+++ b/test/ui-setup.jsx
@@ -46,6 +46,9 @@ global.Howl = Howl
 class Sound {}
 global.Sound = Sound
 
+class Location {}
+global.location = Location
+
 export const flushPromises = () => {
 	return new Promise((resolve) => {
 		// eslint-disable-next-line no-undef


### PR DESCRIPTION
ui: Add support for linking to a message within a thread

New `Copy link to this message` context menu item. The event's ID is added to the URL as a query param.

When the timeline is loaded, if there is an `event` query param in the URL, we scroll to that event. The focused event pulses the CSS outline property 3 times when it is displayed.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
Fix margin on attachment buttons
Closes #4237

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Closes #4066 

Note: when the timeline is paginated (#4322), we will need to revisit this functionality (maybe by also persisting the page as a URL parameter?). But currently all messages in a thread are loaded so the message can always be scrolled to.

![Link to message](https://user-images.githubusercontent.com/2925657/86784956-50192100-c08c-11ea-9c3c-e168e8cdfee0.gif)

