### PR TITLE
Add support for uiSchema 'modes'

### DIFF
--- a/apps/server/default-cards/contrib/checkin.json
+++ b/apps/server/default-cards/contrib/checkin.json
@@ -121,23 +121,33 @@
       ]
     },
     "uiSchema": {
-      "data": {
-        "unnecessary_attendees": {
-          "items": {
-            "ui:widget": "AutoCompleteWidget",
-            "ui:options": {
-              "resource": "user",
-              "keyPath": "slug"
-            }
-          }
-        },
-        "extra_attendees_needed": {
-          "items": {
-            "user": {
-              "ui:widget": "AutoCompleteWidget",
-              "ui:options": {
-                "resource": "user",
-                "keyPath": "slug"
+      "edit": {
+        "$ref": "#/data/uiSchema/definitions/form"
+      },
+      "create": {
+        "$ref": "#/data/uiSchema/edit"
+      },
+      "definitions": {
+        "form": {
+          "data": {
+            "unnecessary_attendees": {
+              "items": {
+                "ui:widget": "AutoCompleteWidget",
+                "ui:options": {
+                  "resource": "user",
+                  "keyPath": "slug"
+                }
+              }
+            },
+            "extra_attendees_needed": {
+              "items": {
+                "user": {
+                  "ui:widget": "AutoCompleteWidget",
+                  "ui:options": {
+                    "resource": "user",
+                    "keyPath": "slug"
+                  }
+                }
               }
             }
           }

--- a/apps/server/default-cards/contrib/form-response-curation.json
+++ b/apps/server/default-cards/contrib/form-response-curation.json
@@ -69,8 +69,18 @@
       }
     },
     "uiSchema": {
-      "data": {
-        "ui:order": [
+      "edit": {
+        "data": {
+          "ui:order": {
+            "$ref": "#/data/uiSchema/definitions/uiOrder"
+          }
+        }
+      },
+      "create": {
+        "$ref": "#/data/uiSchema/edit"
+      },
+      "definitions": {
+        "uiOrder": [
           "origin",
           "originDetail",
           "role",

--- a/apps/server/default-cards/contrib/issue.js
+++ b/apps/server/default-cards/contrib/issue.js
@@ -63,12 +63,22 @@ module.exports = ({
 				]
 			},
 			uiSchema: {
-				data: {
-					repository: {
-						'ui:widget': 'AutoCompleteWidget',
-						'ui:options': {
-							resource: 'issue',
-							keyPath: 'data.repository'
+				edit: {
+					$ref: '#/data/uiSchema/definitions/form'
+				},
+				create: {
+					$ref: '#/data/uiSchema/edit'
+				},
+				definitions: {
+					form: {
+						data: {
+							repository: {
+								'ui:widget': 'AutoCompleteWidget',
+								'ui:options': {
+									resource: 'issue',
+									keyPath: 'data.repository'
+								}
+							}
 						}
 					}
 				}

--- a/apps/server/default-cards/contrib/workflow.json
+++ b/apps/server/default-cards/contrib/workflow.json
@@ -53,19 +53,29 @@
       }
     },
     "uiSchema": {
-      "data": {
-        "loop": {
-          "ui:widget": "AutoCompleteWidget",
-          "ui:options": {
-            "resource": "workflow",
-            "keyPath": "data.loop"
-          }
-        },
-        "lifecycle": {
-          "ui:widget": "AutoCompleteWidget",
-          "ui:options": {
-            "resource": "workflow",
-            "keyPath": "data.lifecycle"
+      "edit": {
+        "$ref": "#/data/uiSchema/definitions/form"
+      },
+      "create": {
+        "$ref": "#/data/uiSchema/edit"
+      },
+      "definitions": {
+        "form": {
+          "data": {
+            "loop": {
+              "ui:widget": "AutoCompleteWidget",
+              "ui:options": {
+                "resource": "workflow",
+                "keyPath": "data.loop"
+              }
+            },
+            "lifecycle": {
+              "ui:widget": "AutoCompleteWidget",
+              "ui:options": {
+                "resource": "workflow",
+                "keyPath": "data.lifecycle"
+              }
+            }
           }
         }
       }

--- a/apps/ui/lens/actions/CreateLens.jsx
+++ b/apps/ui/lens/actions/CreateLens.jsx
@@ -40,8 +40,8 @@ import {
 import FreeFieldForm from '@balena/jellyfish-ui-components/lib/FreeFieldForm'
 import Segment from '../common/Segment'
 import {
-	getUiSchema
-} from '../ui-schema'
+	getUiSchema, UI_SCHEMA_MODE
+} from '../schema-util'
 
 // 'Draft' links are stored in a map in the component's state,
 // keyed by the combination of the target card type and the link verb.
@@ -307,7 +307,7 @@ class CreateLens extends React.Component {
 			'properties.data.properties.alertsGroup'
 		])
 
-		const uiSchema = getUiSchema(selectedTypeTarget)
+		const uiSchema = getUiSchema(selectedTypeTarget, UI_SCHEMA_MODE.create)
 
 		const relationships = _.get(selectedTypeTarget, [ 'data', 'meta', 'relationships' ], [])
 			.filter((relationship) => {

--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -32,8 +32,8 @@ import {
 } from '../../core'
 import FreeFieldForm from '@balena/jellyfish-ui-components/lib/FreeFieldForm'
 import {
-	getUiSchema
-} from '../ui-schema'
+	getUiSchema, UI_SCHEMA_MODE
+} from '../schema-util'
 
 class EditLens extends React.Component {
 	constructor (props) {
@@ -162,7 +162,7 @@ class EditLens extends React.Component {
 
 		const cardType = helpers.getType(card.type, types)
 
-		const uiSchema = getUiSchema(cardType)
+		const uiSchema = getUiSchema(cardType, UI_SCHEMA_MODE.edit)
 
 		const schema = this.state.schema
 

--- a/apps/ui/lens/schema-util.js
+++ b/apps/ui/lens/schema-util.js
@@ -7,6 +7,13 @@
 import _ from 'lodash'
 import AutoCompleteWidget from '@balena/jellyfish-ui-components/lib/AutoCompleteWidget'
 
+export const UI_SCHEMA_MODE = {
+	edit: 'edit',
+	create: 'create',
+	full: 'full',
+	fields: 'fields'
+}
+
 // This object acts as a lookup for widgets by widget component name
 const Widgets = {
 	AutoCompleteWidget
@@ -20,9 +27,9 @@ const replaceWidgetsCustomizer = (value, key) => {
 	return undefined
 }
 
-export const getUiSchema = (cardType) => {
+export const getUiSchema = (cardType, mode = UI_SCHEMA_MODE.full) => {
 	const cardSchema = _.get(cardType, [ 'data', 'schema' ], {})
-	const cardUiSchema = _.get(cardType, [ 'data', 'uiSchema' ], {})
+	const cardUiSchema = _.get(cardType, [ 'data', 'uiSchema', mode ], {})
 	const uiSchema = _.cloneDeepWith(cardUiSchema, replaceWidgetsCustomizer)
 
 	if (!uiSchema['ui:order'] && _.get(cardSchema, [ 'properties', 'name' ])) {


### PR DESCRIPTION
Refactor type cards that already use uiSchema so different UI schemas can be defined for specific modes of use.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR is just a refactor of the `uiSchema` field in type cards. UI Schemas are now organised under 'mode' identifiers. The following modes will be supported (although only `create` and `edit` are currently used):
* create
* edit
* full
* fields
* snippet

Note we use `$ref` to keep our UI Schema definitions as DRY as possible when defining schemas (e.g. when used by both the `create` and `edit` modes).
