### PR TITLE
ci: Test balenaCI sut no output bug

### DIFF
--- a/docs/developing/running-tests.markdown
+++ b/docs/developing/running-tests.markdown
@@ -425,3 +425,5 @@ make test-integration-core test-integration-queue test-integration-sync test-int
 		POSTGRES_DATABASE=$POSTGRES_DATABASE \
 		REDIS_HOST=localhost
 ```
+
+Test Line


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**DO NOT MERGE**
Looking to see if I can replicate what I think is a balenaCI bug on a fresh branch in which `sut` container output completely stops for several minutes until it eventually exits with `1` or `0`.
