### PR TITLE
core: apply permissions to `$$links` appearing anywhere in a schema

### DIFF
--- a/lib/core/permission-filter.js
+++ b/lib/core/permission-filter.js
@@ -272,6 +272,38 @@ exports.getMask = async (context, backend, session) => {
 		await exports.getSessionUser(context, backend, session))
 }
 
+const mergeMaskInLinks = (schema, mask) => {
+	if (Array.isArray(schema)) {
+		for (const item of schema) {
+			mergeMaskInLinks(item, mask)
+		}
+	}
+
+	if (!_.isPlainObject(schema)) {
+		return
+	}
+
+	if ('$$links' in schema) {
+		const links = schema.$$links
+		for (const [ linkType, linkSchema ] of Object.entries(links)) {
+			mergeMaskInLinks(linkSchema, mask)
+			links[linkType] = jsonSchema.merge([ mask, linkSchema ])
+		}
+	}
+
+	if ('properties' in schema) {
+		for (const propertySchema of Object.values(schema.properties)) {
+			mergeMaskInLinks(propertySchema, mask)
+		}
+	}
+
+	for (const keyWithSubSchema of [ 'allOf', 'anyOf', 'contains', 'items', 'not' ]) {
+		if (keyWithSubSchema in schema) {
+			mergeMaskInLinks(schema[keyWithSubSchema], mask)
+		}
+	}
+}
+
 /**
  * @summary Get a final filtered query
  * @function
@@ -287,13 +319,8 @@ exports.getQuery = async (context, backend, session, schema) => {
 	const user = await exports.getSessionUser(context, backend, session)
 	const mask = await getUserMask(context, backend, user)
 
-	// Apply permission mask to links
-	for (const linkName in schema.$$links) {
-		if (schema.$$links[linkName]) {
-			schema.$$links[linkName] =
-				jsonSchema.merge([ mask, schema.$$links[linkName] ])
-		}
-	}
+	// Apply permission mask to links, recursively
+	mergeMaskInLinks(schema, mask)
 
 	return jsonSchema.merge([
 		mask,


### PR DESCRIPTION
This has no functional changes on `master`, but paves the way for PR #4286.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>
