### PR TITLE
Clean up e2e tests

### DIFF
--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -65,7 +65,7 @@ ava.serial.beforeEach(async () => {
 	}))
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/sdk/card.spec.js
+++ b/test/e2e/sdk/card.spec.js
@@ -47,7 +47,7 @@ ava.before(async () => {
 	})
 })
 
-ava.after(async () => {
+ava.after.always(async () => {
 	await helpers.after({
 		context
 	})
@@ -59,7 +59,7 @@ ava.beforeEach(async () => {
 	})
 })
 
-ava.afterEach(async () => {
+ava.afterEach.always(async () => {
 	await helpers.afterEach({
 		context
 	})

--- a/test/e2e/server/actions/action-increment-tag.spec.js
+++ b/test/e2e/server/actions/action-increment-tag.spec.js
@@ -10,10 +10,10 @@ const _ = require('lodash')
 const helpers = require('../../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should create a new tag using using action-increment-tag', async (test) => {
 	const name = test.context.generateRandomSlug({

--- a/test/e2e/server/actions/action-increment.spec.js
+++ b/test/e2e/server/actions/action-increment.spec.js
@@ -8,10 +8,10 @@ const ava = require('ava')
 const helpers = require('../../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should increment a card value using action-increment', async (test) => {
 	const admin = await test.context.sdk.card.get('user-admin')

--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -11,10 +11,10 @@ const {
 const helpers = require('../../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should elevate external event source', async (test) => {
 	const slug = test.context.generateRandomSlug({

--- a/test/e2e/server/attachments.spec.js
+++ b/test/e2e/server/attachments.spec.js
@@ -11,10 +11,10 @@ const {
 const helpers = require('../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should return 404 given a non existent attachment in a card', async (test) => {
 	const result = await test.context.http(

--- a/test/e2e/server/external-support-user-security.spec.js
+++ b/test/e2e/server/external-support-user-security.spec.js
@@ -11,10 +11,10 @@ const {
 const helpers = require('../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/full-text-search.spec.js
+++ b/test/e2e/server/full-text-search.spec.js
@@ -12,10 +12,10 @@ const {
 } = require('uuid')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial.before(async (test) => {
 	// Create support-thread card to execute full-text search tests against.

--- a/test/e2e/server/hooks.spec.js
+++ b/test/e2e/server/hooks.spec.js
@@ -8,10 +8,10 @@ const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should post a dummy "none" event', async (test) => {
 	const result = await test.context.http('POST', '/api/v2/hooks/none', {

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -15,10 +15,10 @@ const environment = require('@balena/jellyfish-environment')
 const packageJson = require('../../../package.json')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/integrations.spec.js
+++ b/test/e2e/server/integrations.spec.js
@@ -17,10 +17,10 @@ const helpers = require('../sdk/helpers')
 const environment = require('@balena/jellyfish-environment')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const balenaAvaTest = _.some(_.values(environment.integration['balena-api']), _.isEmpty)
 	? ava.skip

--- a/test/e2e/server/markers.spec.js
+++ b/test/e2e/server/markers.spec.js
@@ -34,10 +34,10 @@ ava.serial.before(async (test) => {
 	})
 })
 
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/messages.spec.js
+++ b/test/e2e/server/messages.spec.js
@@ -22,10 +22,10 @@ ava.serial.before(async (test) => {
 		})
 	}
 })
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should sanely handle line breaks before tags in messages/whispers', async (test) => {
 	const thread = await test.context.sdk.card.create({

--- a/test/e2e/server/oauth.spec.js
+++ b/test/e2e/server/oauth.spec.js
@@ -8,10 +8,10 @@ const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('/api/v2/oauth should return 400 given an unknown oauth integration', async (test) => {
 	const result = await test.context.http(

--- a/test/e2e/server/security/community.spec.js
+++ b/test/e2e/server/security/community.spec.js
@@ -12,10 +12,10 @@ const _ = require('lodash')
 const helpers = require('../../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/security/index.spec.js
+++ b/test/e2e/server/security/index.spec.js
@@ -12,10 +12,10 @@ const _ = require('lodash')
 const helpers = require('../../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/security/operator.spec.js
+++ b/test/e2e/server/security/operator.spec.js
@@ -12,10 +12,10 @@ const bcrypt = require('bcrypt')
 const helpers = require('../../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/server/sessions.spec.js
+++ b/test/e2e/server/sessions.spec.js
@@ -8,10 +8,10 @@ const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 ava.serial('should fail with a user error given the wrong username during login', async (test) => {
 	const result = await test.context.http('POST', '/api/v2/action', {

--- a/test/e2e/server/signup.spec.js
+++ b/test/e2e/server/signup.spec.js
@@ -8,10 +8,10 @@ const ava = require('ava')
 const helpers = require('../sdk/helpers')
 
 ava.before(helpers.before)
-ava.after(helpers.after)
+ava.after.always(helpers.after)
 
 ava.beforeEach(helpers.beforeEach)
-ava.afterEach(helpers.afterEach)
+ava.afterEach.always(helpers.afterEach)
 
 ava.serial('/signup should not allow requests without username parameter', async (test) => {
 	const result = await test.context.http(

--- a/test/e2e/server/users.spec.js
+++ b/test/e2e/server/users.spec.js
@@ -13,10 +13,10 @@ const {
 const helpers = require('../sdk/helpers')
 
 ava.serial.before(helpers.before)
-ava.serial.after(helpers.after)
+ava.serial.after.always(helpers.after)
 
 ava.serial.beforeEach(helpers.beforeEach)
-ava.serial.afterEach(helpers.afterEach)
+ava.serial.afterEach.always(helpers.afterEach)
 
 const createUserDetails = () => {
 	return {

--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -235,14 +235,14 @@ ava.serial.before(async (test) => {
 	}
 })
 
-ava.serial.after(helpers.mirror.after)
+ava.serial.after.always(helpers.mirror.after)
 ava.serial.beforeEach(async (test) => {
 	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(
 		test, environment.integration.discourse.username)
 })
 
-ava.serial.afterEach(helpers.mirror.afterEach)
+ava.serial.afterEach.always(helpers.mirror.afterEach)
 
 // Skip all tests if there is no Discourse token
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.skip : ava.serial

--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -270,13 +270,13 @@ ava.serial.before(async (test) => {
 	}
 })
 
-ava.serial.after(helpers.mirror.after)
+ava.serial.after.always(helpers.mirror.after)
 ava.serial.beforeEach(async (test) => {
 	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(test, test.context.teammate.replace(/_/g, '-'))
 })
 
-ava.serial.afterEach(helpers.mirror.afterEach)
+ava.serial.afterEach.always(helpers.mirror.afterEach)
 
 // Skip all tests if there is no Front token
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.serial.skip : ava.serial

--- a/test/e2e/sync/github-mirror.spec.js
+++ b/test/e2e/sync/github-mirror.spec.js
@@ -118,13 +118,13 @@ ava.serial.before(async (test) => {
 	})
 })
 
-ava.serial.after(helpers.mirror.after)
+ava.serial.after.always(helpers.mirror.after)
 ava.serial.beforeEach(async (test) => {
 	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(test, uuid())
 })
 
-ava.serial.afterEach(helpers.mirror.afterEach)
+ava.serial.afterEach.always(helpers.mirror.afterEach)
 
 // Skip all tests if there is no GitHub token
 const avaTest = _.some(_.values(TOKEN), _.isEmpty) ? ava.serial.skip : ava.serial

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -73,6 +73,12 @@ ava.serial.before(async () => {
 	context.incognitoPage = incognitoPage
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -73,7 +73,7 @@ ava.serial.before(async () => {
 	context.incognitoPage = incognitoPage
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/file-upload.spec.js
+++ b/test/e2e/ui/file-upload.spec.js
@@ -61,6 +61,12 @@ ava.serial.before(async () => {
 	await context.addUserToBalenaOrg(user.id)
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/file-upload.spec.js
+++ b/test/e2e/ui/file-upload.spec.js
@@ -61,7 +61,7 @@ ava.serial.before(async () => {
 	await context.addUserToBalenaOrg(user.id)
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -98,7 +98,7 @@ ava.serial.before(async () => {
 	context.currentUserSlug = context.currentUser.slug.replace('user-', '')
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -98,6 +98,12 @@ ava.serial.before(async () => {
 	context.currentUserSlug = context.currentUser.slug.replace('user-', '')
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -51,7 +51,13 @@ ava.serial.before(async () => {
 	context.currentUserSlug = context.currentUser.slug.replace('user-', '')
 })
 
-ava.serial.after(async () => {
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -5,6 +5,7 @@
  */
 
 const ava = require('ava')
+const Bluebird = require('bluebird')
 const {
 	v4: uuid
 } = require('uuid')
@@ -88,6 +89,10 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 
 	// Create a new support thread
 	await guidedFlowUtils.createSupportThreadAndNavigate(page)
+
+	await page.waitForSelector('[data-test="support-thread__collapse-status"]')
+
+	await Bluebird.delay(1000)
 
 	await macros.waitForThenClickSelector(page, selectors.closeThreadBtn)
 

--- a/test/e2e/ui/helpers.js
+++ b/test/e2e/ui/helpers.js
@@ -10,6 +10,7 @@ const {
 } = require('uuid')
 const environment = require('@balena/jellyfish-environment')
 const helpers = require('../sdk/helpers')
+const macros = require('./macros')
 
 exports.generateUserDetails = () => {
 	return {
@@ -38,6 +39,14 @@ exports.addPageHandlers = (page, headless = true) => {
 				console.log(`${msg.args()[index]}`)
 			}
 		})
+	}
+}
+
+exports.afterEach = async ({
+	context, test
+}) => {
+	if (!test.passed) {
+		await macros.screenshot(context, test.title)
 	}
 }
 

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -76,7 +76,7 @@ ava.serial.before(async () => {
 	await context.addUserToBalenaOrg(user.id)
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -76,6 +76,12 @@ ava.serial.before(async () => {
 	await context.addUserToBalenaOrg(user.id)
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -14,8 +14,9 @@ exports.WAIT_OPTS = {
 }
 
 // Useful for debugging failed tests
-exports.screenshot = async (test, page) => {
-	test.context.screenshots = (test.context.screenshots || 0) + 1
+exports.screenshot = async (context, title) => {
+	const testTitle = title.replace(/^.*\shook\sfor\s/, '')
+	context.screenshots = (context.screenshots || 0) + 1
 
 	const dir = './tmp/test-results/screenshots'
 
@@ -26,9 +27,9 @@ exports.screenshot = async (test, page) => {
 		if (err) throw err
 	})
 
-	const file = `${test.title}.${test.context.screenshots}.png`
+	const file = `${testTitle}.${context.screenshots}.png`
 	const path = `${dir}/${file}`
-	await page.screenshot({
+	await context.page.screenshot({
 		path
 	})
 }

--- a/test/e2e/ui/oauth.spec.js
+++ b/test/e2e/ui/oauth.spec.js
@@ -33,7 +33,7 @@ ava.serial.before(async () => {
 	})
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/oauth.spec.js
+++ b/test/e2e/ui/oauth.spec.js
@@ -33,6 +33,12 @@ ava.serial.before(async () => {
 	})
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -35,7 +35,7 @@ ava.serial.before(async () => {
 	await macros.loginUser(context.page, user)
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -35,6 +35,12 @@ ava.serial.before(async () => {
 	await macros.loginUser(context.page, user)
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -36,7 +36,7 @@ ava.serial.before(async () => {
 	await macros.loginUser(context.page, user)
 })
 
-ava.serial.after(async () => {
+ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -36,6 +36,12 @@ ava.serial.before(async () => {
 	await macros.loginUser(context.page, user)
 })
 
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
 ava.serial.after.always(async () => {
 	await helpers.browser.afterEach({
 		context

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -234,7 +234,7 @@ ava.serial('You should be able to link support threads to existing support issue
 	)
 	supportIssueOption.click()
 
-	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"] input')
+	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"] input:not(:disabled)')
 
 	await page.type('.jellyfish-async-select__input input', name)
 
@@ -598,20 +598,21 @@ ava.serial('Support threads should close correctly in the UI even when being upd
 
 ava.serial('My Participation shows only support threads that the logged-in user has participated in', async (test) => {
 	const {
-		sdk,
 		page
 	} = context
 
 	// Add a support thread and message that should _not_ appear in the new user's My Participation view
-	const supportThread1 = await sdk.card.create({
-		type: 'support-thread@1.0.0',
-		data: {
-			inbox: 'S/Paid_Support',
-			status: 'open'
-		}
+	const supportThread1 = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'support-thread@1.0.0',
+			data: {
+				inbox: 'S/Paid_Support',
+				status: 'open'
+			}
+		})
 	})
 
-	await sdk.event.create({
+	const messageEvent1 = {
 		target: supportThread1,
 		slug: `message-${uuid()}`,
 		tags: [],
@@ -619,7 +620,11 @@ ava.serial('My Participation shows only support threads that the logged-in user 
 		payload: {
 			message: uuid()
 		}
-	})
+	}
+
+	await page.evaluate((event) => {
+		return window.sdk.event.create(event)
+	}, messageEvent1)
 
 	// Create a new user and login as that user
 	const otherUser = helpers.generateUserDetails()


### PR DESCRIPTION
Some work towards cleaning up e2e tests and making them more reliable.

1. We now use `after.always()` and `afterEach.always()` instead of `after()` and `afterEach()`
2. E2E UI tests will save a screenshot if they fail.
3. Potential fix for the following tests:
    * `My Participation shows only support threads that the logged-in user has participated in`
    * `You should be able to link support threads to existing support issues`
    * `You can teardown a support thread following a specific flow`
