### PR TITLE
Adds ALB ingress(s)

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -9,12 +9,16 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-livechat
-  replicas: 3
+  replicas: 4
   template:
     metadata:
       labels:
         app: jellyfish-livechat
     spec:
+      readinessGates:
+      # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
+      # (TBC) rename to target-health.alb.ingress.k8s.aws/jellyfish-livechat_jellyfish-livechat_80 after DNS change to ALB
+      - conditionType: target-health.alb.ingress.k8s.aws/jellyfish-livechat_jellyfish-livechat-clusterip_80
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-livechat.data.assets.image.url%>>
         name: jellyfish-livechat

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-ingress.tpl.yml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    name: jellyfish-livechat
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  name: jellyfish-livechat
+  # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver
+  annotations:
+    # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:491725000532:certificate/f9995922-ae03-48eb-8fd1-c6ebe891eaf2
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "5"
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-port: "80"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=63,routing.http2.enabled=true
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=60
+    alb.ingress.kubernetes.io/target-type: ip
+    # (TBC) uncomment after DNS change to ALB
+    #external-dns.alpha.kubernetes.io/hostname: '{{{JELLYFISH_LIVECHAT_HOST}}}'
+    #external-dns.alpha.kubernetes.io/ttl: "120"
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+  - host: '{{{JELLYFISH_LIVECHAT_HOST}}}'
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: ssl-redirect
+          servicePort: use-annotation
+      - path: /*
+        backend:
+          serviceName: jellyfish-livechat-clusterip
+          servicePort: 80

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
@@ -1,3 +1,5 @@
+---
+# (TBC) remove jellyfish-livechat service after DNS change to ALB
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +31,19 @@ spec:
       targetPort: 80
       protocol: TCP
       name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    # (TBC) rename to jellyfish-livechat after DNS change to ALB
+    name: jellyfish-livechat-clusterip
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  # (TBC) rename to jellyfish-livechat after DNS change to ALB
+  name: jellyfish-livechat-clusterip
+spec:
+  selector:
+    app: jellyfish-livechat
+  ports:
+  - port: 80
+  sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -9,12 +9,16 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-ui
-  replicas: 3
+  replicas: 4
   template:
     metadata:
       labels:
         app: jellyfish-ui
     spec:
+      readinessGates:
+      # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
+      # (TBC) rename to target-health.alb.ingress.k8s.aws/jellyfish-ui_jellyfish-ui_80 after DNS change to ALB
+      - conditionType: target-health.alb.ingress.k8s.aws/jellyfish-ui_jellyfish-ui-clusterip_80
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-ui.data.assets.image.url%>>
         name: jellyfish-ui

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-ingress.tpl.yml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    name: jellyfish-ui
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  name: jellyfish-ui
+  # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver
+  annotations:
+    # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:491725000532:certificate/f9995922-ae03-48eb-8fd1-c6ebe891eaf2
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "5"
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-port: "80"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=63,routing.http2.enabled=true
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=60
+    alb.ingress.kubernetes.io/target-type: ip
+    # (TBC) uncomment after DNS change to ALB
+    #external-dns.alpha.kubernetes.io/hostname: '{{{JELLYFISH_HOST}}}'
+    #external-dns.alpha.kubernetes.io/ttl: "120"
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+  - host: '{{{JELLYFISH_HOST}}}'
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: ssl-redirect
+          servicePort: use-annotation
+      - path: /*
+        backend:
+          serviceName: jellyfish-ui-clusterip
+          servicePort: 80

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
@@ -1,3 +1,5 @@
+---
+# (TBC) remove jellyfish-ui service after DNS change to ALB
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +31,19 @@ spec:
       targetPort: 80
       protocol: TCP
       name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    # (TBC) rename to jellyfish-ui after DNS change to ALB
+    name: jellyfish-ui-clusterip
+  namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  # (TBC) rename to jellyfish-ui after DNS change to ALB
+  name: jellyfish-ui-clusterip
+spec:
+  selector:
+    app: jellyfish-ui
+  ports:
+  - port: 80
+  sessionAffinity: ClientIP


### PR DESCRIPTION
Adds ability to redirect HTTP=>HTTPS for LC and JF (API already done).

* adds livechat AWS/ALB ingress
* adds ui AWS/ALB ingress
* adds temporary clusterIP services

Change-type: patch
Signed-off-by: ab77 <anton@balena.io>
