### PR TITLE
Pass syntheticCard to sort handler so that the filters aren't lost

### DIFF
--- a/apps/ui/lens/full/View/index.jsx
+++ b/apps/ui/lens/full/View/index.jsx
@@ -380,7 +380,8 @@ class ViewRenderer extends React.Component {
 			}
 		}, () => {
 			const queryOptions = this.getQueryOptions(activeLens)
-			this.props.actions.loadViewData(head.id, queryOptions)
+			const syntheticViewCard = createSyntheticViewCard(head, this.state.filters)
+			this.props.actions.loadViewData(syntheticViewCard, queryOptions)
 		})
 	}
 


### PR DESCRIPTION
We are losing the filter when we re-sort. This small change fixes it