### PR TITLE
ui: Add view to show all chat groups

### DIFF
--- a/apps/server/default-cards/balena/view-all-groups.json
+++ b/apps/server/default-cards/balena/view-all-groups.json
@@ -1,0 +1,36 @@
+{
+  "slug": "view-all-groups",
+  "name": "Chat groups",
+  "version": "1.0.0",
+  "type": "view@1.0.0",
+  "markers": [ "org-balena" ],
+  "tags": [],
+  "links": {},
+  "active": true,
+  "data": {
+    "namespace": "Comms",
+    "allOf": [
+      {
+        "name": "All Groups",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "group@1.0.0"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type"
+          ]
+        }
+      }
+    ],
+    "lenses": [
+      "lens-list"
+    ]
+  },
+  "requires": [],
+  "capabilities": []
+}

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -106,6 +106,7 @@ module.exports = {
 	viewAllContacts: require('./balena/view-all-contacts.json'),
 	viewAllCustomers: require('./balena/view-all-customers.json'),
 	viewAllFaqs: require('./balena/view-all-faqs.json'),
+	viewAllGroups: require('./balena/view-all-groups.json'),
 	viewAllIssues: require('./balena/view-all-issues.json'),
 	viewAllJellyfishSupportThreads: require('./balena/view-all-jellyfish-support-threads.json'),
 	viewAllMessages: require('./balena/view-all-messages.json'),


### PR DESCRIPTION
Appears under the namespace 'Comms'

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

From this view you can add new chat groups, edit existing chat groups and add members to groups.

**TBD: Should we restrict access to creating new chat groups or editing chat groups?**

![image](https://user-images.githubusercontent.com/2925657/89141048-9c615f00-d56d-11ea-9ae4-d08bd0a79617.png)
