### PR TITLE
Pending status

### DIFF
--- a/apps/server/default-cards/contrib/sales-thread.js
+++ b/apps/server/default-cards/contrib/sales-thread.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withIsPending, uiSchemaDef
 }) => {
-	return {
+	return mixin(withIsPending)({
 		slug: 'sales-thread',
 		name: 'Sales Thread',
 		type: 'type@1.0.0',
@@ -113,5 +113,5 @@ module.exports = ({
 				]
 			}
 		}
-	}
+	})
 }

--- a/apps/server/default-cards/contrib/support-thread.js
+++ b/apps/server/default-cards/contrib/support-thread.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	mixin, withEvents, uiSchemaDef
+	mixin, withEvents, withIsPending, uiSchemaDef
 }) => {
-	return mixin(withEvents)({
+	return mixin(withEvents, withIsPending)({
 		slug: 'support-thread',
 		name: 'Support Thread',
 		type: 'type@1.0.0',

--- a/apps/server/default-cards/contrib/triggered-action-support-reset-pending.json
+++ b/apps/server/default-cards/contrib/triggered-action-support-reset-pending.json
@@ -1,0 +1,65 @@
+{
+  "slug": "triggered-action-support-reset-pending",
+  "type": "triggered-action@1.0.0",
+  "name": "Triggered action for resetting the pending status of a support thread because of activity",
+  "markers": [],
+  "data": {
+    "async": false,
+    "filter": {
+      "$$links": {
+        "is attached to": {
+          "type": "object",
+          "required": [ "type", "data" ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "support-thread@1.0.0"
+            },
+            "data": {
+              "type": "object",
+              "required": [ "isPending" ],
+              "properties": {
+                "isPending": {
+                  "type": "boolean",
+                  "const": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [ "active", "type" ],
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "const": true
+        },
+        "type": {
+          "type": "string",
+          "const": "message@1.0.0"
+        }
+      }
+    },
+    "action": "action-update-card@1.0.0",
+    "target": {
+      "$map": {
+        "$eval": "source.links['is attached to'][0:]"
+      },
+      "each(link)": {
+        "$eval": "link.id"
+      }
+    },
+    "mode": "insert",
+    "arguments": {
+      "reason": "Reset pending status because of activity",
+      "patch": [
+        {
+          "op": "replace",
+          "path": "/data/isPending",
+          "value": false
+        }
+      ]
+    }
+  }
+}

--- a/apps/server/default-cards/index.js
+++ b/apps/server/default-cards/index.js
@@ -92,6 +92,7 @@ module.exports = ({
 			'./contrib/triggered-action-integration-outreach-mirror-event.json'),
 		triggeredActionSetUserAvatar: require('./contrib/triggered-action-set-user-avatar.json'),
 		triggeredActionSupportReopen: require('./contrib/triggered-action-support-reopen.json'),
+		triggeredActionSupportResetPending: require('./contrib/triggered-action-support-reset-pending.json'),
 		triggeredActionSupportClosedIssueReopen: require('./contrib/triggered-action-support-closed-issue-reopen.json'),
 		triggeredActionSyncThreadPostLinkWhisper: require(
 			'./contrib/triggered-action-sync-thread-post-link-whisper.json'),

--- a/apps/server/default-cards/mixins/index.js
+++ b/apps/server/default-cards/mixins/index.js
@@ -5,6 +5,7 @@
  */
 
 const withEvents = require('./with-events')
+const withIsPending = require('./with-is-pending')
 
 const uiSchemaDef = (key) => {
 	return `node_modules/@balena/jellyfish-core/lib/cards/mixins/ui-schema-defs.json#/${key}`
@@ -12,6 +13,7 @@ const uiSchemaDef = (key) => {
 
 module.exports = {
 	uiSchemaDef,
+	withIsPending,
 	withEvents: withEvents({
 		uiSchemaDef
 	})

--- a/apps/server/default-cards/mixins/with-is-pending.js
+++ b/apps/server/default-cards/mixins/with-is-pending.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// This mixin defines all fields in cards that support a boolean isPending status
+module.exports = {
+	data: {
+		schema: {
+			properties: {
+				data: {
+					properties: {
+						isPending: {
+							title: 'Pending',
+							type: 'boolean',
+							default: false
+						}
+					}
+				}
+			}
+		},
+		uiSchema: {
+			fields: {
+				data: {
+					// Don't display the isPending field here as it is displayed
+					// separately on the SupportThread lens
+					isPending: null
+				}
+			}
+		}
+	}
+}

--- a/apps/ui/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lens/full/SupportThread/index.jsx
@@ -113,6 +113,37 @@ class SupportThreadBase extends React.Component {
 				})
 		}
 
+		this.togglePending = (event) => {
+			const {
+				card
+			} = this.props
+			if (this.state.isTogglingPending) {
+				return
+			}
+			this.setState({
+				isTogglingPending: true
+			}, () => {
+				const wasPending = _.get(card, [ 'data', 'isPending' ], false)
+				const patch = helpers.patchPath(card, [ 'data', 'isPending' ], !wasPending)
+
+				sdk.card.update(card.id, card.type, patch)
+					.then(() => {
+						addNotification(
+							'success',
+							wasPending ? 'Support thread is no longer pending' : 'Support thread is pending'
+						)
+					})
+					.catch((error) => {
+						addNotification('danger', error.message || error)
+					})
+					.finally(() => {
+						this.setState({
+							isTogglingPending: false
+						})
+					})
+			})
+		}
+
 		this.close = async () => {
 			const {
 				card,
@@ -183,6 +214,7 @@ class SupportThreadBase extends React.Component {
 		this.state = {
 			actor: null,
 			isClosing: false,
+			isTogglingPending: false,
 			linkedSupportIssues: [],
 			linkedGitHubIssues: [],
 			linkedProductImprovements: []
@@ -300,6 +332,7 @@ class SupportThreadBase extends React.Component {
 			getActorHref
 		} = this.props
 		const {
+			isTogglingPending,
 			linkedSupportIssues,
 			linkedGitHubIssues,
 			linkedProductImprovements
@@ -321,6 +354,7 @@ class SupportThreadBase extends React.Component {
 		const isMirrored = !_.isEmpty(mirrors)
 
 		const statusDescription = _.get(card, [ 'data', 'statusDescription' ])
+		const isPending = _.get(card, [ 'data', 'isPending' ], false)
 
 		return (
 			<CardLayout
@@ -328,7 +362,7 @@ class SupportThreadBase extends React.Component {
 				channel={channel}
 				title={(
 					<Flex flex={1} justifyContent="space-between">
-						<Flex flex={1} flexWrap="wrap"
+						<Flex flex={1} mr={1} flexWrap="wrap" alignItems="center"
 							style={{
 								transform: 'translateY(2px)'
 							}}
@@ -403,6 +437,19 @@ class SupportThreadBase extends React.Component {
 								}
 							/>
 						)}
+
+						<Button
+							mr={3}
+							tertiary
+							outline={!isPending}
+							data-test="support-thread__pending"
+							onClick={this.togglePending}
+							icon={<Icon name="hourglass-half" spin={isTogglingPending} />}
+							tooltip={{
+								placement: 'bottom',
+								text: isPending ? 'Support thread is pending' : 'Set this thread as pending'
+							}}
+						/>
 					</Flex>
 				)}
 				actionItems={(

--- a/repo.yml
+++ b/repo.yml
@@ -1,4 +1,6 @@
 type: docker
+esr:
+  version: 'support-v2'
 upstream:
   - repo: 'open-balena-base'
     url: 'https://github.com/balena-io/open-balena-base'


### PR DESCRIPTION
**Reset pending status on support thread activity**
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
**ui: Add Pending Status toggle button**
Displays the pending status of a support thread (dark blue background if pending) and lets the user toggle the pending status.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
**Add isPending boolean field to support-thread and sales-thread**
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![Pending Status](https://user-images.githubusercontent.com/2925657/96109771-37c96580-0f09-11eb-846a-0dd8ca6e8aee.gif)
