### PR TITLE
UI: Surface card markers as text when viewing a card

### DIFF
--- a/apps/ui/components/Markers/index.js
+++ b/apps/ui/components/Markers/index.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	commaListsAnd
+} from 'common-tags'
+import * as _ from 'lodash'
+import React from 'react'
+import {
+	Txt
+} from 'rendition'
+
+export default function CountFavicon ({
+	card
+}) {
+	if (!card || !card.markers || !card.markers.length) {
+		return null
+	}
+
+	const distinctMarkers = _.uniq(_.flatMap(card.markers, (marker) => marker.split('+')))
+
+	const [ users, orgs ] = _.partition(distinctMarkers, _.partial(_.startsWith, _, 'user'))
+
+	const cleanUsers = users.map((user) => user.replace(/^user-/, ''))
+	const cleanOrgs = orgs.map((org) => org.replace(/^org-/, ''))
+
+	let message = 'Only visible to '
+	if (cleanUsers.length === 1) {
+		message += `${cleanUsers[0]} `
+	}
+	if (cleanUsers.length > 1) {
+		message += commaListsAnd `users ${cleanUsers} `
+	}
+
+	if (cleanUsers.length && cleanOrgs.length) {
+		message += 'and '
+	}
+
+	if (cleanOrgs.length) {
+		message += `members of ${commaListsAnd `${cleanOrgs}`}`
+	}
+
+	return (
+		<Txt px={3} italic fontSize={0}>
+			<em>
+				{message}
+			</em>
+		</Txt>
+	)
+}

--- a/apps/ui/layouts/CardLayout/index.jsx
+++ b/apps/ui/layouts/CardLayout/index.jsx
@@ -24,6 +24,7 @@ import {
 	FLOW_IDS
 } from '../../components/Flows/flow-utils'
 import HandoverFlowPanel from '../../components/Flows/HandoverFlowPanel'
+import Markers from '../../components/Markers'
 import {
 	LinksProvider
 } from '../../../../lib/ui-components/LinksProvider'
@@ -92,6 +93,8 @@ const CardLayout = (props) => {
 						/>
 					</Flex>
 				</Flex>
+
+				<Markers card={card} />
 
 				{children}
 				<SlideInFlowPanel

--- a/apps/ui/lens/full/View/Header.jsx
+++ b/apps/ui/lens/full/View/Header.jsx
@@ -12,6 +12,7 @@ import Collapsible from '../../../../../lib/ui-components/Collapsible'
 import {
 	CloseButton
 } from '../../../../../lib/ui-components/shame/CloseButton'
+import Markers from '../../../components/Markers'
 import LensSelection from './LensSelection'
 import SliceOptions from './SliceOptions'
 import ViewFilters from './ViewFilters'
@@ -42,55 +43,59 @@ export default class Header extends React.Component {
 		}
 
 		return (
-			<Flex alignItems="flex-start" mx={3} mt={3} style={{
-				flexShrink: 0
-			}}>
-				<Collapsible
-					title="Filters and Lenses"
-					maxContentHeight="70vh"
-					flex={1}
-					collapsible={isMobile}
-					data-test="filters-and-lense"
-				>
-					<Flex
-						mt={[ 2, 2, 0 ]}
-						flexWrap={[ 'wrap', 'wrap', 'nowrap' ]}
-						flexDirection="row-reverse"
-						alignItems={[ 'flex-start', 'flex-start', 'center' ]}
+			<React.Fragment>
+				<Flex alignItems="flex-start" mx={3} mt={3} style={{
+					flexShrink: 0
+				}}>
+					<Collapsible
+						title="Filters and Lenses"
+						maxContentHeight="70vh"
+						flex={1}
+						collapsible={isMobile}
+						data-test="filters-and-lense"
 					>
-						<Flex mb={3} alignItems="center" justifyContent="flex-end" minWidth={[ '100%', '100%', 'auto' ]}>
-							<SliceOptions
-								sliceOptions={sliceOptions}
-								activeSlice={activeSlice}
-								setSlice={setSlice}
-							/>
-							<LensSelection
-								lenses={lenses}
-								lens={lens}
-								setLens={setLens}
-							/>
+						<Flex
+							mt={[ 2, 2, 0 ]}
+							flexWrap={[ 'wrap', 'wrap', 'nowrap' ]}
+							flexDirection="row-reverse"
+							alignItems={[ 'flex-start', 'flex-start', 'center' ]}
+						>
+							<Flex mb={3} alignItems="center" justifyContent="flex-end" minWidth={[ '100%', '100%', 'auto' ]}>
+								<SliceOptions
+									sliceOptions={sliceOptions}
+									activeSlice={activeSlice}
+									setSlice={setSlice}
+								/>
+								<LensSelection
+									lenses={lenses}
+									lens={lens}
+									setLens={setLens}
+								/>
+							</Flex>
 						</Flex>
-					</Flex>
-					<ViewFilters
-						tailType={tailType}
-						filters={filters}
-						searchFilter={searchFilter}
-						updateFilters={updateFilters}
-						saveView={saveView}
-						searchTerm={searchTerm}
-						updateSearch={updateSearch}
-						updateFiltersFromSummary={updateFiltersFromSummary}
+						<ViewFilters
+							tailType={tailType}
+							filters={filters}
+							searchFilter={searchFilter}
+							updateFilters={updateFilters}
+							saveView={saveView}
+							searchTerm={searchTerm}
+							updateSearch={updateSearch}
+							updateFiltersFromSummary={updateFiltersFromSummary}
+						/>
+					</Collapsible>
+					<CloseButton
+						flex={0}
+						p={3}
+						py={2}
+						mr={-3}
+						mt={[ -2, -2, 0 ]}
+						channel={channel}
 					/>
-				</Collapsible>
-				<CloseButton
-					flex={0}
-					p={3}
-					py={2}
-					mr={-3}
-					mt={[ -2, -2, 0 ]}
-					channel={channel}
-				/>
-			</Flex>
+				</Flex>
+
+				<Markers card={channel.data.head} />
+			</React.Fragment>
 		)
 	}
 }


### PR DESCRIPTION
This change displays the marker permissions (if any) on a card in plain
english, making it easier to understand if a card is restricted by
marker permissions.

![image](https://user-images.githubusercontent.com/15064535/88265938-37cd1700-ccc6-11ea-80f4-14ac3630d973.png)


Connects-to: #3966
Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
