### PR TITLE
Fixes pagination on the repository - ensures paginateStream is passed dispatch and state methods, and fixes how we update the state when we reach the start of the repo timeline

### DIFF
--- a/apps/ui/core/store/actioncreators/index.js
+++ b/apps/ui/core/store/actioncreators/index.js
@@ -1475,7 +1475,7 @@ export default class ActionCreator {
 			const commonOptions = _.pick(options, 'viewId')
 			const appendHandler = (card) => dispatch(this.appendViewData(query, card, commonOptions))
 			const viewId = options.viewId || getViewId(query)
-			return this.paginateStream(viewId, query, options, appendHandler)
+			return this.paginateStream(viewId, query, options, appendHandler)(dispatch, getState)
 		}
 	}
 

--- a/apps/ui/lens/full/Repository/Repository.jsx
+++ b/apps/ui/lens/full/Repository/Repository.jsx
@@ -98,16 +98,13 @@ export default class RepositoryFull extends React.Component {
 
 		return loader(query, options)
 			.then((results) => {
-				if (results.length < LIMIT) {
-					this.setState((state) => {
-						return {
-							options: {
-								...state.options,
-								totalPages: state.options.page + 1
-							}
-						}
-					})
-				}
+				this.setState({
+					options: {
+						...this.state.options,
+						page,
+						totalPages: results.length < LIMIT ? page : this.state.options.totalPages
+					}
+				})
 			})
 	}
 
@@ -141,10 +138,6 @@ export default class RepositoryFull extends React.Component {
 		})
 
 		await this.loadThreadData(options.page, this.state.searchTerm)
-
-		this.setState({
-			options
-		})
 
 		this.isLoadingPage = false
 	}


### PR DESCRIPTION
This should fix two bugs:

- One where the repo wasnt paginating
- Other where it wasn't determining when we had reached the end of the messages on the repo timeline

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
