### PR TITLE
ui: Ensure home channel drawer actions restricted to mobile view

### DIFF
--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -349,19 +349,23 @@ export default class HomeChannel extends React.Component {
 	}
 
 	showDrawer () {
-		this.wrapper.current.style.transform = 'translate3d(0, 0, 0)'
-		this.setState({
-			showDrawer: true,
-			sliding: false
-		})
+		if (this.props.isMobile) {
+			this.wrapper.current.style.transform = 'translate3d(0, 0, 0)'
+			this.setState({
+				showDrawer: true,
+				sliding: false
+			})
+		}
 	}
 
 	hideDrawer () {
-		this.wrapper.current.style.transform = 'translate3d(-100%, 0, 0)'
-		this.setState({
-			showDrawer: false,
-			sliding: false
-		})
+		if (this.props.isMobile) {
+			this.wrapper.current.style.transform = 'translate3d(-100%, 0, 0)'
+			this.setState({
+				showDrawer: false,
+				sliding: false
+			})
+		}
 	}
 
 	toggleDrawerIOS () {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Just wraps the `openDrawer` and `closeDrawer` functionality in a check to ensure we only interact with the drawer in 'mobile view'.
