### PR TITLE
ci: Move S3 upload tests to balenaCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,37 +223,6 @@ jobs:
           name: Docker Compose Down
           command: make compose-stop
 
-  s3_file_upload: &s3_file_upload
-    <<: *job_defaults
-
-    resource_class: xlarge
-
-    steps:
-      - checkout
-
-      - run:
-          name: Authenticate with registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - run:
-          name: Install scripts-template dependencies
-          command: cd scripts/template && npm install
-      - run:
-          name: Compose Build
-          command: make compose-build SIDECAR=1
-      - run:
-          name: Docker Compose Up
-          command: make compose-up SIDECAR=1 DETACH=1 FS_DRIVER=s3FS
-      - run:
-          name: S3 File Upload Tests
-          command: make docker-exec-jellyfish_sidecar_1 COMMAND="/bin/bash -c \". /root/.bashrc && make test FILES=./test/e2e/ui/file-upload.spec.js\""
-      - run:
-          name: Docker Compose Down
-          command: make compose-stop
-
   results:
     <<: *job_defaults
 
@@ -318,11 +287,6 @@ workflows:
                   - build
                 <<: *workflow_filter
 
-            - s3_file_upload:
-                requires:
-                  - build
-                <<: *workflow_filter
-
             - sync_tests_front_mirror:
                 requires:
                   - build
@@ -342,7 +306,6 @@ workflows:
                 requires:
                   - e2e_tests_server
                   - e2e_tests_server_previous_dump
-                  - s3_file_upload
                   - sync_tests_front_mirror
                   - sync_tests_discourse_mirror
                   - sync_tests_github_mirror

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -53,6 +53,9 @@ services:
       - METRICS_PORT=9000
       - SOCKET_METRICS_PORT=9001
       - MONITOR_SECRET_TOKEN=TEST
-      - CI
+      - CI=1
+      - AWS_S3_BUCKET_NAME
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
     networks:
       - internal

--- a/scripts/ci/tests/s3-file-upload.spec.sh
+++ b/scripts/ci/tests/s3-file-upload.spec.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+###
+# Copyright (C) Balena.io - All Rights Reserved
+# Unauthorized copying of this file, via any medium is strictly prohibited.
+# Proprietary and confidential.
+###
+
+set -e
+source "$(dirname $0)/helpers.sh"
+
+# Run S3 file upload tests.
+run_test "S3 File Upload Tests" test \
+  FILES=./test/e2e/ui/file-upload.spec.js \
+	FS_DRIVER=s3FS


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move S3 upload tests from CircleCI to balenaCI