### PR TITLE
Adds readinessGate check to JF API

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -16,6 +16,9 @@ spec:
         app: jellyfish
     spec:
       terminationGracePeriodSeconds: 120
+      readinessGates:
+      # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
+      - conditionType: target-health.alb.ingress.k8s.aws/jellyfish-api_jellyfish-api_8000
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-api.data.assets.image.url%>>
         name: jellyfish


### PR DESCRIPTION
* prevents JF from being scaled down if ALB targets aren't ready

Change-type: patch
Signed-off-by: ab77 <anton@balena.io>
