### PR TITLE
Kubernetes Manifests: Sets the rollout strategy to not allow unavailable pods.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -7,6 +7,11 @@ metadata:
     app.kubernetes.io/name: jellyfish-action-server
 spec:
   replicas: 24
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxSurge: 25%
+       maxUnavailable: 0 
   selector:
     matchLabels:
       app: action-server

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -10,6 +10,11 @@ spec:
     matchLabels:
       app: jellyfish
   replicas: 16
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxSurge: 25%
+       maxUnavailable: 0 
   template:
     metadata:
       labels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -10,6 +10,11 @@ spec:
     matchLabels:
       app: jellyfish-livechat
   replicas: 4
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxSurge: 1
+       maxUnavailable: 0 
   template:
     metadata:
       labels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -10,6 +10,11 @@ spec:
     matchLabels:
       app: jellyfish-ui
   replicas: 4
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxSurge: 1
+       maxUnavailable: 0 
   template:
     metadata:
       labels:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: jellyfish-tick-server
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: tick-server


### PR DESCRIPTION
This should allow a smoother rollout as it avoids having unavailable pods in the fleet
during rollout of updates.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
