### PR TITLE
Use active channel in page title

### DIFF
--- a/apps/ui/JellyfishUI.jsx
+++ b/apps/ui/JellyfishUI.jsx
@@ -46,6 +46,9 @@ import {
 	Redirect,
 	Switch
 } from 'react-router-dom'
+import {
+	name
+} from './manifest.json'
 
 // Register the mermaid and markdown widgets for rendition forms
 // Register the extra format widgets to the Form component
@@ -122,7 +125,7 @@ class JellyfishUI extends React.Component {
 				<Flex flex="1" style={{
 					height: '100%'
 				}}>
-					<PageTitle />
+					<PageTitle siteName={name} />
 					<CountFavicon
 						baseIcons={[
 							{

--- a/apps/ui/components/PageTitle/PageTitle.jsx
+++ b/apps/ui/components/PageTitle/PageTitle.jsx
@@ -5,18 +5,32 @@
  */
 
 import React from 'react'
+import _ from 'lodash'
 import {
 	Helmet
 } from 'react-helmet'
 
 const PageTitle = ({
+	siteName,
+	activeChannel,
 	unreadCount
-}) => (
-	<React.Fragment>
+}) => {
+	const countPrefix = unreadCount ? `(${unreadCount}) ` : ''
+	const channelPrefix = React.useMemo(() => {
+		const prefix = _.get(activeChannel, [ 'data', 'head', 'name' ]) ||
+				_.get(activeChannel, [ 'data', 'head', 'slug' ]) ||
+				_.get(activeChannel, [ 'data', 'target' ], '')
+		return _.truncate(prefix, {
+			length: 30
+		})
+	}, [ activeChannel ])
+	const combinedPrefix = `${countPrefix}${channelPrefix}`.trim()
+	const title = combinedPrefix ? `${combinedPrefix} | ${siteName}` : siteName
+	return (
 		<Helmet>
-			<title>{`Jellyfish${unreadCount ? ` (${unreadCount})` : ''}`}</title>
+			<title>{title}</title>
 		</Helmet>
-	</React.Fragment>
-)
+	)
+}
 
 export default React.memo(PageTitle)

--- a/apps/ui/components/PageTitle/index.js
+++ b/apps/ui/components/PageTitle/index.js
@@ -15,7 +15,9 @@ import PageTitle from './PageTitle'
 
 const mapStateToProps = (state) => {
 	const mentions = selectors.getInboxViewData(state)
+	const channels = selectors.getChannels(state)
 	return {
+		activeChannel: channels.length > 1 ? channels[channels.length - 1] : null,
 		unreadCount: _.get(mentions, [ 'length' ], 0)
 	}
 }

--- a/apps/ui/components/PageTitle/test/PageTitle.spec.jsx
+++ b/apps/ui/components/PageTitle/test/PageTitle.spec.jsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '../../../../../test/ui-setup'
+import ava from 'ava'
+import {
+	shallow
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import PageTitle from '../PageTitle'
+import ViewAllIssues from './fixtures/view-all-issues.json'
+import SupportThread from './fixtures/support-thread.json'
+import ViewAllIssuesLoading from './fixtures/view-all-issues-loading.json'
+
+const sandbox = sinon.createSandbox()
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('PageTitle displays \'Jellyfish\' if only the home channel is displayed', async (test) => {
+	const component = shallow(<PageTitle siteName="Jellyfish" activeChannel={null} unreadCount={0} />)
+	const title = component.find('title')
+	test.is(title.text(), 'Jellyfish')
+})
+
+ava('PageTitle displays unread message count', async (test) => {
+	const component = shallow(<PageTitle siteName="Jellyfish" activeChannel={null} unreadCount={3} />)
+	const title = component.find('title')
+	test.is(title.text(), '(3) | Jellyfish')
+})
+
+ava('PageTitle displays channel card name if set', async (test) => {
+	const component = shallow(<PageTitle siteName="Jellyfish" activeChannel={ViewAllIssues} unreadCount={0} />)
+	const title = component.find('title')
+	test.is(title.text(), 'All GitHub issues | Jellyfish')
+})
+
+ava('PageTitle displays channel card slug if name not set', async (test) => {
+	const component = shallow(<PageTitle siteName="Jellyfish" activeChannel={SupportThread} unreadCount={0} />)
+	const title = component.find('title')
+	test.is(title.text(), 'support-thread-b98847cc-a80... | Jellyfish')
+})
+
+ava('PageTitle displays channel target if card not set', async (test) => {
+	const component = shallow(<PageTitle siteName="Jellyfish" activeChannel={ViewAllIssuesLoading} unreadCount={0} />)
+	const title = component.find('title')
+	test.is(title.text(), 'view-all-issues | Jellyfish')
+})
+
+ava('PageTitle displays unread message count and channel details', async (test) => {
+	const component = shallow(<PageTitle siteName="Jellyfish" activeChannel={ViewAllIssues} unreadCount={3} />)
+	const title = component.find('title')
+	test.is(title.text(), '(3) All GitHub issues | Jellyfish')
+})

--- a/apps/ui/components/PageTitle/test/fixtures/support-thread.json
+++ b/apps/ui/components/PageTitle/test/fixtures/support-thread.json
@@ -1,0 +1,38 @@
+{
+  "id": "8f3edd33-56b6-4190-ada0-d63c87a5032e",
+  "created_at": "2020-10-19T06:08:12.155Z",
+  "slug": "channel-8f3edd33-56b6-4190-ada0-d63c87a5032e",
+  "type": "channel",
+  "active": true,
+  "data": {
+    "target": "72e4d98c-e6af-4024-8a98-b4d82eb927dc",
+    "options": {},
+    "canonical": true,
+    "head": {
+      "id": "72e4d98c-e6af-4024-8a98-b4d82eb927dc",
+      "data": {
+        "inbox": "S/Paid_Support",
+        "status": "open",
+        "category": "general",
+        "participants": [
+          "ee97f2f4-2480-4644-b175-28297bbafb74",
+          "ee97f2f4-2480-4644-b175-28297bbafb74"
+        ]
+      },
+      "name": null,
+      "slug": "support-thread-b98847cc-a804-4ea3-b861-f1f4d699506f",
+      "tags": [],
+      "type": "support-thread@1.0.0",
+      "active": true,
+      "markers": [],
+      "version": "1.0.0",
+      "requires": [],
+      "linked_at": {
+        "has attached element": "2020-10-19T04:15:10.373Z"
+      },
+      "created_at": "2020-10-19T04:15:09.900Z",
+      "updated_at": "2020-10-19T04:15:10.171Z",
+      "capabilities": []
+    }
+  }
+}

--- a/apps/ui/components/PageTitle/test/fixtures/view-all-issues-loading.json
+++ b/apps/ui/components/PageTitle/test/fixtures/view-all-issues-loading.json
@@ -1,0 +1,12 @@
+{
+  "id": "d3cb93a8-2c88-4ea1-a045-f4cd72466e81",
+  "created_at": "2020-10-19T06:03:23.759Z",
+  "slug": "channel-d3cb93a8-2c88-4ea1-a045-f4cd72466e81",
+  "type": "channel",
+  "active": true,
+  "data": {
+    "target": "view-all-issues",
+    "options": {},
+    "canonical": true
+  }
+}

--- a/apps/ui/components/PageTitle/test/fixtures/view-all-issues.json
+++ b/apps/ui/components/PageTitle/test/fixtures/view-all-issues.json
@@ -1,0 +1,75 @@
+{
+  "id": "d3cb93a8-2c88-4ea1-a045-f4cd72466e81",
+  "created_at": "2020-10-19T06:03:23.759Z",
+  "slug": "channel-d3cb93a8-2c88-4ea1-a045-f4cd72466e81",
+  "type": "channel",
+  "active": true,
+  "data": {
+    "target": "view-all-issues",
+    "options": {},
+    "canonical": true,
+    "head": {
+      "id": "421390e8-a9aa-4855-9c8d-080c6c26f812",
+      "data": {
+        "allOf": [
+          {
+            "name": "Active cards",
+            "schema": {
+              "type": "object",
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "message@1.0.0",
+                        "update@1.0.0",
+                        "create@1.0.0",
+                        "whisper@1.0.0"
+                      ]
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "active",
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "issue@1.0.0"
+                },
+                "active": {
+                  "type": "boolean",
+                  "const": true
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        ],
+        "lenses": [
+          "lens-table",
+          "lens-kanban"
+        ]
+      },
+      "name": "All GitHub issues",
+      "slug": "view-all-issues",
+      "tags": [],
+      "type": "view@1.0.0",
+      "links": {},
+      "active": true,
+      "markers": [
+        "org-balena"
+      ],
+      "version": "1.0.0",
+      "requires": [],
+      "linked_at": {},
+      "created_at": "2020-10-06T01:14:50.299Z",
+      "updated_at": null,
+      "capabilities": []
+    }
+  }
+}


### PR DESCRIPTION
This should help the user see which channel is active when viewing the browser tabs/windows.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #1760

![image](https://user-images.githubusercontent.com/2925657/96409275-381a7700-120f-11eb-8a87-554867fb5568.png)

