### PR TITLE
HTTP=>HTTPS redirect on AWS/ALB

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -7,27 +7,33 @@ metadata:
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver
   annotations:
-    kubernetes.io/ingress.class: alb
     # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:491725000532:certificate/f9995922-ae03-48eb-8fd1-c6ebe891eaf2
-    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
-    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=63
-    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
-    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=172800,deregistration_delay.timeout_seconds=60
-    alb.ingress.kubernetes.io/healthcheck-port: "8000"
-    alb.ingress.kubernetes.io/healthcheck-path: /health
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "10"
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-port: "8000"
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "8"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 8000}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=63,routing.http2.enabled=true
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=172800,deregistration_delay.timeout_seconds=60
+    alb.ingress.kubernetes.io/target-type: ip
     external-dns.alpha.kubernetes.io/hostname: '{{{JELLYFISH_API_HOST}}}'
     external-dns.alpha.kubernetes.io/ttl: "120"
+    kubernetes.io/ingress.class: alb
 spec:
   rules:
-    - host: '{{{JELLYFISH_API_HOST}}}'
-      http:
-        paths:
-          - path: /*
-            backend:
-              serviceName: jellyfish-api
-              servicePort: 8000
+  - host: '{{{JELLYFISH_API_HOST}}}'
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: ssl-redirect
+          servicePort: use-annotation
+      - path: /*
+        backend:
+          serviceName: jellyfish-api
+          servicePort: 8000


### PR DESCRIPTION
* implements HTTP=>HTTPS redirect at the AWS ALB using ALB actions

Change-type: patch
Signed-off-by: ab77 <anton@balena.io>