### PR TITLE
ui: Use lens formats and filters to pick action lenses

### DIFF
--- a/apps/ui/components/CardActions/CardActions.jsx
+++ b/apps/ui/components/CardActions/CardActions.jsx
@@ -62,13 +62,13 @@ export default class CardActions extends React.Component {
 		this.openEditChannel = () => {
 			this.props.actions.addChannel({
 				head: {
-					action: 'edit',
 					types: this.props.types,
 					card: this.props.card,
 					onDone: {
 						action: 'close'
 					}
 				},
+				format: 'edit',
 				canonical: false
 			})
 		}

--- a/apps/ui/components/CardLinker/CardLinker.jsx
+++ b/apps/ui/components/CardLinker/CardLinker.jsx
@@ -58,7 +58,6 @@ class CardLinker extends React.Component {
 	openCreateChannel () {
 		this.props.actions.addChannel({
 			head: {
-				action: 'create',
 				seed: {
 					markers: this.props.card.markers
 				},
@@ -67,6 +66,7 @@ class CardLinker extends React.Component {
 					target: this.props.card
 				}
 			},
+			format: 'create',
 			canonical: false
 		})
 	}
@@ -74,9 +74,9 @@ class CardLinker extends React.Component {
 	openVisualizeChannel () {
 		this.props.actions.addChannel({
 			head: {
-				action: 'visualize-links',
 				card: this.props.card
 			},
+			format: 'visualizeLinks',
 			canonical: false
 		})
 	}

--- a/apps/ui/components/ChannelRenderer.jsx
+++ b/apps/ui/components/ChannelRenderer.jsx
@@ -149,7 +149,7 @@ class ChannelRenderer extends React.Component {
 			)
 		}
 
-		const lens = getLens('full', head, user)
+		const lens = getLens(_.get(channel.data, [ 'format' ], 'full'), head, user)
 
 		return (
 			<ErrorBoundary style={style}>

--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -233,11 +233,11 @@ export default class HomeChannel extends React.Component {
 	openCreateViewChannel () {
 		this.props.actions.addChannel({
 			head: {
-				action: 'create-view',
 				onDone: {
 					action: 'open'
 				}
 			},
+			format: 'createView',
 			canonical: false
 		})
 		this.hideDrawer()

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -466,6 +466,9 @@ export default {
 	data: {
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CreateLens),
 		icon: 'address-card',
-		type: '*'
+		type: '*',
+		filter: {
+			type: 'object'
+		}
 	}
 }

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -365,15 +365,19 @@ class CreateLens extends React.Component {
 			>
 				<Box px={3} pb={3}>
 					{Boolean(linkOption) && (
-						<Flex alignItems="center" pb={3}>
+						<Flex alignItems="center" pb={3} mt={2}>
 							<Txt>Create a new</Txt>
 
 							<Select
 								ml={2}
-								value={linkOption.data.title}
+								value={linkOption}
 								onChange={this.handleLinkOptionSelect}
 								options={linkTypeTargets}
 								labelKey="title"
+								valueKey={{
+									key: 'slug',
+									reduce: false
+								}}
 							/>
 						</Flex>
 					)}
@@ -404,7 +408,7 @@ class CreateLens extends React.Component {
 								title={segment.title}
 							>
 								<Segment
-									card={card.types}
+									card={selectedTypeTarget}
 									segment={segment}
 									types={allTypes}
 									actions={actions}

--- a/apps/ui/lens/actions/CreateUserLens/CreateUserLens.jsx
+++ b/apps/ui/lens/actions/CreateUserLens/CreateUserLens.jsx
@@ -177,6 +177,7 @@ class CreateUserLens extends React.Component {
 					<Flex justifyContent="flex-end" mt={4}>
 						<Button
 							onClick={this.close}
+							mr={2}
 						>
 							Cancel
 						</Button>

--- a/apps/ui/lens/actions/CreateUserLens/index.jsx
+++ b/apps/ui/lens/actions/CreateUserLens/index.jsx
@@ -47,6 +47,22 @@ export default {
 		action: {
 			type: 'string',
 			const: 'create'
+		},
+		filter: {
+			type: 'object',
+			required: [ 'types' ],
+			properties: {
+				types: {
+					type: 'object',
+					required: [ 'slug' ],
+					properties: {
+						slug: {
+							type: 'string',
+							const: 'user'
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/apps/ui/lens/actions/CreateView/CreateView.jsx
+++ b/apps/ui/lens/actions/CreateView/CreateView.jsx
@@ -35,7 +35,7 @@ const UserRow = styled(Box) `
 	}
 `
 
-export default class CreateLens extends React.Component {
+export default class CreateView extends React.Component {
 	constructor (props) {
 		super(props)
 

--- a/apps/ui/lens/actions/CreateView/index.jsx
+++ b/apps/ui/lens/actions/CreateView/index.jsx
@@ -44,6 +44,9 @@ export default {
 	data: {
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CreateView),
 		icon: 'address-card',
-		type: '*'
+		type: '*',
+		filter: {
+			type: 'object'
+		}
 	}
 }

--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -253,6 +253,9 @@ export default {
 	data: {
 		renderer: connect(null, mapDispatchToProps)(EditLens),
 		icon: 'pencil',
-		type: '*'
+		type: '*',
+		filter: {
+			type: 'object'
+		}
 	}
 }

--- a/apps/ui/lens/actions/LinksGraphLens.jsx
+++ b/apps/ui/lens/actions/LinksGraphLens.jsx
@@ -244,6 +244,9 @@ export default {
 	data: {
 		renderer: connect(null, mapDispatchToProps)(CreateLens),
 		icon: 'address-card',
-		type: '*'
+		type: '*',
+		filter: {
+			type: 'object'
+		}
 	}
 }

--- a/apps/ui/lens/common/BaseLens.jsx
+++ b/apps/ui/lens/common/BaseLens.jsx
@@ -17,13 +17,13 @@ export default class BaseLens extends React.Component {
 	openCreateChannel () {
 		this.props.actions.addChannel({
 			head: {
-				action: 'create',
 				types: this.props.type,
 				seed: this.getSeedData(),
 				onDone: {
 					action: 'open'
 				}
 			},
+			format: 'create',
 			canonical: false
 		})
 	}

--- a/apps/ui/lens/common/Segment.jsx
+++ b/apps/ui/lens/common/Segment.jsx
@@ -129,7 +129,6 @@ export default class Segment extends React.Component {
 
 		addChannel({
 			head: {
-				action: 'create',
 				types: _.find(types, {
 					slug: segment.type.split('@')[0]
 				}),
@@ -142,6 +141,7 @@ export default class Segment extends React.Component {
 					callback: this.getData
 				}
 			},
+			format: 'create',
 			canonical: false
 		})
 	}

--- a/apps/ui/lens/full/SupportThread/AuditPanel.jsx
+++ b/apps/ui/lens/full/SupportThread/AuditPanel.jsx
@@ -66,7 +66,6 @@ export default function AuditPanel (props) {
 	const createProductImprovement = () => {
 		props.actions.addChannel({
 			head: {
-				action: 'create',
 				types: _.find(props.types, {
 					slug: 'product-improvement'
 				}),
@@ -77,6 +76,7 @@ export default function AuditPanel (props) {
 					callback: skipStep
 				}
 			},
+			format: 'create',
 			canonical: false
 		})
 	}

--- a/apps/ui/lens/index.js
+++ b/apps/ui/lens/index.js
@@ -30,6 +30,23 @@ const lenses = {
 	list: ListLenses,
 	snippet: SnippetLenses,
 
+	edit: [
+		EditLens
+	],
+
+	create: [
+		CreateLens,
+		CreateUserLens
+	],
+
+	createView: [
+		CreateViewLens
+	],
+
+	visualizeLinks: [
+		LinksGraphLens
+	],
+
 	// TODO: Find a more meaningful way to represent these lenses
 	misc: [
 		Kanban,
@@ -68,21 +85,6 @@ export const getLenses = (format, data, user) => {
 }
 
 export const getLens = (format, data, user) => {
-	if (data.action === 'visualize-links') {
-		return LinksGraphLens
-	}
-	if (data.action === 'create') {
-		if (_.get(data, [ 'types', 'slug' ]) === 'user') {
-			return CreateUserLens
-		}
-		return CreateLens
-	}
-	if (data.action === 'create-view') {
-		return CreateViewLens
-	}
-	if (data.action === 'edit') {
-		return EditLens
-	}
 	return _.first(getLenses(format, data, user))
 }
 


### PR DESCRIPTION
ui: Use lens formats and filters to pick action lenses

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***
ui: Display bug-fixes

Ensure selected card type is displayed in the Select component when creating a new card using the CreateLens component.

Fix linking to existing cards when creating a new card using the CreateLens component. 

Cosmetic padding improvements.

Fixed component name of CreateView component.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

The main focus of this PR is removing the hard-coded routing within the `getLens` function. We now make use of the existing 'format + filter' functionality to determine which action lens to render.

Whilst testing these changes I fixed a few minor issues in related components  (see 2nd commit comment above for details)