### PR TITLE
ui: Exclude messages you wrote from your inbox

### DIFF
--- a/apps/ui/core/queries.js
+++ b/apps/ui/core/queries.js
@@ -78,7 +78,7 @@ export const getPingQuery = (user, groupNames, searchTerm) => {
 			},
 			data: {
 				type: 'object',
-				required: [ 'payload' ],
+				required: [ 'payload', 'actor' ],
 				properties: {
 					// If there are no groupNames, don't create a schema fragment looking for groups,
 					// as that would create an `enum` with no values, which is invalid
@@ -86,6 +86,11 @@ export const getPingQuery = (user, groupNames, searchTerm) => {
 						type: 'object',
 						anyOf,
 						additionalProperties: true
+					},
+					actor: {
+						not: {
+							const: user.id
+						}
 					}
 				},
 				additionalProperties: true

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -394,6 +394,17 @@ ava.serial('Only messages that ping a user or one of their groups should appear 
 
 	await macros.createChatMessage(page, columnSelector, msg)
 
+	// And send a message to our own group
+	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+
+	await incognitoPage.waitForSelector(columnSelector)
+
+	const ownGroupMsg = `@@${userGroupNames[0]} ${uuid()}`
+
+	await incognitoPage.waitForSelector('.new-message-input')
+
+	await macros.createChatMessage(incognitoPage, columnSelector, ownGroupMsg)
+
 	// Navigate to the inbox page
 	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
 
@@ -414,6 +425,11 @@ ava.serial('Only messages that ping a user or one of their groups should appear 
 			const text = await incognitoPage.evaluate((ele) => {
 				return ele.textContent
 			}, child)
+
+			const eventId = await macros.getElementAttribute(incognitoPage, child, 'id')
+			if (eventId === ownGroupMsg.id) {
+				test.fail('Message to own group found in inbox')
+			}
 
 			const mentionsGroup = (groupName) => {
 				return text.includes(groupName)

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -55,6 +55,13 @@ exports.getElementValue = async (page, selector) => {
 	return value
 }
 
+exports.getElementAttribute = async (page, element, attributeName) => {
+	return page.evaluate(
+		(item, attr) => { return item.getAttribute(attr) },
+		element, attributeName
+	)
+}
+
 exports.loginUser = async (page, user) => {
 	await page.goto(`${environment.ui.host}:${environment.ui.port}`)
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #4381

Simple PR to exclude messages/whispers where `data.actor` is the authenticated user's ID from the query for unread messages.