### PR TITLE
Update open-balena-base to v10.1.1

### DIFF
--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v9.4.3
+FROM balena/open-balena-base:v10.1.1
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v9.4.3
+FROM balena/open-balena-base:v10.1.1
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.4.3 as base
+FROM balena/open-balena-base:v10.1.1 as base
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v9.4.3
+FROM balena/open-balena-base:v10.1.1
 
 WORKDIR /usr/src/jellyfish
 

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v9.4.3 as base
+FROM balena/open-balena-base:v10.1.1 as base
 
 WORKDIR /usr/src/jellyfish
 


### PR DESCRIPTION
The breaking change is dropping etcd based config which jellyfish doesn't use, outside of that it bumps nodejs from 12.18.3 to 12.19.0 which includes security patches from 12.18.4