### PR TITLE
Deployment Templates: Scaled up API replica count to 16.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish
-  replicas: 12
+  replicas: 16
   template:
     metadata:
       labels:


### PR DESCRIPTION
Scales up the API from 12 to 16 to avoid persistently running at 100%

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
