### PR TITLE
ci: Enable fail-fast for CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,10 +240,7 @@ else
 ESLINT_OPTION_FIX = --fix
 endif
 
-AVA_ARGS = $(AVA_OPTS)
-ifndef CI
-AVA_ARGS += --fail-fast
-endif
+AVA_ARGS = $(AVA_OPTS) --fail-fast
 ifdef MATCH
 AVA_ARGS += --match $(MATCH)
 endif


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Enable ava's `--fail-fast` for all testing environments, instead of specifically turning it off for CI only.
