### PR TITLE
test: Fix headers retrieval in Front integration tests

### DIFF
--- a/test/integration/sync/front-translate.spec.js
+++ b/test/integration/sync/front-translate.spec.js
@@ -30,7 +30,7 @@ scenario.run(ava, {
 		token: TOKEN
 	},
 	isAuthorized: (self, request) => {
-		return request.headers.authorization === `Bearer ${self.options.token.api}` ||
-			request.headers.authorization.startsWith('Basic')
+		return request.options.headers.authorization === `Bearer ${self.options.token.api}` ||
+		request.options.headers.authorization.startsWith('Basic')
 	}
 })


### PR DESCRIPTION
For some reason on every other request the request.headers prop is not set - but request.options.headers is always set.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

