### PR TITLE
Remove pattern omission from CardTable and instead include an omission for the id and slug fields

### DIFF
--- a/apps/ui/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lens/misc/Table/CardTable.jsx
@@ -30,10 +30,14 @@ const RENDERERS = {
 	}
 }
 
-// Do not include markdown or mermaid fields in our table, as well as those with the pattern key
+// Do not include markdown or mermaid fields in our table,
+// as well as the id and slug fields
 const OMISSIONS = [ {
-	key: 'pattern'
+	field: 'id'
 }, {
+	field: 'slug'
+},
+{
 	key: 'format',
 	value: 'markdown'
 }, {


### PR DESCRIPTION
At the moment we aren't showing the name field on our `Table` lens. This is because we have excluded all fields with a pattern key in their schema. 

What we really want to do is exclude the id and the schema fields so I have done this instead

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
