### PR TITLE
Ensure messages are not rendered as pending between the stream and action returning

### DIFF
--- a/lib/ui-components/Timeline/PendingMessages.jsx
+++ b/lib/ui-components/Timeline/PendingMessages.jsx
@@ -13,9 +13,14 @@ import Event from '../Event'
 
 const PendingMessages = ({
 	pendingMessages,
+	sortedEvents,
 	...eventProps
 }) => {
 	return _.map(pendingMessages, (message) => {
+		const noLongerPending = _.find(sortedEvents, [ 'slug', message.slug ])
+		if (noLongerPending) {
+			return null
+		}
 		return (
 			<Box key={message.slug}>
 				<Event

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -469,6 +469,7 @@ class Timeline extends React.Component {
 						<PendingMessages
 							{ ...eventProps }
 							pendingMessages={pendingMessages}
+							sortedEvents={sortedEvents}
 						/>
 						<div ref={this.timelineEnd} />
 					</InfiniteList>


### PR DESCRIPTION
We cleanup the pending messages once the create message is completed. But in the meantime, the updated message can come through stream. This is a quick fix to ensure that if the message comes through the stream we don't render it as a pending message

Change-type: patch
Signed-off-by: Lucy-Jane Walsh <Lucy-Jane@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
