### PR TITLE
ui: Allow for null field values

### DIFF
--- a/apps/ui/components/CardFields/FieldValue.jsx
+++ b/apps/ui/components/CardFields/FieldValue.jsx
@@ -17,6 +17,9 @@ import * as helpers from '@balena/jellyfish-ui-components/lib/services/helpers'
 export default function FieldValue ({
 	fieldValue, fieldKey, schema, parentKey, ...props
 }) {
+	if (_.isNil(fieldValue)) {
+		return null
+	}
 	let value = fieldValue
 
 	if (_.get(schema, [ 'format' ]) === 'date-time') {


### PR DESCRIPTION
Prevents an unhandled exception when trying to call `toString()` on a null value!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

