### PR TITLE
Add relationship type-cards for all known relationships.

### DIFF
--- a/apps/server/bootstrap.js
+++ b/apps/server/bootstrap.js
@@ -138,23 +138,11 @@ module.exports = async (context, options) => {
 			jellyfish.errors.JellyfishNoElement,
 			`Test org does not exist: ${environment.test.user.organization}`)
 
-		await jellyfish.replaceCard(
-			context, jellyfish.sessions.admin, {
-				type: 'link@1.0.0',
-				name: 'has member',
-				slug: `link-${orgCard.id}-has-member-${userCard.id}`,
-				data: {
-					inverseName: 'is member of',
-					from: {
-						id: orgCard.id,
-						type: orgCard.type
-					},
-					to: {
-						id: userCard.id,
-						type: userCard.type
-					}
-				}
-			})
+		await jellyfish.linkCards(context,
+			jellyfish.sessions.admin,
+			orgCard,
+			userCard,
+			'relationship-is-member-of-has-member@1.0.0')
 	}
 
 	logger.info(context, 'Configuring socket server')

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -145,10 +145,11 @@ module.exports = {
 		require('./relationships/relationship-is-backup-owner-of-has-backup-owner')(mixins),
 	relationshipIsContributedToByContribuesTo:
 		require('./relationships/relationship-is-contributed-to-by-contributes-to')(mixins),
+	relationshipIsExecutedByExecutes: require('./relationships/relationship-is-executed-by-executes')(mixins),
 	relationshipIsFeedbackForIsReviewedWith: require('./relationships/relationship-is-feedback-for-is-reviewed-with')(mixins),
 	relationshipIsGroupMemberOfHasMember: require('./relationships/relationship-is-group-member-of-has-member')(mixins),
 	relationshipIsGuidedByGuides: require('./relationships/relationship-is-guided-by-guides')(mixins),
-	relationshipIsMemberOfHas: require('./relationships/relationship-is-member-of-has')(mixins),
+	relationshipIsMemberOfHasMember: require('./relationships/relationship-is-member-of-has-member')(mixins),
 	relationshipIsObservedByObserves: require('./relationships/relationship-is-observed-by-observes')(mixins),
 	relationshipIsOwnedByIsOwnerOf: require('./relationships/relationship-is-owned-by-is-owner-of')(mixins),
 	relationshipIsOwnedByOwns: require('./relationships/relationship-is-owned-by-owns')(mixins),

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -140,6 +140,8 @@ module.exports = {
 	relationshipIsAttachedToHasAttached: require('./relationships/relationship-is-attached-to-has-attached')(mixins),
 	relationshipIsAttachedToHasAttachedContact:
 		require('./relationships/relationship-is-attached-to-has-attached-contact')(mixins),
+	relationshipIsAttachedToHasAttachedElement:
+		require('./relationships/relationship-is-attached-to-has-attached-element')(mixins),
 	relationshipIsAttendedByAttended: require('./relationships/relationship-is-attended-by-attended')(mixins),
 	relationshipIsBackupOwnerOfHasBackupOwner:
 		require('./relationships/relationship-is-backup-owner-of-has-backup-owner')(mixins),

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -133,5 +133,33 @@ module.exports = {
 	viewSecuritySupportThreads: require('./balena/view-security-support-threads.json'),
 	viewSupportThreadsPendingUpdate: require('./balena/view-support-threads-pending-update.json'),
 	viewSupportThreadsToAudit: require('./balena/view-support-threads-to-audit.json'),
-	viewWorkflows: require('./balena/view-workflows.json')
+	viewWorkflows: require('./balena/view-workflows.json'),
+
+	// Relationship type cards
+	relationshipAppearsInHas: require('./relationships/relationship-appears-in-has')(mixins),
+	relationshipIsAttachedToHasAttached: require('./relationships/relationship-is-attached-to-has-attached')(mixins),
+	relationshipIsAttachedToHasAttachedContact:
+		require('./relationships/relationship-is-attached-to-has-attached-contact')(mixins),
+	relationshipIsAttendedByAttended: require('./relationships/relationship-is-attended-by-attended')(mixins),
+	relationshipIsBackupOwnerOfHasBackupOwner:
+		require('./relationships/relationship-is-backup-owner-of-has-backup-owner')(mixins),
+	relationshipIsContributedToByContribuesTo:
+		require('./relationships/relationship-is-contributed-to-by-contributes-to')(mixins),
+	relationshipIsFeedbackForIsReviewedWith: require('./relationships/relationship-is-feedback-for-is-reviewed-with')(mixins),
+	relationshipIsGroupMemberOfHasMember: require('./relationships/relationship-is-group-member-of-has-member')(mixins),
+	relationshipIsGuidedByGuides: require('./relationships/relationship-is-guided-by-guides')(mixins),
+	relationshipIsMemberOfHas: require('./relationships/relationship-is-member-of-has')(mixins),
+	relationshipIsObservedByObserves: require('./relationships/relationship-is-observed-by-observes')(mixins),
+	relationshipIsOwnedByIsOwnerOf: require('./relationships/relationship-is-owned-by-is-owner-of')(mixins),
+	relationshipIsOwnedByOwns: require('./relationships/relationship-is-owned-by-owns')(mixins),
+	relationshipIsSourceForComesFrom: require('./relationships/relationship-is-source-for-comes-from')(mixins),
+	relationshipIsSourceForIsFeedbackFor: require('./relationships/relationship-is-source-for-is-feedback-for')(mixins),
+	relationshipIsSubscribedForIsSubscribedWith:
+		require('./relationships/relationship-is-subscribed-for-is-subscribed-with')(mixins),
+	relationshipRelationshipIsOfHas: require('./relationships/relationship-is-of-has')(mixins),
+	relationshipSupportThreadIsAttachedToIssueIssueHasAttachedSupportThread:
+		require('./relationships/relationship-support-thread-is-attached-to-issue-issue-has-attached-support-thread')(mixins),
+	relationshipSupportThreadIsAttachedToSupportIssueSupportIssuesHasAttachedSupportThread:
+		// eslint-disable-next-line max-len
+		require('./relationships/relationship-support-thread-is-attached-to-support-issue-support-issue-has-attached-support-thread')(mixins)
 }

--- a/apps/server/default-cards/mixins/generate-relationship-schema.js
+++ b/apps/server/default-cards/mixins/generate-relationship-schema.js
@@ -51,9 +51,12 @@ const branchSchema = (sourceType, targetType, forwardName, reverseName) => {
 					},
 					inverseName: {
 						const: reverseName
+					},
+					is_link: {
+						const: true
 					}
 				},
-				required: [ 'from', 'to', 'inverseName' ]
+				required: [ 'from', 'to', 'inverseName', 'is_link' ]
 			}
 		}
 	}

--- a/apps/server/default-cards/mixins/generate-relationship-schema.js
+++ b/apps/server/default-cards/mixins/generate-relationship-schema.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/* eslint-disable camelcase */
+
+const skhema = require('skhema')
+const _ = require('lodash')
+
+// Generates the schema that matches a single branch out of the `oneOf` that is
+// the valid matches for this relationship type.
+const branchSchema = (sourceType, targetType, forwardName, reverseName) => {
+	return {
+		properties: {
+			name: {
+				const: forwardName
+			},
+			data: {
+				type: 'object',
+				properties: {
+					from: {
+						type: 'object',
+						properties: {
+							type: {
+								const: sourceType
+							}
+						},
+						required: [ 'type' ]
+					},
+					to: {
+						type: 'object',
+						properties: {
+							type: {
+								const: targetType
+							}
+						},
+						required: [ 'type' ]
+					},
+					inverseName: {
+						const: reverseName
+					}
+				},
+				required: [ 'from', 'to', 'inverseName' ]
+			}
+		}
+	}
+}
+
+// Some types are just a string value with a name that can be used for
+// inflection, some are objects that have a name and a title.
+const extractTypeName = (type) => {
+	if (_.isString(type)) {
+		return type
+	}
+
+	return type.name
+}
+
+// Generates a schema to match instances of a relationship type card.
+//
+// If the card already has a JSON schema then the generated schema is merged
+// with the existing one.
+module.exports = function (sourceCard) {
+	const {
+		type_pairs, forward, reverse
+	} = sourceCard.data
+
+	const sourceSchema = sourceCard.data.schema || {
+		type: 'object'
+	}
+
+	const branches = (type_pairs || []).reduce((acc, [ sourceType, targetType ]) => {
+		const sourceTypeName = extractTypeName(sourceType)
+		const targetTypeName = extractTypeName(targetType)
+		acc.push(branchSchema(sourceTypeName, targetTypeName, forward, reverse))
+		acc.push(branchSchema(targetTypeName, sourceTypeName, reverse, forward))
+		return acc
+	}, [])
+
+	const newSchema = skhema.merge([ sourceSchema, {
+		type: 'object',
+		oneOf: branches,
+		required: [ 'name', 'data' ]
+	} ])
+
+	const newCard = _.cloneDeep(sourceCard)
+	newCard.data.schema = newSchema
+	return newCard
+}

--- a/apps/server/default-cards/mixins/generate-relationship-schema.js
+++ b/apps/server/default-cards/mixins/generate-relationship-schema.js
@@ -24,19 +24,30 @@ const branchSchema = (sourceType, targetType, forwardName, reverseName) => {
 						type: 'object',
 						properties: {
 							type: {
-								const: sourceType
+								type: 'string',
+								pattern: `^${sourceType}@`
+							},
+							id: {
+								type: 'string',
+								format: 'uuid'
 							}
+
 						},
-						required: [ 'type' ]
+						required: [ 'type', 'id' ]
 					},
 					to: {
 						type: 'object',
 						properties: {
 							type: {
-								const: targetType
+								type: 'string',
+								pattern: `^${targetType}@`
+							},
+							id: {
+								type: 'string',
+								format: 'uuid'
 							}
 						},
-						required: [ 'type' ]
+						required: [ 'type', 'id' ]
 					},
 					inverseName: {
 						const: reverseName

--- a/apps/server/default-cards/mixins/index.js
+++ b/apps/server/default-cards/mixins/index.js
@@ -16,6 +16,8 @@ const mergeWithUniqConcatArrays = (objValue, srcValue) => {
 
 module.exports = {
 	withEvents: require('./with-events'),
+	generateRelationshipSchema: require('./generate-relationship-schema'),
+	sensibleDefaults: require('./sensible-defaults'),
 
 	mixin: (...mixins) => {
 		return (base) => {

--- a/apps/server/default-cards/mixins/sensible-defaults.js
+++ b/apps/server/default-cards/mixins/sensible-defaults.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+
+const DEFAULTS = {
+	version: '1.0.0',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {},
+	requires: [],
+	capabilities: []
+}
+
+// Reverse merge the default fields into the source card.
+module.exports = (sourceCard) => {
+	return _.merge(DEFAULTS, sourceCard)
+}

--- a/apps/server/default-cards/relationships/relationship-appears-in-has.js
+++ b/apps/server/default-cards/relationships/relationship-appears-in-has.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: appears in/has',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'appears in',
 			reverse: 'has',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-appears-in-has.js
+++ b/apps/server/default-cards/relationships/relationship-appears-in-has.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-appears-in-has',
+		type: 'type@1.0.0',
+		name: 'Relationship: appears in/has',
+		data: {
+			is_link: true,
+			forward: 'appears in',
+			reverse: 'has',
+			type_pairs: [
+				[ 'discussion-topic', 'agenda' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached-contact.js
+++ b/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached-contact.js
@@ -14,7 +14,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is attached to/has attached contact',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is attached to',
 			reverse: 'has attached contact',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached-contact.js
+++ b/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached-contact.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// FIXME: This should be moved to the correct `is-attached-to/has-attached` relationship.
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-attached-to-has-attached-contact',
+		type: 'type@1.0.0',
+		name: 'Relationship: is attached to/has attached contact',
+		data: {
+			is_link: true,
+			forward: 'is attached to',
+			reverse: 'has attached contact',
+			type_pairs: [
+				[ 'contact', 'user' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached-element.js
+++ b/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached-element.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// FIXME: This should be moved to the correct `is-attached-to/has-attached` relationship.
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-attached-to-has-attached-element',
+		type: 'type@1.0.0',
+		name: 'Relationship: is attached to/has attached element',
+		data: {
+			is_relationship: true,
+			forward: 'is attached to',
+			reverse: 'has attached element',
+			type_pairs: [
+				[ 'create', 'session' ],
+				[ 'create', 'faq' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached.js
+++ b/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-attached-to-has-attached',
+		type: 'type@1.0.0',
+		name: 'Relationship: is attached to/has attached',
+		data: {
+			is_link: true,
+			forward: 'is attached to',
+			reverse: 'has attached',
+			type_pairs: [
+				[
+					'discussion-topic',
+					{
+						name: 'issue',
+						title: 'GitHub issue'
+					}
+				],
+				[ 'opportunity', 'account' ],
+				[ 'product-improvement', 'discussion-topic' ],
+				[ 'sales-thread', 'opportunity' ],
+				[ 'support-thread', 'product-improvement' ],
+				[ 'support-thread', 'support-issue' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached.js
+++ b/apps/server/default-cards/relationships/relationship-is-attached-to-has-attached.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is attached to/has attached',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is attached to',
 			reverse: 'has attached',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-attended-by-attended.js
+++ b/apps/server/default-cards/relationships/relationship-is-attended-by-attended.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is attended by/attended',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is attended by',
 			reverse: 'attended',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-attended-by-attended.js
+++ b/apps/server/default-cards/relationships/relationship-is-attended-by-attended.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-attended-by-attended',
+		type: 'type@1.0.0',
+		name: 'Relationship: is attended by/attended',
+		data: {
+			is_link: true,
+			forward: 'is attended by',
+			reverse: 'attended',
+			type_pairs: [
+				[
+					'checkin',
+					{
+						name: 'user', title: 'Attendee'
+					}
+				]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-backup-owner-of-has-backup-owner.js
+++ b/apps/server/default-cards/relationships/relationship-is-backup-owner-of-has-backup-owner.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	const userAsBackupOwner = {
+		name: 'user',
+		title: 'Backup owner'
+	}
+
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-backup-owner-of-has-backup-owner',
+		type: 'type@1.0.0',
+		name: 'Relationship: is backup owner of/has backup owner',
+		data: {
+			is_link: true,
+			forward: 'is backup owner of',
+			reverse: 'has backup owner',
+			type_pairs: [
+				[ userAsBackupOwner, 'account' ],
+				[ userAsBackupOwner, 'contact' ],
+				[ userAsBackupOwner, 'opportunity' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-backup-owner-of-has-backup-owner.js
+++ b/apps/server/default-cards/relationships/relationship-is-backup-owner-of-has-backup-owner.js
@@ -17,7 +17,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is backup owner of/has backup owner',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is backup owner of',
 			reverse: 'has backup owner',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-contributed-to-by-contributes-to.js
+++ b/apps/server/default-cards/relationships/relationship-is-contributed-to-by-contributes-to.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is contributed to by/contributes-to',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is contributed to by',
 			reverse: 'contributes to',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-contributed-to-by-contributes-to.js
+++ b/apps/server/default-cards/relationships/relationship-is-contributed-to-by-contributes-to.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-contributed-to-by-contributes-to',
+		type: 'type@1.0.0',
+		name: 'Relationship: is contributed to by/contributes-to',
+		data: {
+			is_link: true,
+			forward: 'is contributed to by',
+			reverse: 'contributes to',
+			type_pairs: [
+				[
+					{
+						name: 'project',
+						title: 'Project contribution'
+					}, {
+						name: 'user',
+						title: 'Contributor'
+					}
+				]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-executed-by-executes.js
+++ b/apps/server/default-cards/relationships/relationship-is-executed-by-executes.js
@@ -7,22 +7,16 @@
 module.exports = ({
 	generateRelationshipSchema, sensibleDefaults
 }) => {
-	const userAsMember = {
-		name: 'user', title: 'Member'
-	}
-
 	return generateRelationshipSchema(sensibleDefaults({
-		slug: 'relationship-is-member-of-has',
+		slug: 'relationship-is-executed-by-executes',
 		type: 'type@1.0.0',
-		name: 'Relationship: is member of/has',
+		name: 'Relationship: is executed by/executes',
 		data: {
 			is_link: true,
-			forward: 'is member of',
-			reverse: 'has',
+			forward: 'is executed by',
+			reverse: 'executes',
 			type_pairs: [
-				[ 'contact', 'account' ],
-				[ userAsMember, 'org' ],
-				[ userAsMember, 'project' ]
+				[ 'action-request', 'execute' ]
 			]
 		}
 	}))

--- a/apps/server/default-cards/relationships/relationship-is-executed-by-executes.js
+++ b/apps/server/default-cards/relationships/relationship-is-executed-by-executes.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is executed by/executes',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is executed by',
 			reverse: 'executes',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-feedback-for-is-reviewed-with.js
+++ b/apps/server/default-cards/relationships/relationship-is-feedback-for-is-reviewed-with.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is feedback for/is reviewed with',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is feedback for',
 			reverse: 'is reviewed with',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-feedback-for-is-reviewed-with.js
+++ b/apps/server/default-cards/relationships/relationship-is-feedback-for-is-reviewed-with.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-feedback-for-is-reviewed-with',
+		type: 'type@1.0.0',
+		name: 'Relationship: is feedback for/is reviewed with',
+		data: {
+			is_link: true,
+			forward: 'is feedback for',
+			reverse: 'is reviewed with',
+			type_pairs: [
+				[ 'feedback-item', 'user' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-group-member-of-has-member.js
+++ b/apps/server/default-cards/relationships/relationship-is-group-member-of-has-member.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	const userAsMember = {
+		name: 'user',
+		title: 'Member'
+	}
+
+	return generateRelationshipSchema(sensibleDefaults({
+
+		slug: 'relationship-is-group-member-of-has-member',
+		type: 'type@1.0.0',
+		name: 'Relationship: is group member of/has member',
+		data: {
+			is_link: true,
+			forward: 'is group member of',
+			reverse: 'has member',
+			type_pairs: [
+				[ userAsMember, 'group' ],
+				[ userAsMember, 'org' ],
+				[ userAsMember, 'project' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-group-member-of-has-member.js
+++ b/apps/server/default-cards/relationships/relationship-is-group-member-of-has-member.js
@@ -18,7 +18,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is group member of/has member',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is group member of',
 			reverse: 'has member',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-guided-by-guides.js
+++ b/apps/server/default-cards/relationships/relationship-is-guided-by-guides.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-guided-by-guides',
+		type: 'type@1.0.0',
+		name: 'Relationship: is guided by/guides',
+		data: {
+			is_link: true,
+			forward: 'is guided by',
+			reverse: 'guides',
+			type_pairs: [
+				[
+					'project',
+					{
+						name: 'user', title: 'Guide'
+					}
+				]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-guided-by-guides.js
+++ b/apps/server/default-cards/relationships/relationship-is-guided-by-guides.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is guided by/guides',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is guided by',
 			reverse: 'guides',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-member-of-has-member.js
+++ b/apps/server/default-cards/relationships/relationship-is-member-of-has-member.js
@@ -16,7 +16,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is member of/has member',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is member of',
 			reverse: 'has member',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-member-of-has-member.js
+++ b/apps/server/default-cards/relationships/relationship-is-member-of-has-member.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	const userAsMember = {
+		name: 'user', title: 'Member'
+	}
+
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-member-of-has-member',
+		type: 'type@1.0.0',
+		name: 'Relationship: is member of/has member',
+		data: {
+			is_link: true,
+			forward: 'is member of',
+			reverse: 'has member',
+			type_pairs: [
+				[ 'contact', 'account' ],
+				[ userAsMember, 'org' ],
+				[ userAsMember, 'project' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-member-of-has.js
+++ b/apps/server/default-cards/relationships/relationship-is-member-of-has.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	const userAsMember = {
+		name: 'user', title: 'Member'
+	}
+
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-member-of-has',
+		type: 'type@1.0.0',
+		name: 'Relationship: is member of/has',
+		data: {
+			is_link: true,
+			forward: 'is member of',
+			reverse: 'has',
+			type_pairs: [
+				[ 'contact', 'account' ],
+				[ userAsMember, 'org' ],
+				[ userAsMember, 'project' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-observed-by-observes.js
+++ b/apps/server/default-cards/relationships/relationship-is-observed-by-observes.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is observed by/observes',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is observed by',
 			reverse: 'observes',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-observed-by-observes.js
+++ b/apps/server/default-cards/relationships/relationship-is-observed-by-observes.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-observed-by-observes',
+		type: 'type@1.0.0',
+		name: 'Relationship: is observed by/observes',
+		data: {
+			is_link: true,
+			forward: 'is observed by',
+			reverse: 'observes',
+			type_pairs: [
+				[
+					{
+						name: 'project',
+						title: 'Project observation'
+					},
+					{
+						name: 'user',
+						title: 'Observer'
+					}
+				]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-of-has.js
+++ b/apps/server/default-cards/relationships/relationship-is-of-has.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is of/has',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is of',
 			reverse: 'has',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-of-has.js
+++ b/apps/server/default-cards/relationships/relationship-is-of-has.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-of-has',
+		type: 'type@1.0.0',
+		name: 'Relationship: is of/has',
+		data: {
+			is_link: true,
+			forward: 'is of',
+			reverse: 'has',
+			type_pairs: [
+				[ 'checkin', 'project' ],
+				[ 'thread', 'repository' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-owned-by-is-owner-of.js
+++ b/apps/server/default-cards/relationships/relationship-is-owned-by-is-owner-of.js
@@ -14,7 +14,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is owned by/is owner of',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is owned by',
 			reverse: 'is owner of',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-owned-by-is-owner-of.js
+++ b/apps/server/default-cards/relationships/relationship-is-owned-by-is-owner-of.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// FIXME: This should be moved to the correct `is-owned-by/owns` relationship.
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-owned-by-is-owner-of',
+		type: 'type@1.0.0',
+		name: 'Relationship: is owned by/is owner of',
+		data: {
+			is_link: true,
+			forward: 'is owned by',
+			reverse: 'is owner of',
+			type_pairs: [
+				[ 'support-thread', 'user' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-owned-by-owns.js
+++ b/apps/server/default-cards/relationships/relationship-is-owned-by-owns.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	// FIXME: Does the prevalence of this alias indicate that we have a missing
+	// type in our model?
+	const userAsOwner = {
+		name: 'user', title: 'Owner'
+	}
+
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-owned-by-owns',
+		type: 'type@1.0.0',
+		name: 'Relationship: is owned by/owns',
+		data: {
+			is_link: true,
+			forward: 'is owned by',
+			reverse: 'owns',
+			type_pairs: [
+				[ 'account', userAsOwner ],
+				[ 'contact', userAsOwner ],
+				[ 'opportunity', userAsOwner ],
+				[ 'project', userAsOwner ],
+				[ 'sales-thread', userAsOwner ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-owned-by-owns.js
+++ b/apps/server/default-cards/relationships/relationship-is-owned-by-owns.js
@@ -18,7 +18,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is owned by/owns',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is owned by',
 			reverse: 'owns',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-source-for-comes-from.js
+++ b/apps/server/default-cards/relationships/relationship-is-source-for-comes-from.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-source-for-comes-from',
+		type: 'type@1.0.0',
+		name: 'Relationship: is source for/comes from',
+		data: {
+			is_link: true,
+			forward: 'is source for',
+			reverse: 'comes from',
+			type_pairs: [
+				[ 'discussion-topic', 'specification' ],
+				[ 'specification', 'issue' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-source-for-comes-from.js
+++ b/apps/server/default-cards/relationships/relationship-is-source-for-comes-from.js
@@ -12,7 +12,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is source for/comes from',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is source for',
 			reverse: 'comes from',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-source-for-is-feedback-for.js
+++ b/apps/server/default-cards/relationships/relationship-is-source-for-is-feedback-for.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// FIXME: Can this be moved to `is-feedback-for/is-reviewed-with`?
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-is-source-for-is-feedback-for',
+		type: 'type@1.0.0',
+		name: 'Relationship: is source for/is feedback for',
+		data: {
+			is_link: true,
+			forward: 'is source for',
+			reverse: 'is feedback for',
+			type_pairs: [
+				[ 'support-thread', 'feedback-item' ]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-source-for-is-feedback-for.js
+++ b/apps/server/default-cards/relationships/relationship-is-source-for-is-feedback-for.js
@@ -14,7 +14,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is source for/is feedback for',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is source for',
 			reverse: 'is feedback for',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-is-subscribed-for-is-subscribed-with.js
+++ b/apps/server/default-cards/relationships/relationship-is-subscribed-for-is-subscribed-with.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+
+		slug: 'relationship-issubscribed-for-is-subscribed-with',
+		type: 'type@1.0.0',
+		name: 'Relationship: is subscribed for/is subscribed with',
+		data: {
+			is_link: true,
+			forward: 'is subscribed for',
+			reverse: 'is subscribed with',
+			type_pairs: [
+				[
+					'web-push-subscription',
+					{
+						name: 'user',
+						title: 'Web push subscription user'
+					}
+				]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-is-subscribed-for-is-subscribed-with.js
+++ b/apps/server/default-cards/relationships/relationship-is-subscribed-for-is-subscribed-with.js
@@ -13,7 +13,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: is subscribed for/is subscribed with',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'is subscribed for',
 			reverse: 'is subscribed with',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-issue-issue-has-attached-support-thread.js
+++ b/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-issue-issue-has-attached-support-thread.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// FIXME: This should be moved to the correct `is-attached-to/has-attached` relationship.
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-support-thread-is-attached-to-issue-issue-has-attached-support-thread',
+		type: 'type@1.0.0',
+		name: 'Relationship: support thread is attached to issue/issue has attached support thread',
+		data: {
+			is_link: true,
+			forward: 'support thread is attached to issue',
+			reverse: 'issue has attached support thread',
+			type_pairs: [
+				[
+					'support-thread',
+					{
+						name: 'issue',
+						title: 'GitHub issue'
+					}
+				]
+			]
+		}
+	}))
+}

--- a/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-issue-issue-has-attached-support-thread.js
+++ b/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-issue-issue-has-attached-support-thread.js
@@ -14,7 +14,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: support thread is attached to issue/issue has attached support thread',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'support thread is attached to issue',
 			reverse: 'issue has attached support thread',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-support-issue-support-issue-has-attached-support-thread.js
+++ b/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-support-issue-support-issue-has-attached-support-thread.js
@@ -14,7 +14,7 @@ module.exports = ({
 		type: 'type@1.0.0',
 		name: 'Relationship: support thread is attached to support issue/support issue has attached support thread',
 		data: {
-			is_link: true,
+			is_relationship: true,
 			forward: 'support thread is attached to issue',
 			reverse: 'issue has attached support thread',
 			type_pairs: [

--- a/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-support-issue-support-issue-has-attached-support-thread.js
+++ b/apps/server/default-cards/relationships/relationship-support-thread-is-attached-to-support-issue-support-issue-has-attached-support-thread.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// FIXME: This should be moved to the correct `is-attached-to/has-attached` relationship.
+
+module.exports = ({
+	generateRelationshipSchema, sensibleDefaults
+}) => {
+	return generateRelationshipSchema(sensibleDefaults({
+		slug: 'relationship-support-thread-is-attached-to-support-issue-support-issue-has-attached-support-thread',
+		type: 'type@1.0.0',
+		name: 'Relationship: support thread is attached to support issue/support issue has attached support thread',
+		data: {
+			is_link: true,
+			forward: 'support thread is attached to issue',
+			reverse: 'issue has attached support thread',
+			type_pairs: [
+				[ 'support-thread', 'support-issue' ]
+			]
+		}
+	}))
+}

--- a/lib/core/backend/postgres/index.js
+++ b/lib/core/backend/postgres/index.js
@@ -153,7 +153,7 @@ const upsertObject = async (context, backend, object, options) => {
 
 	const baseType = insertedObject.type.split('@')[0]
 
-	if (baseType === 'link') {
+	if (baseType === 'link' || insertedObject.data.is_link) {
 		await links.upsert(context, backend.connection, insertedObject)
 
 		// TODO: We only "materialize" links in this way because we haven't

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -443,7 +443,8 @@ module.exports = class Kernel {
 	async insertCard (context, session, object) {
 		const card = this.defaults(object)
 
-		if (typeof (card.type) === 'string' && card.type.startsWith('link@')) {
+		// eslint-disable-next-line no-process-env
+		if (process.env.NODE_ENV === 'development' && typeof (card.type) === 'string' && card.type.startsWith('link@')) {
 			logger.warn(context,
 				'Inserting link cards directly will soon be deprecated.  Please use `kernel.linkCards()` instead.',
 				{

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -804,27 +804,33 @@ module.exports = class Kernel {
 		const newCard = this.defaults({
 			type: `${linkCard.slug}@${linkCard.version}`,
 			slug: `link-${relationshipSlug}-${await uuid.random()}`,
+			name: linkCard.data.forward,
 			data: {
 				is_link: true,
-				from: {
-					type: cardA.type,
-					id: cardA.id
-				},
-				to: {
-					type: cardB.type,
-					id: cardB.id
-				}
+				inverseName: linkCard.data.reverse
 			}
 		})
 
 		if (linkDirection === 1) {
-			newCard.name = linkCard.data.forward
-			newCard.data.inverseName = linkCard.data.reverse
+			newCard.data.from = {
+				type: cardA.type,
+				id: cardA.id
+			}
+			newCard.data.to = {
+				type: cardB.type,
+				id: cardB.id
+			}
 		}
 
 		if (linkDirection === -1) {
-			newCard.name = linkCard.data.reverse
-			newCard.data.inverseName = linkCard.data.forward
+			newCard.data.from = {
+				type: cardB.type,
+				id: cardB.id
+			}
+			newCard.data.to = {
+				type: cardA.type,
+				id: cardA.id
+			}
 		}
 
 		return this.insertCard(context, session, newCard)

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -15,6 +15,7 @@ const CARDS = require('./cards')
 const permissionFilter = require('./permission-filter')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const uuid = require('@balena/jellyfish-uuid')
+const env = require('@balena/jellyfish-env')
 
 const flattenSelected = (selected) => {
 	const flat = selected.properties
@@ -443,8 +444,7 @@ module.exports = class Kernel {
 	async insertCard (context, session, object) {
 		const card = this.defaults(object)
 
-		// eslint-disable-next-line no-process-env
-		if (process.env.NODE_ENV === 'development' && typeof (card.type) === 'string' && card.type.split('@')[0] === 'link') {
+		if (env.isDevelopment() && typeof (card.type) === 'string' && card.type.split('@')[0] === 'link') {
 			logger.warn(context,
 				'Inserting link cards directly will soon be deprecated.  Please use `kernel.linkCards()` instead.',
 				{

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -444,7 +444,7 @@ module.exports = class Kernel {
 		const card = this.defaults(object)
 
 		// eslint-disable-next-line no-process-env
-		if (process.env.NODE_ENV === 'development' && typeof (card.type) === 'string' && card.type.startsWith('link@')) {
+		if (process.env.NODE_ENV === 'development' && typeof (card.type) === 'string' && card.type.split('@')[0] === 'link') {
 			logger.warn(context,
 				'Inserting link cards directly will soon be deprecated.  Please use `kernel.linkCards()` instead.',
 				{
@@ -794,8 +794,8 @@ module.exports = class Kernel {
 
 		assert.INTERNAL(context, linkCard, errors.JellyfishNoElement,
 			`Unknown relationship: ${relationshipType}`)
-		assert.INTERNAL(context, linkCard.data.is_relationship && linkCard.type === 'type@1.0.0', errors.JellyfishNoElement,
-			`Card ${relationshipSlug} is not a relationship type card.`)
+		assert.INTERNAL(context, linkCard.data.is_relationship && linkCard.type.split('@')[0] === 'type',
+			errors.JellyfishNoElement, `Card ${relationshipSlug} is not a relationship type card.`)
 
 		const linkDirection = findLinkDirection(linkCard.data.type_pairs, cardATypeName, cardBTypeName)
 

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -14,6 +14,7 @@ const views = require('./views')
 const CARDS = require('./cards')
 const permissionFilter = require('./permission-filter')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const uuid = require('@balena/jellyfish-uuid')
 
 const flattenSelected = (selected) => {
 	const flat = selected.properties
@@ -194,6 +195,26 @@ const preUpsert = async (instance, context, session, card) => {
 	}
 
 	return filter
+}
+
+// Figure out which direction the link is pointing.
+// Returns `1` for forward, `-1` for reverse, or 0 for no match.
+const findLinkDirection = (typePairs, cardATypeName, cardBTypeName) => {
+	for (let [ source, target ] of typePairs) {
+		if (source.name) {
+			source = source.name
+		}
+		if (target.name) {
+			target = target.name
+		}
+		if (source === cardATypeName && target === cardBTypeName) {
+			return 1
+		}
+		if (target === cardATypeName && source === cardBTypeName) {
+			return -1
+		}
+	}
+	return 0
 }
 
 module.exports = class Kernel {
@@ -421,6 +442,15 @@ module.exports = class Kernel {
    */
 	async insertCard (context, session, object) {
 		const card = this.defaults(object)
+
+		if (card.type.startsWith('link@')) {
+			logger.warn(context,
+				'Inserting link cards directly will soon be deprecated.  Please use `kernel.linkCards()` instead.',
+				{
+					backtrace: new Error().stack
+				})
+		}
+
 		logger.debug(context, 'Inserting card', {
 			slug: card.slug
 		})
@@ -743,5 +773,60 @@ module.exports = class Kernel {
 		return {
 			backend: await this.backend.getStatus()
 		}
+	}
+
+	/**
+	 * @param {Object} context - execution context
+	 * @param {String} session - session id
+	 * @param {Object} cardA - the LHS of the association
+	 * @param {Object} cardB - the RHS of the association
+	 * @param {String} relationshipType - the relationship type to use.
+	 * @summary Link two cards together given a named relationship type.
+	 * @function
+	 * @public
+	 */
+	async linkCards (context, session, cardA, cardB, relationshipType) {
+		const relationshipSlug = relationshipType.split('@')[0]
+		const cardATypeName = cardA.type.split('@')[0]
+		const cardBTypeName = cardB.type.split('@')[0]
+		const linkCard = await this.getCardBySlug(context, session, relationshipType)
+
+		assert.INTERNAL(context, linkCard, errors.JellyfishNoElement,
+			`Unknown relationship: ${relationshipType}`)
+		assert.INTERNAL(context, linkCard.data.is_relationship && linkCard.type === 'type@1.0.0', errors.JellyfishNoElement,
+			`Card ${relationshipSlug} is not a relationship type card.`)
+
+		const linkDirection = findLinkDirection(linkCard.data.type_pairs, cardATypeName, cardBTypeName)
+
+		assert.INTERNAL(context, Math.abs(linkDirection) === 1, errors.JellyfishSchemaMismatch,
+			`Unable to link card of ${cardATypeName} and ${cardBTypeName} with ${relationshipType}: unknown type relationship`)
+
+		const newCard = this.defaults({
+			type: `${linkCard.slug}@${linkCard.version}`,
+			slug: `link-${relationshipSlug}-${await uuid.random()}`,
+			data: {
+				is_link: true,
+				from: {
+					type: cardA.type,
+					id: cardA.id
+				},
+				to: {
+					type: cardB.type,
+					id: cardB.id
+				}
+			}
+		})
+
+		if (linkDirection === 1) {
+			newCard.name = linkCard.data.forward
+			newCard.data.inverseName = linkCard.data.reverse
+		}
+
+		if (linkDirection === -1) {
+			newCard.name = linkCard.data.reverse
+			newCard.data.inverseName = linkCard.data.forward
+		}
+
+		return this.insertCard(context, session, newCard)
 	}
 }

--- a/lib/core/kernel.js
+++ b/lib/core/kernel.js
@@ -443,7 +443,7 @@ module.exports = class Kernel {
 	async insertCard (context, session, object) {
 		const card = this.defaults(object)
 
-		if (card.type.startsWith('link@')) {
+		if (typeof (card.type) === 'string' && card.type.startsWith('link@')) {
 			logger.warn(context,
 				'Inserting link cards directly will soon be deprecated.  Please use `kernel.linkCards()` instead.',
 				{

--- a/package-lock.json
+++ b/package-lock.json
@@ -4336,9 +4336,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.1.2.tgz",
-      "integrity": "sha512-BQJk35l43z7+9CjokUVLZktvVZ968ueEYRkF/J+zHLPyZrjIib1637astm0ZrNL4UqkOv7iXOCWNlkWE66Nmlg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.2.0.tgz",
+      "integrity": "sha512-DeFEuUqoWyrB9xfY8JWWrx26BiWlHrTMug8tKwAsetX6f8HqYn/862JxKXRfPw8x97CFScekJi1OMX2cuEkVcg==",
       "requires": {
         "lodash": "^4.17.19"
       }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@balena/jellyfish-assert": "^0.0.21",
     "@balena/jellyfish-chat-widget": "^0.0.11",
     "@balena/jellyfish-client-sdk": "^2.1.0",
-    "@balena/jellyfish-environment": "^2.1.2",
+    "@balena/jellyfish-environment": "^2.2.0",
     "@balena/jellyfish-logger": "^0.0.24",
     "@balena/jellyfish-metrics": "^0.0.24",
     "@balena/jellyfish-queue": "^0.0.16",

--- a/scripts/migrations/index.js
+++ b/scripts/migrations/index.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const pgp = require('../../lib/core/backend/postgres/pg-promise')
+const environment = require('@balena/jellyfish-environment')
+
+const migrations = [
+	require('./link-cards-to-relationship-cards')
+]
+
+const main = async () => {
+	const connection = pgp({
+		user: environment.postgres.user || process.env.USER,
+		host: environment.postgres.host,
+		password: environment.postgres.password,
+		database: environment.postgres.database || 'jellyfish',
+		port: environment.postgres.port || 5432
+	})
+
+	// Loop through each migration and run them each in their own transaction.
+	migrations.forEach(async (migration) => {
+		await connection.tx(async (transaction) => {
+			await migration(transaction)
+		})
+	})
+
+	await connection.$pool.end()
+}
+
+main()

--- a/scripts/migrations/link-cards-to-relationship-cards/index.js
+++ b/scripts/migrations/link-cards-to-relationship-cards/index.js
@@ -11,7 +11,7 @@ const BATCH_SIZE = 1000
 
 const relationshipCards = Object
 	.values(defaultCards)
-	.filter((card) => { return card.data.is_link === true })
+	.filter((card) => { return card.data.is_relationship === true })
 
 const SELECT_NEXT_BATCH_QUERY = `
 	SELECT
@@ -39,6 +39,9 @@ const updateQuery = (relationshipType, cardId) => {
 // Loop through the relationship cards and find a schema which matches the
 // provided card and return the subtype.
 const findMatchingRelationship = (card) => {
+	// Force the `is_link` property to true so that the schema can match.
+	card.data.is_link = true
+
 	const match = relationshipCards.find((relationship) => {
 		return skhema.isValid(relationship.data.schema, card)
 	})

--- a/scripts/migrations/link-cards-to-relationship-cards/index.js
+++ b/scripts/migrations/link-cards-to-relationship-cards/index.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const defaultCards = require('../../../apps/server/default-cards')
+const skhema = require('skhema')
+
+const BATCH_SIZE = 1000
+
+const relationshipCards = Object
+	.values(defaultCards)
+	.filter((card) => { return card.data.is_link === true })
+
+const SELECT_NEXT_BATCH_QUERY = `
+	SELECT
+		*
+	FROM
+		cards
+	WHERE
+		type = 'link@1.0.0'
+	ORDER BY
+		created_at ASC
+	LIMIT ${BATCH_SIZE}`
+
+// Generate an update query given a card ID and a new relationship type.
+const updateQuery = (relationshipType, cardId) => {
+	return `
+		UPDATE
+			cards
+		SET
+			type='${relationshipType}',
+			data=jsonb_set(data, '{is_link}', 'true')
+		WHERE
+			id = '${cardId}'`
+}
+
+// Loop through the relationship cards and find a schema which matches the
+// provided card and return the subtype.
+const findMatchingRelationship = (card) => {
+	const match = relationshipCards.find((relationship) => {
+		return skhema.isValid(relationship.data.schema, card)
+	})
+	if (match) {
+		return `${match.slug}@${match.version}`
+	}
+	return null
+}
+
+// Stream the list of failing IDs out one at a time rather than joining the
+// collection because there could potentially be a *lot* of them.
+const printFailures = (failures) => {
+	if (failures.length > 0) {
+		process.stdout.write('\nCouldn\'t find matching relationships for the following link cards: ')
+		for (let failureId = 0; failureId < failures.length; failureId++) {
+			process.stdout.write(failures[failureId])
+			if (failureId === failures.length - 1) {
+				process.stdout.write('.\n')
+			} else {
+				process.stdout.write(', ')
+			}
+		}
+	}
+}
+
+module.exports = async (transaction) => {
+	const results = await transaction.one('SELECT COUNT(id) FROM cards WHERE type = \'link@1.0.0\'')
+
+	const toBeMigrated = results.count
+
+	if (toBeMigrated > 0) {
+		process.stdout.write(`Migrating link ${toBeMigrated} link cards in batches of ${BATCH_SIZE}\n\n`)
+
+		const numberOfBatches = Math.ceil(toBeMigrated / BATCH_SIZE)
+
+		// Loop through our batches selecting 1000 cards at a time and generating
+		// update statements for them.
+		for (let batchId = 0; batchId < numberOfBatches; batchId++) {
+			process.stdout.write(`Batch ${batchId + 1}: `)
+			const batchFailures = []
+			await transaction.each(SELECT_NEXT_BATCH_QUERY, [], async (card) => {
+				const relationshipType = findMatchingRelationship(card)
+				if (!relationshipType) {
+					batchFailures.push(card.id)
+					process.stdout.write('!')
+					return
+				}
+
+				await transaction.none(updateQuery(relationshipType, card.id))
+				process.stdout.write('.')
+			})
+
+			printFailures(batchFailures)
+			process.stdout.write('\n\n')
+		}
+	}
+}

--- a/test/integration/core/kernel.spec.js
+++ b/test/integration/core/kernel.spec.js
@@ -51,7 +51,8 @@ ava('should only expose the required methods', (test) => {
 		'query',
 		'stream',
 		'defaults',
-		'getStatus'
+		'getStatus',
+		'linkCards'
 	])
 })
 

--- a/test/integration/core/kernel/links-cards.spec.js
+++ b/test/integration/core/kernel/links-cards.spec.js
@@ -9,9 +9,6 @@
 const ava = require('ava')
 const helpers = require('../helpers')
 const errors = require('../../../../lib/core/errors')
-const {
-	assert
-} = require('sinon')
 
 const context = {
 	context: {}

--- a/test/integration/core/kernel/links-cards.spec.js
+++ b/test/integration/core/kernel/links-cards.spec.js
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/* eslint-disable max-len */
+
+const ava = require('ava')
+const helpers = require('../helpers')
+const errors = require('../../../../lib/core/errors')
+
+const context = {
+	context: {}
+}
+
+// We want an isolated environment for every test.
+ava.beforeEach(async () => {
+	return helpers.before({
+		context
+	}, {
+		suffix: 'relationship-tests'
+	})
+})
+
+ava.afterEach(async () => {
+	return helpers.after({
+		context
+	})
+})
+
+const relationshipTypeCard = {
+	slug: 'relationship-is-driver-of-is-driven-by',
+	type: 'type@1.0.0',
+	version: '1.0.0',
+	data: {
+		schema: {
+			type: 'object'
+		},
+		is_relationship: true,
+		forward: 'is driver of',
+		reverse: 'is driven by',
+		type_pairs: [
+			[
+				{
+					name: 'user', title: 'Driver'
+				},
+				'car'
+			]
+		]
+	}
+}
+
+const carTypeCard = {
+	slug: 'car',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object'
+		}
+	}
+}
+
+const timeMachineTypeCard = {
+	slug: 'time-machine',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object'
+		}
+	}
+}
+
+ava('.linkCards() can link cards in forward direction when possible', async (test) => {
+	const {
+		kernel
+	} = context
+
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(relationshipTypeCard))
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(carTypeCard))
+
+	const cardA = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'user-marty',
+		name: 'Marty McFly',
+		type: 'user@1.0.0',
+		data: {
+			roles: [],
+			hash: 'CHICKEN'
+		}
+	}))
+
+	const cardB = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'delorean-dmc12',
+		name: 'Delorean DMC-12',
+		type: 'car@1.0.0'
+	}))
+
+	const link = await kernel.linkCards(context.context, kernel.sessions.admin, cardA, cardB,
+		`${relationshipTypeCard.slug}@${relationshipTypeCard.version}`)
+
+	test.is(link.name, relationshipTypeCard.data.forward)
+	test.is(link.data.inverseName, relationshipTypeCard.data.reverse)
+	test.true(link.data.is_link)
+	test.is(link.data.from.type, cardA.type)
+	test.is(link.data.from.id, cardA.id)
+	test.is(link.data.to.type, cardB.type)
+	test.is(link.data.to.id, cardB.id)
+})
+
+ava('.linkCards() can link cards in reverse direction when possible', async (test) => {
+	const {
+		kernel
+	} = context
+
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(relationshipTypeCard))
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(carTypeCard))
+
+	const cardA = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'user-marty',
+		name: 'Marty McFly',
+		type: 'user@1.0.0',
+		data: {
+			roles: [],
+			hash: 'CHICKEN'
+		}
+	}))
+
+	const cardB = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'delorean-dmc12',
+		name: 'Delorean DMC-12',
+		type: 'car@1.0.0'
+	}))
+
+	const link = await kernel.linkCards(context.context, kernel.sessions.admin, cardB, cardA,
+		`${relationshipTypeCard.slug}@${relationshipTypeCard.version}`)
+
+	test.is(link.name, relationshipTypeCard.data.reverse)
+	test.is(link.data.inverseName, relationshipTypeCard.data.forward)
+	test.true(link.data.is_link)
+	test.is(link.data.from.type, cardB.type)
+	test.is(link.data.from.id, cardB.id)
+	test.is(link.data.to.type, cardA.type)
+	test.is(link.data.to.id, cardA.id)
+})
+
+ava('.linkCards() will refuse to create links when the types don\'t match the relationship definition', async (test) => {
+	const {
+		kernel
+	} = context
+
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(relationshipTypeCard))
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(timeMachineTypeCard))
+
+	const cardA = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'user-marty',
+		name: 'Marty McFly',
+		type: 'user@1.0.0',
+		data: {
+			roles: [],
+			hash: 'CHICKEN'
+		}
+	}))
+
+	const cardB = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'delorean-dmc12',
+		name: 'Delorean DMC-12',
+		type: 'time-machine@1.0.0'
+	}))
+
+	await test.throwsAsync(async () => {
+		await kernel.linkCards(context.context, kernel.sessions.admin, cardB, cardA,
+			`${relationshipTypeCard.slug}@${relationshipTypeCard.version}`)
+	}, {
+		instanceOf: errors.JellyfishSchemaMismatch,
+		message: 'Unable to link card of time-machine and user with relationship-is-driver-of-is-driven-by@1.0.0: unknown type relationship'
+	})
+})
+
+ava('created links are present in the `links` table.', async (test) => {
+	const {
+		kernel
+	} = context
+
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(relationshipTypeCard))
+	await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults(carTypeCard))
+
+	const cardA = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'user-marty',
+		name: 'Marty McFly',
+		type: 'user@1.0.0',
+		data: {
+			roles: [],
+			hash: 'CHICKEN'
+		}
+	}))
+
+	const cardB = await kernel.insertCard(context.context, kernel.sessions.admin, kernel.defaults({
+		slug: 'delorean-dmc12',
+		name: 'Delorean DMC-12',
+		type: 'car@1.0.0'
+	}))
+
+	const link = await kernel.linkCards(context.context, kernel.sessions.admin, cardB, cardA,
+		`${relationshipTypeCard.slug}@${relationshipTypeCard.version}`)
+
+	const rows = await kernel.backend.connection.any(`SELECT * FROM links WHERE id = '${link.id}'`)
+	test.true(rows.length === 1)
+})

--- a/test/integration/core/kernel/links-cards.spec.js
+++ b/test/integration/core/kernel/links-cards.spec.js
@@ -107,7 +107,7 @@ ava('.linkCards() can link cards in forward direction when possible', async (tes
 	test.is(link.data.to.id, cardB.id)
 })
 
-ava('.linkCards() can link cards in reverse direction when possible', async (test) => {
+ava('.linkCards() link cards in reverse direction are normalised', async (test) => {
 	const {
 		kernel
 	} = context
@@ -134,13 +134,13 @@ ava('.linkCards() can link cards in reverse direction when possible', async (tes
 	const link = await kernel.linkCards(context.context, kernel.sessions.admin, cardB, cardA,
 		`${relationshipTypeCard.slug}@${relationshipTypeCard.version}`)
 
-	test.is(link.name, relationshipTypeCard.data.reverse)
-	test.is(link.data.inverseName, relationshipTypeCard.data.forward)
+	test.is(link.name, relationshipTypeCard.data.forward)
+	test.is(link.data.inverseName, relationshipTypeCard.data.reverse)
 	test.true(link.data.is_link)
-	test.is(link.data.from.type, cardB.type)
-	test.is(link.data.from.id, cardB.id)
-	test.is(link.data.to.type, cardA.type)
-	test.is(link.data.to.id, cardA.id)
+	test.is(link.data.from.type, cardA.type)
+	test.is(link.data.from.id, cardA.id)
+	test.is(link.data.to.type, cardB.type)
+	test.is(link.data.to.id, cardB.id)
 })
 
 ava('.linkCards() will refuse to create links when the types don\'t match the relationship definition', async (test) => {

--- a/test/unit/apps/server/default-cards/mixins/generate-relationship-schema.spec.js
+++ b/test/unit/apps/server/default-cards/mixins/generate-relationship-schema.spec.js
@@ -44,7 +44,7 @@ ava('`generateRelationshipSchema` generates forward and reverse schema branches'
 			},
 			data: {
 				type: 'object',
-				required: [ 'from', 'to', 'inverseName' ],
+				required: [ 'from', 'to', 'inverseName', 'is_link' ],
 				properties: {
 					from: {
 						type: 'object',
@@ -76,6 +76,9 @@ ava('`generateRelationshipSchema` generates forward and reverse schema branches'
 					},
 					inverseName: {
 						const: 'drives'
+					},
+					is_link: {
+						const: true
 					}
 				}
 			}
@@ -89,7 +92,7 @@ ava('`generateRelationshipSchema` generates forward and reverse schema branches'
 			},
 			data: {
 				type: 'object',
-				required: [ 'from', 'to', 'inverseName' ],
+				required: [ 'from', 'to', 'inverseName', 'is_link' ],
 				properties: {
 					from: {
 						type: 'object',
@@ -121,6 +124,9 @@ ava('`generateRelationshipSchema` generates forward and reverse schema branches'
 					},
 					inverseName: {
 						const: 'is driven by'
+					},
+					is_link: {
+						const: true
 					}
 				}
 			}

--- a/test/unit/apps/server/default-cards/mixins/generate-relationship-schema.spec.js
+++ b/test/unit/apps/server/default-cards/mixins/generate-relationship-schema.spec.js
@@ -48,19 +48,29 @@ ava('`generateRelationshipSchema` generates forward and reverse schema branches'
 				properties: {
 					from: {
 						type: 'object',
-						required: [ 'type' ],
+						required: [ 'type', 'id' ],
 						properties: {
+							id: {
+								type: 'string',
+								format: 'uuid'
+							},
 							type: {
-								const: 'time-machine'
+								type: 'string',
+								pattern: '^time-machine@'
 							}
 						}
 					},
 					to: {
 						type: 'object',
-						required: [ 'type' ],
+						required: [ 'type', 'id' ],
 						properties: {
+							id: {
+								type: 'string',
+								format: 'uuid'
+							},
 							type: {
-								const: 'driver'
+								type: 'string',
+								pattern: '^driver@'
 							}
 						}
 					},
@@ -83,19 +93,29 @@ ava('`generateRelationshipSchema` generates forward and reverse schema branches'
 				properties: {
 					from: {
 						type: 'object',
-						required: [ 'type' ],
+						required: [ 'type', 'id' ],
 						properties: {
+							id: {
+								type: 'string',
+								format: 'uuid'
+							},
 							type: {
-								const: 'driver'
+								type: 'string',
+								pattern: '^driver@'
 							}
 						}
 					},
 					to: {
 						type: 'object',
-						required: [ 'type' ],
+						required: [ 'type', 'id' ],
 						properties: {
+							id: {
+								type: 'string',
+								format: 'uuid'
+							},
 							type: {
-								const: 'time-machine'
+								type: 'string',
+								pattern: '^time-machine@'
 							}
 						}
 					},
@@ -140,6 +160,6 @@ ava('`generateRelationshipSchema` correctly extracts type names from types with 
 		}
 	})
 
-	test.is(card.data.schema.oneOf[0].properties.data.properties.from.properties.type.const, 'time-machine')
-	test.is(card.data.schema.oneOf[0].properties.data.properties.to.properties.type.const, 'user')
+	test.is(card.data.schema.oneOf[0].properties.data.properties.from.properties.type.pattern, '^time-machine@')
+	test.is(card.data.schema.oneOf[0].properties.data.properties.to.properties.type.pattern, '^user@')
 })

--- a/test/unit/apps/server/default-cards/mixins/generate-relationship-schema.spec.js
+++ b/test/unit/apps/server/default-cards/mixins/generate-relationship-schema.spec.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const generateRelationshipSchema = require('../../../../../../apps/server/default-cards/mixins/generate-relationship-schema')
+
+ava('`generateRelationshipSchema` generates a top-level oneOf schema', (test) => {
+	const card = generateRelationshipSchema({
+		data: {
+			type_pairs: [
+				[ 'time-machine', 'driver' ]
+			],
+			forward: 'is driven by',
+			reverse: 'drives'
+		}
+	})
+
+	test.is(card.data.schema.type, 'object')
+	test.deepEqual(card.data.schema.required, [ 'name', 'data' ])
+	test.assert(Array.isArray(card.data.schema.oneOf))
+})
+
+ava('`generateRelationshipSchema` generates forward and reverse schema branches', (test) => {
+	const card = generateRelationshipSchema({
+		data: {
+			type_pairs: [
+				[ 'time-machine', 'driver' ]
+			],
+			forward: 'is driven by',
+			reverse: 'drives'
+		}
+	})
+
+	test.assert(card.data.schema.oneOf.length === 2)
+	const [ forward, reverse ] = card.data.schema.oneOf
+
+	test.deepEqual(forward, {
+		properties: {
+			name: {
+				const: 'is driven by'
+			},
+			data: {
+				type: 'object',
+				required: [ 'from', 'to', 'inverseName' ],
+				properties: {
+					from: {
+						type: 'object',
+						required: [ 'type' ],
+						properties: {
+							type: {
+								const: 'time-machine'
+							}
+						}
+					},
+					to: {
+						type: 'object',
+						required: [ 'type' ],
+						properties: {
+							type: {
+								const: 'driver'
+							}
+						}
+					},
+					inverseName: {
+						const: 'drives'
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(reverse, {
+		properties: {
+			name: {
+				const: 'drives'
+			},
+			data: {
+				type: 'object',
+				required: [ 'from', 'to', 'inverseName' ],
+				properties: {
+					from: {
+						type: 'object',
+						required: [ 'type' ],
+						properties: {
+							type: {
+								const: 'driver'
+							}
+						}
+					},
+					to: {
+						type: 'object',
+						required: [ 'type' ],
+						properties: {
+							type: {
+								const: 'time-machine'
+							}
+						}
+					},
+					inverseName: {
+						const: 'is driven by'
+					}
+				}
+			}
+		}
+	})
+})
+
+ava('`generateRelationshipSchema` generates schema branches for all type pairs', (test) => {
+	const card = generateRelationshipSchema({
+		data: {
+			type_pairs: [
+				[ 'time-machine', 'driver' ],
+				[ 'steam-train', 'driver' ]
+			],
+			forward: 'is driven by',
+			reverse: 'drives'
+		}
+	})
+
+	test.assert(card.data.schema.oneOf.length === 4)
+})
+
+ava('`generateRelationshipSchema` correctly extracts type names from types with aliases', (test) => {
+	const card = generateRelationshipSchema({
+		data: {
+			type_pairs: [
+				[
+					'time-machine',
+					{
+						name: 'user',
+						title: 'Driver'
+					}
+				]
+			],
+			forward: 'is driven by',
+			reverse: 'drives'
+		}
+	})
+
+	test.is(card.data.schema.oneOf[0].properties.data.properties.from.properties.type.const, 'time-machine')
+	test.is(card.data.schema.oneOf[0].properties.data.properties.to.properties.type.const, 'user')
+})

--- a/test/unit/apps/server/default-cards/mixins/sensible-defaults.spec.js
+++ b/test/unit/apps/server/default-cards/mixins/sensible-defaults.spec.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const sensibleDefaults = require('../../../../../../apps/server/default-cards/mixins/sensible-defaults')
+
+ava('`sensibleDefaults` sets the version to \'1.0.0\'', (test) => {
+	const card = sensibleDefaults({})
+
+	test.is(card.version, '1.0.0')
+})
+
+ava('`sensibleDefaults` sets the markers to `[]`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.markers, [])
+})
+
+ava('`sensibleDefaults` sets the tags to `[]`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.tags, [])
+})
+
+ava('`sensibleDefaults` sets the links to `{}`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.links, {})
+})
+
+ava('`sensibleDefaults` sets the active to `true`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.active, true)
+})
+
+ava('`sensibleDefaults` sets the data to `{}`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.data, {})
+})
+
+ava('`sensibleDefaults` sets the requires to `[]`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.requires, [])
+})
+
+ava('`sensibleDefaults` sets the capabilities to `[]`', (test) => {
+	const card = sensibleDefaults({})
+
+	test.deepEqual(card.capabilities, [])
+})
+
+ava('`sensibleDefaults` never overwrites a property in the source card', (test) => {
+	const card = sensibleDefaults({
+		version: '2.0.0'
+	})
+
+	test.is(card.version, '2.0.0')
+})


### PR DESCRIPTION
This PR adds a bunch of new "relationship" typecards, which are based on the contents of [the SDK's link constraints file](https://github.com/product-os/jellyfish-client-sdk/blob/master/lib/link-constraints.js). This is work that is needed to make the GraphQL link schemas fully generatable.

So, this PR includes a few important things:

* A whole bunch of new typecards which define the valid relationships between specific types of cards.
* A new `linkCards` method on kernel which handles the creation of links automatically, rather than generating link cards manually.
* A deprecation warning on `insertCard` if the inserted object is of type `link` including a stack-track to aid in identifying all the places where we create link cards.
* An MVP migrations system with a migration written to which matches and updates the `type` property on existing link cards to the correct type.

## New relationship cards:

You'll notice a bunch of new cards in `app/server/default-cards/relationships`.  You'll also notice that they make use of @grahammcculloch's fancy pluggable loading system to dynamically generate the card's JSON Schema based on the other values in the card's data.

### Relationship data:

- `is_relationship` this is currently used to identify that not only is this a type card, but a special relationship card. This will be used by GraphQL to identify these cards for type generation.
- `forward` the name of the association in the forward direction (eg "X is owner of Y").
- `reverse` the name of the association in the reverse direction (eg "Y is owned by X").
- `type_pairs` is a list containing tuples of types in the form of two-element arrays. Pairs are specified in the forward direction (eg `[ 'X', 'Y' ]` in the examples above). Each tuple element can either be the (unversioned) name of a type as a string (slug form) or an object containing a `name` and `title` property for cases where inflecting the association name from the type name wouldn't be appropriate (eg `['group', {name: 'user', title: 'Member'}]`).

### Relationship schema:

The relationship schema is generated based on the `forward`, `reverse` and `type_pairs` properties and generates a JSON schema which matches cards which link any cards of the specified types.

For example, the following relationship:

```
{
  forward: 'is of',
  reverse: 'has',
  type_pairs: [
    ['checkin', 'project'],
    ['thread', 'repository]
  ]
}
```

Would match any of the following link cards:

1. `checkin is of project`
2. `project has checkin`
3. `thread is of repository`
4. `repository has thread`

In this way a single relationship can represent links in both directions.  The `linkCards` kernel method takes this direction information into account when creating link cards.

## The `linkCards` method

This method is primarily just a DX improvement, but should hopefully help us eliminate places where non-complying links are generated in the system.  When provided two cards and the relationship type (eg `relationship-is-observed-by-observes@1.0.0`) it creates a link ~~in the direction matching the order which the cards were passed as arguments~~ with the direction normalised as per the relationship card.  Because this requires a search of the relationship's `type_pairs` array, we can also short-circuit type errors without having to rely on JSON-Schema to validate the entire link card.

## Deprecation warning on `insertCard`

When `insertCard` detects that an old-style link card is being inserted it logs a warning which includes a backtrace to aid in tracking down places in our code which manually create link cards.  At least on the backend this is overwhelmingly in tests, so while I expect it to happen in production quite a lot initially, they should be easy enough to clean up.

## Migrations

Database migrations should probably be a solved problem, but since we don't seem to be able to form a consensus about how to handle it I have implemented a migration for our existing link cards both because we'll need to run this in production at some stage before we will be able to see any historical data via the GraphQL API and because it's easier to have a discussion about existing code than imagined code.

## After this lands

This is just part of an on-going work stream, so there's a lot to follow on from it;
- Modify the client SDK to use these relationship types to generate the link constraints table rather than using a hard-coded one.
- Modify the GraphQL type generation system to generate all necessary type objects which can map from each type to each of it's connected nodes.
- Continue hunting down and updating any code which triggers our deprecation warning.