### PR TITLE
Fixes how we cleanup pending messages on the timeline once the stream returns the message

### DIFF
--- a/lib/ui-components/Timeline/PendingMessages.jsx
+++ b/lib/ui-components/Timeline/PendingMessages.jsx
@@ -17,10 +17,6 @@ const PendingMessages = ({
 	...eventProps
 }) => {
 	return _.map(pendingMessages, (message) => {
-		const noLongerPending = _.find(sortedEvents, [ 'slug', message.slug ])
-		if (noLongerPending) {
-			return null
-		}
 		return (
 			<Box key={message.slug}>
 				<Event

--- a/lib/ui-components/Timeline/tests/helpers.jsx
+++ b/lib/ui-components/Timeline/tests/helpers.jsx
@@ -67,7 +67,8 @@ const createTestContext = (test, sandbox) => {
 	}
 
 	const user = {
-		id: 'fake-user-id'
+		id: 'fake-user-id',
+		slug: 'user-fakeuser'
 	}
 
 	const getActor = sandbox.stub()


### PR DESCRIPTION
In our `Timeline` component at the moment, the code assumes that the stream with return the message before the `create` event completes. Since this is not always the case, sometimes our pending messages are being removed before they are added to the event tail. 

This PR fixes this so that we remove the message from the pendingMessage list only after it has been added to the event tail
