### PR TITLE
ci: Skip E2E GitHub comment if no screenshots were taken

### DIFF
--- a/test/e2e/screenshot.js
+++ b/test/e2e/screenshot.js
@@ -123,8 +123,15 @@ exports.upload = async (path) => {
  * await comment(screenshots)
  */
 exports.comment = async (screenshots) => {
+	// Check that all required environment variables are set
 	if (_.isEmpty(environment.test.ci) || _.isEmpty(environment.integration.github.api)) {
 		console.log('Skipping screenshot PR comment, CI or GitHub API key environment variable not set')
+		return
+	}
+
+	// Make sure we have screenshot data to work with
+	if (_.isEmpty(screenshots)) {
+		console.log('Skipping screenshot PR comment, no screenshot data found')
 		return
 	}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Found a couple cases where E2E failure comments were being posted to GitHub without any screenshot data attached. Adding a small check that screenshot data actually exists before posting comments.

Example:
![e2e-comment-no-screenshots](https://user-images.githubusercontent.com/45343541/90304384-20163680-def2-11ea-894c-07213fc3a464.png)