### PR TITLE
ui: Add support for creating multiple links in LinkModal

### DIFF
--- a/apps/ui/components/CardLinker/CardLinker.jsx
+++ b/apps/ui/components/CardLinker/CardLinker.jsx
@@ -181,7 +181,7 @@ class CardLinker extends React.Component {
 				{showLinkModal && (
 					<LinkModal
 						actions={actions}
-						card={card}
+						cards={[ card ]}
 						types={types}
 						onHide={this.hideLinkModal}
 					/>

--- a/apps/ui/components/ChannelRenderer.jsx
+++ b/apps/ui/components/ChannelRenderer.jsx
@@ -136,7 +136,7 @@ class ChannelRenderer extends React.Component {
 					<LinkModal
 						actions={actions}
 						target={head}
-						card={linkFrom}
+						cards={[ linkFrom ]}
 						types={types}
 						onHide={this.closeLinkModal}
 					/>

--- a/apps/ui/components/LinkModal/LinkModal.jsx
+++ b/apps/ui/components/LinkModal/LinkModal.jsx
@@ -93,6 +93,7 @@ export default class LinkModal extends React.Component {
 		}
 
 		this.handleTargetSelect = this.handleTargetSelect.bind(this)
+		this.handleLinkTypeSelect = this.handleLinkTypeSelect.bind(this)
 		this.linkToExisting = this.linkToExisting.bind(this)
 	}
 
@@ -117,6 +118,12 @@ export default class LinkModal extends React.Component {
 		this.setState({
 			selectedTarget: target,
 			linkType: this.getLinkType(target)
+		})
+	}
+
+	handleLinkTypeSelect (payload) {
+		this.setState({
+			linkType: payload.option
 		})
 	}
 

--- a/apps/ui/components/LinkModal/tests/LinkModal.spec.jsx
+++ b/apps/ui/components/LinkModal/tests/LinkModal.spec.jsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getPromiseResolver,
+	getWrapper
+} from '../../../../../test/ui-setup'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import LinkModal from '../LinkModal'
+import * as AutoCompleteCardSelect from '../../AutoCompleteCardSelect'
+import user from './fixtures/user.json'
+import org from './fixtures/org.json'
+
+const sandbox = sinon.createSandbox()
+
+const {
+	wrapper: Wrapper
+} = getWrapper()
+
+const card = {
+	id: 'U1',
+	slug: 'user-1',
+	type: 'user@1.0.0'
+}
+
+const card2 = {
+	id: 'U2',
+	slug: 'user-2',
+	type: 'user@1.0.0'
+}
+
+const types = [
+	user,
+	org
+]
+
+const targets = [
+	{
+		id: 'R1',
+		slug: 'org-balena',
+		name: 'Balena',
+		type: 'org@1.0.0'
+	},
+	{
+		id: 'R2',
+		slug: 'org-google',
+		name: 'Google',
+		type: 'org@1.0.0'
+	}
+]
+
+const selectedTarget = targets[0]
+
+// Mock the AutoCompleteCardSelect as it doesn't work well outside of the real browser environment
+const mockAutoCompleteCardSelect = () => {
+	const callbacks = {}
+	const FakeAutoCompleteCardSelect = ({
+		onChange
+	}) => {
+		callbacks.onChange = onChange
+		return null
+	}
+	const autoCompleteCardSelectComponentStub = sandbox.stub(AutoCompleteCardSelect, 'default')
+	autoCompleteCardSelectComponentStub.callsFake((props) => FakeAutoCompleteCardSelect(props))
+	return callbacks
+}
+
+const submit = (linkModalComponent) => {
+	const button = linkModalComponent.find('button[data-test="card-linker--existing__submit"]')
+	button.simulate('click')
+}
+
+// TBD: This code assumes that Promise.all in LinkModal will call the async createLink methods
+// in the same order as the cards are provided in the cards prop.
+const verifyCard = (test, commonProps, callIndex, expectedCard) => {
+	const [ theCard, theSelectedTarget, linkTypeName ] = commonProps.actions.createLink.args[callIndex]
+	test.deepEqual(theCard, expectedCard)
+	test.deepEqual(theSelectedTarget, selectedTarget)
+	test.deepEqual(linkTypeName, 'is member of')
+
+	const [ savedSelectedTarget, savedLinkTypeName ] = commonProps.onSaved.args[callIndex]
+	test.deepEqual(savedSelectedTarget, selectedTarget)
+	test.deepEqual(savedLinkTypeName, 'is member of')
+}
+
+ava.beforeEach(async (test) => {
+	const onHidePromise = getPromiseResolver()
+	const onHide = () => {
+		onHidePromise.resolver()
+	}
+	test.context = {
+		...test.context,
+		onHidePromise,
+		autoCompleteCallbacks: mockAutoCompleteCardSelect(),
+		commonProps: {
+			onHide,
+			onSaved: sandbox.stub(),
+			actions: {
+				createLink: sandbox.stub().resolves(null)
+			}
+		}
+	}
+})
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('LinkModal can link one card to another card', async (test) => {
+	const {
+		commonProps,
+		onHidePromise,
+		autoCompleteCallbacks
+	} = test.context
+
+	const linkModalComponent = await mount((
+		<LinkModal
+			{...commonProps}
+			cards={[ card ]}
+			types={types}
+		/>
+	), {
+		wrappingComponent: Wrapper
+	})
+
+	autoCompleteCallbacks.onChange(selectedTarget)
+
+	submit(linkModalComponent)
+
+	await onHidePromise.promise
+
+	verifyCard(test, commonProps, 0, card)
+})
+
+ava('LinkModal can link multiple cards to another card', async (test) => {
+	const {
+		commonProps,
+		onHidePromise,
+		autoCompleteCallbacks
+	} = test.context
+
+	const linkModalComponent = await mount((
+		<LinkModal
+			{...commonProps}
+			cards={[ card, card2 ]}
+			types={types}
+		/>
+	), {
+		wrappingComponent: Wrapper
+	})
+
+	autoCompleteCallbacks.onChange(selectedTarget)
+
+	submit(linkModalComponent)
+
+	await onHidePromise.promise
+
+	test.is(commonProps.actions.createLink.callCount, 2)
+	test.is(commonProps.onSaved.callCount, 2)
+
+	verifyCard(test, commonProps, 0, card)
+	verifyCard(test, commonProps, 1, card2)
+})

--- a/apps/ui/components/LinkModal/tests/LinkModal.spec.jsx
+++ b/apps/ui/components/LinkModal/tests/LinkModal.spec.jsx
@@ -37,6 +37,12 @@ const card2 = {
 	type: 'user@1.0.0'
 }
 
+const orgInstanceCard = {
+	id: 'O2',
+	slug: 'org-1',
+	type: 'org@1.0.0'
+}
+
 const types = [
 	user,
 	org
@@ -168,4 +174,24 @@ ava('LinkModal can link multiple cards to another card', async (test) => {
 
 	verifyCard(test, commonProps, 0, card)
 	verifyCard(test, commonProps, 1, card2)
+})
+
+ava('LinkModal throws exception if card types are different', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	test.throws(() => {
+		mount((
+			<LinkModal
+				{...commonProps}
+				cards={[ card, orgInstanceCard ]}
+				types={types}
+			/>
+		), {
+			wrappingComponent: Wrapper
+		})
+	}, {
+		message: 'All cards must be of the same type'
+	})
 })

--- a/apps/ui/components/LinkModal/tests/fixtures/org.json
+++ b/apps/ui/components/LinkModal/tests/fixtures/org.json
@@ -1,0 +1,66 @@
+{
+  "id": "11d22be7-1be3-493b-986f-54522b004c22",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "has member",
+          "type": "user",
+          "title": "Members"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "profile": {
+              "type": "object",
+              "properties": {
+                "description": {
+                  "type": "string",
+                  "format": "markdown"
+                }
+              }
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "$$formula": "AGGREGATE($events, 'tags')"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    }
+  },
+  "name": "Organisation",
+  "slug": "org",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-10-06T01:14:44.653Z",
+  "updated_at": "2020-10-12T12:47:04.682Z",
+  "capabilities": []
+}

--- a/apps/ui/components/LinkModal/tests/fixtures/user.json
+++ b/apps/ui/components/LinkModal/tests/fixtures/user.json
@@ -1,0 +1,403 @@
+{
+  "id": "8826fc73-5631-4629-a951-a6b7ac48d223",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "has attached contact",
+          "type": "contact",
+          "title": "Contact"
+        },
+        {
+          "query": [
+            {
+              "type": "object",
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "actor"
+                      ],
+                      "properties": {
+                        "actor": {
+                          "const": {
+                            "$eval": "result.id"
+                          }
+                        }
+                      }
+                    },
+                    "type": {
+                      "const": "create@1.0.0"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "const": "sales-thread@1.0.0"
+                }
+              },
+              "additionalProperties": true
+            }
+          ],
+          "title": "Sales"
+        },
+        {
+          "query": [
+            {
+              "type": "object",
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "actor"
+                      ],
+                      "properties": {
+                        "actor": {
+                          "const": {
+                            "$eval": "result.id"
+                          }
+                        }
+                      }
+                    },
+                    "type": {
+                      "const": "create@1.0.0"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "const": "support-thread@1.0.0"
+                }
+              },
+              "additionalProperties": true
+            }
+          ],
+          "title": "Support"
+        },
+        {
+          "query": [
+            {
+              "type": "object",
+              "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "id": {
+                      "const": {
+                        "$eval": "result.id"
+                      }
+                    },
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "enum": [
+                    "support-thread@1.0.0",
+                    "sales-thread@1.0.0"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          ],
+          "title": "Owned conversations"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "slug",
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "roles",
+            "hash"
+          ],
+          "properties": {
+            "hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "email": {
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "type": "string",
+                "format": "email"
+              },
+              "format": "email",
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "oauth": {
+              "type": "object",
+              "description": "Linked accounts"
+            },
+            "roles": {
+              "type": "array",
+              "items": {
+                "not": {
+                  "const": "user-admin"
+                },
+                "type": "string",
+                "pattern": "^[a-z0-9-]+$"
+              }
+            },
+            "avatar": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "title": "Avatar"
+            },
+            "status": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "Do Not Disturb"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "DoNotDisturb"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "On Annual Leave"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "AnnualLeave"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "In a Meeting"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "Meeting"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "Available"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "Available"
+                    }
+                  }
+                }
+              ]
+            },
+            "profile": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "title": "City"
+                },
+                "name": {
+                  "type": "object",
+                  "properties": {
+                    "last": {
+                      "type": "string",
+                      "title": "Last name"
+                    },
+                    "first": {
+                      "type": "string",
+                      "title": "First name"
+                    },
+                    "pronouns": {
+                      "type": "string",
+                      "title": "Pronouns"
+                    },
+                    "preffered": {
+                      "type": "string",
+                      "title": "Preferred name"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "string"
+                },
+                "about": {
+                  "type": "object",
+                  "properties": {
+                    "aboutMe": {
+                      "type": "string",
+                      "title": "About me"
+                    },
+                    "askMeAbout": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Ask me about"
+                    },
+                    "externalLinks": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Links"
+                    }
+                  }
+                },
+                "title": {
+                  "type": "string"
+                },
+                "company": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string",
+                  "title": "Country"
+                },
+                "birthday": {
+                  "type": "string",
+                  "title": "Birthday",
+                  "pattern": "^(0[1-9]|1[0-2])/(0[1-9]|1[0-9]|2[0-9]|3[01])$"
+                },
+                "homeView": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The default view that is loaded after you login"
+                },
+                "timezone": {
+                  "type": "string",
+                  "title": "Timezone"
+                },
+                "startDate": {
+                  "type": "string",
+                  "title": "Started at the company",
+                  "format": "date"
+                },
+                "sendCommand": {
+                  "enum": [
+                    "shift+enter",
+                    "ctrl+enter",
+                    "enter"
+                  ],
+                  "type": "string",
+                  "default": "shift+enter",
+                  "description": "Command to send a message"
+                },
+                "starredViews": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of view slugs that are starred"
+                },
+                "viewSettings": {
+                  "type": "object",
+                  "description": "A map of settings for view cards, keyed by the view id",
+                  "patternProperties": {
+                    "^.*$": {
+                      "lens": {
+                        "type": "string"
+                      },
+                      "slice": {
+                        "type": "string"
+                      },
+                      "notifications": {
+                        "type": "object",
+                        "properties": {
+                          "web": {
+                            "type": "object",
+                            "title": "Web",
+                            "properties": {
+                              "alert": {
+                                "type": "boolean"
+                              },
+                              "update": {
+                                "type": "boolean"
+                              },
+                              "mention": {
+                                "type": "boolean"
+                              }
+                            },
+                            "description": "Alert me with desktop notifications"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "description": "Configuration options for your account"
+            }
+          }
+        },
+        "slug": {
+          "type": "string",
+          "pattern": "^user-[a-z0-9-]+$"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    }
+  },
+  "name": "Jellyfish User",
+  "slug": "user",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-10-06T01:14:44.601Z",
+  "updated_at": "2020-10-12T12:47:04.558Z",
+  "capabilities": []
+}

--- a/apps/ui/lens/common/Segment.jsx
+++ b/apps/ui/lens/common/Segment.jsx
@@ -227,7 +227,7 @@ export default class Segment extends React.Component {
 					<LinkModal
 						linkVerb={segment.link}
 						actions={actions}
-						card={card}
+						cards={[ card ]}
 						types={[ type ]}
 						onHide={this.hideLinkModal}
 						onSave={onSave}


### PR DESCRIPTION
Input card prop replaced by a cards (array) prop.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Added a couple of unit tests to LinkModal so we're now able to test a bit more of the functionality in isolation!

Also [fixes a regression bug](https://github.com/product-os/jellyfish/pull/4921/commits/8a56ee3ae76a9aa6bc7e30ecd11acbac42d669fd) that was preventing the selection of the link type if linking two cards that have multiple possible link types between them!
