### PR TITLE
Bump test/sidecar tags to v1.3.15

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-test:v1.3.14
+FROM resinci/jellyfish-test:v1.3.15
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-sidecar:v1.3.14
+FROM resinci/jellyfish-sidecar:v1.3.15
 
 WORKDIR /usr/src/jellyfish
 

--- a/test/containers/Dockerfile.test
+++ b/test/containers/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM resinci/jellyfish-test:v1.3.14
+FROM resinci/jellyfish-test:v1.3.15
 
 WORKDIR /usr/src/jellyfish
 ARG NPM_TOKEN


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `jellyfish-test` and `jellyfish-sidecar` base image tags to `v1.3.15` to take advantage of `puppeteer@5.2.0`.