### PR TITLE
core: use explicit locking for `CREATE FUNCTION`/`CREATE TYPE` statements

### DIFF
--- a/lib/core/backend/postgres/cards.js
+++ b/lib/core/backend/postgres/cards.js
@@ -49,6 +49,9 @@ const CARDS_SELECT = [
 	'data'
 ].join(', ')
 
+// Functions cannot be created concurrently
+const CREATE_IMMUTABLE_ARRAY_TO_STRING_FUNCTION_LOCK = 3043989439426746
+
 // Just a random fixed number used as the advisory lock ID for SQL
 // initialization scripts that modify the `cards` table
 exports.INIT_LOCK = 1142043989439426746
@@ -185,9 +188,16 @@ exports.setup = async (context, connection, database, options = {}) => {
 		 * Create function that allows us to create tsvector indexes from text[] fields.
 		 */
 		connection.any(`
+			BEGIN;
+
+			SELECT pg_advisory_xact_lock(${CREATE_IMMUTABLE_ARRAY_TO_STRING_FUNCTION_LOCK});
+
 			CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text) RETURNS text AS $$
 				SELECT array_to_string(arr, sep);
-			$$ LANGUAGE SQL IMMUTABLE`)
+			$$ LANGUAGE SQL IMMUTABLE;
+
+			COMMIT;
+		`)
 	])
 }
 

--- a/lib/core/backend/postgres/links.js
+++ b/lib/core/backend/postgres/links.js
@@ -10,6 +10,9 @@ const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const LINK_ORIGIN_PROPERTY = '$link'
 const LINK_TABLE = 'links'
 
+// Types cannot be created concurrently
+const CREATE_LINK_EDGE_TYPES_LOCK = 104312345639426746
+
 exports.TABLE = LINK_TABLE
 
 exports.setup = async (context, connection, database, options) => {
@@ -19,13 +22,19 @@ exports.setup = async (context, connection, database, options) => {
 	})
 
 	const initTasks = [ connection.any(`
+		BEGIN;
+
+		SELECT pg_advisory_xact_lock(${CREATE_LINK_EDGE_TYPES_LOCK});
+
 		DO $$
 		BEGIN
 			IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'linkedge') THEN
 				CREATE TYPE linkEdge AS (source UUID, idx INT, sink UUID);
 				CREATE TYPE cardAndLinkEdges AS (cardId UUID, edges linkEdge[]);
 			END IF;
-		END$$
+		END$$;
+
+		COMMIT;
 	`) ]
 
 	await connection.any(`

--- a/lib/core/backend/postgres/streams.js
+++ b/lib/core/backend/postgres/streams.js
@@ -19,6 +19,9 @@ const UPDATE_EVENT = 'update'
 const DELETE_EVENT = 'delete'
 const UNMATCH_EVENT = 'unmatch'
 
+// Functions cannot be created concurrently
+const CREATE_ROW_CHANGED_FUNCTION_LOCK = 2043989439426746
+
 exports.start = async (backend, connection, table, columns) => {
 	const streamer = new Streamer(backend, table)
 	await streamer.init(await connection.connect(), columns)
@@ -30,8 +33,11 @@ const setupTrigger = async (connection, table, columns) => {
 	const tableIdent = pgFormat.ident(table)
 	const channel = `stream-${table}`
 	const trigger = pgFormat.ident(`trigger-${channel}`)
+
 	await connection.any(`
 		BEGIN;
+
+		SELECT pg_advisory_xact_lock(${CREATE_ROW_CHANGED_FUNCTION_LOCK});
 
 		CREATE OR REPLACE FUNCTION rowChanged() RETURNS TRIGGER AS $$
 		DECLARE
@@ -71,6 +77,10 @@ const setupTrigger = async (connection, table, columns) => {
 			RETURN NULL;
 		END;
 		$$ LANGUAGE PLPGSQL;
+
+		COMMIT;
+
+		BEGIN;
 
 		SELECT pg_advisory_xact_lock(${INIT_LOCK});
 


### PR DESCRIPTION
In Postgres these statements cannot be run concurrently.
    
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>