### PR TITLE
docs: Add npm link doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ as a cross between Slack and Excel!
 	- [**Adding a new type**](https://github.com/product-os/jellyfish/blob/master/docs/developing/add-new-type.markdown)
 	- [**Developing locally**](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-on-balena.markdown)
 	- [**Adding metrics**](https://github.com/product-os/jellyfish-metrics/blob/master/doc/adding-metrics.markdown)
+	- [**Working with dependencies**](https://github.com/product-os/jellyfish/blob/master/docs/developing/working-with-dependencies.markdown)
 - **Links**
 	- [**Rapid7**](https://eu.ops.insight.rapid7.com/op/8306227C3C134F65ACF1#/search?logs=%5B%225df30105-2e0a-4e5a-b76a-baa5fc997b36%22%5D&range=Last%2020%20Minutes)
 	- [**Sentry**](https://sentry.io/organizations/balena/issues/?project=1366139)

--- a/docs/developing/working-with-dependencies.markdown
+++ b/docs/developing/working-with-dependencies.markdown
@@ -1,0 +1,31 @@
+# Working with Dependencies
+
+There are times in which you may want to make changes a dependency while working on a service component.
+This is where `npm link` comes in. In the example below, we set up `@balena/jellyfish-metrics` as a dependency using this strategy.
+```
+$ cd ~/git
+$ git clone git@github.com:product-os/jellyfish-metrics.git
+$ cd jellyfish-metrics && npm i && cd ..
+$ git clone git@github.com:product-os/jellyfish.git
+$ cd jellyfish && npm i
+$ sudo npm link ../jellyfish-metrics
+...
+/usr/lib/node_modules/@balena/jellyfish-metrics -> /home/josh/git/jellyfish-metrics
+/home/josh/git/jellyfish/node_modules/@balena/jellyfish-metrics -> /usr/lib/node_modules/@balena/jellyfish-metrics -> /home/josh/git/jellyfish-metrics
+```
+
+Now any changes made in `~/git/jellyfish-metrics` will be reflected in `~/git/jellyfish/node_modules/@balena/jellyfish-metrics`.
+
+To remove the global link:
+```
+$ cd ~/git/jellyfish-metrics
+$ sudo npm uninstall
+```
+
+`npm link` uses the global `node_modules` directory for linking, which is usually in a path not owned by a normal user, making it necessary to run with `sudo`.
+A way around this is to configure `npm` to use a directory the current user is the owner of:
+```
+$ mkdir ~/.npm-global
+$ npm config set prefix '~/.npm-global'
+$ export PATH=~/.npm-global/bin:$PATH
+```


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Trying to figure out a good way to edit libraries moved to external repositories and packages. `npm link` is one way, check out the doc in this PR and let me know what you think.
