### PR TITLE
Fix the hideWhispers bug where more content was not always loading

### DIFF
--- a/lib/ui-components/InfiniteList.jsx
+++ b/lib/ui-components/InfiniteList.jsx
@@ -19,7 +19,6 @@ export class InfiniteList extends React.Component {
 	constructor (props, context) {
 		super(props, context)
 
-		this.processing = false
 		this.handleRef = this.handleRef.bind(this)
 		this.handleScroll = this.handleScroll.bind(this)
 		this.queryForMoreIfNecessary = this.queryForMoreIfNecessary.bind(this)
@@ -43,14 +42,15 @@ export class InfiniteList extends React.Component {
 		}
 	}
 
-	async queryForMoreIfNecessary () {
-		if (this.processing) {
-			return
-		}
+	queryForMoreIfNecessary () {
 		const {
 			onScrollBeginning,
-			onScrollEnding
+			onScrollEnding,
+			processing
 		} = this.props
+		if (processing) {
+			return
+		}
 		const {
 			clientHeight,
 			scrollHeight
@@ -58,26 +58,22 @@ export class InfiniteList extends React.Component {
 		const noScrollBar = clientHeight === scrollHeight
 		if (noScrollBar) {
 			if (onScrollBeginning) {
-				this.processing = true
-				await onScrollBeginning()
-				this.processing = false
+				onScrollBeginning()
 			}
 			if (onScrollEnding) {
-				this.processing = true
-				await onScrollEnding()
-				this.processing = false
+				onScrollEnding()
 			}
 		}
 	}
 
-	async handleScroll () {
+	handleScroll () {
 		const {
 			processing,
 			onScrollBeginning,
 			onScrollEnding,
 			triggerOffset
 		} = this.props
-		if (this.processing || processing) {
+		if (processing) {
 			return
 		}
 		const {
@@ -87,9 +83,7 @@ export class InfiniteList extends React.Component {
 		} = this.scrollArea
 
 		if (scrollTop < triggerOffset && onScrollBeginning) {
-			this.processing = true
-			await onScrollBeginning()
-			this.processing = false
+			onScrollBeginning()
 		}
 
 		const scrollOffset = scrollHeight - (scrollTop + offsetHeight)
@@ -99,9 +93,7 @@ export class InfiniteList extends React.Component {
 		}
 
 		if (onScrollEnding) {
-			this.processing = true
-			await onScrollEnding()
-			this.processing = false
+			onScrollEnding()
 		}
 	}
 

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -181,12 +181,12 @@ class Timeline extends React.Component {
 						}
 					}
 				}).then((newEvents) => {
-					const receivedNewEvents = newEvents.length === 0
+					const receivedNewEvents = newEvents.length > 0
 					this.setState({
 						events: _.concat(events, newEvents),
-						eventSkip: receivedNewEvents ? eventSkip : eventSkip + PAGE_SIZE,
+						eventSkip: receivedNewEvents ? eventSkip + PAGE_SIZE : eventSkip,
 						loadingMoreEvents: false,
-						reachedBeginningOfTimeline: receivedNewEvents
+						reachedBeginningOfTimeline: !receivedNewEvents
 					})
 					resolve()
 				}

--- a/lib/ui-components/Timeline/index.jsx
+++ b/lib/ui-components/Timeline/index.jsx
@@ -422,7 +422,8 @@ class Timeline extends React.Component {
 			hideWhispers,
 			loadingMoreEvents,
 			reachedBeginningOfTimeline,
-			ready
+			ready,
+			uploadingFiles
 		} = this.state
 
 		// Due to a bug in syncing, sometimes there can be duplicate cards in events
@@ -470,6 +471,7 @@ class Timeline extends React.Component {
 					<InfiniteList
 						fillMaxArea
 						onScrollBeginning={!reachedBeginningOfTimeline && ready && this.handleScrollBeginning}
+						processing={loadingMoreEvents}
 					>
 						<div ref={this.timelineStart} />
 						{ reachedBeginningOfTimeline && <TimelineStart />}
@@ -480,7 +482,7 @@ class Timeline extends React.Component {
 							getActor={getActor}
 							hideWhispers={hideWhispers}
 							sortedEvents={sortedEvents}
-							uploadingFiles={this.state.uploadingFiles}
+							uploadingFiles={uploadingFiles}
 							messagesOnly={messagesOnly}
 						/>
 						<PendingMessages

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -79,7 +79,8 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 			type: 'product-improvement@1.0.0',
 			name,
 			data: {
-				phase: 'proposed'
+				phase: 'proposed',
+				status: 'open'
 			}
 		})
 	}, productImprovement1Name)


### PR DESCRIPTION
This fixes a bug where sometimes the `handleOnScrollBeginning` query returns its query results to the `InfiniteList` component before it has time to mark that it is no longer processing. When this occurs, the `queryForMoreIfNecessary` returns early and since there are no more updates coming through, we do not attempt it again. This means that sometimes when you click the `hideWhispers` button we don't query for more messages and we are left with a component with no scroll bar and no way to manually trigger the query.

 To fix this, I have ensured that the `processing` value is passed down from the query rather than set in the `InfiniteList`

Also fixed some logic in the `handleOnScrollBeggining` method which was working fine but didn't make sense with the variable name we had