### PR TITLE
ui: Remove duplicate 'success' in notification

### DIFF
--- a/apps/ui/lens/actions/EditLens.jsx
+++ b/apps/ui/lens/actions/EditLens.jsx
@@ -109,7 +109,7 @@ class EditLens extends React.Component {
 				})
 			})
 			.then(() => {
-				addNotification('success', 'Successfully updated card')
+				addNotification('success', 'Card updated')
 			})
 			.catch((error) => {
 				addNotification('danger', error.message)


### PR DESCRIPTION
Now that we preface all 'success' notifications with **Success** we shouldn't also use the word 'success' in the notification message!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

