### PR TITLE
lens/actions/CreateLens: Order form response curation form

### DIFF
--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -381,6 +381,13 @@ class CreateLens extends React.Component {
 
 		const head = this.props.channel.data.head
 
+		if (selectedTypeTarget.slug === 'form-response-curation' && head.types.data.fieldOrder) {
+			const order = _.cloneDeep(head.types.data.fieldOrder).concat([ '*' ])
+			_.set(uiSchema, [ 'data' ], {
+				'ui:order': order
+			})
+		}
+
 		let linkTypeTargets = null
 
 		if (linkOption) {


### PR DESCRIPTION
<img width="615" alt="Screenshot 2020-07-26 at 10 01 56 PM" src="https://user-images.githubusercontent.com/7872396/88487377-28332400-cf8d-11ea-87aa-bc81e043da22.png">

With this, when creating a new form-response-curation, the card's [fieldOrder](https://github.com/product-os/jellyfish/blob/496a0415332641bd6919547a18e3e380e48b2556/apps/server/default-cards/contrib/form-response-curation.json#L71-L80) property is taken into account and the fields are rendered in the right order.