### PR TITLE
Remove debug html tag from default list lens

### DIFF
--- a/apps/ui/lens/list/List.jsx
+++ b/apps/ui/lens/list/List.jsx
@@ -89,7 +89,6 @@ class CardList extends BaseLens {
 					rowIndex={rowProps.index}
 				>
 					<Box px={3} pb={3} style={rowProps.style}>
-						<h2>{rowProps.index}</h2>
 						<lens.data.renderer card={card}/>
 						<Divider color="#eee" m={0} style={{
 							height: 1


### PR DESCRIPTION
I left an html tag for debugging in PR: https://github.com/product-os/jellyfish/pull/4624. This follow up PR removed that element.

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
