### PR TITLE
Fix translate test scripts for balenaCI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3957,9 +3957,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
-      "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
+      "version": "2.0.7-trim-front-token-48255d66138e98ed590fbb971d1ef21a3dd385b1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.7-trim-front-token-48255d66138e98ed590fbb971d1ef21a3dd385b1.tgz",
+      "integrity": "sha512-4P7hlzAszIIz/z1G+ibn5XuGbvVYx6oRv+Tq/weVvKLAEor5auW7hroJfAwbvDeK5uOHdxcVmJWPAb1NHLgLTg==",
       "requires": {
         "lodash": "^4.17.19"
       }
@@ -4010,6 +4010,14 @@
           "requires": {
             "lodash": "^4.17.19"
           }
+        },
+        "@balena/jellyfish-environment": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
+          "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
+          "requires": {
+            "lodash": "^4.17.19"
+          }
         }
       }
     },
@@ -4021,6 +4029,16 @@
         "@balena/jellyfish-environment": "^2.0.5",
         "request": "^2.88.2",
         "request-promise": "^4.2.5"
+      },
+      "dependencies": {
+        "@balena/jellyfish-environment": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
+          "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
+          "requires": {
+            "lodash": "^4.17.19"
+          }
+        }
       }
     },
     "@balena/jellyfish-metrics": {
@@ -4039,6 +4057,14 @@
           "version": "0.0.16",
           "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-0.0.16.tgz",
           "integrity": "sha512-eIrXxrllChZqu4mV/fbZRSX+zxHbtlOajBt9XPDXTMgCqaNufdpAbsktFOwCHDxXNaglQe6GtAiIoLai1Iatow==",
+          "requires": {
+            "lodash": "^4.17.19"
+          }
+        },
+        "@balena/jellyfish-environment": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
+          "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
           "requires": {
             "lodash": "^4.17.19"
           }
@@ -4082,6 +4108,14 @@
           "version": "0.0.18",
           "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-0.0.18.tgz",
           "integrity": "sha512-H+qtgWx6NNifDOXsH9/iXN03JKFSfyAnx1TJX0nfI1LlPDS4FOSuVEDIaoKp+OSN2q00ciGdEROhnc5ftxirfA==",
+          "requires": {
+            "lodash": "^4.17.19"
+          }
+        },
+        "@balena/jellyfish-environment": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
+          "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
           "requires": {
             "lodash": "^4.17.19"
           }
@@ -4227,6 +4261,14 @@
               "version": "0.0.16",
               "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-0.0.16.tgz",
               "integrity": "sha512-eIrXxrllChZqu4mV/fbZRSX+zxHbtlOajBt9XPDXTMgCqaNufdpAbsktFOwCHDxXNaglQe6GtAiIoLai1Iatow==",
+              "requires": {
+                "lodash": "^4.17.19"
+              }
+            },
+            "@balena/jellyfish-environment": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
+              "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
               "requires": {
                 "lodash": "^4.17.19"
               }
@@ -21326,11 +21368,15 @@
     "scripts-template": {
       "version": "file:scripts/template",
       "dev": true,
+      "requires": {
+        "mustache": "^4.0.1"
+      },
       "dependencies": {
         "mustache": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
-          "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+          "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@babel/polyfill": "^7.10.4",
     "@balena/jellyfish-assert": "0.0.19",
     "@balena/jellyfish-client-sdk": "^1.3.0",
-    "@balena/jellyfish-environment": "^2.0.6",
+    "@balena/jellyfish-environment": "2.0.7-trim-front-token-48255d66138e98ed590fbb971d1ef21a3dd385b1",
     "@balena/jellyfish-logger": "0.0.20",
     "@balena/jellyfish-mail": "0.0.13",
     "@balena/jellyfish-metrics": "0.0.20",

--- a/scripts/ci/tests/discourse-translate.spec.sh
+++ b/scripts/ci/tests/discourse-translate.spec.sh
@@ -10,5 +10,5 @@ set -e
 source "$(dirname $0)/helpers.sh"
 
 # Run Discourse translate tests.
-CHECK_FOR=discourse-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+#CHECK_FOR=discourse-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
 	run_test "Discourse Translate Tests" test FILES=./test/integration/sync/discourse-translate.spec.js

--- a/scripts/ci/tests/front-translate.spec.sh
+++ b/scripts/ci/tests/front-translate.spec.sh
@@ -10,5 +10,6 @@ set -e
 source "$(dirname $0)/helpers.sh"
 
 # Run Front translate tests.
-CHECK_FOR=front-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
-	run_test "Front Translate Tests" test FILES=./test/integration/sync/front-translate.spec.js
+#CHECK_FOR=front-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+run_test "Front Translate Tests" test FILES=./test/integration/sync/front-translate.spec.js \
+	INTEGRATION_FRONT_TOKEN=foobar

--- a/scripts/ci/tests/translate.spec.sh
+++ b/scripts/ci/tests/translate.spec.sh
@@ -10,22 +10,22 @@ set -e
 source "$(dirname $0)/helpers.sh"
 
 # Run Outreach translate tests.
-CHECK_FOR=outreach-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
-	run_test "Outreach Translate Tests" test FILES=./test/integration/sync/outreach-translate.spec.js
+#CHECK_FOR=outreach-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+run_test "Outreach Translate Tests" test FILES=./test/integration/sync/outreach-translate.spec.js
 
 # Run Balena API translate tests.
-CHECK_FOR=balena-api-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
-	run_test "Balena API Translate Tests" test FILES=./test/integration/sync/balena-api-translate.spec.js
+#CHECK_FOR=balena-api-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+run_test "Balena API Translate Tests" test FILES=./test/integration/sync/balena-api-translate.spec.js
 
 # Run GitHub translate tests.
-CHECK_FOR=github-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
-	run_test "GitHub Translate Tests" test FILES=./test/integration/sync/github-translate.spec.js
+#CHECK_FOR=github-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+run_test "GitHub Translate Tests" test FILES=./test/integration/sync/github-translate.spec.js
 
 # Run Flowdock translate tests.
-CHECK_FOR=flowdock-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
-	run_test "Flowdock Translate Tests" test FILES=./test/integration/sync/flowdock-translate.spec.js
+#CHECK_FOR=flowdock-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+run_test "Flowdock Translate Tests" test FILES=./test/integration/sync/flowdock-translate.spec.js
 
 # Run Typeform translate tests.
-CHECK_FOR=typeform-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
-	run_test "Typeform Translate Tests" test FILES=./test/integration/sync/typeform-translate.spec.js
+#CHECK_FOR=typeform-translate.spec.js ./scripts/ci/skip_tests_if_only.sh ui ui-components chat-widget livechat || \
+run_test "Typeform Translate Tests" test FILES=./test/integration/sync/typeform-translate.spec.js
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Get translate tests passing again on balenaCI, they are currently failing with something like:

```
...
sut_1                    | [front-translate.spec.sh]   ✖ (3-1-2-5) sales-inbound-whisper-outbound Rejected promise returned by test
sut_1                    | [translate.spec.sh]   ✖ (2-1) create-sequence-update-owner Rejected promise returned by test
sut_1                    | [discourse-translate.spec.sh]   ✖ (2-3-1) external-inbound-message Rejected promise returned by test
...
```