### PR TITLE
ui: Ensure home channel drawer opens and closes correctly

### DIFF
--- a/lib/chat-widget/components/TaskButton.jsx
+++ b/lib/chat-widget/components/TaskButton.jsx
@@ -18,7 +18,7 @@ import {
 export const TaskButton = ({
 	task, children, ...rest
 }) => {
-	const icon = task.started && <Loader color="white" />
+	const icon = task.started ? <Loader color="white" /> : null
 
 	return (
 		<React.Fragment>


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

**Disclaimer: Yup - it's ugly and we should refactor the HomeChannel component soon to abstract out the drawer functionality!!**

This PR fixes the logic the `HomeChannel` component uses to determine when to open/close the drawer. Specifically:
* it fixes a bug that was causing Jellyfish to throw an exception on startup on a mobile screen
* it ensures the home channel drawer behaves correctly when opening/closing the following:
    * Inbox
    * Chat Widget
    * CreateThread channel

Also fixes a small react warning about a button's `icon` prop being set to `false` in the chat-widget.
