### PR TITLE
ui: Use getSnapshotBeforeUpdate to handle scroll position

### DIFF
--- a/apps/ui/lens/list/Interleaved.jsx
+++ b/apps/ui/lens/list/Interleaved.jsx
@@ -179,7 +179,7 @@ export class Interleaved extends BaseLens {
 		this.bindScrollArea = this.bindScrollArea.bind(this)
 	}
 
-	componentWillUpdate () {
+	getSnapshotBeforeUpdate () {
 		if (!this.scrollArea) {
 			return
 		}


### PR DESCRIPTION
This is a more appropriate technique than the deprecated `componentWillUpdate`.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
