### PR TITLE
Query for roles in the User lens so we can determine whether a user is an operator or not

### DIFF
--- a/apps/ui/lens/full/User/User.jsx
+++ b/apps/ui/lens/full/User/User.jsx
@@ -10,6 +10,9 @@ import {
 	ActionLink
 } from '@balena/jellyfish-ui-components/lib/shame/ActionLink'
 import singleCardLens from '../SingleCard'
+import {
+	sdk
+} from '../../../core'
 
 export default class User extends React.Component {
 	constructor (props) {
@@ -17,8 +20,41 @@ export default class User extends React.Component {
 		this.sendFirstTimeLoginLink = this.sendFirstTimeLoginLink.bind(this)
 
 		this.state = {
-			isOperator: _.includes(_.get(props, [ 'user', 'data', 'roles' ], []), 'user-operator')
+			isOperator: false
 		}
+	}
+
+	componentDidMount () {
+		return sdk.query({
+			type: 'object',
+			required: [ 'id', 'type', 'data' ],
+			properties: {
+				id: {
+					const: this.props.user.id
+				},
+				type: {
+					const: 'user@1.0.0'
+				},
+				data: {
+					type: 'object',
+					required: [ 'roles' ],
+					properties: {
+						roles: {
+							type: 'array',
+							items: 'string'
+						}
+					}
+				}
+			}
+		}).then(([ userWithRoles ]) => {
+			const roles = _.get(userWithRoles, [ 'data', 'roles' ])
+			if (_.includes(roles, 'user-operator')) {
+				console.log('here')
+				this.setState({
+					isOperator: true
+				})
+			}
+		})
 	}
 
 	sendFirstTimeLoginLink () {

--- a/apps/ui/lens/full/User/User.spec.jsx
+++ b/apps/ui/lens/full/User/User.spec.jsx
@@ -5,13 +5,17 @@
  */
 
 import {
-	getWrapper
+	getWrapper,
+	flushPromises
 } from '../../../../../test/ui-setup'
 import ava from 'ava'
 import {
 	mount
 } from 'enzyme'
 import sinon from 'sinon'
+import {
+	sdk
+} from '../../../core'
 import React from 'react'
 
 // TODO: Remove this unused import if we resolve the circular dependency
@@ -35,13 +39,7 @@ const {
 
 const USER = {
 	slug: 'user-operator',
-	type: 'user@1.0.0',
-	data: {
-		roles: [
-			'user-community',
-			'user-operator'
-		]
-	}
+	type: 'user@1.0.0'
 }
 
 const CARD = {
@@ -57,6 +55,14 @@ ava.afterEach(() => {
 
 ava.serial('actionItem "send first-time login link"  can be used to fire' +
 ' the sendFirstTimeLoginLink action when the user has an operator role', async (test) => {
+	sdk.query = sandbox.stub()
+	sdk.query.resolves([ {
+		...USER,
+		data: {
+			roles: [ 'user-community', 'user-operator' ]
+		}
+	} ])
+
 	const actions = {
 		sendFirstTimeLoginLink: sandbox.stub()
 	}
@@ -70,6 +76,9 @@ ava.serial('actionItem "send first-time login link"  can be used to fire' +
 			wrappingComponent: wrapper
 		}
 	)
+
+	await flushPromises()
+	component.update()
 
 	const actionMenu = component.find('button[data-test="card-action-menu"]')
 	actionMenu.simulate('click')
@@ -89,7 +98,14 @@ ava.serial('actionItem "send first-time login link"  can be used to fire' +
 
 ava.serial('actionItem "send first-time login link"  does not appear ' +
 'in the action menu when the user has no operator role', async (test) => {
-	USER.data.roles = [ 'user-community' ]
+	sdk.query = sandbox.stub()
+	sdk.query.resolves([ {
+		...USER,
+		data: {
+			roles: [ 'user-community' ]
+		}
+	} ])
+
 	const component = mount(
 		<User
 			card={CARD}
@@ -98,6 +114,8 @@ ava.serial('actionItem "send first-time login link"  does not appear ' +
 			wrappingComponent: wrapper
 		}
 	)
+	await flushPromises()
+	component.update()
 
 	const actionMenu = component.find('button[data-test="card-action-menu"]')
 	actionMenu.simulate('click')


### PR DESCRIPTION
Before we were assuming this would come through in the user props but it isnt anymore and it seems more sensible to query for it directly

Change-type: patch
Signed-off-by: Lucy-Jane Walsh <lucy-jane@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
