### PR TITLE
ci: Update existing e2e test screenshot comments

### DIFF
--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -25,6 +25,7 @@ tasks:
     attempts: 1
     dependencies:
       - 'clean-github'
+      - 'front-mirror'
   - name: 'pipeline-sync'
     description: 'Pipeline Sync Tests'
     command: 'make test'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Update previously existing E2E test failure comment instead of always creating a new comment.
Create new comment if non yet exist.

This will also overwrite the `Ship shape and ready to sail!` comment, seeing as how the PR is no longer "ready to sail". Planning on putting some work into creating/updating this comment for other test suites as well (including lint) to ensure the comment correctly reflects the current state of the PR.

See the example comment below created using the changes in this PR, noting the multiple updates.