### PR TITLE
ui: Close inbox stream when unmounting

### DIFF
--- a/apps/ui/components/Inbox/Inbox.jsx
+++ b/apps/ui/components/Inbox/Inbox.jsx
@@ -31,6 +31,7 @@ const InboxColumn = styled(Column) `
 
 const Inbox = ({
 	setupStream,
+	clearViewData,
 	paginateStream
 }) => {
 	// State controller for managing the active tab
@@ -38,6 +39,7 @@ const Inbox = ({
 
 	const defaultTabProps = {
 		setupStream,
+		clearViewData,
 		paginateStream,
 		currentTab,
 		key: currentTab

--- a/apps/ui/components/Inbox/InboxTab.jsx
+++ b/apps/ui/components/Inbox/InboxTab.jsx
@@ -67,6 +67,7 @@ const InboxTab = ({
 	getQuery,
 	currentTab,
 	setupStream,
+	clearViewData,
 	paginateStream,
 	canMarkAsRead
 }) => {
@@ -161,6 +162,11 @@ const InboxTab = ({
 	// then we need to reload the data
 	useEffect(() => {
 		loadViewData()
+		return () => {
+			clearViewData(null, {
+				viewId: STREAM_ID
+			})
+		}
 	}, [ currentTab, searchTerm ])
 
 	return (

--- a/apps/ui/components/Inbox/index.jsx
+++ b/apps/ui/components/Inbox/index.jsx
@@ -20,6 +20,7 @@ const mapDispatchToProps = (dispatch) => {
 	return bindActionCreators(
 		_.pick(actionCreators, [
 			'setupStream',
+			'clearViewData',
 			'paginateStream'
 		]),
 		dispatch


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Use the return cleanup function of the `React.useEffect` method to close the stream/clean up the view data when unmounting the Inbox tab.

Note: without this you get an unhandled exception in the InboxTab component's `updateMessage` method as the stream is still open and receiving messages (and calling back to the InboxTab) but the InboxTab component is unmounted and `messagesRef.current` is undefined!
