### PR TITLE
Update edited_at field when a message is edited and display this info on the event.

### DIFF
--- a/apps/server/default-cards/contrib/message.json
+++ b/apps/server/default-cards/contrib/message.json
@@ -102,6 +102,10 @@
                 }
               }
             },
+            "edited_at": {
+              "type": "string",
+              "format": "date-time"
+            },
             "readBy": {
               "description": "Users that have seen this message",
               "type": "array",

--- a/apps/server/default-cards/contrib/triggered-action-update-event-edited-at.json
+++ b/apps/server/default-cards/contrib/triggered-action-update-event-edited-at.json
@@ -1,0 +1,84 @@
+{
+  "slug": "triggered-action-update-event-edited-at",
+  "type": "triggered-action@1.0.0",
+  "version": "1.0.0",
+  "name": "Triggered action for updating the event's edited_at field when the payload is updated",
+  "markers": [],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "async": false,
+    "filter": {
+      "$$links": {
+        "is attached to": {
+          "type": "object",
+          "required": [ "active", "type" ],
+          "properties": {
+            "active": {
+              "type": "boolean",
+              "const": true
+            },
+            "type": {
+              "type": "string",
+              "enum": [ "message@1.0.0", "whisper@1.0.0" ]
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [ "active", "type", "data" ],
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "const": true
+        },
+        "type": {
+          "type": "string",
+          "const": "update@1.0.0"
+        },
+        "data": {
+          "type": "object",
+          "required": [ "payload" ],
+          "properties": {
+            "payload": {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "required": [ "op", "path" ],
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "enum": [ "replace", "add", "remove" ]
+                  },
+                  "path": {
+                    "type": "string",
+                    "pattern": "^/data/payload/.*"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "action": "action-update-card@1.0.0",
+    "target": {
+      "$eval": "source.links['is attached to'][0].id"
+    },
+    "arguments": {
+      "reason": "Event was edited",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/data/edited_at",
+          "value": {
+            "$eval": "source.links['is attached to'][0].updated_at"
+          }
+        }
+      ]
+    }
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/apps/server/default-cards/contrib/whisper.json
+++ b/apps/server/default-cards/contrib/whisper.json
@@ -85,6 +85,10 @@
                 }
               }
             },
+            "edited_at": {
+              "type": "string",
+              "format": "date-time"
+            },
             "readBy": {
               "description": "Users that have seen this message",
               "type": "array",

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -81,6 +81,7 @@ module.exports = {
 	triggeredActionSupportClosedIssueReopen: require('./contrib/triggered-action-support-closed-issue-reopen.json'),
 	triggeredActionSyncThreadPostLinkWhisper: require(
 		'./contrib/triggered-action-sync-thread-post-link-whisper.json'),
+	triggeredActionUpdateEventEditedAt: require('./contrib/triggered-action-update-event-edited-at.json'),
 
 	// User facing views
 	viewAllViews: require('./contrib/view-all-views.json'),

--- a/lib/ui-components/Event/EventContext.jsx
+++ b/lib/ui-components/Event/EventContext.jsx
@@ -59,6 +59,7 @@ export default function EventContext ({
 	}
 
 	const timestamp = _.get(card, [ 'data', 'timestamp' ]) || card.created_at
+	const editedAt = _.get(card, [ 'data', 'edited_at' ])
 
 	const copyJSON = (event) => {
 		event.preventDefault()
@@ -146,12 +147,27 @@ export default function EventContext ({
 			{ threadIsMirrored && <MirrorIcon mirrors={_.get(card, [ 'data', 'mirrors' ])} /> }
 			{Boolean(card.data) && Boolean(timestamp) && (
 				<Txt
-					className="event-card--timestamp"
+					data-test="event-card--timestamp"
 					color={Theme.colors.text.light}
 					fontSize={1}
 					ml={1}
 				>
 					{formatTimestamp(timestamp, true)}
+				</Txt>
+			)}
+			{Boolean(editedAt) && (
+				<Txt
+					data-test="event-card--edited-at"
+					color={Theme.colors.text.light}
+					fontSize={1}
+					italic
+					ml={1}
+					tooltip={{
+						placement: 'top',
+						text: formatTimestamp(editedAt, true)
+					}}
+				>
+					(edited)
 				</Txt>
 			)}
 			{menuOptions !== false && (

--- a/test/e2e/sdk/event.spec.js
+++ b/test/e2e/sdk/event.spec.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const {
+	v4: uuid
+} = require('uuid')
+const moment = require('moment')
+const helpers = require('./helpers')
+
+// TODO: Possibly move this file to test/integration/sdk if/when
+// we resolve where to place sdk helper methods that are used by
+// both e2e tests and integration tests.
+
+const context = {
+	context: {
+		id: `SDK-EVENT-E2E-TEST-${uuid()}`
+	}
+}
+
+const createSupportThread = async (sdk) => {
+	return sdk.card.create({
+		type: 'support-thread@1.0.0',
+		data: {
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
+	})
+}
+
+const createMessage = async (sdk, target, payload) => {
+	const msg = await sdk.event.create({
+		type: 'message',
+		tags: [],
+		target,
+		payload
+	})
+	return sdk.card.get(msg.id)
+}
+
+ava.before(async () => {
+	await helpers.before({
+		context
+	})
+
+	// Create a support thread and support issue
+	context.supportThread = await createSupportThread(context.sdk)
+})
+
+ava.after.always(async () => {
+	await helpers.after({
+		context
+	})
+})
+
+ava.beforeEach(async () => {
+	await helpers.beforeEach({
+		context
+	})
+})
+
+ava.afterEach.always(async () => {
+	await helpers.afterEach({
+		context
+	})
+})
+
+ava('Editing a message triggers an update to the edited_at field', async (test) => {
+	const {
+		sdk,
+		supportThread
+	} = context
+	const messageBefore = 'Before'
+	const update1 = 'update 1'
+	const update2 = 'update 2'
+
+	let msg = await createMessage(sdk, supportThread, {
+		message: messageBefore
+	})
+
+	// Verify that initiall the edited_at field is undefined
+	test.is(typeof msg.data.edited_at, 'undefined')
+
+	// Now update the message text
+	await sdk.card.update(msg.id, msg.type, [ {
+		op: 'replace',
+		path: '/data/payload/message',
+		value: update1
+	} ])
+	msg = await sdk.card.get(msg.id)
+
+	// And check that the edited_at field now has a valid date-time value
+	const firstEditedAt = moment(msg.data.edited_at)
+	test.true(firstEditedAt.isValid())
+	test.is(msg.data.payload.message, update1)
+
+	// Now modify the message text again
+	await sdk.card.update(msg.id, msg.type, [ {
+		op: 'replace',
+		path: '/data/payload/message',
+		value: update2
+	} ])
+	msg = await sdk.card.get(msg.id)
+
+	// And check that the edited_at field has been updated again
+	const secondEditedAt = moment(msg.data.edited_at)
+	test.true(firstEditedAt.isValid())
+	test.is(msg.data.payload.message, update2)
+
+	test.true(firstEditedAt.isBefore(secondEditedAt))
+})
+
+ava('Updating a meta field in the message payload triggers an update to the edited_at field', async (test) => {
+	const {
+		sdk,
+		supportThread
+	} = context
+	const mentionsUserBefore = []
+	const user1 = 'user-1'
+
+	let msg = await createMessage(sdk, supportThread, {
+		message: 'test',
+		mentionsUser: mentionsUserBefore
+	})
+
+	// Verify that initiall the edited_at field is undefined
+	test.is(typeof msg.data.edited_at, 'undefined')
+
+	// Now add a mentionsUser item
+	await sdk.card.update(msg.id, msg.type, [ {
+		op: 'add',
+		path: '/data/payload/mentionsUser/0',
+		value: user1
+	} ])
+	msg = await sdk.card.get(msg.id)
+
+	// And check that the edited_at field now has a valid date-time value
+	const firstEditedAt = moment(msg.data.edited_at)
+	test.true(firstEditedAt.isValid())
+	test.deepEqual(msg.data.payload.mentionsUser, [ user1 ])
+
+	// Now remove the mentioned user
+	await sdk.card.update(msg.id, msg.type, [ {
+		op: 'remove',
+		path: '/data/payload/mentionsUser/0'
+	} ])
+	msg = await sdk.card.get(msg.id)
+
+	// And check that the edited_at field has been updated again
+	const secondEditedAt = moment(msg.data.edited_at)
+	test.true(firstEditedAt.isValid())
+	test.deepEqual(msg.data.payload.mentionsUser, [ ])
+
+	test.true(firstEditedAt.isBefore(secondEditedAt))
+})

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -726,6 +726,10 @@ ava.serial('A user can edit their own message', async (test) => {
 	// Wait for the message to be updated and verify the message text
 	const newMessageText = await macros.getElementText(page, `${eventSelector} [data-test="event-card__message"]`)
 	test.is(newMessageText.trim(), messageTextAfter)
+
+	// Verify the event context shows that it has been edited
+	await page.hover(eventSelector)
+	await page.waitForSelector(`${eventSelector} [data-test="event-card--edited-at"]`)
 })
 
 ava.serial('You can trigger a quick search for cards from the message input', async (test) => {


### PR DESCRIPTION
**Add 'edited_at' field to message and whisper cards**

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
**Add new triggered action to update edited_at field**
When any field in the message payload is modified, an 'action-update-card' action is triggered to set the /data/edited_at field to the value of the card's updated_at field.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
**ui: Show when a message has been edited**
The event context (displayed when you hover over a message) now displays the text `(edited)` if a message has been edited. Hovering over the `(edited)` text displays a tooltip with the timestamp of when it was edited.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Closes #3944 

![edited_at](https://user-images.githubusercontent.com/2925657/87109048-d6508580-c28d-11ea-9409-52f591e57c04.gif)

