### PR TITLE
Add a colon to renovate patch commit prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
     "npm"
   ],
   "rangeStrategy": "bump",
-  "commitMessagePrefix": "patch",
+  "commitMessagePrefix": "patch:",
   "prHourlyLimit": 0,
   "labels": [
     "dependencies"


### PR DESCRIPTION
The colon is required for for versionbot compatibility

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>