### PR TITLE
Remove limit from the support-threads list lens

### DIFF
--- a/apps/ui/lens/list/SupportThreads.jsx
+++ b/apps/ui/lens/list/SupportThreads.jsx
@@ -353,7 +353,6 @@ const lens = {
 			}
 		},
 		queryOptions: {
-			limit: 100,
 			sortBy: [ 'created_at' ],
 			sortDir: 'desc'
 		}


### PR DESCRIPTION
This is causing some issues for Georgia: https://www.flowdock.com/app/rulemotion/p-cyclops/threads/OPPh4k4yrRm4MlcqirlgzNoHZ7b?filter=search&query=psa

I imagine that this limit was set due to the fact that we were querying for all the data when we loaded this page. Now that we have pagination on our queries, this should no longer be an issue.

I would still like to wait for Lucian to confirm this before we merge it