### PR TITLE
ui: Add checkboxes and multi-card actions to table lens

### DIFF
--- a/apps/server/default-cards/balena/view-all-brainstorm-calls.json
+++ b/apps/server/default-cards/balena/view-all-brainstorm-calls.json
@@ -30,6 +30,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
 	}

--- a/apps/server/default-cards/balena/view-all-brainstorm-topics.json
+++ b/apps/server/default-cards/balena/view-all-brainstorm-topics.json
@@ -30,6 +30,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-all-faqs.json
+++ b/apps/server/default-cards/balena/view-all-faqs.json
@@ -23,7 +23,8 @@
       }
     ],
     "lenses": [
-      "lens-list"
+      "lens-list",
+      "lens-table"
     ]
   }
 }

--- a/apps/server/default-cards/balena/view-all-groups.json
+++ b/apps/server/default-cards/balena/view-all-groups.json
@@ -24,7 +24,8 @@
       }
     ],
     "lenses": [
-      "lens-list"
+      "lens-list",
+      "lens-table"
     ]
   }
 }

--- a/apps/server/default-cards/balena/view-all-jellyfish-support-threads.json
+++ b/apps/server/default-cards/balena/view-all-jellyfish-support-threads.json
@@ -61,6 +61,7 @@
       ],
       "lenses": [
         "lens-support-threads",
+        "lens-table",
         "lens-kanban"
       ]
     },

--- a/apps/server/default-cards/balena/view-all-product-improvements.json
+++ b/apps/server/default-cards/balena/view-all-product-improvements.json
@@ -29,6 +29,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-all-products.json
+++ b/apps/server/default-cards/balena/view-all-products.json
@@ -24,6 +24,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-all-projects.json
+++ b/apps/server/default-cards/balena/view-all-projects.json
@@ -25,6 +25,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-all-sales-threads.json
+++ b/apps/server/default-cards/balena/view-all-sales-threads.json
@@ -45,7 +45,8 @@
       }
     ],
     "lenses": [
-      "lens-support-threads"
+      "lens-support-threads",
+      "lens-table"
     ]
   }
 }

--- a/apps/server/default-cards/balena/view-all-specifications.json
+++ b/apps/server/default-cards/balena/view-all-specifications.json
@@ -44,7 +44,8 @@
       }
     ],
     "lenses": [
-      "lens-list"
+      "lens-list",
+      "lens-table"
     ]
   }
 }

--- a/apps/server/default-cards/balena/view-all-users-feedback.json
+++ b/apps/server/default-cards/balena/view-all-users-feedback.json
@@ -24,6 +24,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban",
       "lens-chart"
     ]

--- a/apps/server/default-cards/balena/view-all-users.json
+++ b/apps/server/default-cards/balena/view-all-users.json
@@ -24,6 +24,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-curate-typeform-responses.json
+++ b/apps/server/default-cards/balena/view-curate-typeform-responses.json
@@ -24,6 +24,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-curated-users-feedback.json
+++ b/apps/server/default-cards/balena/view-curated-users-feedback.json
@@ -39,6 +39,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban",
       "lens-chart"
     ]

--- a/apps/server/default-cards/balena/view-customer-success-support-threads.json
+++ b/apps/server/default-cards/balena/view-customer-success-support-threads.json
@@ -55,6 +55,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-devices-support-threads.json
+++ b/apps/server/default-cards/balena/view-devices-support-threads.json
@@ -55,6 +55,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-fleetops-support-threads.json
+++ b/apps/server/default-cards/balena/view-fleetops-support-threads.json
@@ -56,6 +56,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-new-users-feedback.json
+++ b/apps/server/default-cards/balena/view-new-users-feedback.json
@@ -32,6 +32,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban",
       "lens-chart"
     ]

--- a/apps/server/default-cards/balena/view-security-support-threads.json
+++ b/apps/server/default-cards/balena/view-security-support-threads.json
@@ -56,6 +56,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-support-threads-participation.json
+++ b/apps/server/default-cards/balena/view-support-threads-participation.json
@@ -67,6 +67,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-support-threads-pending-update.json
+++ b/apps/server/default-cards/balena/view-support-threads-pending-update.json
@@ -66,6 +66,7 @@
     ],
     "lenses": [
       "lens-support-threads",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/balena/view-support-threads-to-audit.json
+++ b/apps/server/default-cards/balena/view-support-threads-to-audit.json
@@ -59,6 +59,7 @@
     ],
     "lenses": [
       "lens-support-threads-to-audit",
+      "lens-table",
       "lens-kanban",
       "lens-support-audit-chart"
     ]

--- a/apps/server/default-cards/balena/view-workflows.json
+++ b/apps/server/default-cards/balena/view-workflows.json
@@ -24,6 +24,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/contrib/view-all-pipelines.json
+++ b/apps/server/default-cards/contrib/view-all-pipelines.json
@@ -25,6 +25,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban"
     ]
   }

--- a/apps/server/default-cards/contrib/view-all-pull-requests.json
+++ b/apps/server/default-cards/contrib/view-all-pull-requests.json
@@ -24,6 +24,7 @@
     ],
     "lenses": [
       "lens-list",
+      "lens-table",
       "lens-kanban",
       "lens-chart"
     ]

--- a/apps/ui/components/LinkModal/LinkModal.jsx
+++ b/apps/ui/components/LinkModal/LinkModal.jsx
@@ -6,6 +6,7 @@
 
 import _ from 'lodash'
 import memoize from 'memoize-one'
+import pluralize from 'pluralize'
 import React from 'react'
 import {
 	Box,
@@ -200,8 +201,9 @@ export default class LinkModal extends React.Component {
 		const typeCard = _.find(types, [ 'slug', fromType ])
 		const typeName = typeCard ? typeCard.name : fromType
 
-		const title = `Link this ${typeName} to ${linkTypeTargets.length === 1
-			? linkTypeTargets[0].title : 'another element'}`
+		const titleSource = `${cards.length > 1 ? 'these' : 'this'} ${pluralize(typeName, cards.length, cards.length > 1)}`
+		const titleTarget = linkTypeTargets.length === 1 ? linkTypeTargets[0].title : 'another element'
+		const title = `Link ${titleSource} to ${titleTarget}`
 
 		// Selected target display
 		let selectedTargetValue = null

--- a/apps/ui/lens/misc/CRMTable/index.jsx
+++ b/apps/ui/lens/misc/CRMTable/index.jsx
@@ -18,12 +18,13 @@ import {
 import CRMTable from './CRMTable'
 
 const mapStateToProps = (state) => {
+	const allTypes = selectors.getTypes(state)
 	return {
 		user: selectors.getCurrentUser(state),
 
-		// Types: selectors.getTypes(state)
+		allTypes,
 		types: _.get(
-			_.find(selectors.getTypes(state), [ 'slug', 'opportunity' ]), [
+			_.find(allTypes, [ 'slug', 'opportunity' ]), [
 				'data',
 				'schema',
 				'properties',
@@ -40,7 +41,8 @@ const mapDispatchToProps = (dispatch) => {
 	return {
 		actions: bindActionCreators(
 			_.pick(actionCreators, [
-				'addChannel'
+				'addChannel',
+				'createLink'
 			]), dispatch)
 	}
 }

--- a/apps/ui/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lens/misc/Table/CardTable.jsx
@@ -11,15 +11,20 @@ import {
 	Button,
 	Flex,
 	Table,
-	Txt
+	Txt,
+	DropDownButton
 } from 'rendition'
 import {
 	getPathsInSchema
 } from '@balena/jellyfish-ui-components/lib/services/helpers'
+import {
+	ActionLink
+} from '@balena/jellyfish-ui-components/lib/shame/ActionLink'
 import flatten from 'flat'
 import BaseLens from '../../common/BaseLens'
 import Link from '@balena/jellyfish-ui-components/lib/Link'
 import Column from '@balena/jellyfish-ui-components/lib/shame/Column'
+import LinkModal from '../../../components/LinkModal'
 
 const PAGE_SIZE = 25
 
@@ -50,6 +55,60 @@ export default class CardTable extends BaseLens {
 		super(props)
 		this.generateTableData = this.generateTableData.bind(this)
 		this.generateTableColumns = this.generateTableColumns.bind(this)
+		this.state = {
+			checkedCards: [],
+			showLinkModal: false
+		}
+		this.onChecked = this.onChecked.bind(this)
+		this.showLinkModal = this.showLinkModal.bind(this)
+		this.hideLinkModal = this.hideLinkModal.bind(this)
+		this.openCreateChannelForLinking = this.openCreateChannelForLinking.bind(this)
+	}
+
+	onChecked (checkedRows) {
+		const {
+			tail
+		} = this.props
+		this.setState({
+			checkedCards: checkedRows.map(({
+				slug
+			}) => {
+				return _.find(tail, {
+					slug
+				})
+			})
+		})
+	}
+
+	showLinkModal () {
+		this.setState({
+			showLinkModal: true
+		})
+	}
+
+	hideLinkModal () {
+		this.setState({
+			showLinkModal: false
+		})
+	}
+
+	openCreateChannelForLinking () {
+		const {
+			checkedCards
+		} = this.state
+		this.props.actions.addChannel({
+			head: {
+				seed: {
+					markers: this.props.channel.data.head.markers
+				},
+				onDone: {
+					action: 'link',
+					targets: checkedCards
+				}
+			},
+			format: 'create',
+			canonical: false
+		})
 	}
 
 	generateTableColumns () {
@@ -106,9 +165,15 @@ export default class CardTable extends BaseLens {
 
 	render () {
 		const {
+			actions,
+			allTypes,
 			generateData,
 			columns
 		} = this.props
+		const {
+			checkedCards,
+			showLinkModal
+		} = this.state
 		const tableColumns = columns || this.generateTableColumns()
 		const data = generateData ? generateData() : this.generateTableData()
 
@@ -117,17 +182,48 @@ export default class CardTable extends BaseLens {
 				<Box flex="1" style={{
 					position: 'relative'
 				}}>
-					{Boolean(data) && data.length > 0 && (
-						<Table
-							rowKey={this.props.rowKey}
-							data={data}
-							columns={tableColumns}
-							usePager={true}
-							itemsPerPage={PAGE_SIZE}
-							pagerPosition={'both'}
-							data-test="table-component"
-							onPageChange={this.props.setPage}
+					{showLinkModal && (
+						<LinkModal
+							actions={actions}
+							cards={checkedCards}
+							types={allTypes}
+							onHide={this.hideLinkModal}
 						/>
+					)}
+					{Boolean(data) && data.length > 0 && (
+						<React.Fragment>
+							<DropDownButton
+								data-test="cardTableActions__dropdown"
+								m={2}
+								joined
+								label={`With ${checkedCards.length} selected`}
+								disabled={!checkedCards.length}
+							>
+								<ActionLink
+									data-test="cardTableActions__link-existing"
+									onClick={this.showLinkModal}
+								>
+									Link to existing element
+								</ActionLink>
+								<ActionLink
+									data-test="cardTableActions__link-new"
+									onClick={this.openCreateChannelForLinking}
+								>
+									Create a new element to link to
+								</ActionLink>
+							</DropDownButton>
+							<Table
+								rowKey={this.props.rowKey}
+								data={data}
+								columns={tableColumns}
+								usePager={true}
+								itemsPerPage={PAGE_SIZE}
+								pagerPosition="bottom"
+								data-test="table-component"
+								onPageChange={this.props.setPage}
+								onCheck={this.onChecked}
+							/>
+						</React.Fragment>
 					)}
 					{Boolean(data) && data.length === 0 &&
 							<Txt.p p={3}>No results found</Txt.p>}

--- a/apps/ui/lens/misc/Table/index.js
+++ b/apps/ui/lens/misc/Table/index.js
@@ -19,6 +19,7 @@ import CardTable from './CardTable'
 
 const mapStateToProps = (state) => {
 	return {
+		allTypes: selectors.getTypes(state),
 		user: selectors.getCurrentUser(state)
 	}
 }
@@ -27,7 +28,8 @@ const mapDispatchToProps = (dispatch) => {
 	return {
 		actions: bindActionCreators(
 			_.pick(actionCreators, [
-				'addChannel'
+				'addChannel',
+				'createLink'
 			]), dispatch)
 	}
 }

--- a/apps/ui/lens/misc/Table/tests/CardTable.spec.jsx
+++ b/apps/ui/lens/misc/Table/tests/CardTable.spec.jsx
@@ -4,15 +4,22 @@
  * Proprietary and confidential.
  */
 
-import '../../../../../../test/ui-setup'
+import {
+	getWrapper
+} from '../../../../../../test/ui-setup'
 import ava from 'ava'
 import {
-	shallow
+	shallow,
+	mount
 } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
 import CardTable from '../CardTable'
 import props from './fixtures/props.json'
+
+const sandbox = sinon.createSandbox()
+
+const wrappingComponent = getWrapper().wrapper
 
 const {
 	channel,
@@ -24,8 +31,62 @@ const {
 	types
 } = props
 
+const mountCardTable = async (actions, setPageStub) => {
+	return mount((
+		<CardTable
+			actions={actions}
+			channel={channel}
+			tail={tail}
+			page={page}
+			totalPages={totalPages}
+			type={type}
+			user={user}
+			types={types}
+			setPage={setPageStub}
+		/>
+	), {
+		wrappingComponent
+	})
+}
+
+const checkRow = (component, rowIndex) => {
+	const tableBody = component.find('div[data-display="table-body"]')
+	const rows = tableBody.find('div[data-display="table-row"]')
+	const firstCheckbox = rows.at(rowIndex).find('div[data-display="table-cell"]').first().find('input')
+	firstCheckbox.simulate('change', {
+		target: {
+			checked: true
+		}
+	})
+}
+
+const openActions = (component) => {
+	component.find('button[data-test="cardTableActions__dropdown"]').simulate('click')
+}
+
+const takeAction = (component, action) => {
+	component.find(`a[data-test="cardTableActions__${action}"]`).simulate('click')
+}
+
+ava.beforeEach(async (test) => {
+	test.context = {
+		...test.context,
+		setPageStub: sinon.spy(),
+		actions: {
+			addChannel: sinon.stub().resolves(null),
+			createLink: sinon.stub().resolves(null)
+		}
+	}
+})
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
 ava('It should render', (test) => {
-	const setPageStub = sinon.spy()
+	const {
+		setPageStub
+	} = test.context
 
 	test.notThrows(() => {
 		shallow(
@@ -44,7 +105,9 @@ ava('It should render', (test) => {
 })
 
 ava('It should trigger setPage when clicking the pager button next', (test) => {
-	const setPageStub = sinon.spy()
+	const {
+		setPageStub
+	} = test.context
 
 	const component = shallow(<CardTable
 		channel={channel}
@@ -66,4 +129,66 @@ ava('It should trigger setPage when clicking the pager button next', (test) => {
 		.simulate('click')
 
 	test.true(setPageStub.calledOnce)
+})
+
+ava('It should let you select multiple cards', async (test) => {
+	const {
+		setPageStub,
+		actions
+	} = test.context
+
+	const cardTableComponent = await mountCardTable(actions, setPageStub)
+
+	checkRow(cardTableComponent, 0)
+	checkRow(cardTableComponent, 1)
+
+	test.is(cardTableComponent.state().checkedCards.length, 2)
+})
+
+ava('It should let you link multiple selected cards to a newly created card', async (test) => {
+	const {
+		setPageStub,
+		actions
+	} = test.context
+
+	const cardTableComponent = await mountCardTable(actions, setPageStub)
+
+	checkRow(cardTableComponent, 0)
+	checkRow(cardTableComponent, 1)
+	openActions(cardTableComponent)
+	takeAction(cardTableComponent, 'link-new')
+
+	test.true(actions.addChannel.calledOnce)
+	const newChannel = actions.addChannel.getCall(0).args[0]
+	test.deepEqual(newChannel, {
+		head: {
+			seed: {
+				markers: channel.data.head.markers
+			},
+			onDone: {
+				action: 'link',
+
+				// We're linking the first two cards in the table
+				targets: [ tail[0], tail[1] ]
+			}
+		},
+		format: 'create',
+		canonical: false
+	})
+})
+
+ava.only('It should let you link multiple selected cards to an existing card', async (test) => {
+	const {
+		setPageStub,
+		actions
+	} = test.context
+
+	const cardTableComponent = await mountCardTable(actions, setPageStub)
+
+	checkRow(cardTableComponent, 0)
+	checkRow(cardTableComponent, 1)
+	openActions(cardTableComponent)
+	takeAction(cardTableComponent, 'link-existing')
+
+	test.true(cardTableComponent.state().showLinkModal)
 })


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![Multi-Select-Actions](https://user-images.githubusercontent.com/2925657/95957520-029a1600-0e2a-11eb-9fb9-e535dfbd134c.gif)

This PR adds checkboxes to the Table Lens. Selecting one or more items in the table enables the 'Actions' DropDownButton. Currently, there are two actions supported:
1. Link to existing element
2. Create a new element to link to

Notes:
* The intention is that these actions will become 'generic card actions' so the list of `ActionLinks` will be automatically generated in the future. But for now we 'hard-code' these two actions.
* Items remain checked after an action is executed on them
* Items remain checked when you change page. TBD: is this desired behaviour? I've tried to allude to it by using the number of checked items in the label of the `DropDownButton` (e.g. 'With 3 selected')

I've added unit tests for the two actions. Note - it's difficult to test the display of the LinkModal itself as it is created in a portal outside of the rendered component.