### PR TITLE
Improve CRM table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@
 	scrub \
 	clean-front \
 	clean-github \
-	npm-install
+	npm-install \
+	npm-ci
 
 # See https://stackoverflow.com/a/18137056
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -258,6 +259,13 @@ npm-install:
 	cd apps/livechat && npm install
 	cd apps/server && npm install
 	cd apps/ui && npm install
+
+npm-ci:
+	npm ci
+	cd apps/action-server && npm ci
+	cd apps/livechat && npm ci
+	cd apps/server && npm ci
+	cd apps/ui && npm ci
 
 .tmp:
 	mkdir -p $@

--- a/apps/server/lib/default-cards/balena/view-all-opportunities.json
+++ b/apps/server/lib/default-cards/balena/view-all-opportunities.json
@@ -20,6 +20,14 @@
                     }
                   },
                   "additionalProperties": true
+                },
+                "is owned by": {
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  },
+                  "additionalProperties": true
                 }
               }
             },
@@ -45,8 +53,8 @@
       }
     ],
     "lenses": [
-      "lens-list",
       "lens-crm-table",
+      "lens-list",
       "lens-kanban"
     ]
   }

--- a/apps/server/lib/default-cards/balena/view-my-opportunities.json
+++ b/apps/server/lib/default-cards/balena/view-my-opportunities.json
@@ -2,7 +2,9 @@
   "slug": "view-my-opportunities",
   "name": "My opportunities",
   "type": "view@1.0.0",
-  "markers": [ "org-balena" ],
+  "markers": [
+    "org-balena"
+  ],
   "data": {
     "namespace": "Sales",
     "allOf": [
@@ -60,8 +62,8 @@
       }
     ],
     "lenses": [
-      "lens-list",
       "lens-crm-table",
+      "lens-list",
       "lens-kanban"
     ]
   }

--- a/apps/server/lib/default-cards/contrib/opportunity.js
+++ b/apps/server/lib/default-cards/contrib/opportunity.js
@@ -94,9 +94,6 @@ module.exports = ({
 					}
 				}
 			},
-			slices: [
-				'properties.data.properties.status'
-			],
 			meta: {
 				relationships: [
 					{

--- a/apps/ui/lib/components/CardActions/CardActions.jsx
+++ b/apps/ui/lib/components/CardActions/CardActions.jsx
@@ -5,6 +5,7 @@
  */
 
 import copy from 'copy-to-clipboard'
+import _ from 'lodash'
 import React from 'react'
 import {
 	Button,
@@ -83,6 +84,8 @@ export default class CardActions extends React.Component {
 
 	render () {
 		const supportsOwnership = supportsLink(this.props.card.type, 'is owned by')
+		const owner = _.head(_.get(this.props.card, [ 'links', 'is owned by' ], null))
+
 		return (
 			<React.Fragment>
 				<Flex alignItems="center" justifyContent="flex-end">
@@ -92,7 +95,9 @@ export default class CardActions extends React.Component {
 							user={this.props.user}
 							types={this.props.types}
 							card={this.props.card}
+							channel={this.props.channel}
 							sdk={this.props.sdk}
+							cardOwner={owner}
 							actions={this.props.actions} />
 					)}
 					<Button

--- a/apps/ui/lib/components/CardOwner/CardOwner.jsx
+++ b/apps/ui/lib/components/CardOwner/CardOwner.jsx
@@ -56,10 +56,6 @@ export default class CardOwner extends React.Component {
 
 			await sdk.card.link(card, user, 'is owned by')
 
-			this.props.updateCardOwnerCache(user)
-
-			addNotification('success', `${cardTypeName} assigned to me`)
-
 			// Now generate a whisper in this card's timeline to detail the self-assignment
 			const whisper = handoverUtils.getHandoverWhisperEventCard(
 				card, cardOwner, user, null, _.get(card, [ 'data', 'statusDescription' ])
@@ -71,6 +67,7 @@ export default class CardOwner extends React.Component {
 						console.error('Failed to create whisper', err)
 					})
 			}
+			addNotification('success', `Assigned ${helpers.userDisplayName(user)} to ${cardTypeName} ${card.name}`)
 		} catch (err) {
 			addNotification('danger', `Failed to assign ${cardTypeName}`)
 			console.error('Failed to create link', err)
@@ -80,10 +77,12 @@ export default class CardOwner extends React.Component {
 	handover (unassigned) {
 		const {
 			actions,
-			card
+			card,
+			channel
 		} = this.props
 		const flowState = {
 			isOpen: true,
+			type: FLOW_IDS.GUIDED_HANDOVER,
 			card,
 			unassigned,
 			statusDescription: _.get(card, [ 'data', 'statusDescription' ], '')
@@ -93,7 +92,7 @@ export default class CardOwner extends React.Component {
 			flowState.newOwner = null
 			flowState.userError = null
 		}
-		actions.setFlow(FLOW_IDS.GUIDED_HANDOVER, card.id, flowState)
+		actions.setFlow(channel.data.target, card.id, flowState)
 	}
 
 	unassign () {
@@ -137,7 +136,6 @@ export default class CardOwner extends React.Component {
 		} = this.props
 
 		const cardTypeName = helpers.getType(card.type, types).name
-
 		return (
 			<DropDownButton
 				data-test="card-owner-dropdown"

--- a/apps/ui/lib/components/CardOwner/index.js
+++ b/apps/ui/lib/components/CardOwner/index.js
@@ -11,11 +11,7 @@ import {
 	compose
 } from 'redux'
 import CardOwner from './CardOwner'
-import {
-	withLink
-} from '@balena/jellyfish-ui-components'
 
 export default compose(
-	withRouter,
-	withLink('is owned by', 'cardOwner')
+	withRouter
 )(CardOwner)

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react'
 import Bluebird from 'bluebird'
+import _ from 'lodash'
 import {
 	addNotification,
 	helpers
@@ -22,11 +23,10 @@ import {
 	TextareaStep
 } from '../Steps'
 
-export default function HandoverFlowPanel ({
+const HandoverFlowPanel = ({
 	flowId,
 	card,
-	cardOwner,
-	updateCardOwnerCache,
+	channel,
 	flowState,
 	user,
 	types,
@@ -34,12 +34,13 @@ export default function HandoverFlowPanel ({
 	analytics,
 	sdk,
 	onClose
-}) {
+}) => {
+	const cardOwner = _.head(_.get(card, [ 'links', 'is owned by' ], null))
 	const setFlow = (updatedFlowState) => {
-		return actions.setFlow(flowId, card.id, updatedFlowState)
+		return actions.setFlow(channel.data.target, card.id, updatedFlowState)
 	}
 	const removeFlow = () => {
-		return actions.removeFlow(flowId, card.id)
+		return actions.removeFlow(channel.data.target, card.id)
 	}
 	const transferOwnership = async () => {
 		const {
@@ -63,6 +64,7 @@ export default function HandoverFlowPanel ({
 			// Unassign the current owner
 			if (cardOwner) {
 				await sdk.card.unlink(card, cardOwner, 'is owned by')
+				addNotification('success', `Unassigned ${helpers.userDisplayName(cardOwner)}`)
 			} else if (unassigned) {
 				console.warn(`No current owner found when unassigning the card ${card.slug}`)
 			}
@@ -70,6 +72,7 @@ export default function HandoverFlowPanel ({
 			if (newOwner) {
 				// Link the new owner to the card
 				linkActions.push(sdk.card.link(card, newOwner, 'is owned by'))
+				addNotification('success', `Assigned ${helpers.userDisplayName(newOwner)} tp ${cardTypeName}`)
 			}
 
 			if (handoverUtils.schemaSupportsStatusText(types, card)) {
@@ -95,9 +98,6 @@ export default function HandoverFlowPanel ({
 					}
 				})
 			}
-
-			// Finally, update the card owner cache
-			updateCardOwnerCache(newOwner || null)
 		} catch (error) {
 			console.error('Failed to assign card', error)
 			addNotification('danger', 'Handover failed. Refresh the page and try again.')
@@ -176,3 +176,5 @@ export default function HandoverFlowPanel ({
 		</StepsFlow>
 	)
 }
+
+export default HandoverFlowPanel

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/index.js
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/index.js
@@ -5,8 +5,5 @@
  */
 
 import HandoverFlowPanel from './HandoverFlowPanel'
-import {
-	withLink
-} from '@balena/jellyfish-ui-components'
 
-export default withLink('is owned by', 'cardOwner')(HandoverFlowPanel)
+export default HandoverFlowPanel

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
@@ -9,25 +9,33 @@ import _ from 'lodash'
 import {
 	SlideInPanel
 } from '@balena/jellyfish-ui-components'
+import HandoverFlowPanel from '../HandoverFlowPanel'
+import TeardownFlowPanel from '../TeardownFlowPanel'
+import {
+	FLOW_IDS
+} from '../flow-utils'
 
-export default function SlideInFlowPanel ({
-	flowId,
+const SlideInFlowPanel = ({
+	sdk,
 	card,
+	channel,
 	slideInPanelProps,
 	flowState,
 	actions,
 	children,
 	...rest
-}) {
+}) => {
+	const flowId = _.get(flowState, [ 'type' ])
+	const isOpen = _.get(flowState, [ 'isOpen' ], false)
+
 	if (_.isArray(children)) {
 		throw new Error('SlideInFlowPanel only accepts a single child component')
 	}
 	const close = () => {
-		actions.setFlow(flowId, card.id, {
+		actions.setFlow(channel.data.target, card.id, {
 			isOpen: false
 		})
 	}
-	const isOpen = _.get(flowState, [ 'isOpen' ], false)
 
 	return (
 		<SlideInPanel
@@ -37,14 +45,31 @@ export default function SlideInFlowPanel ({
 			isOpen={isOpen}
 			onClose={close}
 		>
-			{Boolean(flowState) && React.cloneElement(children, {
-				flowId,
-				card,
-				flowState,
-				actions,
-				onClose: close,
-				...rest
-			})}
+			{flowId === FLOW_IDS.GUIDED_HANDOVER && Boolean(flowState) && (
+				<HandoverFlowPanel
+					sdk={sdk}
+					card={card}
+					channel={channel}
+					flowId={flowId}
+					onClose={close}
+					flowState={flowState}
+					actions={actions}
+					{...rest} />
+			)}
+
+			{flowId === FLOW_IDS.GUIDED_TEARDOWN && Boolean(flowState) && (
+				<TeardownFlowPanel
+					sdk={sdk}
+					card={card}
+					channel={channel}
+					flowId={flowId}
+					onClose={close}
+					flowState={flowState}
+					actions={actions}
+					{...rest} />
+			)}
 		</SlideInPanel>
 	)
 }
+
+export default SlideInFlowPanel

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/index.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/index.jsx
@@ -20,11 +20,14 @@ import {
 import SlideInFlowPanel from './SlideInFlowPanel'
 
 const mapStateToProps = (state, props) => {
+	const channelTarget = _.get(props, [ 'channel', 'data', 'target' ])
+
 	return {
 		sdk,
 		analytics,
 		types: selectors.getTypes(state),
-		flowState: selectors.getFlow(props.flowId, props.card.id)(state)
+		flowState: selectors.getFlow(channelTarget, _.get(props, [ 'card', 'id' ]))(state),
+		card: _.get(props, [ 'card' ]) || null
 	}
 }
 

--- a/apps/ui/lib/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
@@ -46,21 +46,21 @@ const getSummaryEvent = (target, summary) => {
 	}
 }
 
-export default function TeardownFlowPanel ({
-	flowId,
+const TeardownFlowPanel = ({
 	card,
+	channel,
 	flowState,
 	types,
 	actions,
 	analytics,
 	sdk,
 	onClose
-}) {
+}) => {
 	const setFlow = (updatedFlowState) => {
-		return actions.setFlow(flowId, card.id, updatedFlowState)
+		return actions.setFlow(channel.data.target, card.id, updatedFlowState)
 	}
 	const removeFlow = () => {
-		return actions.removeFlow(flowId, card.id)
+		return actions.removeFlow(channel.data.target, card.id)
 	}
 	const teardown = async () => {
 		const {
@@ -139,3 +139,5 @@ export default function TeardownFlowPanel ({
 		</StepsFlow>
 	)
 }
+
+export default TeardownFlowPanel

--- a/apps/ui/lib/components/Flows/TeardownFlowPanel/index.js
+++ b/apps/ui/lib/components/Flows/TeardownFlowPanel/index.js
@@ -4,30 +4,6 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash'
-import {
-	connect
-} from 'react-redux'
-import {
-	bindActionCreators
-} from 'redux'
-import {
-	actionCreators
-}	from '../../../core'
 import TeardownFlowPanel from './TeardownFlowPanel'
 
-const mapDispatchToProps = (dispatch, ownProps) => {
-	const teardownActions = bindActionCreators(
-		_.pick(actionCreators, [
-			'addChannel',
-			'createLink',
-			'getLinks'
-		]),
-		dispatch
-	)
-	return {
-		actions: Object.assign({}, ownProps.actions, teardownActions)
-	}
-}
-
-export default connect(null, mapDispatchToProps)(TeardownFlowPanel)
+export default TeardownFlowPanel

--- a/apps/ui/lib/core/store/helpers.js
+++ b/apps/ui/lib/core/store/helpers.js
@@ -6,6 +6,10 @@
 
 import _ from 'lodash'
 import update from 'immutability-helper'
+import {
+	constraints
+} from '@balena/jellyfish-client-sdk/lib/link-constraints'
+import memoize from 'memoize-one'
 
 /**
  * Given a target card id and a card that's been updated, finds all channels
@@ -76,3 +80,17 @@ export const mentionsUser = (card, user, groups) => {
 		return _.get(groups, [ groupName, 'isMine' ])
 	})
 }
+
+export const getAllLinkQueries = memoize(() => {
+	let links = {}
+	constraints.forEach((constraint) => {
+		links = {
+			...links,
+			[constraint.name]: {
+				type: 'object',
+				additionalProperties: true
+			}
+		}
+	})
+	return links
+})

--- a/apps/ui/lib/core/store/reducer.js
+++ b/apps/ui/lib/core/store/reducer.js
@@ -189,13 +189,13 @@ const uiReducer = (state = defaultState.ui, action = {}) => {
 		}
 		case actions.SET_FLOW: {
 			const {
-				flowId,
+				channelId,
 				cardId,
 				flowState
 			} = action.value
 			return update(state, {
 				flows: {
-					[flowId]: (flowsById) => update(flowsById || {}, {
+					[channelId]: (channelsById) => update(channelsById || {}, {
 						[cardId]: {
 							$apply: (existingFlowState) => {
 								return _.merge({}, existingFlowState || {}, flowState)
@@ -207,12 +207,12 @@ const uiReducer = (state = defaultState.ui, action = {}) => {
 		}
 		case actions.REMOVE_FLOW: {
 			const {
-				flowId,
+				channelId,
 				cardId
 			} = action.value
 			return update(state, {
 				flows: {
-					[flowId]: (flowsById) => update(flowsById || {}, {
+					[channelId]: (channelsById) => update(channelsById || {}, {
 						$unset: [ cardId ]
 					})
 				}

--- a/apps/ui/lib/core/store/reducer.spec.js
+++ b/apps/ui/lib/core/store/reducer.spec.js
@@ -473,7 +473,7 @@ ava('USER_STOPPED_TYPING action removes the user from the usersTyping for that c
 
 ava('SET_FLOW adds flow state if it doesn\'t already exist', (test) => {
 	const initialState = _.cloneDeep(defaultState)
-	const flowId = 'HANDOVER'
+	const channelId = 'view-all-opportunities'
 	const cardId = '3'
 	const flowStateUpdates = {
 		someItem: 'someValue'
@@ -482,14 +482,14 @@ ava('SET_FLOW adds flow state if it doesn\'t already exist', (test) => {
 	const newState = reducer(initialState, {
 		type: actions.SET_FLOW,
 		value: {
-			flowId,
+			channelId,
 			cardId,
 			flowState: flowStateUpdates
 		}
 	})
 
 	test.deepEqual(newState.ui.flows, {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: {
 				someItem: 'someValue'
 			}
@@ -499,14 +499,14 @@ ava('SET_FLOW adds flow state if it doesn\'t already exist', (test) => {
 
 ava('SET_FLOW merges an existing flow state', (test) => {
 	const initialState = _.cloneDeep(defaultState)
-	const flowId = 'HANDOVER'
+	const channelId = 'view-all-opportunities'
 	const cardId = '3'
 	const flowState = {
 		isOpen: true,
 		valA: 'initial'
 	}
 	initialState.ui.flows = {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: flowState
 		}
 	}
@@ -517,14 +517,14 @@ ava('SET_FLOW merges an existing flow state', (test) => {
 	const newState = reducer(initialState, {
 		type: actions.SET_FLOW,
 		value: {
-			flowId,
+			channelId,
 			cardId,
 			flowState: flowStateUpdates
 		}
 	})
 
 	test.deepEqual(newState.ui.flows, {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: {
 				isOpen: true,
 				valA: 'changed'
@@ -533,15 +533,45 @@ ava('SET_FLOW merges an existing flow state', (test) => {
 	})
 })
 
-ava('REMOVE_FLOW removes flow state', (test) => {
+ava('REMOVE_FLOW removes flow state from channel with multiple flows', (test) => {
 	const initialState = _.cloneDeep(defaultState)
-	const flowId = 'HANDOVER'
+	const channelId = 'view-all-opportunities'
+	const cardId = '3'
+	const card2Id = '22'
+	const flowState = {
+		isOpen: true
+	}
+	initialState.ui.flows = {
+		[channelId]: {
+			[cardId]: flowState,
+			[card2Id]: flowState
+		}
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.REMOVE_FLOW,
+		value: {
+			channelId,
+			cardId
+		}
+	})
+
+	test.deepEqual(newState.ui.flows, {
+		[channelId]: {
+			[card2Id]: flowState
+		}
+	})
+})
+
+ava('REMOVE_FLOW removes flow state from channel with single flow', (test) => {
+	const initialState = _.cloneDeep(defaultState)
+	const channelId = 'view-all-opportunities'
 	const cardId = '3'
 	const flowState = {
 		isOpen: true
 	}
 	initialState.ui.flows = {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: flowState
 		}
 	}
@@ -549,13 +579,13 @@ ava('REMOVE_FLOW removes flow state', (test) => {
 	const newState = reducer(initialState, {
 		type: actions.REMOVE_FLOW,
 		value: {
-			flowId,
+			channelId,
 			cardId
 		}
 	})
 
 	test.deepEqual(newState.ui.flows, {
-		[flowId]: {}
+		[channelId]: {}
 	})
 })
 

--- a/apps/ui/lib/layouts/CardLayout/CardLayout.jsx
+++ b/apps/ui/lib/layouts/CardLayout/CardLayout.jsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	CloseButton,
+	Column
+} from '@balena/jellyfish-ui-components'
+import * as _ from 'lodash'
+import React from 'react'
+import {
+	Flex,
+	Heading,
+	Txt
+} from 'rendition'
+import CardActions from '../../components/CardActions'
+import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
+import Markers from '../../components/Markers'
+
+const CardLayout = (props) => {
+	const {
+		inlineActionItems,
+		actionItems,
+		card,
+		channel,
+		children,
+		noActions,
+		overflowY,
+		title,
+		types,
+		flowId
+	} = props
+
+	const typeBase = card.type && card.type.split('@')[0]
+
+	const typeName = _.get(_.find(types, {
+		slug: typeBase
+	}), [ 'name' ], null)
+
+	return (
+		<Column
+			className={`column--${typeBase || 'unknown'} column--slug-${card.slug || 'unkown'}`}
+			overflowY={overflowY}
+			data-test={props['data-test']}
+		>
+			<Flex
+				p={3} pb={0}
+				flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
+				justifyContent="space-between"
+				alignItems="center">
+				<Flex flex={1} alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
+					{title}
+
+					{!title && (
+						<div>
+							<Heading.h4>
+								{card.name || card.slug || card.type}
+							</Heading.h4>
+
+							{Boolean(typeName) && (
+								<Txt color="text.light" fontSize="0">{typeName}</Txt>
+							)}
+						</div>
+					)}
+				</Flex>
+				<Flex alignSelf={[ 'flex-end', 'flex-end', 'flex-start' ]}>
+					{!noActions && (
+						<CardActions card={card} channel={channel} inlineActionItems={inlineActionItems}>
+							{actionItems}
+						</CardActions>
+					)}
+					<CloseButton
+						flex={0}
+						onClick={props.onClose}
+						channel={channel} />
+				</Flex>
+			</Flex>
+
+			<Markers card={card} />
+
+			{children}
+			<SlideInFlowPanel
+				slideInPanelProps={{
+					height: 480
+				}}
+				card={card}
+				channel={channel}
+				flowId={flowId} />
+		</Column>
+	)
+}
+
+export default CardLayout

--- a/apps/ui/lib/layouts/CardLayout/index.jsx
+++ b/apps/ui/lib/layouts/CardLayout/index.jsx
@@ -5,114 +5,27 @@
  */
 
 import * as _ from 'lodash'
-import React from 'react'
 import {
 	connect
 } from 'react-redux'
 import {
-	Flex,
-	Heading,
-	Txt
-} from 'rendition'
-import {
-	CloseButton,
-	Column,
-	LinksProvider
-} from '@balena/jellyfish-ui-components'
-import CardActions from '../../components/CardActions'
-import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
-import {
 	FLOW_IDS
 } from '../../components/Flows/flow-utils'
-import HandoverFlowPanel from '../../components/Flows/HandoverFlowPanel'
-import Markers from '../../components/Markers'
 import {
-	selectors,
-	sdk
+	selectors
 } from '../../core'
+import CardLayout from './CardLayout'
 
-const CardLayout = (props) => {
-	const {
-		inlineActionItems,
-		actionItems,
-		card,
-		channel,
-		children,
-		noActions,
-		overflowY,
-		title,
-		types,
-		user
-	} = props
+const mapStateToProps = (state, props) => {
+	const channelTarget = _.get(props, [ 'channel', 'data', 'target' ])
+	const flows = _.values(selectors.getAllChannelFlows(channelTarget)(state))
+	const flow = _.head(flows)
 
-	const typeBase = card.type && card.type.split('@')[0]
-
-	const typeName = _.get(_.find(types, {
-		slug: typeBase
-	}), [ 'name' ], null)
-
-	return (
-		<LinksProvider sdk={sdk} cards={typeBase ? [ card ] : []} link="is owned by">
-			<Column
-				className={`column--${typeBase || 'unknown'} column--slug-${card.slug || 'unkown'}`}
-				overflowY={overflowY}
-				data-test={props['data-test']}
-			>
-				<Flex
-					p={3} pb={0}
-					flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
-					justifyContent="space-between"
-					alignItems="center">
-					<Flex flex={1} alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
-						{title}
-
-						{!title && (
-							<div>
-								<Heading.h4>
-									{card.name || card.slug || card.type}
-								</Heading.h4>
-
-								{Boolean(typeName) && (
-									<Txt color="text.light" fontSize="0">{typeName}</Txt>
-								)}
-							</div>
-						)}
-					</Flex>
-					<Flex alignSelf={[ 'flex-end', 'flex-end', 'flex-start' ]}>
-						{!noActions && (
-							<CardActions card={card} inlineActionItems={inlineActionItems}>
-								{actionItems}
-							</CardActions>
-						)}
-						<CloseButton
-							flex={0}
-							onClick={props.onClose}
-							channel={channel}
-						/>
-					</Flex>
-				</Flex>
-
-				<Markers card={card} />
-
-				{children}
-				<SlideInFlowPanel
-					slideInPanelProps={{
-						height: 480
-					}}
-					card={card}
-					flowId={FLOW_IDS.GUIDED_HANDOVER}
-				>
-					<HandoverFlowPanel user={user} />
-				</SlideInFlowPanel>
-			</Column>
-		</LinksProvider>
-	)
-}
-
-const mapStateToProps = (state) => {
 	return {
 		user: selectors.getCurrentUser(state),
-		types: selectors.getTypes(state)
+		types: selectors.getTypes(state),
+		flowId: props.flowId || FLOW_IDS.GUIDED_HANDOVER,
+		flowState: selectors.getFlow(props.flowId, channelTarget, _.get(flow, [ 'card', 'id' ]))(state)
 	}
 }
 

--- a/apps/ui/lib/layouts/LensLayout/LensLayout.jsx
+++ b/apps/ui/lib/layouts/LensLayout/LensLayout.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import * as React from 'react'
+import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
+
+const LensLayout = ({
+	sdk, channelFlows, children, channel, flowId, ...rest
+}) => {
+	const openFlows = _.values(channelFlows).filter((flow) => {
+		return flow.isOpen
+	})
+	const firstFlow = _.head(openFlows)
+
+	return (
+		<React.Fragment>
+			{children}
+
+			{firstFlow && (
+				<SlideInFlowPanel
+					slideInPanelProps={{
+						height: 480
+					}}
+					channel={channel}
+					flowId={firstFlow.type}
+					card={firstFlow.card}
+				/>
+			)}
+		</React.Fragment>
+	)
+}
+
+export default LensLayout

--- a/apps/ui/lib/layouts/LensLayout/index.jsx
+++ b/apps/ui/lib/layouts/LensLayout/index.jsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	connect
+} from 'react-redux'
+import {
+	sdk,
+	selectors
+} from '../../core'
+import LensLayout from './LensLayout'
+
+const mapStateToProps = (state, props) => {
+	return {
+		channelFlows: selectors.getAllChannelFlows(props.channel.data.target)(state),
+		sdk
+	}
+}
+
+export default connect(mapStateToProps)(LensLayout)

--- a/apps/ui/lib/lens/actions/CreateUserLens/CreateUserLens.jsx
+++ b/apps/ui/lib/lens/actions/CreateUserLens/CreateUserLens.jsx
@@ -157,7 +157,7 @@ class CreateUserLens extends React.Component {
 				data-test="create-user-lens"
 				title={(
 					<Heading.h4>
-						Add User
+            Add User
 					</Heading.h4>
 				)}
 			>
@@ -170,16 +170,16 @@ class CreateUserLens extends React.Component {
 					>
 					</Form>
 					<Txt mb={4}>
-						On submit, your user will be created without a password.
-						A first-time-login link is then sent to their email.
-						New users can use this token to set their password and login
+            On submit, your user will be created without a password.
+            A first-time-login link is then sent to their email.
+            New users can use this token to set their password and login
 					</Txt>
 					<Flex justifyContent="flex-end" mt={4}>
 						<Button
 							onClick={this.close}
 							mr={2}
 						>
-							Cancel
+              Cancel
 						</Button>
 						<Button
 							primary

--- a/apps/ui/lib/lens/actions/CreateUserLens/index.jsx
+++ b/apps/ui/lib/lens/actions/CreateUserLens/index.jsx
@@ -8,15 +8,16 @@ import _ from 'lodash'
 import {
 	connect
 } from 'react-redux'
-import * as redux from 'redux'
+import {
+	bindActionCreators
+} from 'redux'
 import {
 	actionCreators,
 	selectors
 } from '../../../core'
-
 import CreateUserLens from './CreateUserLens'
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
 	return {
 		user: selectors.getCurrentUser(state)
 	}
@@ -24,7 +25,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
 	return {
-		actions: redux.bindActionCreators(
+		actions: bindActionCreators(
 			_.pick(actionCreators, [
 				'removeChannel',
 				'addUser'

--- a/apps/ui/lib/lens/misc/CRMTable/InlineLinkButton.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/InlineLinkButton.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React, {
+	useState
+} from 'react'
+import {
+	Button
+} from 'rendition'
+import withCardUpdater from '@balena/jellyfish-ui-components/lib/HOC/with-card-updater'
+import LinkModal from '../../../components/LinkModal'
+import * as _ from 'lodash'
+import {
+	formatAsConjunction
+} from './helpers'
+
+const InlineLinkButton = (props) => {
+	const {
+		card, types, actions, ...rest
+	} = props
+
+	const [ isLinkModalVisible, setIsLinkModalVisible ] = useState(false)
+
+	const typeNames = _.compact(_.map(types, 'name'))
+
+	return (
+		<React.Fragment>
+			<Button
+				{...rest}
+				success
+				onClick={() => setIsLinkModalVisible(true)}
+			>Link to {formatAsConjunction(typeNames)}</Button>
+
+			{isLinkModalVisible && (
+				<LinkModal
+					actions={actions}
+					cards={[ card ]}
+					types={types}
+					onHide={() => setIsLinkModalVisible(false)}
+				/>
+			)}
+		</React.Fragment>
+	)
+}
+
+export default withCardUpdater()(InlineLinkButton)

--- a/apps/ui/lib/lens/misc/CRMTable/SelectWrapper.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/SelectWrapper.jsx
@@ -4,24 +4,21 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash'
-import React from 'react'
-import {
-	Select,
-	Badge
-} from 'rendition'
-import styled from 'styled-components'
 import {
 	helpers,
 	withCardUpdater
 } from '@balena/jellyfish-ui-components'
-
-const SingleLineSpan = styled.span `
-	whiteSpace: 'nowrap'
-`
+import _ from 'lodash'
+import React from 'react'
+import {
+	Badge, Select
+} from 'rendition'
+import {
+	SingleLineSpan
+} from './helpers'
 
 const SelectWrapper = ({
-	card, types, onUpdateCard
+	card, statusTypes, onUpdateCard
 }) => {
 	const setValue = ({
 		option
@@ -33,11 +30,11 @@ const SelectWrapper = ({
 	const label = _.get(card, [ 'data', 'status' ])
 	return (
 		<Select
-			options={types}
+			options={statusTypes}
 			onChange={setValue}
 			value={
 				<SingleLineSpan>
-					<Badge shade={types.indexOf(label)} xsmall m={1}>{label}</Badge>
+					<Badge shade={statusTypes.indexOf(label)} xsmall m={1}>{label}</Badge>
 				</SingleLineSpan>
 			}
 		>

--- a/apps/ui/lib/lens/misc/CRMTable/helpers.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/helpers.jsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '@formatjs/intl-listformat/locale-data/en'
+import '@formatjs/intl-listformat/polyfill'
+import styled from 'styled-components'
+
+/**
+ * Formats an array of words to a conjuction
+ *
+ * @param {Array} words - for example: [ 'Account', 'Org', 'User' ]
+ * @returns {String} - for example: Account, Org, and User
+ */
+export const formatAsConjunction = (words = []) => {
+	return new Intl.ListFormat('en', {
+		style: 'long', type: 'conjunction'
+	}).format(words)
+}
+
+/**
+ * An inline span that doesn't line wrap
+ */
+export const SingleLineSpan = styled.span `
+	white-space: 'nowrap'
+`

--- a/apps/ui/lib/lens/misc/CRMTable/index.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/index.jsx
@@ -13,18 +13,18 @@ import {
 } from 'redux'
 import {
 	actionCreators,
-	selectors
+	selectors,
+	sdk
 } from '../../../core'
 import CRMTable from './CRMTable'
 
-const mapStateToProps = (state) => {
-	const allTypes = selectors.getTypes(state)
+const mapStateToProps = (state, props) => {
 	return {
+		sdk,
 		user: selectors.getCurrentUser(state),
-
-		allTypes,
-		types: _.get(
-			_.find(allTypes, [ 'slug', 'opportunity' ]), [
+		types: selectors.getTypes(state),
+		statusTypes: _.get(
+			_.find(selectors.getTypes(state), [ 'slug', 'opportunity' ]), [
 				'data',
 				'schema',
 				'properties',
@@ -42,7 +42,10 @@ const mapDispatchToProps = (dispatch) => {
 		actions: bindActionCreators(
 			_.pick(actionCreators, [
 				'addChannel',
-				'createLink'
+				'addNotification',
+				'createLink',
+				'setFlow',
+				'queryAPI'
 			]), dispatch)
 	}
 }

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1659,6 +1659,37 @@
         }
       }
     },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.4.0.tgz",
+      "integrity": "sha512-Mv027hcLFjE45K8UJ8PjRpdDGfR0aManEFj1KzoN8zXNveHGEygpZGfFf/FTTMl+QEVSrPAUlyxaCApvmv47AQ==",
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
+    "@formatjs/intl-listformat": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-4.3.6.tgz",
+      "integrity": "sha512-+ePU3/rmgUd8QHcf7EGJAIU12+Y6eMGaDhI3tPw3kKN/vByE9hJAyR8etXTk9fSIV6D7us2tEDM4h0wn8eenig==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.4.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.32",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -43,6 +43,7 @@
     "@balena/jellyfish-client-sdk": "^2.5.2",
     "@balena/jellyfish-environment": "^2.2.56",
     "@balena/jellyfish-ui-components": "^5.3.12",
+    "@formatjs/intl-listformat": "^4.3.6",
     "@primer/styled-octicons": "^11.1.0",
     "analytics-client": "^0.11.2",
     "babel-loader": "^8.2.1",


### PR DESCRIPTION
This PR does the following:

## Refactor flow actions and deprecate LinksProvider component

The LinksProvider component was designed to be used with a single SlideInFlowPanel and a single withLinks child component. Using it on a view wil multiple withLinks child components was not possible. This together with the introduction of optional link queries we have no reason to query for card links seperately. We can remove the LinksProvider logic and streamline our SlideInFlowPanel.

This PR also refactors the object stucture to be referenced on the channel target instead of just the card id. With this we can use a single SlideInFlowPanel component with multiple components controlling it's state.

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
<img width="1506" alt="Screen Shot 2020-09-22 at 6 22 04 PM" src="https://user-images.githubusercontent.com/11800807/93909842-89167880-fd00-11ea-9412-807906708565.png">
