### PR TITLE
Add link to home from 404 view

### DIFF
--- a/apps/ui/components/ChannelNotFound/ChannelNotFound.jsx
+++ b/apps/ui/components/ChannelNotFound/ChannelNotFound.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import styled from 'styled-components'
+import {
+	Box,
+	Flex,
+	Heading
+} from 'rendition'
+import Link from '@balena/jellyfish-ui-components/lib/Link'
+import {
+	px
+} from '@balena/jellyfish-ui-components/lib/services/helpers'
+import {
+	CloseButton
+} from '@balena/jellyfish-ui-components/lib/shame/CloseButton'
+
+const ErrorTitle = styled(Heading.h1) `
+	background: url(/icons/jellyfish.svg) repeat;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	line-height: 1;
+	background-size: 14px;
+	background-color: #c5edff;
+`
+
+const CloseWrapper = styled(Box) `
+	position: absolute;
+	top: ${(props) => { return px(props.theme.space[3]) }};
+	right: ${(props) => { return px(props.theme.space[2]) }};
+`
+
+const ChannelNotFound = ({
+	channel,
+	displayHomeLink
+}) => {
+	return (
+		<Flex flexDirection='column' height="100%" justifyContent='center' alignItems='center'>
+			<CloseWrapper>
+				<CloseButton p={2} channel={channel} />
+			</CloseWrapper>
+			<ErrorTitle fontSize={[ '150px', '150px', '200px' ]}>404</ErrorTitle>
+			{ displayHomeLink && <Link to="/">Take me home!</Link>}
+		</Flex>
+	)
+}
+
+export default ChannelNotFound

--- a/apps/ui/components/ChannelNotFound/index.js
+++ b/apps/ui/components/ChannelNotFound/index.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	connect
+} from 'react-redux'
+import {
+	selectors
+} from '../../core'
+import ChannelNotFound from './ChannelNotFound'
+
+const mapStateToProps = (state) => {
+	return {
+		// Only display a home link if this is the only channel (apart from the home channel)
+		displayHomeLink: selectors.getChannels(state).length === 2
+	}
+}
+
+export default connect(mapStateToProps)(ChannelNotFound)

--- a/apps/ui/components/ChannelRenderer.jsx
+++ b/apps/ui/components/ChannelRenderer.jsx
@@ -11,27 +11,12 @@ import {
 } from 'react-dnd'
 import {
 	Alert,
-	Box,
-	Flex
+	Box
 } from 'rendition'
-import styled from 'styled-components'
 import ErrorBoundary from '@balena/jellyfish-ui-components/lib/shame/ErrorBoundary'
 import Icon from '@balena/jellyfish-ui-components/lib/shame/Icon'
-import {
-	CloseButton
-} from '@balena/jellyfish-ui-components/lib/shame/CloseButton'
 import LinkModal from './LinkModal'
-
-const ErrorNotFound = styled.h1 `
-	color: white;
-	background: url(/icons/jellyfish.svg) repeat;
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	font-size: 200px;
-	background-size: 14px;
-	margin: 10% auto;
-	background-color: #c5edff;
-`
+import ChannelNotFound from './ChannelNotFound'
 
 // Selects an appropriate renderer for a card
 class ChannelRenderer extends React.Component {
@@ -119,21 +104,7 @@ class ChannelRenderer extends React.Component {
 			if (head === null) {
 				return (
 					<div style={style}>
-						<Flex flexDirection='column' alignItems='center' flex={1}>
-							<Box
-								flex={0}
-								alignSelf='flex-end'
-								mr={3}
-								mt={3}
-							>
-								<CloseButton
-									channel={channel}
-								/>
-							</Box>
-							<ErrorNotFound flex={1}>
-							404
-							</ErrorNotFound>
-						</Flex>
+						<ChannelNotFound channel={channel} />
 					</div>
 				)
 			}


### PR DESCRIPTION
Link to home is only displayed if the channel is the only one (apart from the home channel). 

Refactored 404 view into it's own component.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #4533 

![TakeMeHome](https://user-images.githubusercontent.com/2925657/90100076-19f34f00-dd66-11ea-83a0-529cb1d99828.jpg)

