### PR TITLE
ui: Wrap chat widget with error boundary

### DIFF
--- a/apps/ui/components/ChatWidgetSidebar.jsx
+++ b/apps/ui/components/ChatWidgetSidebar.jsx
@@ -12,6 +12,7 @@ import {
 import {
 	App
 } from '@balena/jellyfish-chat-widget'
+import ErrorBoundary from '@balena/jellyfish-ui-components/lib/shame/ErrorBoundary'
 import {
 	sdk
 } from '../core'
@@ -40,12 +41,14 @@ export const ChatWidgetSidebar = ({
 		<Container
 			width={[ 'calc(100% - 20px)', 'calc(100% - 20px)', '376px' ]}
 		>
-			<App
-				sdk={sdk}
-				productTitle={'Jelly'}
-				product={'jellyfish'}
-				onClose={onClose}
-			/>
+			<ErrorBoundary>
+				<App
+					sdk={sdk}
+					productTitle={'Jelly'}
+					product={'jellyfish'}
+					onClose={onClose}
+				/>
+			</ErrorBoundary>
 		</Container>
 	)
 }


### PR DESCRIPTION
Ensure errors thrown by the chat widget do not bring down the whole of Jellyfish

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

cc @karaxuna 