### PR TITLE
Consolidate logic for loading all cards

### DIFF
--- a/apps/server/bootstrap.js
+++ b/apps/server/bootstrap.js
@@ -18,8 +18,11 @@ const cardLoader = require('./card-loader')
 const http = require('./http')
 const socket = require('./socket')
 const graphql = require('./graphql')
+const loadDefaultCards = require('./default-cards')
 
 module.exports = async (context, options) => {
+	context.defaultCards = loadDefaultCards(core.cardMixins)
+
 	logger.info(context, 'Configuring HTTP server')
 	const webServer = await http(context, {
 		port: environment.http.port,

--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -6,20 +6,15 @@
 
 const _ = require('lodash')
 const Bluebird = require('bluebird')
-const $RefParser = require('json-schema-ref-parser')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const environment = require('@balena/jellyfish-environment')
 const defaultCards = require('./default-cards')
-
-const loadCard = async (card) => {
-	return $RefParser.dereference(card)
-}
 
 module.exports = async (context, jellyfish, worker, session) => {
 	logger.info(context, 'Setting up guest user')
 
 	const guestUser = await jellyfish.replaceCard(
-		context, session, await loadCard(defaultCards.userGuest))
+		context, session, defaultCards.userGuest)
 
 	const guestUserSession = await jellyfish.replaceCard(
 		context, session, jellyfish.defaults({
@@ -46,7 +41,6 @@ module.exports = async (context, jellyfish, worker, session) => {
 				return !cardsToSkip.includes(card.slug)
 			}
 		)
-		.map(loadCard)
 
 	await Bluebird.each(cardLoaders, async (card) => {
 		if (!card) {

--- a/apps/server/card-loader.js
+++ b/apps/server/card-loader.js
@@ -8,13 +8,12 @@ const _ = require('lodash')
 const Bluebird = require('bluebird')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const environment = require('@balena/jellyfish-environment')
-const defaultCards = require('./default-cards')
 
 module.exports = async (context, jellyfish, worker, session) => {
 	logger.info(context, 'Setting up guest user')
 
 	const guestUser = await jellyfish.replaceCard(
-		context, session, defaultCards.userGuest)
+		context, session, context.defaultCards.userGuest)
 
 	const guestUserSession = await jellyfish.replaceCard(
 		context, session, jellyfish.defaults({
@@ -35,7 +34,7 @@ module.exports = async (context, jellyfish, worker, session) => {
 	}
 
 	const cardLoaders = _
-		.values(defaultCards)
+		.values(context.defaultCards)
 		.filter(
 			(card) => {
 				return !cardsToSkip.includes(card.slug)

--- a/apps/server/default-cards/balena/org-balena.json
+++ b/apps/server/default-cards/balena/org-balena.json
@@ -1,13 +1,6 @@
 {
   "slug": "org-balena",
   "type": "org@1.0.0",
-  "version": "1.0.0",
   "name": "Balena",
-  "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
-  "data": {},
-  "requires": [],
-  "capabilities": []
+  "data": {}
 }

--- a/apps/server/default-cards/balena/os-test-result.js
+++ b/apps/server/default-cards/balena/os-test-result.js
@@ -10,12 +10,8 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'os-test-result',
 		name: 'OS test result',
-		version: '1.0.0',
 		type: 'type@1.0.0',
 		markers: [ 'org-balena' ],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -64,8 +60,6 @@ module.exports = ({
 			slices: [
 				'properties.data.properties.status'
 			]
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/balena/product-balena-cloud.json
+++ b/apps/server/default-cards/balena/product-balena-cloud.json
@@ -1,15 +1,8 @@
 {
   "slug": "product-balena-cloud",
   "type": "product@1.0.0",
-  "version": "1.0.0",
   "name": "Balena Product",
-  "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
       "url": "https://github.com/balena-io/balena/"
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/product-jellyfish.json
+++ b/apps/server/default-cards/balena/product-jellyfish.json
@@ -1,15 +1,8 @@
 {
   "slug": "product-jellyfish",
   "type": "product@1.0.0",
-  "version": "1.0.0",
   "name": "Jellyfish Product",
-  "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "url": "https://github.com/product-os/jellyfish"
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-agendas.json
+++ b/apps/server/default-cards/balena/view-all-agendas.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-agendas",
   "name": "Agendas",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Brainstorms",
     "allOf": [
@@ -35,7 +31,5 @@
     "lenses": [
       "lens-list"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-blog-posts.json
+++ b/apps/server/default-cards/balena/view-all-blog-posts.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-blog-posts",
   "name": "Blog posts",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -30,7 +26,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-checkins.json
+++ b/apps/server/default-cards/balena/view-all-checkins.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-checkins",
   "name": "Checkins",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Projects",
     "allOf": [
@@ -31,7 +27,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-contacts.json
+++ b/apps/server/default-cards/balena/view-all-contacts.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-contacts",
   "name": "All contacts",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Sales",
     "allOf": [
@@ -36,7 +32,5 @@
       "lens-table",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-customers.json
+++ b/apps/server/default-cards/balena/view-all-customers.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-customers",
   "name": "All accounts",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Sales",
     "allOf": [
@@ -37,7 +33,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-faqs.json
+++ b/apps/server/default-cards/balena/view-all-faqs.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-faqs",
   "name": "FAQs",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -29,7 +25,5 @@
     "lenses": [
       "lens-list"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-groups.json
+++ b/apps/server/default-cards/balena/view-all-groups.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-groups",
   "name": "Chat groups",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Comms",
     "allOf": [
@@ -30,7 +26,5 @@
     "lenses": [
       "lens-list"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-issues.json
+++ b/apps/server/default-cards/balena/view-all-issues.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-issues",
   "name": "All GitHub issues",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -51,7 +47,5 @@
       "lens-table",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-jellyfish-support-threads.json
+++ b/apps/server/default-cards/balena/view-all-jellyfish-support-threads.json
@@ -1,13 +1,9 @@
 {
     "slug": "view-all-jellyfish-support-threads",
     "name": "Jellyfish threads",
-    "version": "1.0.0",
-    "type": "view@1.0.0",
+      "type": "view@1.0.0",
     "markers": [ "org-balena" ],
-    "tags": [],
-    "links": {},
-    "active": true,
-    "data": {
+          "data": {
       "namespace": "Support",
       "allOf": [
         {

--- a/apps/server/default-cards/balena/view-all-messages.json
+++ b/apps/server/default-cards/balena/view-all-messages.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-messages",
   "name": "All messages",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -36,7 +32,5 @@
     "lenses": [
       "lens-interleaved"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-opportunities.json
+++ b/apps/server/default-cards/balena/view-all-opportunities.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-opportunities",
   "name": "All opportunities",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Sales",
     "allOf": [
@@ -48,7 +44,5 @@
       "lens-crm-table",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-patterns.json
+++ b/apps/server/default-cards/balena/view-all-patterns.json
@@ -1,14 +1,10 @@
 {
   "slug": "view-all-patterns",
   "name": "Patterns",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [
     "org-balena"
   ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -31,7 +27,5 @@
     "lenses": [
       "lens-list"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-product-improvements.json
+++ b/apps/server/default-cards/balena/view-all-product-improvements.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-product-improvements",
   "name": "Product improvements",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -35,7 +31,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-products.json
+++ b/apps/server/default-cards/balena/view-all-products.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-products",
   "name": "Products",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -30,7 +26,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-projects.json
+++ b/apps/server/default-cards/balena/view-all-projects.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-projects",
   "name": "All projects",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Projects",
     "allOf": [
@@ -31,7 +27,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-sales-threads.json
+++ b/apps/server/default-cards/balena/view-all-sales-threads.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-sales-threads",
   "name": "All sales threads",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Sales",
     "allOf": [
@@ -51,7 +47,5 @@
     "lenses": [
       "lens-support-threads"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-specifications.json
+++ b/apps/server/default-cards/balena/view-all-specifications.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-specifications",
   "name": "Specifications",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -50,7 +46,5 @@
     "lenses": [
       "lens-list"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-support-issues.json
+++ b/apps/server/default-cards/balena/view-all-support-issues.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-support-issues",
   "name": "Support knowledge base",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -31,7 +27,5 @@
       "lens-list",
       "lens-support-issue-table"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-support-threads.json
+++ b/apps/server/default-cards/balena/view-all-support-threads.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-support-threads",
   "name": "General",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -64,7 +60,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-all-users.json
+++ b/apps/server/default-cards/balena/view-all-users.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-users",
   "name": "Users",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -30,7 +26,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-architecture-call-topics.json
+++ b/apps/server/default-cards/balena/view-architecture-call-topics.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-architecture-call-topics",
   "name": "Architecture call topics",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Brainstorms",
     "allOf": [
@@ -44,7 +40,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-balena-chat.json
+++ b/apps/server/default-cards/balena/view-balena-chat.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-balena-chat",
   "name": "Balena chat",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Comms",
     "allOf": [
@@ -43,7 +39,5 @@
     "lenses": [
       "lens-interleaved"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-changelogs.json
+++ b/apps/server/default-cards/balena/view-changelogs.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-changelogs",
   "name": "Changelogs",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -57,7 +53,5 @@
       "lens-table",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-curate-typeform-responses.json
+++ b/apps/server/default-cards/balena/view-curate-typeform-responses.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-curate-typeform-responses",
   "name": "Curate Users' Feedback",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "User Feedback",
     "allOf": [
@@ -30,7 +26,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-customer-success-support-threads.json
+++ b/apps/server/default-cards/balena/view-customer-success-support-threads.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-customer-success-support-threads",
   "name": "Customer success",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -61,7 +57,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-devices-support-threads.json
+++ b/apps/server/default-cards/balena/view-devices-support-threads.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-devices-support-threads",
   "name": "Devices",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -61,7 +57,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-fleetops-support-threads.json
+++ b/apps/server/default-cards/balena/view-fleetops-support-threads.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-fleetops-support-threads",
   "name": "FleetOps",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -62,7 +58,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-os-test-results.json
+++ b/apps/server/default-cards/balena/view-os-test-results.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-os-test-results",
   "name": "OS test results",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -56,7 +52,5 @@
       "lens-table",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-product-specs.json
+++ b/apps/server/default-cards/balena/view-product-specs.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-product-specs",
   "name": "Product specs",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -72,7 +68,5 @@
       "lens-table",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-security-support-threads.json
+++ b/apps/server/default-cards/balena/view-security-support-threads.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-security-support-threads",
   "name": "Security",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -62,7 +58,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-support-knowledge-base.json
+++ b/apps/server/default-cards/balena/view-support-knowledge-base.json
@@ -1,11 +1,8 @@
 {
   "slug": "view-support-knowledge-base",
   "name": "Support knowledge base",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
   "active": false,
   "data": {
     "namespace": "Support",
@@ -31,7 +28,5 @@
       "lens-list",
       "lens-support-issue-table"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-support-threads-participation.json
+++ b/apps/server/default-cards/balena/view-support-threads-participation.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-support-threads-participation",
   "name": "My participation",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -73,7 +69,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-support-threads-pending-update.json
+++ b/apps/server/default-cards/balena/view-support-threads-pending-update.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-support-threads-to-audit",
   "name": "Users Pending Update",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -72,7 +68,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-support-threads-to-audit.json
+++ b/apps/server/default-cards/balena/view-support-threads-to-audit.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-support-threads-to-audit",
   "name": "To audit",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Support",
     "allOf": [
@@ -66,7 +62,5 @@
       "lens-kanban",
       "lens-support-audit-chart"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-typeform-responses.json
+++ b/apps/server/default-cards/balena/view-typeform-responses.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-typeform-responses",
   "name": "All Users' Feedback",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "User Feedback",
     "allOf": [
@@ -30,7 +26,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/balena/view-workflows.json
+++ b/apps/server/default-cards/balena/view-workflows.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-workflows",
   "name": "Workflows",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -30,7 +26,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/account.json
+++ b/apps/server/default-cards/contrib/account.json
@@ -2,11 +2,7 @@
   "slug": "account",
   "type": "type@1.0.0",
   "name": "Account",
-  "version": "1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -110,7 +106,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/agenda.json
+++ b/apps/server/default-cards/contrib/agenda.json
@@ -1,12 +1,8 @@
 {
   "slug": "agenda",
   "name": "Agenda",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -45,7 +41,5 @@
 				}
 			]
 		}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/blog-post.json
+++ b/apps/server/default-cards/contrib/blog-post.json
@@ -1,12 +1,8 @@
 {
   "slug": "blog-post",
   "name": "Blog post",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -257,7 +253,5 @@
       "content",
       "post_promo"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/changelog.json
+++ b/apps/server/default-cards/contrib/changelog.json
@@ -1,12 +1,8 @@
 {
   "slug": "changelog",
   "name": "Changelog",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -46,7 +42,5 @@
         "data"
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/checkin.json
+++ b/apps/server/default-cards/contrib/checkin.json
@@ -1,12 +1,8 @@
 {
   "slug": "checkin",
   "name": "Checkin",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -168,7 +164,5 @@
 				}
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/contact.json
+++ b/apps/server/default-cards/contrib/contact.json
@@ -2,11 +2,7 @@
   "slug": "contact",
   "type": "type@1.0.0",
   "name": "Contact",
-  "version": "1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -150,7 +146,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/discussion-topic.json
+++ b/apps/server/default-cards/contrib/discussion-topic.json
@@ -1,12 +1,8 @@
 {
   "slug": "discussion-topic",
   "name": "Discussion topic",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -75,7 +71,5 @@
 				}
 			]
 		}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/email-sequence.json
+++ b/apps/server/default-cards/contrib/email-sequence.json
@@ -1,12 +1,8 @@
 {
   "slug": "email-sequence",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Email Sequence",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -17,7 +13,5 @@
         }
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/external-event.json
+++ b/apps/server/default-cards/contrib/external-event.json
@@ -1,12 +1,8 @@
 {
   "slug": "external-event",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "External event",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -41,7 +37,5 @@
         "data"
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/faq.json
+++ b/apps/server/default-cards/contrib/faq.json
@@ -2,11 +2,7 @@
   "slug": "faq",
   "name": "F.A.Q",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -35,7 +31,5 @@
         "data"
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/feedback-item.json
+++ b/apps/server/default-cards/contrib/feedback-item.json
@@ -1,12 +1,8 @@
 {
   "slug": "feedback-item",
   "name": "Feedback item",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -82,7 +78,5 @@
         "data"
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/first-time-login.json
+++ b/apps/server/default-cards/contrib/first-time-login.json
@@ -1,12 +1,8 @@
 {
   "slug": "first-time-login",
   "name": "first-time login",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -30,7 +26,5 @@
         }
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/form-response-curation.json
+++ b/apps/server/default-cards/contrib/form-response-curation.json
@@ -2,11 +2,7 @@
   "slug": "form-response-curation",
   "name": "Form response curation",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -93,7 +89,5 @@
         ]
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/form-response.json
+++ b/apps/server/default-cards/contrib/form-response.json
@@ -2,11 +2,7 @@
   "slug": "form-response",
   "name": "form-response",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -90,7 +86,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/group.json
+++ b/apps/server/default-cards/contrib/group.json
@@ -1,12 +1,8 @@
 {
   "slug": "group",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Group",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -43,7 +39,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/issue.js
+++ b/apps/server/default-cards/contrib/issue.js
@@ -10,12 +10,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'issue',
 		name: 'GitHub Issue',
-		version: '1.0.0',
 		type: 'type@1.0.0',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -86,8 +81,6 @@ module.exports = ({
 			slices: [
 				'properties.data.properties.status'
 			]
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/message.json
+++ b/apps/server/default-cards/contrib/message.json
@@ -1,12 +1,8 @@
 {
   "slug": "message",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Chat message",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -132,7 +128,5 @@
       [ "data.payload.mentionsGroup" ],
       [ "data.payload.alertsGroup" ]
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/milestone.json
+++ b/apps/server/default-cards/contrib/milestone.json
@@ -2,11 +2,7 @@
   "slug": "milestone",
   "name": "Milestone",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -27,7 +23,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/opportunity.json
+++ b/apps/server/default-cards/contrib/opportunity.json
@@ -1,12 +1,8 @@
 {
   "slug": "opportunity",
   "name": "Opportunity",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -102,7 +98,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/password-reset.json
+++ b/apps/server/default-cards/contrib/password-reset.json
@@ -1,12 +1,8 @@
 {
   "slug": "password-reset",
   "name": "Password Reset",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -30,7 +26,5 @@
         }
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/pattern.js
+++ b/apps/server/default-cards/contrib/pattern.js
@@ -10,12 +10,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'pattern',
 		name: 'Pattern',
-		version: '1.0.0',
 		type: 'type@1.0.0',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -48,8 +43,6 @@ module.exports = ({
 					}
 				]
 			}
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/ping.json
+++ b/apps/server/default-cards/contrib/ping.json
@@ -1,14 +1,8 @@
 {
   "slug": "ping",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "The ping card",
   "markers": [],
-  "requires": [],
-  "capabilities": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",

--- a/apps/server/default-cards/contrib/pipeline.json
+++ b/apps/server/default-cards/contrib/pipeline.json
@@ -1,12 +1,8 @@
 {
   "slug": "pipeline",
   "name": "Pipeline",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -57,7 +53,5 @@
 				}
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/product-improvement.js
+++ b/apps/server/default-cards/contrib/product-improvement.js
@@ -13,12 +13,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'product-improvement',
 		name: 'Product improvement',
-		version: '1.0.0',
 		type: 'type@1.0.0',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -125,8 +120,6 @@ module.exports = ({
 					}
 				]
 			}
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/product.json
+++ b/apps/server/default-cards/contrib/product.json
@@ -1,14 +1,8 @@
 {
   "slug": "product",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Product",
   "markers": [],
-  "requires": [],
-  "capabilities": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",

--- a/apps/server/default-cards/contrib/project.json
+++ b/apps/server/default-cards/contrib/project.json
@@ -1,12 +1,8 @@
 {
   "slug": "project",
   "name": "Project",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -67,7 +63,5 @@
 				}
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/pull-request.js
+++ b/apps/server/default-cards/contrib/pull-request.js
@@ -10,12 +10,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'pull-request',
 		name: 'Pull Request',
-		version: '1.0.0',
 		type: 'type@1.0.0',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -90,8 +85,6 @@ module.exports = ({
 					'data'
 				]
 			}
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/push.json
+++ b/apps/server/default-cards/contrib/push.json
@@ -1,12 +1,8 @@
 {
   "slug": "gh-push",
   "name": "Push",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -46,7 +42,5 @@
         "data"
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/repository.json
+++ b/apps/server/default-cards/contrib/repository.json
@@ -1,12 +1,8 @@
 {
   "slug": "repository",
   "name": "Github Repository",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -36,7 +32,5 @@
     "indexed_fields": [
       [ "data.name" ]
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/role-user-community.json
+++ b/apps/server/default-cards/contrib/role-user-community.json
@@ -1,14 +1,8 @@
 {
   "slug": "role-user-community",
   "name": "Community role permissions",
-  "version": "1.0.0",
   "type": "role@1.0.0",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "requires": [],
-  "capabilities": [],
-  "active": true,
   "data": {
     "read": {
       "type": "object",

--- a/apps/server/default-cards/contrib/role-user-external-support.json
+++ b/apps/server/default-cards/contrib/role-user-external-support.json
@@ -1,14 +1,8 @@
 {
   "slug": "role-user-external-support",
   "name": "External support user role permissions",
-  "version": "1.0.0",
   "type": "role@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "requires": [],
-  "capabilities": [],
-  "active": true,
   "data": {
     "read": {
       "type": "object",

--- a/apps/server/default-cards/contrib/role-user-guest.json
+++ b/apps/server/default-cards/contrib/role-user-guest.json
@@ -1,14 +1,8 @@
 {
   "slug": "role-user-guest",
   "name": "Guest role permissions",
-  "version": "1.0.0",
   "type": "role@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "requires": [],
-  "capabilities": [],
-  "active": true,
   "data": {
     "read": {
       "type": "object",

--- a/apps/server/default-cards/contrib/role-user-operator.json
+++ b/apps/server/default-cards/contrib/role-user-operator.json
@@ -1,14 +1,8 @@
 {
   "slug": "role-user-operator",
   "name": "Operator role permissions",
-  "version": "1.0.0",
   "type": "role@1.0.0",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "requires": [],
-  "capabilities": [],
-  "active": true,
   "data": {
     "read": {
 			"type": "object",
@@ -39,7 +33,7 @@
 					"properties": {
 						"slug": {
 							"type": "string",
-							"enum": [ 
+							"enum": [
 								"first-time-login",
 								"action-create-user"
 							]

--- a/apps/server/default-cards/contrib/role-user-test.json
+++ b/apps/server/default-cards/contrib/role-user-test.json
@@ -1,17 +1,11 @@
 {
   "slug": "role-user-test",
   "name": "Test role permissions",
-  "version": "1.0.0",
   "type": "role@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "read": {
       "type": "object"
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/sales-thread.json
+++ b/apps/server/default-cards/contrib/sales-thread.json
@@ -1,12 +1,8 @@
 {
   "slug": "sales-thread",
   "name": "Sales Thread",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -77,7 +73,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/specification.json
+++ b/apps/server/default-cards/contrib/specification.json
@@ -1,12 +1,8 @@
 {
   "slug": "specification",
   "name": "Specification",
-  "version": "1.0.0",
   "type": "type@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -57,7 +53,5 @@
 				}
 			]
 		}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/summary.json
+++ b/apps/server/default-cards/contrib/summary.json
@@ -1,12 +1,8 @@
 {
   "slug": "summary",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Summary",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -89,7 +85,5 @@
       [ "data.payload.mentionsGroup" ],
       [ "data.payload.alertsGroup" ]
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/support-issue.js
+++ b/apps/server/default-cards/contrib/support-issue.js
@@ -10,12 +10,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'support-issue',
 		type: 'type@1.0.0',
-		version: '1.0.0',
 		name: 'Support Issue',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -95,8 +90,6 @@ module.exports = ({
 				'problem',
 				'solution'
 			]
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/support-thread.js
+++ b/apps/server/default-cards/contrib/support-thread.js
@@ -10,12 +10,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'support-thread',
 		name: 'Support Thread',
-		version: '1.0.0',
 		type: 'type@1.0.0',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -96,8 +91,6 @@ module.exports = ({
 			indexed_fields: [
 				[ 'data.status', 'data.category', 'data.product' ]
 			]
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/tag.json
+++ b/apps/server/default-cards/contrib/tag.json
@@ -1,12 +1,8 @@
 {
   "slug": "tag",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Tag",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -30,7 +26,5 @@
         }
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/thread.js
+++ b/apps/server/default-cards/contrib/thread.js
@@ -10,12 +10,7 @@ module.exports = ({
 	return mixin(withEvents)({
 		slug: 'thread',
 		type: 'type@1.0.0',
-		version: '1.0.0',
 		name: 'Chat thread',
-		markers: [],
-		tags: [],
-		links: {},
-		active: true,
 		data: {
 			schema: {
 				type: 'object',
@@ -31,8 +26,6 @@ module.exports = ({
 					}
 				}
 			}
-		},
-		requires: [],
-		capabilities: []
+		}
 	})
 }

--- a/apps/server/default-cards/contrib/triggered-action-github-issue-link.json
+++ b/apps/server/default-cards/contrib/triggered-action-github-issue-link.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-github-issue-link",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for broadcasting links from a support thread to GitHub issue or pull request",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": true,
     "filter": {
@@ -60,7 +56,5 @@
     "arguments": {
       "message": "This ${source.data.inverseName} https://jel.ly.fish/${source.data.from.id}"
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-hangouts-link.json
+++ b/apps/server/default-cards/contrib/triggered-action-hangouts-link.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-hangouts-link",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for creating messages with Hangouts link",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": true,
     "filter": {
@@ -57,7 +53,5 @@
         }
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-increment-tag.json
+++ b/apps/server/default-cards/contrib/triggered-action-increment-tag.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-increment-tag",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for incrementing count value of a tag",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": true,
     "filter": {
@@ -53,7 +49,5 @@
         "$eval": "matchRE('(\\s|^)(#[a-zA-Z\\d-_\\/]+)', 'gm', source.data.payload.message)"
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-integration-discourse-mirror-event",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for Discourse mirrors",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -43,7 +39,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-integration-front-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-front-mirror-event.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-integration-front-mirror-event",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for Front mirrors",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -54,7 +50,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-integration-github-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-github-mirror-event.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-integration-github-mirror-event",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for GitHub mirrors",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -33,7 +29,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-integration-import-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-import-event.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-integration-import-event",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for external service import events",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": true,
     "filter": {
@@ -47,7 +43,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
+++ b/apps/server/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-integration-outreach-mirror-event",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for Outreach mirrors",
-  "tags": [],
   "markers": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -24,7 +20,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-set-user-avatar.json
+++ b/apps/server/default-cards/contrib/triggered-action-set-user-avatar.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-set-user-avatar",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for user avatars",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -24,7 +20,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-support-closed-issue-reopen",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for reopening support threads when issues are closed",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -119,7 +115,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-reopen.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-support-reopen",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for reopening support threads because of activity",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -67,7 +63,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-summary.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-support-summary",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for support summaries",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -84,7 +80,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
+++ b/apps/server/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-sync-thread-post-link-whisper",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for creating a whisper with link on thread sync",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "filter": {
       "title": "Support threads created with a 'mirrors' field",
@@ -70,7 +66,5 @@
       },
       "type": "whisper"
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-update-event-edited-at.json
+++ b/apps/server/default-cards/contrib/triggered-action-update-event-edited-at.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-update-event-edited-at",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for updating the event's edited_at field when the payload is updated",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -78,7 +74,5 @@
         }
       ]
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/triggered-action-user-contact.json
+++ b/apps/server/default-cards/contrib/triggered-action-user-contact.json
@@ -1,12 +1,8 @@
 {
   "slug": "triggered-action-user-contact",
   "type": "triggered-action@1.0.0",
-  "version": "1.0.0",
   "name": "Triggered action for maintaining user contact information",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "async": false,
     "filter": {
@@ -24,7 +20,5 @@
       "$eval": "source.id"
     },
     "arguments": {}
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/user-guest.json
+++ b/apps/server/default-cards/contrib/user-guest.json
@@ -1,17 +1,11 @@
 {
   "slug": "user-guest",
   "type": "user@1.0.0",
-  "version": "1.0.0",
   "name": "The guest user",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "email": "accounts+jellyfish@resin.io",
     "hash": "PASSWORDLESS",
     "roles": []
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-active-triggered-actions.json
+++ b/apps/server/default-cards/contrib/view-active-triggered-actions.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-active-triggered-actions",
   "name": "Active Triggered Actions",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -35,7 +31,5 @@
         }
       }
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-active.json
+++ b/apps/server/default-cards/contrib/view-active.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-active",
   "name": "Active cards",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -35,7 +31,5 @@
       "lens-default-list",
       "lens-default-card"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-all-by-type.json
+++ b/apps/server/default-cards/contrib/view-all-by-type.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-by-type",
   "name": "All cards by type",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -46,7 +42,5 @@
         }
       }
     }
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-all-pipelines.json
+++ b/apps/server/default-cards/contrib/view-all-pipelines.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-pipelines",
   "name": "All pipelines",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [ "org-balena" ],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "namespace": "Pipelines",
     "allOf": [
@@ -31,7 +27,5 @@
       "lens-list",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-all-pull-requests.json
+++ b/apps/server/default-cards/contrib/view-all-pull-requests.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-pull-requests",
   "name": "All pull requests",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -31,7 +27,5 @@
       "lens-kanban",
       "lens-pull-request-chart"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-all-views.json
+++ b/apps/server/default-cards/contrib/view-all-views.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-all-views",
   "name": "All views",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -30,7 +26,5 @@
         }
       }
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-my-conversations.json
+++ b/apps/server/default-cards/contrib/view-my-conversations.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-my-conversations",
   "name": "My conversations",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -45,7 +41,5 @@
       "lens-support-threads",
       "lens-kanban"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-my-orgs.json
+++ b/apps/server/default-cards/contrib/view-my-orgs.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-my-orgs",
   "name": "My organisations",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -37,7 +33,5 @@
     "lenses": [
       "lens-list"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/view-non-executed-action-requests.json
+++ b/apps/server/default-cards/contrib/view-non-executed-action-requests.json
@@ -1,12 +1,8 @@
 {
   "slug": "view-non-executed-action-requests",
   "name": "Pending actions",
-  "version": "1.0.0",
   "type": "view@1.0.0",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "allOf": [
       {
@@ -80,7 +76,5 @@
       "lens-default-list",
       "lens-default-card"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/web-push-subscription.json
+++ b/apps/server/default-cards/contrib/web-push-subscription.json
@@ -1,14 +1,8 @@
 {
   "slug": "web-push-subscription",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Web Push subscription",
   "markers": [],
-  "requires": [],
-  "capabilities": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",

--- a/apps/server/default-cards/contrib/whisper.json
+++ b/apps/server/default-cards/contrib/whisper.json
@@ -1,12 +1,8 @@
 {
   "slug": "whisper",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Whisper message",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -116,7 +112,5 @@
       [ "data.payload.mentionsGroup" ],
       [ "data.payload.alertsGroup" ]
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/contrib/workflow.json
+++ b/apps/server/default-cards/contrib/workflow.json
@@ -1,12 +1,8 @@
 {
   "slug": "workflow",
   "type": "type@1.0.0",
-  "version": "1.0.0",
   "name": "Workflow",
   "markers": [],
-  "tags": [],
-  "links": {},
-  "active": true,
   "data": {
     "schema": {
       "type": "object",
@@ -83,7 +79,5 @@
     "slices": [
       "properties.data.properties.status"
     ]
-  },
-  "requires": [],
-  "capabilities": []
+  }
 }

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -4,9 +4,21 @@
  * Proprietary and confidential.
  */
 
-const mixins = require('./mixins')
+const _ = require('lodash')
+const {
+	mixin,
+	initialize,
+	...coreMixins
+} = require('../../../lib/core/cards/mixins')
+const defaultCardMixins = require('./mixins')
 
-module.exports = {
+const mixins = {
+	mixin,
+	...coreMixins,
+	...defaultCardMixins
+}
+
+const defaultCards = {
 	// Users
 	userGuest: require('./contrib/user-guest.json'),
 
@@ -135,3 +147,5 @@ module.exports = {
 	viewSupportThreadsToAudit: require('./balena/view-support-threads-to-audit.json'),
 	viewWorkflows: require('./balena/view-workflows.json')
 }
+
+module.exports = _.mapValues(defaultCards, initialize)

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -5,147 +5,147 @@
  */
 
 const _ = require('lodash')
-const {
-	mixin,
-	initialize,
-	...coreMixins
-} = require('../../../lib/core/cards/mixins')
+
 const defaultCardMixins = require('./mixins')
 
-const mixins = {
-	mixin,
-	...coreMixins,
-	...defaultCardMixins
+module.exports = ({
+	mixin, initialize, ...coreMixins
+}) => {
+	const mixins = {
+		mixin,
+		...coreMixins,
+		...defaultCardMixins
+	}
+
+	const defaultCards = {
+		// Users
+		userGuest: require('./contrib/user-guest.json'),
+
+		// Roles
+		roleUserCommunity: require('./contrib/role-user-community.json'),
+		roleUserOperator: require('./contrib/role-user-operator.json'),
+		roleUserGuest: require('./contrib/role-user-guest.json'),
+		roleUserTest: require('./contrib/role-user-test.json'),
+		roleUserExternalSuport: require('./contrib/role-user-external-support.json'),
+
+		// Internal views
+		viewActiveTriggeredActions: require('./contrib/view-active-triggered-actions.json'),
+		viewActive: require('./contrib/view-active.json'),
+		viewNonExecutedActionRequests: require('./contrib/view-non-executed-action-requests.json'),
+
+		// Types
+		account: require('./contrib/account.json'),
+		agenda: require('./contrib/agenda.json'),
+		blogPost: require('./contrib/blog-post.json'),
+		changelog: require('./contrib/changelog.json'),
+		checkin: require('./contrib/checkin.json'),
+		contract: require('./contrib/contact.json'),
+		discussionTopic: require('./contrib/discussion-topic.json'),
+		emailSequence: require('./contrib/email-sequence.json'),
+		externalEvent: require('./contrib/external-event.json'),
+		faq: require('./contrib/faq.json'),
+		feedbackItem: require('./contrib/feedback-item.json'),
+		formResponse: require('./contrib/form-response.json'),
+		formResponseCuration: require('./contrib/form-response-curation.json'),
+		issue: require('./contrib/issue.js')(mixins),
+		message: require('./contrib/message.json'),
+		firstTimeLogin: require('./contrib/first-time-login.json'),
+		opportunity: require('./contrib/opportunity.json'),
+		passwordReset: require('./contrib/password-reset.json'),
+		pattern: require('./contrib/pattern.js')(mixins),
+		ping: require('./contrib/ping.json'),
+		pipeline: require('./contrib/pipeline.json'),
+		milestone: require('./contrib/milestone.json'),
+		productImprovement: require('./contrib/product-improvement')(mixins),
+		product: require('./contrib/product.json'),
+		project: require('./contrib/project.json'),
+		pullRequest: require('./contrib/pull-request')(mixins),
+		push: require('./contrib/push.json'),
+		repository: require('./contrib/repository.json'),
+		specification: require('./contrib/specification.json'),
+		salesThread: require('./contrib/sales-thread.json'),
+		supportIssue: require('./contrib/support-issue')(mixins),
+		supportThread: require('./contrib/support-thread')(mixins),
+		tag: require('./contrib/tag.json'),
+		thread: require('./contrib/thread')(mixins),
+		viewAllPipelines: require('./contrib/view-all-pipelines.json'),
+		whisper: require('./contrib/whisper.json'),
+		workflow: require('./contrib/workflow.json'),
+		webPushSubscription: require('./contrib/web-push-subscription.json'),
+		group: require('./contrib/group.json'),
+		summary: require('./contrib/summary.json'),
+
+		// Triggered actions
+		triggeredActionGitHubIssueLink: require('./contrib/triggered-action-github-issue-link.json'),
+		triggeredActionHangoutsLink: require('./contrib/triggered-action-hangouts-link.json'),
+		triggeredActionIncrementTag: require('./contrib/triggered-action-increment-tag.json'),
+		triggeredActionUserContact: require('./contrib/triggered-action-user-contact.json'),
+		triggeredActionIntegrationImportEvent: require('./contrib/triggered-action-integration-import-event.json'),
+		triggeredActionIntegrationGitHubMirrorEvent: require(
+			'./contrib/triggered-action-integration-github-mirror-event.json'),
+		triggeredActionIntegrationFrontMirrorEvent: require(
+			'./contrib/triggered-action-integration-front-mirror-event.json'),
+		triggeredActionIntegrationDiscourseMirrorEvent: require(
+			'./contrib/triggered-action-integration-discourse-mirror-event.json'),
+		triggeredActionIntegrationOutreactMirrorEvent: require(
+			'./contrib/triggered-action-integration-outreach-mirror-event.json'),
+		triggeredActionSetUserAvatar: require('./contrib/triggered-action-set-user-avatar.json'),
+		triggeredActionSupportSummary: require('./contrib/triggered-action-support-summary.json'),
+		triggeredActionSupportReopen: require('./contrib/triggered-action-support-reopen.json'),
+		triggeredActionSupportClosedIssueReopen: require('./contrib/triggered-action-support-closed-issue-reopen.json'),
+		triggeredActionSyncThreadPostLinkWhisper: require(
+			'./contrib/triggered-action-sync-thread-post-link-whisper.json'),
+		triggeredActionUpdateEventEditedAt: require('./contrib/triggered-action-update-event-edited-at.json'),
+
+		// User facing views
+		viewAllViews: require('./contrib/view-all-views.json'),
+		viewMyOrgs: require('./contrib/view-my-orgs.json'),
+		viewMyConversations: require('./contrib/view-my-conversations.json'),
+		viewAllByType: require('./contrib/view-all-by-type.json'),
+		viewAllPullRequests: require('./contrib/view-all-pull-requests.json'),
+
+		// Balena org cards
+		orgBalena: require('./balena/org-balena.json'),
+		osTestResult: require('./balena/os-test-result')(mixins),
+		productBalenaCloud: require('./balena/product-balena-cloud.json'),
+		productJellyfish: require('./balena/product-jellyfish.json'),
+		viewAllAgendas: require('./balena/view-all-agendas.json'),
+		viewAllBlogPosts: require('./balena/view-all-blog-posts.json'),
+		viewTypeformResponses: require('./balena/view-typeform-responses.json'),
+		viewCurateTypeformResponses: require('./balena/view-curate-typeform-responses.json'),
+		viewAllCheckins: require('./balena/view-all-checkins.json'),
+		viewAllContacts: require('./balena/view-all-contacts.json'),
+		viewAllCustomers: require('./balena/view-all-customers.json'),
+		viewAllFaqs: require('./balena/view-all-faqs.json'),
+		viewAllGroups: require('./balena/view-all-groups.json'),
+		viewAllIssues: require('./balena/view-all-issues.json'),
+		viewAllJellyfishSupportThreads: require('./balena/view-all-jellyfish-support-threads.json'),
+		viewAllMessages: require('./balena/view-all-messages.json'),
+		viewAllOpportunities: require('./balena/view-all-opportunities.json'),
+		viewAllPatterns: require('./balena/view-all-patterns.json'),
+		viewAllProductImprovements: require('./balena/view-all-product-improvements.json'),
+		viewAllProducts: require('./balena/view-all-products.json'),
+		viewAllProjects: require('./balena/view-all-projects.json'),
+		viewAllSalesThreads: require('./balena/view-all-sales-threads.json'),
+		viewAllSpecifications: require('./balena/view-all-specifications.json'),
+		viewAllSupportIssues: require('./balena/view-all-support-issues.json'),
+		viewBalenaChat: require('./balena/view-balena-chat.json'),
+		viewSupportKnowledgeBase: require('./balena/view-support-knowledge-base.json'),
+		viewSupportThreadsParticipation: require('./balena/view-support-threads-participation.json'),
+		viewAllSupportThreads: require('./balena/view-all-support-threads.json'),
+		viewAllUsers: require('./balena/view-all-users.json'),
+		viewArchitectureCallTopics: require('./balena/view-architecture-call-topics.json'),
+		viewChangelogs: require('./balena/view-changelogs.json'),
+		viewCustomerSuccessSuppotThreads: require('./balena/view-customer-success-support-threads.json'),
+		viewDevicesSupportThreads: require('./balena/view-devices-support-threads.json'),
+		viewFleetopsSupportThreads: require('./balena/view-fleetops-support-threads.json'),
+		viewOSTestResults: require('./balena/view-os-test-results.json'),
+		viewProductSpecs: require('./balena/view-product-specs.json'),
+		viewSecuritySupportThreads: require('./balena/view-security-support-threads.json'),
+		viewSupportThreadsPendingUpdate: require('./balena/view-support-threads-pending-update.json'),
+		viewSupportThreadsToAudit: require('./balena/view-support-threads-to-audit.json'),
+		viewWorkflows: require('./balena/view-workflows.json')
+	}
+
+	return _.mapValues(defaultCards, initialize)
 }
-
-const defaultCards = {
-	// Users
-	userGuest: require('./contrib/user-guest.json'),
-
-	// Roles
-	roleUserCommunity: require('./contrib/role-user-community.json'),
-	roleUserOperator: require('./contrib/role-user-operator.json'),
-	roleUserGuest: require('./contrib/role-user-guest.json'),
-	roleUserTest: require('./contrib/role-user-test.json'),
-	roleUserExternalSuport: require('./contrib/role-user-external-support.json'),
-
-	// Internal views
-	viewActiveTriggeredActions: require('./contrib/view-active-triggered-actions.json'),
-	viewActive: require('./contrib/view-active.json'),
-	viewNonExecutedActionRequests: require('./contrib/view-non-executed-action-requests.json'),
-
-	// Types
-	account: require('./contrib/account.json'),
-	agenda: require('./contrib/agenda.json'),
-	blogPost: require('./contrib/blog-post.json'),
-	changelog: require('./contrib/changelog.json'),
-	checkin: require('./contrib/checkin.json'),
-	contract: require('./contrib/contact.json'),
-	discussionTopic: require('./contrib/discussion-topic.json'),
-	emailSequence: require('./contrib/email-sequence.json'),
-	externalEvent: require('./contrib/external-event.json'),
-	faq: require('./contrib/faq.json'),
-	feedbackItem: require('./contrib/feedback-item.json'),
-	formResponse: require('./contrib/form-response.json'),
-	formResponseCuration: require('./contrib/form-response-curation.json'),
-	issue: require('./contrib/issue.js')(mixins),
-	message: require('./contrib/message.json'),
-	firstTimeLogin: require('./contrib/first-time-login.json'),
-	opportunity: require('./contrib/opportunity.json'),
-	passwordReset: require('./contrib/password-reset.json'),
-	pattern: require('./contrib/pattern.js')(mixins),
-	ping: require('./contrib/ping.json'),
-	pipeline: require('./contrib/pipeline.json'),
-	milestone: require('./contrib/milestone.json'),
-	productImprovement: require('./contrib/product-improvement')(mixins),
-	product: require('./contrib/product.json'),
-	project: require('./contrib/project.json'),
-	pullRequest: require('./contrib/pull-request')(mixins),
-	push: require('./contrib/push.json'),
-	repository: require('./contrib/repository.json'),
-	specification: require('./contrib/specification.json'),
-	salesThread: require('./contrib/sales-thread.json'),
-	supportIssue: require('./contrib/support-issue')(mixins),
-	supportThread: require('./contrib/support-thread')(mixins),
-	tag: require('./contrib/tag.json'),
-	thread: require('./contrib/thread')(mixins),
-	viewAllPipelines: require('./contrib/view-all-pipelines.json'),
-	whisper: require('./contrib/whisper.json'),
-	workflow: require('./contrib/workflow.json'),
-	webPushSubscription: require('./contrib/web-push-subscription.json'),
-	group: require('./contrib/group.json'),
-	summary: require('./contrib/summary.json'),
-
-	// Triggered actions
-	triggeredActionGitHubIssueLink: require('./contrib/triggered-action-github-issue-link.json'),
-	triggeredActionHangoutsLink: require('./contrib/triggered-action-hangouts-link.json'),
-	triggeredActionIncrementTag: require('./contrib/triggered-action-increment-tag.json'),
-	triggeredActionUserContact: require('./contrib/triggered-action-user-contact.json'),
-	triggeredActionIntegrationImportEvent: require('./contrib/triggered-action-integration-import-event.json'),
-	triggeredActionIntegrationGitHubMirrorEvent: require(
-		'./contrib/triggered-action-integration-github-mirror-event.json'),
-	triggeredActionIntegrationFrontMirrorEvent: require(
-		'./contrib/triggered-action-integration-front-mirror-event.json'),
-	triggeredActionIntegrationDiscourseMirrorEvent: require(
-		'./contrib/triggered-action-integration-discourse-mirror-event.json'),
-	triggeredActionIntegrationOutreactMirrorEvent: require(
-		'./contrib/triggered-action-integration-outreach-mirror-event.json'),
-	triggeredActionSetUserAvatar: require('./contrib/triggered-action-set-user-avatar.json'),
-	triggeredActionSupportSummary: require('./contrib/triggered-action-support-summary.json'),
-	triggeredActionSupportReopen: require('./contrib/triggered-action-support-reopen.json'),
-	triggeredActionSupportClosedIssueReopen: require('./contrib/triggered-action-support-closed-issue-reopen.json'),
-	triggeredActionSyncThreadPostLinkWhisper: require(
-		'./contrib/triggered-action-sync-thread-post-link-whisper.json'),
-	triggeredActionUpdateEventEditedAt: require('./contrib/triggered-action-update-event-edited-at.json'),
-
-	// User facing views
-	viewAllViews: require('./contrib/view-all-views.json'),
-	viewMyOrgs: require('./contrib/view-my-orgs.json'),
-	viewMyConversations: require('./contrib/view-my-conversations.json'),
-	viewAllByType: require('./contrib/view-all-by-type.json'),
-	viewAllPullRequests: require('./contrib/view-all-pull-requests.json'),
-
-	// Balena org cards
-	orgBalena: require('./balena/org-balena.json'),
-	osTestResult: require('./balena/os-test-result')(mixins),
-	productBalenaCloud: require('./balena/product-balena-cloud.json'),
-	productJellyfish: require('./balena/product-jellyfish.json'),
-	viewAllAgendas: require('./balena/view-all-agendas.json'),
-	viewAllBlogPosts: require('./balena/view-all-blog-posts.json'),
-	viewTypeformResponses: require('./balena/view-typeform-responses.json'),
-	viewCurateTypeformResponses: require('./balena/view-curate-typeform-responses.json'),
-	viewAllCheckins: require('./balena/view-all-checkins.json'),
-	viewAllContacts: require('./balena/view-all-contacts.json'),
-	viewAllCustomers: require('./balena/view-all-customers.json'),
-	viewAllFaqs: require('./balena/view-all-faqs.json'),
-	viewAllGroups: require('./balena/view-all-groups.json'),
-	viewAllIssues: require('./balena/view-all-issues.json'),
-	viewAllJellyfishSupportThreads: require('./balena/view-all-jellyfish-support-threads.json'),
-	viewAllMessages: require('./balena/view-all-messages.json'),
-	viewAllOpportunities: require('./balena/view-all-opportunities.json'),
-	viewAllPatterns: require('./balena/view-all-patterns.json'),
-	viewAllProductImprovements: require('./balena/view-all-product-improvements.json'),
-	viewAllProducts: require('./balena/view-all-products.json'),
-	viewAllProjects: require('./balena/view-all-projects.json'),
-	viewAllSalesThreads: require('./balena/view-all-sales-threads.json'),
-	viewAllSpecifications: require('./balena/view-all-specifications.json'),
-	viewAllSupportIssues: require('./balena/view-all-support-issues.json'),
-	viewBalenaChat: require('./balena/view-balena-chat.json'),
-	viewSupportKnowledgeBase: require('./balena/view-support-knowledge-base.json'),
-	viewSupportThreadsParticipation: require('./balena/view-support-threads-participation.json'),
-	viewAllSupportThreads: require('./balena/view-all-support-threads.json'),
-	viewAllUsers: require('./balena/view-all-users.json'),
-	viewArchitectureCallTopics: require('./balena/view-architecture-call-topics.json'),
-	viewChangelogs: require('./balena/view-changelogs.json'),
-	viewCustomerSuccessSuppotThreads: require('./balena/view-customer-success-support-threads.json'),
-	viewDevicesSupportThreads: require('./balena/view-devices-support-threads.json'),
-	viewFleetopsSupportThreads: require('./balena/view-fleetops-support-threads.json'),
-	viewOSTestResults: require('./balena/view-os-test-results.json'),
-	viewProductSpecs: require('./balena/view-product-specs.json'),
-	viewSecuritySupportThreads: require('./balena/view-security-support-threads.json'),
-	viewSupportThreadsPendingUpdate: require('./balena/view-support-threads-pending-update.json'),
-	viewSupportThreadsToAudit: require('./balena/view-support-threads-to-audit.json'),
-	viewWorkflows: require('./balena/view-workflows.json')
-}
-
-module.exports = _.mapValues(defaultCards, initialize)

--- a/apps/ui/components/UserStatusMenuItem.spec.jsx
+++ b/apps/ui/components/UserStatusMenuItem.spec.jsx
@@ -12,7 +12,9 @@ import {
 } from 'enzyme'
 import sinon from 'sinon'
 import UserStatusMenuItem from './UserStatusMenuItem'
-import user from '../../../lib/core/cards/user'
+import {
+	user
+} from '../../../lib/core/cards'
 
 const DND = {
 	title: 'Do Not Disturb',

--- a/lib/core/cards/action-request.js
+++ b/lib/core/cards/action-request.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'action-request',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish Action Request',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -80,7 +75,5 @@ module.exports = {
 				'data'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/action.js
+++ b/lib/core/cards/action.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'action',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish action',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -55,7 +50,5 @@ module.exports = {
 				'data'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/card.js
+++ b/lib/core/cards/card.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'card',
 	name: 'Jellyfish Card',
-	version: '1.0.0',
-	markers: [],
 	type: 'type@1.0.0',
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -104,7 +99,5 @@ module.exports = {
 				'version'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/event.js
+++ b/lib/core/cards/event.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'event',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish Event',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -52,7 +47,5 @@ module.exports = {
 				'data'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/index.js
+++ b/lib/core/cards/index.js
@@ -4,18 +4,22 @@
  * Proprietary and confidential.
  */
 
+const {
+	initialize
+} = require('./mixins')
+
 module.exports = {
-	'action-request': require('./action-request'),
-	action: require('./action'),
-	card: require('./card'),
-	role: require('./role'),
-	org: require('./org'),
-	event: require('./event'),
-	link: require('./link'),
-	session: require('./session'),
-	type: require('./type'),
-	'user-admin': require('./user-admin'),
-	user: require('./user'),
-	'role-user-admin': require('./role-user-admin'),
-	view: require('./view')
+	'action-request': initialize(require('./action-request')),
+	action: initialize(require('./action')),
+	card: initialize(require('./card')),
+	role: initialize(require('./role')),
+	org: initialize(require('./org')),
+	event: initialize(require('./event')),
+	link: initialize(require('./link')),
+	session: initialize(require('./session')),
+	type: initialize(require('./type')),
+	'user-admin': initialize(require('./user-admin')),
+	user: initialize(require('./user')),
+	'role-user-admin': initialize(require('./role-user-admin')),
+	view: initialize(require('./view'))
 }

--- a/lib/core/cards/link.js
+++ b/lib/core/cards/link.js
@@ -7,11 +7,6 @@
 module.exports = {
 	slug: 'link',
 	type: 'type@1.0.0',
-	version: '1.0.0',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -84,7 +79,5 @@ module.exports = {
 		indexed_fields: [
 			[ 'data.from.id', 'name', 'data.to.id' ]
 		]
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/mixins/index.js
+++ b/lib/core/cards/mixins/index.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const deref = require('json-schema-deref-sync')
+const sensibleDefaults = require('./with-sensible-defaults')
+const baseUiSchema = require('./with-ui-schema')
+
+const mergeWithUniqConcatArrays = (objValue, srcValue) => {
+	if (_.isArray(objValue)) {
+		return _.uniq(objValue.concat(srcValue))
+	}
+	// eslint-disable-next-line no-undefined
+	return undefined
+}
+
+module.exports = {
+	mixin: (...mixins) => {
+		return (base) => {
+			return _.mergeWith({}, base, ...mixins, mergeWithUniqConcatArrays)
+		}
+	},
+	initialize: (card) => {
+		const snippets = [ {}, sensibleDefaults, card ]
+
+		// All type cards should have a UI schema
+		if (card.type.split('@')[0] === 'type') {
+			snippets.push(baseUiSchema)
+		}
+		const intializedCard = _.mergeWith(...snippets, mergeWithUniqConcatArrays)
+
+		// Dereference all $ref values
+		return deref(intializedCard, {
+			failOnMissing: true,
+			mergeAdditionalProperties: true
+		})
+	}
+}

--- a/lib/core/cards/mixins/with-sensible-defaults.js
+++ b/lib/core/cards/mixins/with-sensible-defaults.js
@@ -5,5 +5,11 @@
  */
 
 module.exports = {
-	withEvents: require('./with-events')
+	version: '1.0.0',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	requires: [],
+	capabilities: []
 }

--- a/lib/core/cards/mixins/with-ui-schema.js
+++ b/lib/core/cards/mixins/with-ui-schema.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// This mixin defines all common fields in cards that support
+// UI Schemas (i.e. type cards)
+module.exports = {
+	data: {
+		uiSchema: {
+			// Only display the data field for the fields UI schema mode
+			fields: {
+				name: null,
+				slug: null,
+				type: null,
+				version: null,
+				markers: null,
+				tags: null,
+				links: null,
+				active: null,
+				requires: null,
+				capabilities: null
+			},
+			snippet: {
+				$ref: '#/data/uiSchema/fields',
+				name: {},
+				links: {}
+			}
+		}
+	}
+}

--- a/lib/core/cards/org.js
+++ b/lib/core/cards/org.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'org',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Organisation',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -62,7 +57,5 @@ module.exports = {
 				}
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/role-user-admin.js
+++ b/lib/core/cards/role-user-admin.js
@@ -7,17 +7,10 @@
 module.exports = {
 	slug: 'role-user-admin',
 	name: 'Kernel admin user permissions',
-	version: '1.0.0',
 	type: 'role@1.0.0',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		read: {
 			type: 'object'
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/role.js
+++ b/lib/core/cards/role.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'role',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish Role',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -33,7 +28,5 @@ module.exports = {
 				}
 			}
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/session.js
+++ b/lib/core/cards/session.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'session',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish Session',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -38,7 +33,5 @@ module.exports = {
 				'data'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/type.js
+++ b/lib/core/cards/type.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'type',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish Card Type',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -29,6 +24,9 @@ module.exports = {
 					type: 'object',
 					properties: {
 						schema: {
+							type: 'object'
+						},
+						uiSchema: {
 							type: 'object'
 						},
 						slices: {
@@ -59,7 +57,5 @@ module.exports = {
 				'data'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/user-admin.js
+++ b/lib/core/cards/user-admin.js
@@ -7,17 +7,10 @@
 module.exports = {
 	slug: 'user-admin',
 	type: 'user@1.0.0',
-	version: '1.0.0',
 	name: 'The admin user',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		email: 'accounts+jellyfish@resin.io',
 		hash: 'PASSWORDLESS',
 		roles: []
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/user.js
+++ b/lib/core/cards/user.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'user',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish User',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			type: 'object',
@@ -395,7 +390,5 @@ module.exports = {
 				}
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/cards/view.js
+++ b/lib/core/cards/view.js
@@ -7,12 +7,7 @@
 module.exports = {
 	slug: 'view',
 	type: 'type@1.0.0',
-	version: '1.0.0',
 	name: 'Jellyfish view',
-	markers: [],
-	tags: [],
-	links: {},
-	active: true,
 	data: {
 		schema: {
 			description: 'Jellyfish View',
@@ -116,7 +111,5 @@ module.exports = {
 				'data'
 			]
 		}
-	},
-	requires: [],
-	capabilities: []
+	}
 }

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -9,9 +9,11 @@ const Backend = require('./backend')
 const Cache = require('./cache')
 const errors = require('./errors')
 const cards = require('./cards')
+const cardMixins = require('./cards/mixins')
 
 exports.MemoryCache = Cache
 exports.cards = cards
+exports.cardMixins = cardMixins
 
 exports.create = async (context, cache, options) => {
 	const backend = new Backend(cache, errors, options.backend)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
     "@ava/babel": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@ava/babel/-/babel-1.0.1.tgz",
@@ -5098,11 +5088,6 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
     "@json-schema-org/tests": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@json-schema-org/tests/-/tests-1.0.0.tgz",
@@ -9070,6 +9055,11 @@
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
       "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chart.js": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
@@ -10484,6 +10474,11 @@
         }
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "crypto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
@@ -10950,6 +10945,11 @@
         "d3-selection": "1",
         "d3-transition": "1"
       }
+    },
+    "dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc="
     },
     "dagre-d3-renderer": {
       "version": "0.5.8",
@@ -16643,6 +16643,29 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -16790,6 +16813,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-uuid/-/is-uuid-1.0.2.tgz",
       "integrity": "sha1-rRiY3fFUlHwlyOVJZvSGBOnK7MQ="
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -17064,6 +17095,27 @@
         "lodash": "^4.17.4"
       }
     },
+    "json-schema-deref-sync": {
+      "version": "github:cvent/json-schema-deref-sync#8bdbac1ff3e001a7b459e08229d3aa93f42b5f13",
+      "from": "github:cvent/json-schema-deref-sync#8bdbac1ff3e001a7b459e08229d3aa93f42b5f13",
+      "requires": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        }
+      }
+    },
     "json-schema-faker": {
       "version": "0.5.0-rcv.26",
       "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.26.tgz",
@@ -17094,14 +17146,6 @@
         "compute-lcm": "^1.1.0",
         "json-schema-compare": "^0.2.2",
         "lodash": "^4.17.4"
-      }
-    },
-    "json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-z0JGv7rRD3CnJbZY/qCpscyArdtLJhr/wRBmFUdoZ8xMjsFyNdILSprG2degqRLjBjyhZHAEBpGOxniO9rKTxA==",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "9.0.6"
       }
     },
     "json-schema-test-suite": {
@@ -17763,6 +17807,23 @@
         }
       }
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
+      }
+    },
     "md5-hex": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
@@ -17822,6 +17883,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
       "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -25150,6 +25216,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "immutability-helper": "^3.1.1",
     "is-uuid": "^1.0.2",
     "json-e": "^4.1.0",
-    "json-schema-ref-parser": "^9.0.6",
+    "json-schema-deref-sync": "github:cvent/json-schema-deref-sync#8bdbac1ff3e001a7b459e08229d3aa93f42b5f13",
     "jsonwebtoken": "^8.5.1",
     "localforage": "^1.9.0",
     "lodash": "^4.17.19",

--- a/test/integration/queue/helpers.js
+++ b/test/integration/queue/helpers.js
@@ -7,12 +7,13 @@
 const Bluebird = require('bluebird')
 const uuid = require('@balena/jellyfish-uuid')
 const helpers = require('../core/helpers')
-const defaultCards = require('../../../apps/server/default-cards')
 const Consumer = require('@balena/jellyfish-queue').Consumer
 const Producer = require('@balena/jellyfish-queue').Producer
 const actionLibrary = require('@balena/jellyfish-action-library')
 const queueErrors = require('@balena/jellyfish-queue').errors
 const utils = require('../utils')
+
+const defaultCards = utils.loadDefaultCards()
 
 exports.before = async (test, options) => {
 	await helpers.before(test, options && {

--- a/test/integration/sync/scenario.js
+++ b/test/integration/sync/scenario.js
@@ -12,9 +12,11 @@ const {
 } = require('uuid')
 const path = require('path')
 const _ = require('lodash')
-const defaultCards = require('../../../apps/server/default-cards')
 const syncHelpers = require('../../integration/sync/helpers')
 const helpers = require('./helpers')
+const utils = require('../utils')
+
+const defaultCards = utils.loadDefaultCards()
 
 const TRANSLATE_PREFIX = uuid()
 

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -7,6 +7,12 @@
 const {
 	v4: uuid
 } = require('uuid')
+const coreMixins = require('../../lib/core/cards/mixins')
+const loadDefaultCards = require('../../apps/server/default-cards')
+
+exports.loadDefaultCards = () => {
+	return loadDefaultCards(coreMixins)
+}
 
 exports.generateRandomID = () => {
 	return uuid()

--- a/test/unit/apps/server/graphql/card-handlers/card-handler.spec.js
+++ b/test/unit/apps/server/graphql/card-handlers/card-handler.spec.js
@@ -6,7 +6,9 @@
 
 const _ = require('lodash')
 const ava = require('ava')
-const CardCard = require('../../../../../../lib/core/cards/card')
+const {
+	card: CardCard
+} = require('../../../../../../lib/core/cards')
 const CardHandler = require('../../../../../../apps/server/graphql/card-handlers/card-handler')
 const graphql = require('graphql')
 const {

--- a/test/unit/apps/server/graphql/card-handlers/card-interface-handler.spec.js
+++ b/test/unit/apps/server/graphql/card-handlers/card-interface-handler.spec.js
@@ -7,7 +7,9 @@
 const ava = require('ava')
 const CardHandler = require('../../../../../../apps/server/graphql/card-handlers/card-handler')
 const CardInterfaceHandler = require('../../../../../../apps/server/graphql/card-handlers/card-interface-handler')
-const CardCard = require('../../../../../../lib/core/cards/card')
+const {
+	card: CardCard
+} = require('../../../../../../lib/core/cards')
 const Types = require('../../../../../../apps/server/graphql/types')
 const {
 	OVERRIDES

--- a/test/unit/core/cards.spec.js
+++ b/test/unit/core/cards.spec.js
@@ -31,7 +31,6 @@ _.each(CARDS, async (value, key) => {
 		const cardSchema = (await CARDS.card).data.schema
 		const typeSchema = (await CARDS[card.type.split('@')[0]]).data.schema
 		const cardWithCreation = addCreatedField(card)
-
 		test.true(skhema.isValid(cardSchema, cardWithCreation))
 		test.true(skhema.isValid(typeSchema, cardWithCreation))
 	})


### PR DESCRIPTION
* All cards are (synchronously) de-referenced when loaded.
* All cards are now initialized with 'sensible defaults' so these fields do not need to explicitly appear in the card definition file.
* All type cards are initialized with a base UI schema.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR paves the way for defining sensible UI schemas on type cards which can then be used by `JsonSchemaRenderer`.

Note: You may notice a dependency on a particular commit from a GitHub repo. This is because they haven't published a new version since that commit (which contains an important bug fix). I've submitted [an issue](https://github.com/cvent/json-schema-deref-sync/issues/40) asking them to publish a new version. But until then I think it's worth doing it this way as there doesn't seem to be a good alternative _synchronous_ json-schema deference utility.
