### PR TITLE
Fix scrolling bug with Timeline and add loading icon

### DIFF
--- a/lib/ui-components/InfiniteList.jsx
+++ b/lib/ui-components/InfiniteList.jsx
@@ -43,7 +43,10 @@ export class InfiniteList extends React.Component {
 		}
 	}
 
-	queryForMoreIfNecessary () {
+	async queryForMoreIfNecessary () {
+		if (this.processing) {
+			return
+		}
 		const {
 			onScrollBeginning,
 			onScrollEnding
@@ -55,10 +58,14 @@ export class InfiniteList extends React.Component {
 		const noScrollBar = clientHeight === scrollHeight
 		if (noScrollBar) {
 			if (onScrollBeginning) {
-				onScrollBeginning()
+				this.processing = true
+				await onScrollBeginning()
+				this.processing = false
 			}
 			if (onScrollEnding) {
-				onScrollEnding()
+				this.processing = true
+				await onScrollEnding()
+				this.processing = false
 			}
 		}
 	}

--- a/lib/ui-components/Timeline/Loading.jsx
+++ b/lib/ui-components/Timeline/Loading.jsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Flex
+} from 'rendition'
+import Icon from '../shame/Icon'
+
+const Loading = () => {
+	return (
+		<Flex
+			justifyContent="center"
+		>
+			<Icon spin name="cog" />
+		</Flex>
+	)
+}
+
+export default Loading

--- a/lib/ui-components/Timeline/tests/index.spec.jsx
+++ b/lib/ui-components/Timeline/tests/index.spec.jsx
@@ -181,9 +181,8 @@ ava('getWithTimeline is used to get all the events for the timeline when' +
 			}
 		})
 
-	// GetWithTimeline should only be called once by JSDom is playing up and calling the handleScrollBeginning before the component is mounted
-	test.is(getWithTimeline.callCount, 2)
-	test.deepEqual(getWithTimeline.args[1], [ 'fake-card', {
+	test.is(getWithTimeline.callCount, 1)
+	test.deepEqual(getWithTimeline.args, [ [ 'fake-card', {
 		queryOptions: {
 			links: {
 				'has attached element': {
@@ -192,5 +191,5 @@ ava('getWithTimeline is used to get all the events for the timeline when' +
 				}
 			}
 		}
-	} ])
+	} ] ])
 })


### PR DESCRIPTION
Fixes bug where we attempt to paginate the query before we have scrolled to the bottom. Added some checks to make sure that the scroll has occurred and that we aren't already processing the pagination query before we attempt to make the query.

Also added a loading icon for when we are loading more results.

Change-type: patch
Signed-off-by: Lucy-Jane Walsh <Lucy-Jane@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
