### PR TITLE
Handle attached events after triggers

### DIFF
--- a/lib/worker/executor.js
+++ b/lib/worker/executor.js
@@ -76,86 +76,6 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 		return null
 	}
 
-	if (options.attachEvents) {
-		const time = options.timestamp
-			? new Date(options.timestamp)
-			: options.currentTime
-
-		const request = {
-			action: 'action-create-event@1.0.0',
-			card: insertedCard,
-			actor: options.actor,
-			context,
-			timestamp: time.toISOString(),
-			epoch: time.valueOf(),
-			arguments: {
-				name: options.reason,
-				type: options.eventType,
-				payload: options.eventPayload,
-				tags: []
-			}
-		}
-
-		// We use a privileged session here as we want the worker
-		// to be able to create update/create events but not necessarily
-		// the user.
-		await options.library[request.action.split('@')[0]].handler(
-			options.context.privilegedSession,
-			options.context,
-			insertedCard,
-			request)
-	}
-
-	// If the card markers have changed then update the timeline of the card
-	if (current && !fastEquals.deepEqual(current.markers, insertedCard.markers)) {
-		const timeline = await jellyfish.query(context, session, {
-			$$links: {
-				'is attached to': {
-					type: 'object',
-					required: [ 'slug', 'type' ],
-					properties: {
-						slug: {
-							type: 'string',
-							const: insertedCard.slug
-						},
-						type: {
-							type: 'string',
-							const: insertedCard.type
-						}
-					}
-				}
-			},
-			type: 'object',
-			required: [ 'slug', 'version', 'type' ],
-			properties: {
-				slug: {
-					type: 'string'
-				},
-				version: {
-					type: 'string'
-				},
-				type: {
-					type: 'string'
-				}
-			}
-		})
-
-		for (const event of timeline) {
-			if (!fastEquals.deepEqual(event.markers, insertedCard.markers)) {
-				await jellyfish.patchCardBySlug(
-					context, session, `${event.slug}@${event.version}`, [
-						{
-							op: 'replace',
-							path: '/markers',
-							value: insertedCard.markers
-						}
-					], {
-						type: event.type
-					})
-			}
-		}
-	}
-
 	if (options.triggers) {
 		const runTrigger = async (trigger) => {
 			// Ignore triggered actions whose start date is in the future
@@ -245,6 +165,86 @@ const commit = async (context, jellyfish, session, typeCard, current, options, f
 		}, {
 			concurrency: 1
 		})
+	}
+
+	if (options.attachEvents) {
+		const time = options.timestamp
+			? new Date(options.timestamp)
+			: options.currentTime
+
+		const request = {
+			action: 'action-create-event@1.0.0',
+			card: insertedCard,
+			actor: options.actor,
+			context,
+			timestamp: time.toISOString(),
+			epoch: time.valueOf(),
+			arguments: {
+				name: options.reason,
+				type: options.eventType,
+				payload: options.eventPayload,
+				tags: []
+			}
+		}
+
+		// We use a privileged session here as we want the worker
+		// to be able to create update/create events but not necessarily
+		// the user.
+		await options.library[request.action.split('@')[0]].handler(
+			options.context.privilegedSession,
+			options.context,
+			insertedCard,
+			request)
+	}
+
+	// If the card markers have changed then update the timeline of the card
+	if (current && !fastEquals.deepEqual(current.markers, insertedCard.markers)) {
+		const timeline = await jellyfish.query(context, session, {
+			$$links: {
+				'is attached to': {
+					type: 'object',
+					required: [ 'slug', 'type' ],
+					properties: {
+						slug: {
+							type: 'string',
+							const: insertedCard.slug
+						},
+						type: {
+							type: 'string',
+							const: insertedCard.type
+						}
+					}
+				}
+			},
+			type: 'object',
+			required: [ 'slug', 'version', 'type' ],
+			properties: {
+				slug: {
+					type: 'string'
+				},
+				version: {
+					type: 'string'
+				},
+				type: {
+					type: 'string'
+				}
+			}
+		})
+
+		for (const event of timeline) {
+			if (!fastEquals.deepEqual(event.markers, insertedCard.markers)) {
+				await jellyfish.patchCardBySlug(
+					context, session, `${event.slug}@${event.version}`, [
+						{
+							op: 'replace',
+							path: '/markers',
+							value: insertedCard.markers
+						}
+					], {
+						type: event.type
+					})
+			}
+		}
 	}
 
 	if (insertedCard.type === CARD_TYPE_TYPE) {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #4393

This is an attempt to solve a race-condition problem where an async trigger (initiated first) was in a race condition with a sync trigger (initiated after).

This PR just moves the code that initiates the async trigger(s) so that they are executed _after_ the sync triggers are finished.
