### PR TITLE
ui: handle messages that just contain a URL to an image

### DIFF
--- a/lib/ui-components/Event/EventBody.jsx
+++ b/lib/ui-components/Event/EventBody.jsx
@@ -47,6 +47,7 @@ const StyledMarkdown = styled(Markdown)(({
 
 const FRONT_MARKDOWN_IMG_RE = /\[\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+\]/g
 const FRONT_HTML_IMG_RE = /\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+/g
+const IMAGE_URL_RE = /^https?:\/\/.*\.(?:png|jpg|gif)(?:\?\S*)*$/
 
 const OverflowButton = styled(Button) `
 	color: inherit;
@@ -62,6 +63,10 @@ const OverflowButton = styled(Button) `
 
 export const getMessage = (card) => {
 	const message = _.get(card, [ 'data', 'payload', 'message' ], '')
+
+	if (message.trim().match(IMAGE_URL_RE)) {
+		return `![image](${message.trim()})`
+	}
 
 	// Fun hack to extract attached images embedded in HTML from synced front messages
 	if (message.includes('<img src="/api/1/companies/resin_io/attachments')) {

--- a/lib/ui-components/Event/tests/EventBody.spec.jsx
+++ b/lib/ui-components/Event/tests/EventBody.spec.jsx
@@ -7,11 +7,14 @@
 import '../../../../test/ui-setup'
 import ava from 'ava'
 import sinon from 'sinon'
+import _ from 'lodash'
 import {
 	shallow
 } from 'enzyme'
 import React from 'react'
-import EventBody from '../EventBody'
+import EventBody, {
+	getMessage
+} from '../EventBody'
 import {
 	card
 } from './fixtures'
@@ -43,6 +46,32 @@ ava.beforeEach((test) => {
 
 ava.afterEach(() => {
 	sandbox.restore()
+})
+
+ava('getMessage detects a message that only contains an image url and wraps it', (test) => {
+	const jpgURL = 'http://test.com/image.jpg?some-data=2'
+	const pngURL = 'http://test.co.uk/image%20again.png?some-data=+2'
+	const gifURL = 'https://wwww.test.com/image.gif'
+	const imageMessage = (url) => {
+		return `![image](${url})`
+	}
+	const getMessageInCard = (message) => {
+		const newCard = _.merge(card, {
+			data: {
+				payload: {
+					message
+				}
+			}
+		})
+		return getMessage(newCard)
+	}
+	test.is(getMessageInCard(jpgURL), imageMessage(jpgURL))
+	test.is(getMessageInCard(pngURL), imageMessage(pngURL))
+	test.is(getMessageInCard(gifURL), imageMessage(gifURL))
+	test.is(getMessageInCard(` ${jpgURL}`), imageMessage(jpgURL))
+	test.is(getMessageInCard(`${jpgURL} `), imageMessage(jpgURL))
+	test.not(getMessageInCard(`>${jpgURL}`), imageMessage(jpgURL))
+	test.not(getMessageInCard(`${jpgURL}!`), imageMessage(jpgURL))
 })
 
 ava('Auto-complete textarea is shown if message is being edited', (test) => {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

If you write a message that is just an image URL then we render it as an image.

![Image message](https://user-images.githubusercontent.com/2925657/87894353-b29af580-ca6c-11ea-9a48-964f06c10ee5.gif)

**Exceptions**
* image URLs that do not have a `.jgp`, `.png` or `.gif` file extension
* Image URLs that are contained within the body of a message that contains other text.

Note: I originally wrote this change in order to better support [Hubot integration](https://github.com/product-os/jellyfish/issues/4074). But I think it is a useful addition anyway.

At some point we should come up with a more elegant way of structuring the logic for modifying a message for display. But for now this follows the existing pattern.