### PR TITLE
ui: View search now searches within timeline events as well

### DIFF
--- a/apps/ui/core/queries.js
+++ b/apps/ui/core/queries.js
@@ -6,7 +6,7 @@
 
 import _ from 'lodash'
 
-const mergeWithUniqConcatArrays = (objValue, srcValue) => {
+export const mergeWithUniqConcatArrays = (objValue, srcValue) => {
 	if (_.isArray(objValue)) {
 		return _.uniq(objValue.concat(srcValue))
 	}

--- a/apps/ui/lens/full/View/constants.jsx
+++ b/apps/ui/lens/full/View/constants.jsx
@@ -5,6 +5,7 @@
  */
 
 const FULL_TEXT_SEARCH_TITLE = 'full_text_search'
+const EVENTS_FULL_TEXT_SEARCH_TITLE = 'events_full_text_search'
 
 const USER_FILTER_NAME = 'user-generated-filter'
 
@@ -12,6 +13,7 @@ const TIMELINE_FILTER_PROP = '$$links'
 
 export {
 	FULL_TEXT_SEARCH_TITLE,
+	EVENTS_FULL_TEXT_SEARCH_TITLE,
 	USER_FILTER_NAME,
 	TIMELINE_FILTER_PROP
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR modifies the behaviour of the View searchbox so that in addition to searching within the fields of the target cards, we also search within the fields of timeline events (messages/whispers) attached to the target cards.

Note: running a _single_ query that checks both fields on the target card _and_ fields on any attached timeline event cards results in an extremely slow query that times out on production data. As a work-around we create two separate queries, run them in parallel and then merge the results. This is a slight inefficiency as it can result in fetching the same target cards twice (e.g. if a filter matches the target card and the search term is found on a message/whisper attached to the same card). But both queries run relatively fast.
 