### PR TITLE
ci: Improve Front and GitHub test data cleanup scripts

### DIFF
--- a/scripts/ci/tests/clean-front.spec.sh
+++ b/scripts/ci/tests/clean-front.spec.sh
@@ -6,7 +6,6 @@
 # Proprietary and confidential.
 ###
 
-set -e
 source "$(dirname $0)/helpers.sh"
 
 # Clean old Front test data.

--- a/scripts/ci/tests/clean-github.spec.sh
+++ b/scripts/ci/tests/clean-github.spec.sh
@@ -6,7 +6,6 @@
 # Proprietary and confidential.
 ###
 
-set -e
 source "$(dirname $0)/helpers.sh"
 
 # Clean old GitHub test data.


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

## GitHub Cleanup Script
- Exit with `0` instead of `1` if token is invalid

## Front Cleanup Script
- Exit with `0` instead of `1` if token is invalid
- Only delay after deleting a conversation to speed up script
- Pass entire conversation object to delete function so we can properly check `created_at`
- Only check up to 10,000 conversations. Going to be moving to creating test inboxes for each CI cycle and deleting them later so this is only temporary. The script currently runs for an absurd amount of time because the Front API doesn't allow us to search through conversation by date created, so we have to literally sort through all conversations. *1
- Delete conversations that are older than 2 hours instead of ~1 day

*1: Will be looking into creating new test inboxes on each CI cycle and then deleting them with this script which, if possible, should relieve this problem.

**Alternatively, we could just drop this script for now until the test inbox creation/deletion script is done.**