### PR TITLE
test: Fix flaky e2e server test

### DIFF
--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -455,8 +455,6 @@ ava.serial('should be able to resolve links', async (test) => {
 
 	await test.context.sdk.auth.login(userDetails)
 
-	const user = await test.context.sdk.auth.whoami()
-
 	const id = uuid()
 	const thread = await sdk.card.create({
 		type: 'thread',
@@ -495,7 +493,7 @@ ava.serial('should be able to resolve links', async (test) => {
 						const: 'thread@1.0.0'
 					},
 					data: {
-						additionalProperties: true,
+						additionalProperties: false,
 						required: [ 'uuid' ],
 						properties: {
 							uuid: {
@@ -550,7 +548,6 @@ ava.serial('should be able to resolve links', async (test) => {
 						id: thread.id,
 						type: thread.type,
 						data: {
-							participants: [ user.id ],
 							uuid: id
 						}
 					}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This should ensure [this test](https://github.com/product-os/jellyfish/blob/8ea46bb2f6608a56036daeea7840a64137622ca5/test/e2e/server/index.spec.js#L438) passes. 
