### PR TITLE
Ensure loadViewData and loadMoreViewData actions are shared between the inbox and the other views

### DIFF
--- a/apps/ui/components/Inbox/Inbox.jsx
+++ b/apps/ui/components/Inbox/Inbox.jsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	circularDeepEqual
+} from 'fast-equals'
+import styled from 'styled-components'
+import React, {
+	useState
+} from 'react'
+import {
+	Flex,
+	Heading,
+	Tabs,
+	Tab
+} from 'rendition'
+import Column from '@balena/jellyfish-ui-components/lib/shame/Column'
+import InboxTab from './InboxTab'
+import * as queries from './queries'
+
+const InboxColumn = styled(Column) `
+	[role="tabpanel"] {
+		display: flex;
+	  flex-direction: column;
+	  height: 100vh;
+	}
+`
+
+const Inbox = ({
+	setupStream,
+	paginateStream
+}) => {
+	// State controller for managing the active tab
+	const [ currentTab, setCurrentTab ] = useState(0)
+
+	const defaultTabProps = {
+		setupStream,
+		paginateStream,
+		currentTab,
+		key: currentTab
+	}
+
+	return (
+		<InboxColumn>
+			<Flex p={3} justifyContent="space-between">
+				<Heading.h4>
+					Inbox
+				</Heading.h4>
+			</Flex>
+
+			<Tabs
+				activeIndex={currentTab}
+				onActive={setCurrentTab}
+			>
+				<Tab title="Unread">
+					<InboxTab
+						{ ...defaultTabProps }
+						getQuery={queries.getUnreadQuery}
+						canMarkAsRead
+					/>
+				</Tab>
+
+				<Tab title="Read">
+					<InboxTab
+						{ ...defaultTabProps }
+						getQuery={queries.getReadQuery}
+					/>
+				</Tab>
+
+				<Tab title="Sent">
+					<InboxTab
+						{ ...defaultTabProps }
+						getQuery={queries.getSentQuery}
+					/>
+				</Tab>
+			</Tabs>
+		</InboxColumn>
+	)
+}
+
+export default React.memo(Inbox, circularDeepEqual)

--- a/apps/ui/components/Inbox/InboxTab.jsx
+++ b/apps/ui/components/Inbox/InboxTab.jsx
@@ -92,10 +92,6 @@ const InboxTab = ({
 	const messagesRef = useRef(messages)
 	messagesRef.current = messages
 
-	// Also setting up pageRef so we do not have a stale closure
-	const pageRef = useRef(page)
-	pageRef.current = page
-
 	const removeMessage = (id) => {
 		const updatedMessages = messagesRef.current.filter((item) => {
 			return item.id !== id
@@ -132,13 +128,12 @@ const InboxTab = ({
 		setLoading(false)
 	}
 
-	const loadMoreViewData = async () => {
+	const loadMoreViewData = async (nextPage) => {
 		setLoading(true)
-		const currentPage = pageRef.current
 		const query = getQuery(user, groupNames, searchTerm)
 		const options = {
 			...DEFAULT_OPTIONS,
-			page: currentPage
+			page: nextPage
 		}
 		const newMessages = await paginateStream(STREAM_ID, query, options, _.noop)
 		setMessages([ ...messagesRef.current, ...newMessages ])
@@ -156,8 +151,9 @@ const InboxTab = ({
 
 	const loadNextPage = async () => {
 		if (!loadedAllResults && !loading) {
-			await setPage(page + 1)
-			loadMoreViewData()
+			const nextPage = page + 1
+			await setPage(nextPage)
+			await loadMoreViewData(nextPage)
 		}
 	}
 

--- a/apps/ui/components/Inbox/MarkAsReadButton.jsx
+++ b/apps/ui/components/Inbox/MarkAsReadButton.jsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import Bluebird from 'bluebird'
+import React, {
+	useState,
+	useCallback
+} from 'react'
+import {
+	Button
+} from 'rendition'
+import Icon from '@balena/jellyfish-ui-components/lib/shame/Icon'
+
+const markMessagesAsRead = (sdk, inboxData, user, groupNames) => {
+	return Bluebird.map(inboxData, (card) => {
+		return sdk.card.markAsRead(user.slug, card, groupNames)
+	}, {
+		concurrency: 10
+	})
+}
+
+const MarkAsReadButton = ({
+	canMarkAsRead,
+	inboxData,
+	user,
+	groupNames,
+	sdk
+}) => {
+	if (!canMarkAsRead) {
+		return null
+	}
+	const [ isMarkingAllAsRead, setIsMarkingAllAsRead ] = useState(false)
+
+	const markAllAsRead = useCallback(async () => {
+		setIsMarkingAllAsRead(true)
+		if (inboxData) {
+			await markMessagesAsRead(sdk, inboxData, user, groupNames)
+		}
+		setIsMarkingAllAsRead(false)
+	}, [ inboxData, sdk, user, groupNames ])
+
+	return (
+		<Button
+			ml={3}
+			disabled={isMarkingAllAsRead}
+			onClick={markAllAsRead}
+			data-test="inbox__mark-all-as-read"
+			icon={isMarkingAllAsRead ? <Icon name="cog" spin /> : <Icon name="check-circle" />}
+		>
+			{`Mark ${inboxData ? inboxData.length : 'all'} as read`}
+		</Button>
+	)
+}
+
+export default MarkAsReadButton

--- a/apps/ui/components/Inbox/index.jsx
+++ b/apps/ui/components/Inbox/index.jsx
@@ -9,6 +9,9 @@ import {
 	circularDeepEqual
 } from 'fast-equals'
 import styled from 'styled-components'
+import {
+	connect
+} from 'react-redux'
 import React, {
 	useState
 } from 'react'
@@ -18,11 +21,15 @@ import {
 	Tabs,
 	Tab
 } from 'rendition'
-import Column from '@balena/jellyfish-ui-components/lib/shame/Column'
-import InboxTab from './InboxTab'
 import {
-	queries
+	bindActionCreators
+} from 'redux'
+import Column from '@balena/jellyfish-ui-components/lib/shame/Column'
+import {
+	actionCreators
 } from '../../core'
+import InboxTab from './InboxTab'
+import * as queries from './queries'
 
 const InboxColumn = styled(Column) `
 	[role="tabpanel"] {
@@ -32,60 +39,19 @@ const InboxColumn = styled(Column) `
 	}
 `
 
-const getReadQuery = (user, groupNames, searchTerm) => {
-	return _.merge(queries.getPingQuery(user, groupNames, searchTerm), {
-		type: 'object',
-		properties: {
-			data: {
-				type: 'object',
-				properties: {
-					readBy: {
-						type: 'array',
-						contains: {
-							const: user.slug
-						},
-						minLength: 1
-					}
-				},
-				required: [
-					'readBy',
-					'payload'
-				]
-			}
-		}
-	})
-}
-
-const getSentQuery = (user, groupNames, searchTerm) => {
-	return queries.withSearch({
-		type: 'object',
-		properties: {
-			type: {
-				type: 'string',
-				enum: [
-					'message@1.0.0',
-					'whisper@1.0.0',
-					'summary@1.0.0'
-				]
-			},
-			data: {
-				type: 'object',
-				properties: {
-					actor: {
-						type: 'string',
-						const: user.id
-					}
-				},
-				additionalProperties: true
-			}
-		},
-		additionalProperties: true
-	}, searchTerm)
-}
-
-export default React.memo((props) => {
+const Inbox = React.memo(({
+	setupStream,
+	paginateStream
+}) => {
 	// State controller for managing the active tab
 	const [ currentTab, setCurrentTab ] = useState(0)
+
+	const defaultTabProps = {
+		setupStream,
+		paginateStream,
+		currentTab,
+		key: currentTab
+	}
 
 	return (
 		<InboxColumn>
@@ -101,8 +67,7 @@ export default React.memo((props) => {
 			>
 				<Tab title="Unread">
 					<InboxTab
-						key={currentTab}
-						currentTab={currentTab}
+						{ ...defaultTabProps }
 						getQuery={queries.getUnreadQuery}
 						canMarkAsRead
 					/>
@@ -110,20 +75,30 @@ export default React.memo((props) => {
 
 				<Tab title="Read">
 					<InboxTab
-						key={currentTab}
-						getQuery={getReadQuery}
-						currentTab={currentTab}
+						{ ...defaultTabProps }
+						getQuery={queries.getReadQuery}
 					/>
 				</Tab>
 
 				<Tab title="Sent">
 					<InboxTab
-						key={currentTab}
-						getQuery={getSentQuery}
-						currentTab={currentTab}
+						{ ...defaultTabProps }
+						getQuery={queries.getSentQuery}
 					/>
 				</Tab>
 			</Tabs>
 		</InboxColumn>
 	)
 }, circularDeepEqual)
+
+const mapDispatchToProps = (dispatch) => {
+	return bindActionCreators(
+		_.pick(actionCreators, [
+			'setupStream',
+			'paginateStream'
+		]),
+		dispatch
+	)
+}
+
+export default connect(null, mapDispatchToProps)(Inbox)

--- a/apps/ui/components/Inbox/index.jsx
+++ b/apps/ui/components/Inbox/index.jsx
@@ -6,90 +6,15 @@
 
 import _ from 'lodash'
 import {
-	circularDeepEqual
-} from 'fast-equals'
-import styled from 'styled-components'
-import {
 	connect
 } from 'react-redux'
-import React, {
-	useState
-} from 'react'
-import {
-	Flex,
-	Heading,
-	Tabs,
-	Tab
-} from 'rendition'
 import {
 	bindActionCreators
 } from 'redux'
-import Column from '@balena/jellyfish-ui-components/lib/shame/Column'
 import {
 	actionCreators
 } from '../../core'
-import InboxTab from './InboxTab'
-import * as queries from './queries'
-
-const InboxColumn = styled(Column) `
-	[role="tabpanel"] {
-		display: flex;
-	  flex-direction: column;
-	  height: 100vh;
-	}
-`
-
-const Inbox = React.memo(({
-	setupStream,
-	paginateStream
-}) => {
-	// State controller for managing the active tab
-	const [ currentTab, setCurrentTab ] = useState(0)
-
-	const defaultTabProps = {
-		setupStream,
-		paginateStream,
-		currentTab,
-		key: currentTab
-	}
-
-	return (
-		<InboxColumn>
-			<Flex p={3} justifyContent="space-between">
-				<Heading.h4>
-					Inbox
-				</Heading.h4>
-			</Flex>
-
-			<Tabs
-				activeIndex={currentTab}
-				onActive={setCurrentTab}
-			>
-				<Tab title="Unread">
-					<InboxTab
-						{ ...defaultTabProps }
-						getQuery={queries.getUnreadQuery}
-						canMarkAsRead
-					/>
-				</Tab>
-
-				<Tab title="Read">
-					<InboxTab
-						{ ...defaultTabProps }
-						getQuery={queries.getReadQuery}
-					/>
-				</Tab>
-
-				<Tab title="Sent">
-					<InboxTab
-						{ ...defaultTabProps }
-						getQuery={queries.getSentQuery}
-					/>
-				</Tab>
-			</Tabs>
-		</InboxColumn>
-	)
-}, circularDeepEqual)
+import Inbox from './Inbox'
 
 const mapDispatchToProps = (dispatch) => {
 	return bindActionCreators(

--- a/apps/ui/components/Inbox/queries.js
+++ b/apps/ui/components/Inbox/queries.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import {
+	queries
+} from '../../core'
+
+export const getUnreadQuery = queries.getUnreadQuery
+
+export const getReadQuery = (user, groupNames, searchTerm) => {
+	return _.merge(queries.getPingQuery(user, groupNames, searchTerm), {
+		type: 'object',
+		properties: {
+			data: {
+				type: 'object',
+				properties: {
+					readBy: {
+						type: 'array',
+						contains: {
+							const: user.slug
+						},
+						minLength: 1
+					}
+				},
+				required: [
+					'readBy',
+					'payload'
+				]
+			}
+		}
+	})
+}
+
+export const getSentQuery = (user, groupNames, searchTerm) => {
+	return queries.withSearch({
+		type: 'object',
+		properties: {
+			type: {
+				type: 'string',
+				enum: [
+					'message@1.0.0',
+					'whisper@1.0.0',
+					'summary@1.0.0'
+				]
+			},
+			data: {
+				type: 'object',
+				properties: {
+					actor: {
+						type: 'string',
+						const: user.id
+					}
+				},
+				additionalProperties: true
+			}
+		},
+		additionalProperties: true
+	}, searchTerm)
+}


### PR DESCRIPTION
**NOTE**: I would recommend reviewing this by commit rather than all at once

At the moment, the Inbox has its own bespoke code for loading and paginating through the messages. I have a suspicion that the notification bug is being caused by the lack of consideration for race conditions in the stream updates (the loadViewData action creates a queue to manage race conditions)

As part of a wider process to de-duplicate the loading and pagination of lists in Jellyfish, I decided to break the stream management out of loadViewData and loadMoreViewData into two new actions named `setupStream` and `paginateStream`. Extracting them out like this will help when we move stream pagination to the sdk.

This PR covers the extraction of these methods, as well as the work to update the `InboxTab` component to use the new methods. I also extracted out the `MarkAsReadButton` code to its own file