### PR TITLE
ui: Add table lens to patterns, support issues and support threads views

### DIFF
--- a/apps/server/default-cards/balena/view-all-patterns.json
+++ b/apps/server/default-cards/balena/view-all-patterns.json
@@ -25,7 +25,8 @@
       }
     ],
     "lenses": [
-      "lens-list"
+      "lens-list",
+      "lens-table"
     ]
   }
 }

--- a/apps/server/default-cards/balena/view-all-support-issues.json
+++ b/apps/server/default-cards/balena/view-all-support-issues.json
@@ -25,7 +25,7 @@
     ],
     "lenses": [
       "lens-list",
-      "lens-support-issue-table"
+      "lens-table"
     ]
   }
 }

--- a/apps/server/default-cards/balena/view-all-support-threads.json
+++ b/apps/server/default-cards/balena/view-all-support-threads.json
@@ -58,6 +58,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/ui/components/HomeChannel/tests/fixtures/tail.json
+++ b/apps/ui/components/HomeChannel/tests/fixtures/tail.json
@@ -1962,7 +1962,7 @@
       ],
       "lenses": [
         "lens-list",
-        "lens-support-issue-table"
+        "lens-table"
       ],
       "namespace": "Support"
     },


### PR DESCRIPTION
Removed reference to non-existent 'lens-support-issue-table'

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Just adding the table lens to the following views:
* view-all-support-threads
* view-all-support-issues
* view-all-patterns

This will pave the way for taking actions on multiple cards at a time (e.g. linking multiple cards to a target card).
