### PR TITLE
Bump sidecar and test base images to v1.3.16

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-test:v1.3.15
+FROM resinci/jellyfish-test:v1.3.16
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/sidecar/Dockerfile
+++ b/apps/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-sidecar:v1.3.15
+FROM resinci/jellyfish-sidecar:v1.3.16
 
 WORKDIR /usr/src/jellyfish
 

--- a/test/containers/Dockerfile.test
+++ b/test/containers/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM resinci/jellyfish-test:v1.3.15
+FROM resinci/jellyfish-test:v1.3.16
 
 WORKDIR /usr/src/jellyfish
 ARG NPM_TOKEN


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `jellyfish-sidecar` and `jellyfish-test` base image tags to `v1.3.16`, which includes update to Puppeteer `5.2.1`