### PR TITLE
Fix logic for wrapping whispers in Discourse

### DIFF
--- a/lib/sync/integrations/discourse.js
+++ b/lib/sync/integrations/discourse.js
@@ -882,12 +882,14 @@ module.exports = class DiscourseIntegration {
 			const messageUsername = isAllowed
 				? username
 				: this.options.token.username
-			const messageBody = isAllowed
+
+			const explanation = `This message was posted as @${messageUsername} because @${username} is not a Discourse moderator`
+
+			const messageBody = isAllowed || card.data.payload.message.includes(explanation)
 				? card.data.payload.message
 				: [
 					`(${username}) ${card.data.payload.message}`,
-					`\n\n***\n\n> This message was posted as @${messageUsername}`,
-					`because @${username} is not a Discourse moderator`
+					`\n\n***\n\n> ${explanation}`
 				].join(' ')
 
 			if (discourseUrl) {
@@ -902,7 +904,7 @@ module.exports = class DiscourseIntegration {
 					this.options.errors.SyncNoExternalResource,
 					`Could not find post ${discourseUrl}`)
 
-				if (card.data.payload.message === postData.raw) {
+				if (messageBody === postData.raw) {
 					return []
 				}
 
@@ -930,7 +932,7 @@ module.exports = class DiscourseIntegration {
 					this.options.errors.SyncExternalRequestError, () => {
 						return [
 							`Could not update comment ${topicResponse.id}`,
-							`with content: ${card.data.payload.message}:`,
+							`with content: ${messageBody}:`,
 							JSON.stringify(editResponse, null, 2)
 						].join(' ')
 					})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: #4389

Ensure `messageBody` is handled correctly and we don't keep expanding a whisper on each sync!
