### PR TITLE
Add uiSchema to type cards

### DIFF
--- a/apps/server/default-cards/contrib/checkin.json
+++ b/apps/server/default-cards/contrib/checkin.json
@@ -120,6 +120,30 @@
         "data"
       ]
     },
+    "uiSchema": {
+      "data": {
+        "unnecessary_attendees": {
+          "items": {
+            "ui:widget": "AutoCompleteWidget",
+            "ui:options": {
+              "resource": "user",
+              "keyPath": "slug"
+            }
+          }
+        },
+        "extra_attendees_needed": {
+          "items": {
+            "user": {
+              "ui:widget": "AutoCompleteWidget",
+              "ui:options": {
+                "resource": "user",
+                "keyPath": "slug"
+              }
+            }
+          }
+        }
+      }
+    },
 		"meta": {
 			"relationships": [
 				{

--- a/apps/server/default-cards/contrib/form-response-curation.json
+++ b/apps/server/default-cards/contrib/form-response-curation.json
@@ -68,16 +68,21 @@
         }
       }
     },
-    "fieldOrder": [
-      "origin",
-      "originDetail",
-      "role",
-      "useCaseSegment",
-      "useCaseDetail",
-      "experienceEvaluation",
-      "issuesWants",
-      "highlights"
-    ]
+    "uiSchema": {
+      "data": {
+        "ui:order": [
+          "origin",
+          "originDetail",
+          "role",
+          "useCaseSegment",
+          "useCaseDetail",
+          "experienceEvaluation",
+          "issuesWants",
+          "highlights",
+          "*"
+        ]
+      }
+    }
   },
   "requires": [],
   "capabilities": []

--- a/apps/server/default-cards/contrib/issue.js
+++ b/apps/server/default-cards/contrib/issue.js
@@ -62,6 +62,17 @@ module.exports = ({
 					'data'
 				]
 			},
+			uiSchema: {
+				data: {
+					repository: {
+						'ui:widget': 'AutoCompleteWidget',
+						'ui:options': {
+							resource: 'issue',
+							keyPath: 'data.repository'
+						}
+					}
+				}
+			},
 			slices: [
 				'properties.data.properties.status'
 			]

--- a/apps/server/default-cards/contrib/workflow.json
+++ b/apps/server/default-cards/contrib/workflow.json
@@ -52,6 +52,24 @@
         }
       }
     },
+    "uiSchema": {
+      "data": {
+        "loop": {
+          "ui:widget": "AutoCompleteWidget",
+          "ui:options": {
+            "resource": "workflow",
+            "keyPath": "data.loop"
+          }
+        },
+        "lifecycle": {
+          "ui:widget": "AutoCompleteWidget",
+          "ui:options": {
+            "resource": "workflow",
+            "keyPath": "data.lifecycle"
+          }
+        }
+      }
+    },
     "slices": [
       "properties.data.properties.status"
     ]

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -39,9 +39,11 @@ import {
 	sdk,
 	selectors
 } from '../../core'
-import AutoCompleteWidget from '../../../../lib/ui-components/AutoCompleteWidget'
 import FreeFieldForm from '../../../../lib/ui-components/FreeFieldForm'
 import Segment from '../common/Segment'
+import {
+	getUiSchema
+} from '../ui-schema'
 
 // 'Draft' links are stored in a map in the component's state,
 // keyed by the combination of the target card type and the link verb.
@@ -306,65 +308,14 @@ class CreateLens extends React.Component {
 			'properties.data.properties.mentionsGroup',
 			'properties.data.properties.alertsGroup'
 		])
-		const uiSchema = _.get(schema, [ 'properties', 'name' ])
-			? {
-				'ui:order': [ 'name', 'tags', '*' ]
-			}
-			: {}
+
+		const uiSchema = getUiSchema(selectedTypeTarget)
 
 		const relationships = _.get(selectedTypeTarget, [ 'data', 'meta', 'relationships' ], [])
 			.filter((relationship) => {
 				// We only support relationships that define a particular link
 				return typeof relationship.type !== 'undefined' && typeof relationship.link !== 'undefined'
 			})
-
-		// TODO: Encode these relationships in the type card, instead of hacking it
-		// into the UI
-		if (selectedTypeTarget.slug === 'issue') {
-			_.set(uiSchema, [ 'data', 'repository' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'issue',
-					keyPath: 'data.repository'
-				}
-			})
-		}
-
-		if (selectedTypeTarget.slug === 'checkin') {
-			_.set(uiSchema, [ 'data', 'unnecessary_attendees', 'items' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'user',
-					keyPath: 'slug'
-				}
-			})
-
-			_.set(uiSchema, [ 'data', 'extra_attendees_needed', 'items', 'user' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'user',
-					keyPath: 'slug'
-				}
-			})
-		}
-
-		if (selectedTypeTarget.slug === 'workflow') {
-			_.set(uiSchema, [ 'data', 'loop' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'workflow',
-					keyPath: 'data.loop'
-				}
-			})
-
-			_.set(uiSchema, [ 'data', 'lifecycle' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'workflow',
-					keyPath: 'data.lifecycle'
-				}
-			})
-		}
 
 		// Always show tags input
 		if (!schema.properties.tags) {
@@ -380,13 +331,6 @@ class CreateLens extends React.Component {
             skhema.isValid(localSchema, helpers.removeUndefinedArrayItems(freeFieldData))
 
 		const head = this.props.channel.data.head
-
-		if (selectedTypeTarget.slug === 'form-response-curation' && head.types.data.fieldOrder) {
-			const order = _.cloneDeep(head.types.data.fieldOrder).concat([ '*' ])
-			_.set(uiSchema, [ 'data' ], {
-				'ui:order': order
-			})
-		}
 
 		let linkTypeTargets = null
 

--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -32,8 +32,10 @@ import {
 	analytics,
 	sdk
 } from '../../core'
-import AutoCompleteWidget from '../../../../lib/ui-components/AutoCompleteWidget'
 import FreeFieldForm from '../../../../lib/ui-components/FreeFieldForm'
+import {
+	getUiSchema
+} from '../ui-schema'
 
 class EditLens extends React.Component {
 	constructor (props) {
@@ -148,6 +150,7 @@ class EditLens extends React.Component {
 		} = this.state
 		const localSchema = helpers.getLocalSchema(editModel)
 		const {
+			types,
 			card
 		} = this.props.channel.data.head
 
@@ -159,59 +162,9 @@ class EditLens extends React.Component {
 			return carry
 		}, {})
 
-		const uiSchema = _.get(this.state.schema, [ 'properties', 'name' ])
-			? {
-				'ui:order': [ 'name', '*' ]
-			}
-			: {}
+		const cardType = helpers.getType(card.type, types)
 
-		// TODO: Encode these relationships in the type card, instead of hacking it
-		// into the UI
-		if (card.type === 'issue') {
-			_.set(uiSchema, [ 'data', 'repository' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'issue',
-					keyPath: 'data.repository'
-				}
-			})
-		}
-
-		if (card.type === 'checkin') {
-			_.set(uiSchema, [ 'data', 'unnecessary_attendees', 'items' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'user',
-					keyPath: 'slug'
-				}
-			})
-
-			_.set(uiSchema, [ 'data', 'extra_attendees_needed', 'items', 'user' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'user',
-					keyPath: 'slug'
-				}
-			})
-		}
-
-		if (card.type === 'workflow') {
-			_.set(uiSchema, [ 'data', 'loop' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'workflow',
-					keyPath: 'data.loop'
-				}
-			})
-
-			_.set(uiSchema, [ 'data', 'lifecycle' ], {
-				'ui:widget': AutoCompleteWidget,
-				'ui:options': {
-					resource: 'workflow',
-					keyPath: 'data.lifecycle'
-				}
-			})
-		}
+		const uiSchema = getUiSchema(cardType)
 
 		const schema = this.state.schema
 

--- a/apps/ui/lens/ui-schema.js
+++ b/apps/ui/lens/ui-schema.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import AutoCompleteWidget from '../../../lib/ui-components/AutoCompleteWidget'
+
+// This object acts as a lookup for widgets by widget component name
+const Widgets = {
+	AutoCompleteWidget
+}
+
+const replaceWidgetsCustomizer = (value, key) => {
+	if (key === 'ui:widget' && Widgets[value]) {
+		return Widgets[value]
+	}
+	// eslint-disable-next-line no-undefined
+	return undefined
+}
+
+export const getUiSchema = (cardType) => {
+	const cardSchema = _.get(cardType, [ 'data', 'schema' ], {})
+	const cardUiSchema = _.get(cardType, [ 'data', 'uiSchema' ], {})
+	const uiSchema = _.cloneDeepWith(cardUiSchema, replaceWidgetsCustomizer)
+
+	if (!uiSchema['ui:order'] && _.get(cardSchema, [ 'properties', 'name' ])) {
+		uiSchema['ui:order'] = [ 'name', 'tags', '*' ]
+	}
+	return uiSchema
+}


### PR DESCRIPTION
server: Add uiSchema to checkin, issue and workflow type cards

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
ui: Use uiSchema from type cards

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR adds a `uiSchema` field to these type cards:
* `issue`
* `workflow`
* `checkin`
* `form-response-curation`

The `CreateLens` and `EditLens` components now use the type card's uiSchema (if it exists) rather than manually creating it with specific rules for specific type cards!

The result? Less hacky code, more flexibility! 💪 

_Note: this PR hints at the direction we are going with defining UI schema in the type card itself. See [this spec](https://github.com/product-os/product-os/blob/jellyfish-ui-schema/specs/jellyfish-ui-schema.md) for more details._

