### PR TITLE
ui: Do not treat elements as 'visible' if the document is hidden

### DIFF
--- a/apps/ui/index.jsx
+++ b/apps/ui/index.jsx
@@ -40,8 +40,9 @@ import {
 } from '@balena/jellyfish-ui-components/lib/services/helpers'
 import ErrorBoundary from '@balena/jellyfish-ui-components/lib/shame/ErrorBoundary'
 import {
-	ResponsiveProvider
-} from '@balena/jellyfish-ui-components/lib/hooks/ResponsiveProvider'
+	ResponsiveProvider,
+	DocumentVisibilityProvider
+} from '@balena/jellyfish-ui-components/lib/hooks'
 import {
 	ConnectedRouter
 } from 'connected-react-router'
@@ -109,21 +110,23 @@ ReactDOM.render(
 			}}
 		>
 			<ResponsiveProvider>
-				<SetupProvider environment={environment} sdk={sdk} analytics={analytics} errorReporter={errorReporter}>
-					<Provider store={store}>
-						<PersistGate loading={null} persistor={persistor}>
-							<ConnectedRouter history={history}>
-								<GlobalStyle />
+				<DocumentVisibilityProvider>
+					<SetupProvider environment={environment} sdk={sdk} analytics={analytics} errorReporter={errorReporter}>
+						<Provider store={store}>
+							<PersistGate loading={null} persistor={persistor}>
+								<ConnectedRouter history={history}>
+									<GlobalStyle />
 
-								<ErrorBoundary>
-									<DndProvider backend={HTML5Backend}>
-										<JellyfishUI />
-									</DndProvider>
-								</ErrorBoundary>
-							</ConnectedRouter>
-						</PersistGate>
-					</Provider>
-				</SetupProvider>
+									<ErrorBoundary>
+										<DndProvider backend={HTML5Backend}>
+											<JellyfishUI />
+										</DndProvider>
+									</ErrorBoundary>
+								</ConnectedRouter>
+							</PersistGate>
+						</Provider>
+					</SetupProvider>
+				</DocumentVisibilityProvider>
 			</ResponsiveProvider>
 		</RProvider>
 	),


### PR DESCRIPTION
The combination of the `DocumentVisibilityProvider` and the `SmartVisibilitySensor` components ensures that we don't call the `onCardVisible` callback with a `true` value if the document (tab) is hidden.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Note: this PR is really just the finishing touch to the implementation introduced in [this jellyfish-ui-components PR](https://github.com/product-os/jellyfish-ui-components/pull/63). That PR ensures we don't call `markAsRead` when an `Event` component becomes visible if the document (tab) is hidden.

Fixes #4687 
