### PR TITLE
ui: Fix logic for determining focused event

### DIFF
--- a/lib/ui-components/Event/Event.jsx
+++ b/lib/ui-components/Event/Event.jsx
@@ -326,7 +326,7 @@ export default class Event extends React.Component {
 					{...rest}
 					squashTop={squashTop}
 					className={classnames(`event-card event-card--${typeBase}`, {
-						'event--focused': focusedEvent === card.id
+						'event--focused': focusedEvent && (focusedEvent === card.id)
 					})}
 					id={`event-${card.id}`}
 				>


### PR DESCRIPTION
Pending messages do not have an `id` yet so they are showing up as 'focused'!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

