### PR TITLE
ui: Add support for linking newly created card to multiple cards

### DIFF
--- a/apps/ui/components/CardLinker/CardLinker.jsx
+++ b/apps/ui/components/CardLinker/CardLinker.jsx
@@ -63,7 +63,7 @@ class CardLinker extends React.Component {
 				},
 				onDone: {
 					action: 'link',
-					target: this.props.card
+					targets: [ this.props.card ]
 				}
 			},
 			format: 'create',

--- a/apps/ui/lens/actions/tests/CreateLens.spec.jsx
+++ b/apps/ui/lens/actions/tests/CreateLens.spec.jsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getPromiseResolver,
+	getWrapper
+} from '../../../../../test/ui-setup'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import {
+	CreateLens
+} from '../CreateLens'
+import {
+	contact, allTypes
+} from '../../../../../test/unit/apps/ui/fixtures/types'
+
+const sandbox = sinon.createSandbox()
+
+const contactName = 'Contact A'
+
+const createdCard = {
+	id: 'C1',
+	slug: 'contact-1',
+	name: contactName,
+	type: 'contact@1.0.0'
+}
+
+const account1 = {
+	id: 'A1',
+	slug: 'account-1',
+	name: 'Account 1',
+	type: 'account@1.0.0'
+}
+
+const account2 = {
+	id: 'A2',
+	slug: 'account-2',
+	name: 'Account 2',
+	type: 'account@1.0.0'
+}
+
+const user1 = {
+	id: 'U1',
+	slug: 'user-1',
+	name: 'User 1',
+	type: 'user@1.0.0'
+}
+
+const seed = {
+	active: true,
+	markers: [ 'org-balena' ],
+	type: 'contact@1.0.0'
+}
+
+const createChannel = (card) => {
+	return {
+		data: {
+			head: card
+		}
+	}
+}
+
+const wrappingComponent = getWrapper({
+	core: {
+		types: allTypes
+	}
+}).wrapper
+
+const mountCreateLens = async (commonProps, card) => {
+	return mount((
+		<CreateLens {...commonProps} card={card} channel={createChannel(card)} />
+	), {
+		wrappingComponent
+	})
+}
+
+const enterName = (component) => {
+	const nameInput = component.find('input#root_name')
+	nameInput.simulate('change', {
+		target: {
+			value: contactName
+		}
+	})
+}
+
+const submit = (component) => {
+	const submitButton = component.find('button[data-test="card-creator__submit"]')
+	submitButton.simulate('click')
+}
+
+ava.beforeEach(async (test) => {
+	const onDonePromise = getPromiseResolver()
+	test.context = {
+		...test.context,
+		onDonePromise,
+		commonProps: {
+			sdk: {
+				card: {
+					create: sandbox.stub().resolves(createdCard)
+				}
+			},
+			allTypes,
+			actions: {
+				removeChannel: sandbox.stub().resolves(null),
+				createLink: sandbox.stub().resolves(null),
+				getLinks: sandbox.stub().resolves([]),
+				queryAPI: sandbox.stub()
+			}
+		}
+	}
+})
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('CreateLens can create a new card', async (test) => {
+	const {
+		commonProps,
+		onDonePromise
+	} = test.context
+
+	let callbackCard = null
+
+	const card = {
+		onDone: {
+			action: 'open',
+			callback: (newCard) => {
+				callbackCard = newCard
+				onDonePromise.resolver()
+			}
+		},
+		seed,
+		types: [ contact ]
+	}
+
+	const createLensComponent = await mountCreateLens(commonProps, card)
+	enterName(createLensComponent)
+	submit(createLensComponent)
+
+	test.true(commonProps.sdk.card.create.calledOnce)
+	test.true(commonProps.actions.createLink.notCalled)
+	await onDonePromise.promise
+	test.deepEqual(callbackCard, createdCard)
+})
+
+ava('CreateLens can link to multiple cards after creation', async (test) => {
+	const {
+		commonProps,
+		onDonePromise
+	} = test.context
+
+	let callbackCard = null
+	const targets = [ account1, account2 ]
+
+	const card = {
+		onDone: {
+			action: 'link',
+			targets,
+			callback: (newCard) => {
+				callbackCard = newCard
+				onDonePromise.resolver()
+			}
+		},
+		seed,
+		types: [ contact ]
+	}
+
+	const createLensComponent = await mountCreateLens(commonProps, card)
+	enterName(createLensComponent)
+	submit(createLensComponent)
+
+	await onDonePromise.promise
+	test.true(commonProps.sdk.card.create.calledOnce)
+	test.is(commonProps.actions.createLink.callCount, targets.length)
+	test.true(commonProps.actions.removeChannel.calledOnce)
+	test.deepEqual(callbackCard, createdCard)
+})
+
+ava.only('CreateLens throws exception if trying to link cards of different types', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	// Note the targets are of different types
+	const targets = [ account1, user1 ]
+
+	const card = {
+		onDone: {
+			action: 'link',
+			targets
+		},
+		seed,
+		types: [ contact ]
+	}
+
+	await test.throwsAsync(async () => {
+		await mountCreateLens(commonProps, card)
+	}, {
+		message: 'All target cards must be of the same type'
+	})
+})

--- a/apps/ui/lens/common/Segment.jsx
+++ b/apps/ui/lens/common/Segment.jsx
@@ -137,7 +137,7 @@ export default class Segment extends React.Component {
 				},
 				onDone: {
 					action: 'link',
-					target: card,
+					targets: [ card ],
 					callback: this.getData
 				}
 			},

--- a/apps/ui/lens/full/SupportThread/AuditPanel.jsx
+++ b/apps/ui/lens/full/SupportThread/AuditPanel.jsx
@@ -75,7 +75,7 @@ export default function AuditPanel (props) {
 				onDone: {
 					action: 'link',
 					name: 'support thread is attached to product improvement',
-					target: props.card,
+					targets: [ props.card ],
 					callback: skipStep
 				}
 			},

--- a/test/unit/apps/ui/fixtures/types/account.json
+++ b/test/unit/apps/ui/fixtures/types/account.json
@@ -1,0 +1,279 @@
+{
+  "id": "9397c2d7-f27c-463c-9982-608896a897b2",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "has attached",
+          "type": "opportunity",
+          "title": "Opportunities"
+        },
+        {
+          "link": "has",
+          "type": "contact",
+          "title": "Contacts"
+        },
+        {
+          "link": "is owned by",
+          "type": "user",
+          "title": "Owner"
+        },
+        {
+          "link": "has backup owner",
+          "type": "user",
+          "title": "Backup owners"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "name",
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "Lead",
+                "Customer"
+              ],
+              "default": "Lead"
+            },
+            "email": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "email"
+              },
+              "title": "Email address",
+              "uniqueItems": true
+            },
+            "industry": {
+              "type": "string",
+              "title": "Industry",
+              "readOnly": true
+            },
+            "isLegacy": {
+              "type": "boolean",
+              "title": "is Legacy",
+              "readOnly": true
+            },
+            "location": {
+              "type": "string",
+              "title": "Location"
+            },
+            "endsOnDate": {
+              "type": "string",
+              "title": "Ends on date",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "annualPrice": {
+              "type": "number",
+              "title": "Annual price",
+              "readOnly": true,
+              "description": "Annual price without discounts or plan addons included"
+            },
+            "billingCode": {
+              "type": "string",
+              "title": "Billing code",
+              "readOnly": true
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "format": "markdown"
+            },
+            "billingCycle": {
+              "type": "string",
+              "title": "Billing cycle",
+              "readOnly": true
+            },
+            "canSelfServe": {
+              "type": "boolean",
+              "title": "can self serve",
+              "readOnly": true
+            },
+            "monthlyPrice": {
+              "type": "number",
+              "title": "Monthly price",
+              "readOnly": true,
+              "description": "Monthly price without discounts or plan addons included"
+            },
+            "startsOnDate": {
+              "type": "string",
+              "title": "Starts on date",
+              "format": "date-time",
+              "readOnly": true
+            },
+            "SumAnnualPrice": {
+              "type": "number",
+              "title": "Sum Annual price",
+              "readOnly": true,
+              "$$formula": "SUM(this.data.annualPrice * (1 - this.data.discountPercentage))",
+              "description": "Calculated with the formula: annualPrice * (1 - discountPercentage). This number is excluding plan addons"
+            },
+            "SumMonthlyPrice": {
+              "type": "number",
+              "title": "Sum Monthly price",
+              "readOnly": true,
+              "$$formula": "SUM(this.data.monthlyPrice * (1-this.data.discountPercentage))",
+              "description": "Calculated with the formula: monthlyPrice * (1 - discountPercentage). This number is excluding plan addons"
+            },
+            "stageOfBusiness": {
+              "type": "string",
+              "title": "Stage of business"
+            },
+            "discountPercentage": {
+              "type": "number",
+              "title": "Discount percentage",
+              "readOnly": true,
+              "description": "The percentage of discount for the current subscription. 0.1 will stand for 10% discount, -0.1 will stand for 10% surcharge"
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    },
+    "slices": [
+      "properties.data.properties.profile.properties.status"
+    ],
+    "uiSchema": {
+      "fields": {
+        "id": null,
+        "data": {
+          "type": {
+            "ui:widget": "HighlightedName"
+          },
+          "email": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "mailto:${source}"
+              }
+            },
+            "ui:widget": {
+              "$if": "typeof(source) == \"string\"",
+              "else": "Array",
+              "then": "Link"
+            },
+            "ui:options": {
+              "href": {
+                "$if": "typeof(source) == \"string\"",
+                "else": null,
+                "then": "mailto:${source}"
+              }
+            }
+          },
+          "origin": null,
+          "ui:title": null,
+          "endsOnDate": {
+            "ui:options": {
+              "dtFormat": "MMM do, yyyy"
+            }
+          },
+          "startsOnDate": {
+            "ui:options": {
+              "dtFormat": "MMM do, yyyy"
+            }
+          },
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": null,
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": null,
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      },
+      "snippet": {
+        "id": null,
+        "data": {
+          "type": {
+            "ui:widget": "HighlightedName"
+          },
+          "email": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "mailto:${source}"
+              }
+            },
+            "ui:widget": {
+              "$if": "typeof(source) == \"string\"",
+              "else": "Array",
+              "then": "Link"
+            },
+            "ui:options": {
+              "href": {
+                "$if": "typeof(source) == \"string\"",
+                "else": null,
+                "then": "mailto:${source}"
+              }
+            }
+          },
+          "origin": null,
+          "ui:title": null,
+          "endsOnDate": {
+            "ui:options": {
+              "dtFormat": "MMM do, yyyy"
+            }
+          },
+          "startsOnDate": {
+            "ui:options": {
+              "dtFormat": "MMM do, yyyy"
+            }
+          },
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": {},
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": {},
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      }
+    }
+  },
+  "name": "Account",
+  "slug": "account",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-10-06T01:14:45.996Z",
+  "updated_at": null,
+  "capabilities": []
+}

--- a/test/unit/apps/ui/fixtures/types/contact.json
+++ b/test/unit/apps/ui/fixtures/types/contact.json
@@ -1,0 +1,283 @@
+{
+  "id": "052c5cc0-03d9-4314-b16b-ce118b289676",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "is member of",
+          "type": "account",
+          "title": "Account"
+        },
+        {
+          "link": "is owned by",
+          "type": "user",
+          "title": "Owner"
+        },
+        {
+          "link": "has backup owner",
+          "type": "user",
+          "title": "Backup owners"
+        },
+        {
+          "query": [
+            {
+              "link": "is attached to user",
+              "type": "user"
+            },
+            {
+              "type": "object",
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "actor"
+                      ],
+                      "properties": {
+                        "actor": {
+                          "const": {
+                            "$eval": "result.id"
+                          }
+                        }
+                      }
+                    },
+                    "type": {
+                      "const": "create"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "const": "support-thread"
+                }
+              }
+            }
+          ],
+          "title": "Support"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "profile": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "object",
+                  "properties": {
+                    "last": {
+                      "type": "string"
+                    },
+                    "first": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "string"
+                },
+                "email": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "title": "string",
+                      "format": "email"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "title": "array",
+                      "minItems": 1,
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "company": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "slug": {
+          "type": "string",
+          "pattern": "^contact-[a-z0-9-]+$"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    },
+    "uiSchema": {
+      "fields": {
+        "id": null,
+        "data": {
+          "origin": null,
+          "mirrors": null,
+          "profile": {
+            "name": {
+              "last": {
+                "ui:title": "Last name"
+              },
+              "first": {
+                "ui:title": "First name"
+              },
+              "ui:order": [
+                "first",
+                "last"
+              ],
+              "ui:title": null
+            },
+            "email": {
+              "items": {
+                "ui:widget": "Link",
+                "ui:options": {
+                  "href": "mailto:${source}"
+                }
+              },
+              "ui:widget": {
+                "$if": "typeof(source) == \"string\"",
+                "else": "Array",
+                "then": "Link"
+              },
+              "ui:options": {
+                "href": {
+                  "$if": "typeof(source) == \"string\"",
+                  "else": null,
+                  "then": "mailto:${source}"
+                }
+              }
+            },
+            "ui:title": null
+          },
+          "ui:title": null,
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": null,
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": null,
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      },
+      "snippet": {
+        "id": null,
+        "data": {
+          "origin": null,
+          "mirrors": null,
+          "profile": {
+            "name": {
+              "last": {
+                "ui:title": "Last name"
+              },
+              "first": {
+                "ui:title": "First name"
+              },
+              "ui:order": [
+                "first",
+                "last"
+              ],
+              "ui:title": null
+            },
+            "email": {
+              "items": {
+                "ui:widget": "Link",
+                "ui:options": {
+                  "href": "mailto:${source}"
+                }
+              },
+              "ui:widget": {
+                "$if": "typeof(source) == \"string\"",
+                "else": "Array",
+                "then": "Link"
+              },
+              "ui:options": {
+                "href": {
+                  "$if": "typeof(source) == \"string\"",
+                  "else": null,
+                  "then": "mailto:${source}"
+                }
+              }
+            },
+            "ui:title": null
+          },
+          "ui:title": null,
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": {},
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": {},
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      }
+    }
+  },
+  "name": "Contact",
+  "slug": "contact",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-10-06T01:14:46.293Z",
+  "updated_at": null,
+  "capabilities": []
+}

--- a/test/unit/apps/ui/fixtures/types/index.js
+++ b/test/unit/apps/ui/fixtures/types/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
 const user = require('./user.json')
 const org = require('./org.json')
 const contact = require('./contact.json')

--- a/test/unit/apps/ui/fixtures/types/index.js
+++ b/test/unit/apps/ui/fixtures/types/index.js
@@ -1,0 +1,16 @@
+const user = require('./user.json')
+const org = require('./org.json')
+const contact = require('./contact.json')
+const account = require('./account.json')
+
+const allTypes = [
+	user, org, contact, account
+]
+
+module.exports = {
+	user,
+	org,
+	contact,
+	account,
+	allTypes
+}

--- a/test/unit/apps/ui/fixtures/types/org.json
+++ b/test/unit/apps/ui/fixtures/types/org.json
@@ -1,0 +1,112 @@
+{
+  "id": "11d22be7-1be3-493b-986f-54522b004c22",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "has member",
+          "type": "user",
+          "title": "Members"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "profile": {
+              "type": "object",
+              "properties": {
+                "description": {
+                  "type": "string",
+                  "format": "markdown"
+                }
+              }
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "$$formula": "AGGREGATE($events, 'tags')"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    },
+    "uiSchema": {
+      "fields": {
+        "id": null,
+        "data": {
+          "origin": null,
+          "ui:title": null,
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": null,
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": null,
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      },
+      "snippet": {
+        "id": null,
+        "data": {
+          "origin": null,
+          "ui:title": null,
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": {},
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": {},
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      }
+    }
+  },
+  "name": "Organisation",
+  "slug": "org",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-10-06T01:14:44.653Z",
+  "updated_at": "2020-10-13T08:50:30.054Z",
+  "capabilities": []
+}

--- a/test/unit/apps/ui/fixtures/types/user.json
+++ b/test/unit/apps/ui/fixtures/types/user.json
@@ -1,0 +1,587 @@
+{
+  "id": "8826fc73-5631-4629-a951-a6b7ac48d223",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "has attached contact",
+          "type": "contact",
+          "title": "Contact"
+        },
+        {
+          "query": [
+            {
+              "type": "object",
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "actor"
+                      ],
+                      "properties": {
+                        "actor": {
+                          "const": {
+                            "$eval": "result.id"
+                          }
+                        }
+                      }
+                    },
+                    "type": {
+                      "const": "create@1.0.0"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "const": "sales-thread@1.0.0"
+                }
+              },
+              "additionalProperties": true
+            }
+          ],
+          "title": "Sales"
+        },
+        {
+          "query": [
+            {
+              "type": "object",
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "actor"
+                      ],
+                      "properties": {
+                        "actor": {
+                          "const": {
+                            "$eval": "result.id"
+                          }
+                        }
+                      }
+                    },
+                    "type": {
+                      "const": "create@1.0.0"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "const": "support-thread@1.0.0"
+                }
+              },
+              "additionalProperties": true
+            }
+          ],
+          "title": "Support"
+        },
+        {
+          "query": [
+            {
+              "type": "object",
+              "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "id": {
+                      "const": {
+                        "$eval": "result.id"
+                      }
+                    },
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": {
+                  "enum": [
+                    "support-thread@1.0.0",
+                    "sales-thread@1.0.0"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          ],
+          "title": "Owned conversations"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "slug",
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "roles",
+            "hash"
+          ],
+          "properties": {
+            "hash": {
+              "type": "string",
+              "minLength": 1
+            },
+            "email": {
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "type": "string",
+                "format": "email"
+              },
+              "format": "email",
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "oauth": {
+              "type": "object",
+              "description": "Linked accounts"
+            },
+            "roles": {
+              "type": "array",
+              "items": {
+                "not": {
+                  "const": "user-admin"
+                },
+                "type": "string",
+                "pattern": "^[a-z0-9-]+$"
+              }
+            },
+            "avatar": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "title": "Avatar"
+            },
+            "status": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "Do Not Disturb"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "DoNotDisturb"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "On Annual Leave"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "AnnualLeave"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "In a Meeting"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "Meeting"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "const": "Available"
+                    },
+                    "value": {
+                      "type": "string",
+                      "const": "Available"
+                    }
+                  }
+                }
+              ]
+            },
+            "profile": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "title": "City"
+                },
+                "name": {
+                  "type": "object",
+                  "properties": {
+                    "last": {
+                      "type": "string",
+                      "title": "Last name"
+                    },
+                    "first": {
+                      "type": "string",
+                      "title": "First name"
+                    },
+                    "pronouns": {
+                      "type": "string",
+                      "title": "Pronouns"
+                    },
+                    "preffered": {
+                      "type": "string",
+                      "title": "Preferred name"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "string"
+                },
+                "about": {
+                  "type": "object",
+                  "properties": {
+                    "aboutMe": {
+                      "type": "string",
+                      "title": "About me"
+                    },
+                    "askMeAbout": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Ask me about"
+                    },
+                    "externalLinks": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Links"
+                    }
+                  }
+                },
+                "title": {
+                  "type": "string"
+                },
+                "company": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string",
+                  "title": "Country"
+                },
+                "birthday": {
+                  "type": "string",
+                  "title": "Birthday",
+                  "pattern": "^(0[1-9]|1[0-2])/(0[1-9]|1[0-9]|2[0-9]|3[01])$"
+                },
+                "homeView": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The default view that is loaded after you login"
+                },
+                "timezone": {
+                  "type": "string",
+                  "title": "Timezone"
+                },
+                "startDate": {
+                  "type": "string",
+                  "title": "Started at the company",
+                  "format": "date"
+                },
+                "sendCommand": {
+                  "enum": [
+                    "shift+enter",
+                    "ctrl+enter",
+                    "enter"
+                  ],
+                  "type": "string",
+                  "default": "shift+enter",
+                  "description": "Command to send a message"
+                },
+                "starredViews": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of view slugs that are starred"
+                },
+                "viewSettings": {
+                  "type": "object",
+                  "description": "A map of settings for view cards, keyed by the view id",
+                  "patternProperties": {
+                    "^.*$": {
+                      "lens": {
+                        "type": "string"
+                      },
+                      "slice": {
+                        "type": "string"
+                      },
+                      "notifications": {
+                        "type": "object",
+                        "properties": {
+                          "web": {
+                            "type": "object",
+                            "title": "Web",
+                            "properties": {
+                              "alert": {
+                                "type": "boolean"
+                              },
+                              "update": {
+                                "type": "boolean"
+                              },
+                              "mention": {
+                                "type": "boolean"
+                              }
+                            },
+                            "description": "Alert me with desktop notifications"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "description": "Configuration options for your account"
+            }
+          }
+        },
+        "slug": {
+          "type": "string",
+          "pattern": "^user-[a-z0-9-]+$"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_/:+]+$"
+          }
+        }
+      }
+    },
+    "uiSchema": {
+      "fields": {
+        "id": null,
+        "data": {
+          "hash": null,
+          "email": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "mailto:${source}"
+              }
+            },
+            "ui:widget": {
+              "$if": "typeof(source) == \"string\"",
+              "else": "Array",
+              "then": "Link"
+            },
+            "ui:options": {
+              "href": {
+                "$if": "typeof(source) == \"string\"",
+                "else": null,
+                "then": "mailto:${source}"
+              }
+            }
+          },
+          "roles": {
+            "items": {
+              "ui:widget": "Badge"
+            }
+          },
+          "avatar": {
+            "ui:widget": "Img",
+            "ui:options": {
+              "alt": "Avatar",
+              "width": 100
+            }
+          },
+          "origin": null,
+          "status": {
+            "title": {
+              "ui:title": "Current status"
+            },
+            "value": null,
+            "ui:title": null
+          },
+          "profile": {
+            "name": {
+              "ui:title": null
+            },
+            "homeView": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "https://jel.ly.fish/${source}"
+              }
+            },
+            "sendCommand": {
+              "ui:value": {
+                "$if": "source",
+                "else": null,
+                "then": "`${source}`"
+              },
+              "ui:widget": "Markdown"
+            },
+            "starredViews": {
+              "items": {
+                "ui:widget": "Link",
+                "ui:options": {
+                  "href": "https://jel.ly.fish/${source}"
+                }
+              }
+            },
+            "viewSettings": null,
+            "ui:description": null
+          },
+          "ui:title": null,
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": null,
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": null,
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      },
+      "snippet": {
+        "id": null,
+        "data": {
+          "hash": null,
+          "email": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "mailto:${source}"
+              }
+            },
+            "ui:widget": {
+              "$if": "typeof(source) == \"string\"",
+              "else": "Array",
+              "then": "Link"
+            },
+            "ui:options": {
+              "href": {
+                "$if": "typeof(source) == \"string\"",
+                "else": null,
+                "then": "mailto:${source}"
+              }
+            }
+          },
+          "roles": {
+            "items": {
+              "ui:widget": "Badge"
+            }
+          },
+          "avatar": {
+            "ui:widget": "Img",
+            "ui:options": {
+              "alt": "Avatar",
+              "width": 100
+            }
+          },
+          "origin": null,
+          "status": {
+            "title": {
+              "ui:title": "Current status"
+            },
+            "value": null,
+            "ui:title": null
+          },
+          "profile": {
+            "name": {
+              "ui:title": null
+            },
+            "homeView": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "https://jel.ly.fish/${source}"
+              }
+            },
+            "sendCommand": {
+              "ui:value": {
+                "$if": "source",
+                "else": null,
+                "then": "`${source}`"
+              },
+              "ui:widget": "Markdown"
+            },
+            "starredViews": {
+              "items": {
+                "ui:widget": "Link",
+                "ui:options": {
+                  "href": "https://jel.ly.fish/${source}"
+                }
+              }
+            },
+            "viewSettings": null,
+            "ui:description": null
+          },
+          "ui:title": null,
+          "$$localSchema": null,
+          "translateDate": null
+        },
+        "name": {},
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": {},
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      }
+    }
+  },
+  "name": "Jellyfish User",
+  "slug": "user",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-10-06T01:14:44.601Z",
+  "updated_at": "2020-10-13T08:50:29.823Z",
+  "capabilities": []
+}


### PR DESCRIPTION
Basically the 'target' field of the 'onDone' object has been changed to 'targets'.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This is a pre-requisite for adding support for taking actions (in this case linking to a newly created card) on multiple cards (selected in the table lens).

`CreateLens` is now unit-tested!

_Also added fixtures for type cards in a new `test/unit/apps/ui/fixtures/types` directory. In a separate PR I want to consolidate some of our test fixtures so we don't have so many duplicate type card test fixtures everywhere._
