### PR TITLE
Fix inbox pagination

### DIFF
--- a/apps/ui/components/Inbox/InboxTab.jsx
+++ b/apps/ui/components/Inbox/InboxTab.jsx
@@ -167,16 +167,15 @@ export default (props) => {
 				})
 			}
 
-			const updatePage = (newPage) => {
-				// If we haven't seen the maximum results, set the new page
+			const updatePage = (oldPage) => {
+				// If we have been returned the maximum results, set the new page
 				// TODO: Fix this hack once we can fetch a count from the API
-				if (options.limit * page === results.length) {
-					setPage(newPage)
+				if (options.limit * oldPage === resultsRef.current.length) {
+					setPage(oldPage + 1)
 
 					// If the search term or page changes, rerun the query
-					return loadResults(searchTerm, newPage)
+					return loadResults(searchTerm, oldPage + 1)
 				}
-
 				return null
 			}
 
@@ -243,7 +242,7 @@ export default (props) => {
 				<MessageList
 					page={page}
 					setPage={async () => {
-						return (await fetchRef.current).updatePage
+						return (await fetchRef.current).updatePage(page)
 					}}
 					tail={results}
 				/>


### PR DESCRIPTION
I'm not sure if this is the best way of solving this. Essentially the `updatePage` captures the state of both `results` and `page` on first render. Even when these are updated, `updatePage` continues to use the stale values. To get around this, Carol has stored the results as a ref and we can access this. I could setup an additional ref for page but I felt it was easier to pass the old page through as an argument.

Great guide on stale closures here: https://dmitripavlutin.com/react-hooks-stale-closures/
