### PR TITLE
Be more expressive with error logs when unable to retrieve attachments from Front.

### DIFF
--- a/lib/sync/integrations/front.js
+++ b/lib/sync/integrations/front.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+/* eslint-disable no-underscore-dangle */
+
 const Bluebird = require('bluebird')
 const _ = require('lodash')
 const url = require('native-url')
@@ -1492,7 +1494,6 @@ module.exports = class FrontIntegration {
 
 		try {
 			const response = await request(requestOpts)
-
 			return Buffer.from(response, 'utf8')
 		} catch (error) {
 			assert.USER(null, error.statusCode !== 500,
@@ -1502,10 +1503,22 @@ module.exports = class FrontIntegration {
 			// Because the response is a buffer, the error is sent as a buffer as well
 			if (_.isBuffer(error.error)) {
 				const errorMessage = Buffer.from(error.error, 'utf8').toString()
+				let parsedError = ''
 				try {
-					throw JSON.parse(errorMessage)
+					parsedError = JSON.parse(errorMessage)
 				} catch (parseError) {
-					throw errorMessage
+					throw new Error(`Unable to parse response payload: ${errorMessage}`)
+				}
+
+				if (parsedError._error) {
+					parsedError = parsedError._error
+					let newErrorMessage = `Received error from Front API: ${parsedError.status} - ${parsedError.title}`
+					if (parsedError.message) {
+						newErrorMessage = `${newErrorMessage}: ${parsedError.message}`
+					}
+					throw new Error(newErrorMessage)
+				} else {
+					throw new Error(`Received unknown error response from from Front API: ${errorMessage}`)
 				}
 			}
 


### PR DESCRIPTION
This doesn't fix #4347 but it does make the server provide better logging information when it is unable to retrieve a file attachment from Front.