### PR TITLE
ui: Close user menu when navigating

### DIFF
--- a/apps/ui/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/components/HomeChannel/HomeChannel.jsx
@@ -430,6 +430,9 @@ export default class HomeChannel extends React.Component {
 		if (!prevProps.channel.data.head && this.props.channel.data.head) {
 			this.props.actions.loadViewData(this.props.channel.data.head)
 		}
+		if (this.state.showMenu && prevProps.location.pathname !== this.props.location.pathname) {
+			this.hideMenu()
+		}
 		if (this.props.isMobile) {
 			if (this.wrapper.current) {
 				const prevPath = cleanPath(prevProps.location)


### PR DESCRIPTION
This is a work-around for the fact that the `Link` component stops the click event propagation and overwrites the onClick prop so we can't specifically close the user menu after clicking on one of the links in the user menu!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
