### PR TITLE
Inbox: Improve inbox UI and it's different states

### DIFF
--- a/apps/ui/components/Inbox/MessageList.jsx
+++ b/apps/ui/components/Inbox/MessageList.jsx
@@ -32,11 +32,28 @@ import {
 	withDefaultGetActorHref
 } from '@balena/jellyfish-ui-components/lib/HOC/with-default-get-actor-href'
 import EventsContainer from '@balena/jellyfish-ui-components/lib/EventsContainer'
+import {
+	Box,
+	Txt,
+	Img,
+	Flex
+} from 'rendition'
+import Icon from '@balena/jellyfish-ui-components/lib/shame/Icon'
+import moment from 'moment'
+
+const StyledFlex = styled(Flex)(() => {
+	return {
+		width: '100%',
+		textAlign: 'center',
+		opacity: 0.8,
+		flexDirection: 'column',
+		alignItems: 'center'
+	}
+})
 
 const MessageListColumn = styled(Column) `
 	position: relative;
 	min-height: 0;
-	height: auto;
 `
 
 const eventActionNames = [ 'addNotification' ]
@@ -122,12 +139,49 @@ class MessageList extends React.Component {
 	render () {
 		let tail = this.props.tail ? this.props.tail.slice() : null
 
+		const {
+			loading,
+			loadedAllResults
+		} = this.props
+
 		if (tail) {
 			tail = _.sortBy(tail, 'created_at')
 			tail.reverse()
 		}
 
 		const eventActions = pickEventActions(this.props.actions, eventActionNames)
+
+		// Todo: These date groupings should be replaced with a
+		// proper sectionlist component
+		// for example: https://github.com/lucasferreira/react-virtualized-sectionlist
+
+		const todayCards = []
+		const yesterdayCards = []
+		const thisWeekCards = []
+		const olderCards = []
+
+		tail.forEach((card) => {
+			const cardDate = new Date(card.data.timestamp)
+			const now = new Date()
+			const yesterday = moment().subtract(1, 'day').toDate()
+
+			if (moment(cardDate).isSame(now, 'day')) {
+				todayCards.push(card)
+				return
+			}
+
+			if (moment(cardDate).isSame(yesterday, 'day')) {
+				yesterdayCards.push(card)
+				return
+			}
+
+			if (moment(cardDate).isSame(now, 'week')) {
+				thisWeekCards.push(card)
+				return
+			}
+
+			olderCards.push(card)
+		})
 
 		return (
 			<MessageListColumn flex="1">
@@ -136,36 +190,212 @@ class MessageList extends React.Component {
 					onScroll={this.handleScroll}
 					data-test={'messageList-ListWrapper'}
 				>
-					{(Boolean(tail) && tail.length > 0) && _.map(tail, (card) => {
-						return (
-							<Event
-								key={card.id}
-								user={this.props.user}
-								groups={this.props.groups}
-								openChannel={this.openChannel}
-								card={card}
-								selectCard={selectors.getCard}
-								getCard={this.props.actions.getCard}
-								actions={eventActions}
-								getActorHref={this.props.getActorHref}
-								menuOptions={_.includes(card.data.readBy, this.props.user.slug) ? (
-									<ActionLink
-										data-cardid={card.id}
-										onClick={this.handleCardUnread}
-									>
-										Mark as unread
-									</ActionLink>
-								) : (
-									<ActionLink
-										data-cardid={card.id}
-										onClick={this.handleCardRead}
-									>
-										Mark as read
-									</ActionLink>
-								)}
-							/>
-						)
-					})}
+					{(todayCards.length > 0) && (
+						<Box>
+							<Box>
+								<StyledFlex
+									pb={14}
+									pt={14}
+								>
+									<Txt>Today</Txt>
+								</StyledFlex>
+							</Box>
+							{todayCards && _.map(todayCards, (card) => {
+								return (
+									<Event
+										data-test={'messageList-event'}
+										key={card.id}
+										user={this.props.user}
+										groups={this.props.groups}
+										openChannel={this.openChannel}
+										card={card}
+										selectCard={selectors.getCard}
+										getCard={this.props.actions.getCard}
+										actions={eventActions}
+										getActorHref={this.props.getActorHref}
+										menuOptions={_.includes(card.data.readBy, this.props.user.slug) ? (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardUnread}
+											>
+												Mark as unread
+											</ActionLink>
+										) : (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardRead}
+											>
+												Mark as read
+											</ActionLink>
+										)}
+									/>
+								)
+							})}
+						</Box>
+					)}
+					{(yesterdayCards.length > 0) && (
+						<Box>
+							<Box>
+								<StyledFlex
+									pb={14}
+									pt={14}
+								>
+									<Txt>Yesterday</Txt>
+								</StyledFlex>
+							</Box>
+							{yesterdayCards && _.map(yesterdayCards, (card) => {
+								return (
+									<Event
+										data-test={'messageList-event'}
+										key={card.id}
+										user={this.props.user}
+										groups={this.props.groups}
+										openChannel={this.openChannel}
+										card={card}
+										selectCard={selectors.getCard}
+										getCard={this.props.actions.getCard}
+										actions={eventActions}
+										getActorHref={this.props.getActorHref}
+										menuOptions={_.includes(card.data.readBy, this.props.user.slug) ? (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardUnread}
+											>
+												Mark as unread
+											</ActionLink>
+										) : (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardRead}
+											>
+												Mark as read
+											</ActionLink>
+										)}
+									/>
+								)
+							})}
+						</Box>
+					)}
+					{(thisWeekCards.length > 0) && (
+						<Box>
+							<Box>
+								<StyledFlex
+									pb={14}
+									pt={14}
+								>
+									<Txt>This week</Txt>
+								</StyledFlex>
+							</Box>
+							{thisWeekCards && _.map(thisWeekCards, (card) => {
+								return (
+									<Event
+										data-test={'messageList-event'}
+										key={card.id}
+										user={this.props.user}
+										groups={this.props.groups}
+										openChannel={this.openChannel}
+										card={card}
+										selectCard={selectors.getCard}
+										getCard={this.props.actions.getCard}
+										actions={eventActions}
+										getActorHref={this.props.getActorHref}
+										menuOptions={_.includes(card.data.readBy, this.props.user.slug) ? (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardUnread}
+											>
+												Mark as unread
+											</ActionLink>
+										) : (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardRead}
+											>
+												Mark as read
+											</ActionLink>
+										)}
+									/>
+								)
+							})}
+						</Box>
+					)}
+					{(olderCards.length > 0) && (
+						<Box>
+							<Box>
+								<StyledFlex
+									pb={14}
+									pt={14}
+								>
+									<Txt>Older than 1 week</Txt>
+								</StyledFlex>
+							</Box>
+							{olderCards && _.map(olderCards, (card) => {
+								return (
+									<Event
+										data-test={'messageList-event'}
+										key={card.id}
+										user={this.props.user}
+										groups={this.props.groups}
+										openChannel={this.openChannel}
+										card={card}
+										selectCard={selectors.getCard}
+										getCard={this.props.actions.getCard}
+										actions={eventActions}
+										getActorHref={this.props.getActorHref}
+										menuOptions={_.includes(card.data.readBy, this.props.user.slug) ? (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardUnread}
+											>
+												Mark as unread
+											</ActionLink>
+										) : (
+											<ActionLink
+												data-cardid={card.id}
+												onClick={this.handleCardRead}
+											>
+												Mark as read
+											</ActionLink>
+										)}
+									/>
+								)
+							})}
+						</Box>
+					)}
+
+					{loading && (
+						<StyledFlex
+							pb={14}
+							pt={14}
+						>
+							<Txt><Icon name="cog" spin /> Loading older messages</Txt>
+						</StyledFlex>
+					)}
+
+					{loadedAllResults && !loading && (tail.length > 0) && (
+						<StyledFlex
+							pb={14}
+							pt={14}
+						>
+							<Txt>End of list</Txt>
+						</StyledFlex>
+					)}
+
+					{!loading && (tail.length === 0) && (
+						<StyledFlex
+							pb={14}
+							pt={14}
+						>
+							<Flex
+								px={14}
+								maxWidth="200px"
+								width="80vw"
+							>
+								<Img src="/icons/jellyfish.svg" />
+							</Flex>
+							<Txt pt={14}>No messages found</Txt>
+						</StyledFlex>
+					)}
 				</EventsContainer>
 			</MessageListColumn>
 		)

--- a/apps/ui/components/Inbox/index.jsx
+++ b/apps/ui/components/Inbox/index.jsx
@@ -27,7 +27,8 @@ import {
 const InboxColumn = styled(Column) `
 	[role="tabpanel"] {
 		display: flex;
-  	flex-direction: column;
+	  flex-direction: column;
+	  height: 100vh;
 	}
 `
 

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -454,7 +454,7 @@ ava.serial(
 
 		// Get all children of the messageList-ListWrapper
 		// These should be all messages
-		const children = await incognitoPage.$$('[data-test="messageList-ListWrapper"] > div')
+		const children = await incognitoPage.$$('[data-test="messageList-event"]')
 
 		const messagesWithUser = []
 


### PR DESCRIPTION
This Pr contains multiple small UI improvements to the inbox design:

# Group mentions
The groups are: 
- Today
- Yesterday
- This week
- Older

## Before
<img width="1259" alt="Screenshot 2020-09-01 at 11 21 05" src="https://user-images.githubusercontent.com/11800807/91832367-9d0d1400-ec45-11ea-9fd5-1f4a292231b0.png">

## After
<img width="1188" alt="Screenshot 2020-09-01 at 11 18 24" src="https://user-images.githubusercontent.com/11800807/91832388-a39b8b80-ec45-11ea-978e-5d1deba2c868.png">

# Show background full height + inbox empty state
## Before
<img width="1259" alt="Screenshot 2020-09-01 at 11 20 47" src="https://user-images.githubusercontent.com/11800807/91832548-d8a7de00-ec45-11ea-8d01-8624329e17f1.png">

## After
<img width="1259" alt="Screenshot 2020-09-01 at 11 19 58" src="https://user-images.githubusercontent.com/11800807/91832500-c29a1d80-ec45-11ea-97fd-f004ce02775a.png">

# Inbox states loading state
## Before
<img width="784" alt="Screenshot 2020-09-01 at 11 26 47" src="https://user-images.githubusercontent.com/11800807/91832953-5966da00-ec46-11ea-925f-274601303f1a.png">

## After
<img width="1183" alt="Screenshot 2020-09-01 at 11 30 42" src="https://user-images.githubusercontent.com/11800807/91833135-96cb6780-ec46-11ea-959b-9200105de1a6.png">

# End of list indicator

## Before
<img width="1259" alt="Screenshot 2020-09-01 at 11 27 54" src="https://user-images.githubusercontent.com/11800807/91832882-3e946580-ec46-11ea-8e05-eb18d63f4b09.png">

## After
<img width="1188" alt="Screenshot 2020-09-01 at 11 17 28" src="https://user-images.githubusercontent.com/11800807/91832915-4b18be00-ec46-11ea-869f-a0d08a8f19a7.png">


Fixes: https://github.com/product-os/jellyfish/issues/4670

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

