### PR TITLE
Bump js-combinatorics (major)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18527,9 +18527,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-combinatorics": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.6.1.tgz",
-      "integrity": "sha512-VDPHc5J++qdzvngxUhOnUGwegFB9vlNzyWTD6oXKCd9qvw8NAsZdFaWK44W91U0GtBR9R0yppMgzNwTJQYymqg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-1.4.5.tgz",
+      "integrity": "sha512-lIBPgsZnIK5S8kCyTUY4L34Kq5YXj2LXyk9WJDPsK6iklV96+ZahxIsgHtXcwHhG9XZhqrS1EbnaEkUh5gyXdg==",
       "dev": true
     },
     "js-string-escape": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "file-loader": "^6.0.0",
     "html-webpack-plugin": "^4.4.1",
-    "js-combinatorics": "^0.6.1",
+    "js-combinatorics": "^1.4.5",
     "js-yaml": "^3.14.0",
     "mermaid.cli": "^0.5.1",
     "morgan": "^1.10.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Trying out bumping `js-combinatorics` originally set be to upgraded in https://github.com/product-os/jellyfish/pull/4480. We will be dropping `@json-schema-org/tests` from this repo once we move `lib/core` out to `product-os/jellyfish-core`.
