### PR TITLE
core: refactor the database initialization code

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -49,6 +49,9 @@ const CARDS_SELECT = [
 	'data'
 ].join(', ')
 
+// Just a random fixed number used as the advisory lock ID for SQL
+// initialization scripts that modify the `cards` table
+exports.INIT_LOCK = 1142043989439426746
 exports.TABLE = CARDS_TABLE
 exports.TRIGGER_COLUMNS = CARDS_TRIGGER_COLUMNS
 
@@ -60,6 +63,10 @@ exports.setup = async (context, connection, database, options = {}) => {
 	'table_name')
 	if (!tables.includes(table)) {
 		await connection.any(`
+			BEGIN;
+
+			SELECT pg_advisory_xact_lock(${exports.INIT_LOCK});
+
 			CREATE TABLE IF NOT EXISTS ${table} (
 				id UUID PRIMARY KEY NOT NULL,
 				slug VARCHAR (255) NOT NULL,
@@ -82,18 +89,18 @@ exports.setup = async (context, connection, database, options = {}) => {
 				new_updated_at TIMESTAMP WITH TIME ZONE,
 				UNIQUE (slug, version_major, version_minor, version_patch),
 				CONSTRAINT version_positive
-					CHECK (version_major >= 0 AND version_minor >= 0 AND version_patch >= 0))`)
+					CHECK (version_major >= 0 AND version_minor >= 0 AND version_patch >= 0));
 
-		/*
-		 * Disable compression on the jsonb columns so we can access
-		 * its properties faster.
-		 * See http://erthalion.info/2017/12/21/advanced-json-benchmarks/
-		 */
-		await connection.any(`
+			-- Disable compression on the jsonb columns so we can access its
+			-- properties faster.
+			-- See http://erthalion.info/2017/12/21/advanced-json-benchmarks/
 			ALTER TABLE ${table}
 			ALTER COLUMN data SET STORAGE EXTERNAL,
 			ALTER COLUMN links SET STORAGE EXTERNAL,
-			ALTER COLUMN linked_at SET STORAGE EXTERNAL`)
+			ALTER COLUMN linked_at SET STORAGE EXTERNAL;
+
+			COMMIT;
+		`)
 	}
 
 	/*
@@ -101,14 +108,6 @@ exports.setup = async (context, connection, database, options = {}) => {
 	 * on a particular table.
 	 */
 	const indexes = _.map(await connection.any(`SELECT * FROM pg_indexes WHERE tablename = '${table}'`), 'indexname')
-
-	/*
-	 * Remove slug unique constraint
-	 */
-	await connection.any(`
-		SET statement_timeout = 0;
-		ALTER TABLE ${table}
-		DROP CONSTRAINT IF EXISTS ${table}_slug_key;`)
 
 	if (options.noIndexes) {
 		return
@@ -122,61 +121,74 @@ exports.setup = async (context, connection, database, options = {}) => {
 		SET work_mem TO '256 MB';
 	`)
 
-	await Bluebird.map([ {
-		column: 'slug'
-	}, {
-		column: 'tags',
-		indexType: 'GIN'
-	}, {
-		column: 'type'
-	}, {
-		name: 'data_mirrors',
-		column: '(data->\'mirrors\')',
-		indexType: 'GIN',
-		options: 'jsonb_path_ops'
-	}, {
-		column: 'created_at',
-		options: 'DESC'
-	}, {
-		column: 'updated_at'
-	} ], async (secondaryIndex) => {
-		/*
-		 * This is the actual name of the index that we will create
-		 * in Postgres.
-		 *
-		 * Keep in mind that if you change this, then this code will
-		 * not be able to cleanup older indexes with the older
-		 * name convention.
-		 */
-		const fullyQualifiedIndexName = `${secondaryIndex.name || secondaryIndex.column}_${table}_idx`
+	await Promise.all([
+		Bluebird.map(
+			[
+				{
+					column: 'slug'
+				},
+				{
+					column: 'tags',
+					indexType: 'GIN'
+				},
+				{
+					column: 'type'
+				},
+				{
+					name: 'data_mirrors',
+					column: '(data->\'mirrors\')',
+					indexType: 'GIN',
+					options: 'jsonb_path_ops'
+				},
+				{
+					column: 'created_at',
+					options: 'DESC'
+				},
+				{
+					column: 'updated_at'
+				}
+			],
+			async (secondaryIndex) => {
+				/*
+				 * This is the actual name of the index that we will create
+				 * in Postgres.
+				 *
+				 * Keep in mind that if you change this, then this code will
+				 * not be able to cleanup older indexes with the older
+				 * name convention.
+				 */
+				const fullyQualifiedIndexName = `${secondaryIndex.name || secondaryIndex.column}_${table}_idx`
+
+				/*
+				 * Lets not create the index if it already exists.
+				 */
+				if (indexes.includes(fullyQualifiedIndexName)) {
+					return
+				}
+
+				logger.debug(context, 'Attempting to create table index', {
+					table,
+					database,
+					index: secondaryIndex.column
+				})
+
+				await connection.any(`
+					CREATE INDEX IF NOT EXISTS ${fullyQualifiedIndexName} ON ${table}
+					USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
+			},
+			{
+				concurrency: 4
+			}
+		),
 
 		/*
-		 * Lets not create the index if it already exists.
+		 * Create function that allows us to create tsvector indexes from text[] fields.
 		 */
-		if (indexes.includes(fullyQualifiedIndexName)) {
-			return
-		}
-
-		logger.debug(context, 'Attempting to create table index', {
-			table,
-			database,
-			index: secondaryIndex.column
-		})
-
-		await connection.any(`
-			CREATE INDEX IF NOT EXISTS ${fullyQualifiedIndexName} ON ${table}
-			USING ${secondaryIndex.indexType || 'BTREE'} (${secondaryIndex.column} ${secondaryIndex.options || ''})`)
-	}, {
-		concurrency: 4
-	})
-
-	/*
-	 * Create function that allows us to create tsvector indexes from text[] fields.
-	 */
-	await connection.any(`
-		CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text) RETURNS text AS $$
-			SELECT array_to_string(arr, sep);
-		$$ LANGUAGE SQL IMMUTABLE`)
+		connection.any(`
+			CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text) RETURNS text AS $$
+				SELECT array_to_string(arr, sep);
+			$$ LANGUAGE SQL IMMUTABLE`)
+	])
 }
 
 exports.getById = async (context, connection, id, options = {}) => {

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -18,19 +18,15 @@ exports.setup = async (context, connection, database, options) => {
 		database
 	})
 
-	await connection.any(`
+	const initTasks = [ connection.any(`
 		DO $$
 		BEGIN
-			IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'linkref') THEN
-				DROP TYPE cardAndLinkIds;
-				DROP TYPE linkRef;
-			END IF;
-
 			IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'linkedge') THEN
 				CREATE TYPE linkEdge AS (source UUID, idx INT, sink UUID);
 				CREATE TYPE cardAndLinkEdges AS (cardId UUID, edges linkEdge[]);
 			END IF;
-		END$$`)
+		END$$
+	`) ]
 
 	await connection.any(`
 		CREATE TABLE IF NOT EXISTS ${LINK_TABLE} (
@@ -45,11 +41,6 @@ exports.setup = async (context, connection, database, options) => {
 			toId UUID REFERENCES ${options.cards} (id) NOT NULL,
 			UNIQUE (slug, version_major, version_minor, version_patch))`)
 
-	await connection.any(`
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_major INTEGER;
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_minor INTEGER;
-		ALTER TABLE ${LINK_TABLE} ADD COLUMN IF NOT EXISTS version_patch INTEGER;`)
-
 	const indexes = _.map(await connection.any(`
 		SELECT * FROM pg_indexes WHERE tablename = '${LINK_TABLE}'`),
 	'indexname')
@@ -57,17 +48,12 @@ exports.setup = async (context, connection, database, options) => {
 	const slugVersionIndex =
 		`${LINK_TABLE}_slug_version_major_version_minor_version_patch_key`
 	if (!indexes.includes(slugVersionIndex)) {
-		await connection.task(async (task) => {
+		initTasks.push(connection.task(async (task) => {
 			await task.any('SET statement_timeout = 0')
 			await task.any(`CREATE UNIQUE INDEX CONCURRENTLY ${slugVersionIndex}
 				ON ${LINK_TABLE} USING btree (slug, version_major, version_minor, version_patch)`)
-		})
+		}))
 	}
-
-	await connection.any(`
-		SET statement_timeout = 0;
-		ALTER TABLE ${LINK_TABLE}
-		DROP CONSTRAINT IF EXISTS ${LINK_TABLE}_slug_key;`)
 
 	for (const [ name, column ] of [
 		[ 'idx_links_fromid_name', 'fromid, name' ],
@@ -83,10 +69,12 @@ exports.setup = async (context, connection, database, options) => {
 			index: name
 		})
 
-		await connection.any(`
+		initTasks.push(connection.any(`
 			CREATE INDEX IF NOT EXISTS ${name} ON ${LINK_TABLE}
-			USING BTREE (${column})`)
+			USING BTREE (${column})`))
 	}
+
+	await Promise.all(initTasks)
 }
 
 exports.upsert = async (context, connection, link) => {

--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -10,10 +10,9 @@ const EventEmitter = require('events').EventEmitter
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const uuid = require('@balena/jellyfish-uuid')
 const metrics = require('@balena/jellyfish-metrics')
-
-// Just a random fixed number used as the advisory lock ID for the SQL
-// initialization script
-const INIT_LOCK = 1142043989439426746
+const {
+	INIT_LOCK
+} = require('./cards')
 
 const INSERT_EVENT = 'insert'
 const UPDATE_EVENT = 'update'
@@ -33,8 +32,6 @@ const setupTrigger = async (connection, table, columns) => {
 	const trigger = pgFormat.ident(`trigger-${channel}`)
 	await connection.any(`
 		BEGIN;
-
-		SELECT pg_advisory_xact_lock(${INIT_LOCK});
 
 		CREATE OR REPLACE FUNCTION rowChanged() RETURNS TRIGGER AS $$
 		DECLARE
@@ -75,7 +72,10 @@ const setupTrigger = async (connection, table, columns) => {
 		END;
 		$$ LANGUAGE PLPGSQL;
 
+		SELECT pg_advisory_xact_lock(${INIT_LOCK});
+
 		DROP TRIGGER IF EXISTS ${trigger} ON ${tableIdent};
+
 		CREATE TRIGGER ${trigger} AFTER
 		INSERT OR
 		UPDATE OF ${columns.join(', ')} OR


### PR DESCRIPTION
- Use advisory locks to avoid deadlocks on initialization
- Agglutinate sequential initialization statements into a single
  transaction
- Parallelize initialization as much as possible

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>