### PR TITLE
Temporarily ignore monaco-editor bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
   "labels": [
     "dependencies"
   ],
+  "ignoreDeps": [
+    "monaco-editor",
+    "monaco-editor-webpack-plugin"
+  ],
   "packageRules": [
     {
       "groupName": "non-major",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Need to temporarily ignore `monaco-editor` related bumps as it currently [breaks Safari](https://github.com/product-os/jellyfish/pull/4851). If we don't ignore them, they end up blocking multiple patch/minor bump PRs.
