### PR TITLE
test: Re-instate skipped e2e tests

### DIFF
--- a/test/e2e/server/actions/action-maintain-contact.spec.js
+++ b/test/e2e/server/actions/action-maintain-contact.spec.js
@@ -792,7 +792,7 @@ ava.serial('should not remove a property from an existing linked contact', async
 	})
 })
 
-ava.serial.only('should merge and relink a diverging contact with a matching slug', async (test) => {
+ava.serial('should merge and relink a diverging contact with a matching slug', async (test) => {
 	const slug = test.context.generateRandomSlug({
 		prefix: 'user'
 	})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Proposal: I'd like to add some sort of lint rule that checks for `ava.only` or `ava.serial.only`. I can't think of a situation where we would want to use this in production. It's basically always an accidental commit after adding the `.only` for testing a particular test locally. These particular tests have been accidentally skipped for 7 months!!
