### PR TITLE
Update open-balena-base to 9.4.3

### DIFF
--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v9.4.1
+FROM balena/open-balena-base:v9.4.3
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v9.4.1
+FROM balena/open-balena-base:v9.4.3
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.4.1 as base
+FROM balena/open-balena-base:v9.4.3 as base
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v9.4.1
+FROM balena/open-balena-base:v9.4.3
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.4.1 as base
+FROM balena/open-balena-base:v9.4.3 as base
 
 WORKDIR /usr/src/jellyfish
 


### PR DESCRIPTION
Update open-balena-base from 9.4.1 to 9.4.3

Change-type: patch

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
