### PR TITLE
Handle trailing whitespace in integration env vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3957,9 +3957,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.6.tgz",
-      "integrity": "sha512-r9C7FwYsvFvgbwFXe041AiCv/MqwX6/daWY1BGfxoGpHDdqOSTFdaDRoaTNHdU1D1UaOZVS6AM9aHd+cz5apWQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.7.tgz",
+      "integrity": "sha512-3iKxJnb3hImdanxYIPbPE45L8FXwjWPp23zwXMdmPPg194vMizkgisHFvbv5QE3JccUeY8OzHEuTaibLxG1jZg==",
       "requires": {
         "lodash": "^4.17.19"
       }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@babel/polyfill": "^7.10.4",
     "@balena/jellyfish-assert": "0.0.19",
     "@balena/jellyfish-client-sdk": "^1.3.0",
-    "@balena/jellyfish-environment": "^2.0.6",
+    "@balena/jellyfish-environment": "^2.0.7",
     "@balena/jellyfish-logger": "0.0.20",
     "@balena/jellyfish-mail": "0.0.13",
     "@balena/jellyfish-metrics": "0.0.20",


### PR DESCRIPTION
The latest version of the environment module trims whitespace from the
integration env vars.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
