### PR TITLE
ci: Group failed e2e test screenshot comments

### DIFF
--- a/test/e2e/livechat/helpers.js
+++ b/test/e2e/livechat/helpers.js
@@ -14,7 +14,15 @@ exports.afterEach = async ({
 	context, test
 }) => {
 	if (!test.passed) {
-		await screenshot.takeScreenshot(context, test.title)
+		await screenshot.take(context, test.title)
+	}
+}
+
+exports.after = async ({
+	context
+}) => {
+	if (context.screenshots) {
+		await screenshot.comment(context.screenshots)
 	}
 }
 

--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -66,6 +66,9 @@ ava.serial.beforeEach(async () => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -80,6 +80,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/file-upload.spec.js
+++ b/test/e2e/ui/file-upload.spec.js
@@ -68,6 +68,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/form-response.spec.js
+++ b/test/e2e/ui/form-response.spec.js
@@ -42,6 +42,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/guided-handover.spec.js
+++ b/test/e2e/ui/guided-handover.spec.js
@@ -105,6 +105,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -57,6 +57,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/helpers.js
+++ b/test/e2e/ui/helpers.js
@@ -46,7 +46,15 @@ exports.afterEach = async ({
 	context, test
 }) => {
 	if (!test.passed) {
-		await screenshot.takeScreenshot(context, test.title)
+		await screenshot.take(context, test.title)
+	}
+}
+
+exports.after = async ({
+	context
+}) => {
+	if (context.screenshots) {
+		await screenshot.comment(context.screenshots)
 	}
 }
 

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -83,6 +83,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/oauth.spec.js
+++ b/test/e2e/ui/oauth.spec.js
@@ -40,6 +40,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/repository.spec.js
+++ b/test/e2e/ui/repository.spec.js
@@ -88,6 +88,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -42,6 +42,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -43,6 +43,9 @@ ava.serial.afterEach.always(async (test) => {
 })
 
 ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
 	await helpers.browser.afterEach({
 		context
 	})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Group up failed E2E Livechat/UI test failure screenshot links into a single comment.

When we switch to using `ci-task-runner` to run our tests on balenaCI, we will be automatically retrying certain tasks when they fail. As the comments are created at the end of a test suite with ava's `after`, if `e2e-ui` or `e2e-livechat` tests are failing consistently, we will still get multiple comments. This change reduces the number of comments created per test suite run, limiting to a single comment per run.

See comments below for examples of what the comments look like. These were created by the code in this PR when failing certain tests on purpose.