### PR TITLE
Add page tracking using analytics-client

### DIFF
--- a/apps/ui/lib/JellyfishUI.jsx
+++ b/apps/ui/lib/JellyfishUI.jsx
@@ -71,14 +71,14 @@ const transformLegacyPath = (path) => {
 	return path.replace(LEGACY_PATH_REPLACE_RE, '')
 }
 
-class JellyfishUI extends React.Component {
-	constructor (props) {
-		super(props)
-
+const JellyfishUI = ({
+	actions, status, channels, isChatWidgetOpen
+}) => {
+	React.useEffect(() => {
 		// Add a utility to the window to dump the core state, this is useful for
 		// debugging
 		window.dumpState = async () => {
-			const state = await this.props.actions.dumpState()
+			const state = await actions.dumpState()
 
 			const blob = new Blob(
 				[ JSON.stringify(state) ],
@@ -89,58 +89,56 @@ class JellyfishUI extends React.Component {
 
 			saveAs(blob, `jellyfish-ui-dump__${new Date().toISOString()}.json`)
 		}
+	}, [])
 
-		this.handleChatWidgetClose = () => {
-			this.props.actions.setChatWidgetOpen(false)
-		}
+	const handleChatWidgetClose = () => {
+		actions.setChatWidgetOpen(false)
 	}
 
-	render () {
-		const path = window.location.pathname + window.location.hash
+	const path = window.location.pathname + window.location.hash
 
-		if (this.props.status === 'initializing') {
-			return <Splash />
-		}
-		if (this.props.status === 'unauthorized') {
-			return (
-				<AuthContainer>
-					<Switch>
-						<Route path='/request_password_reset' component={RequestPasswordReset} />
-						<Route path='/password_reset/:resetToken/:username?' component={CompletePasswordReset} />
-						<Route path='/first_time_login/:firstTimeLoginToken/:username?' component={CompleteFirstTimeLogin} />
-						<Route path="/*" component={Login} />
-					</Switch>
-				</AuthContainer>
-			)
-		}
-		const [ home ] = this.props.channels
-
+	if (status === 'initializing') {
+		return <Splash />
+	}
+	if (status === 'unauthorized') {
 		return (
-			<React.Fragment>
-				{isLegacyPath(path) && (
-					<Redirect to={transformLegacyPath(path)} />
-				)}
-
-				<Flex flex="1" style={{
-					height: '100%'
-				}}>
-					<PageTitle siteName={name} />
-					<HomeChannel channel={home}/>
-
-					<Switch>
-						<Route path="/oauth/:integration" component={Oauth} />
-						<Route path="/*" component={RouteHandler} />
-					</Switch>
-				</Flex>
-
-				{this.props.isChatWidgetOpen && (
-					<ChatWidgetSidebar
-						onClose={this.handleChatWidgetClose}
-					/>
-				)}
-			</React.Fragment>
+			<AuthContainer>
+				<Switch>
+					<Route path='/request_password_reset' component={RequestPasswordReset} />
+					<Route path='/password_reset/:resetToken/:username?' component={CompletePasswordReset} />
+					<Route path='/first_time_login/:firstTimeLoginToken/:username?' component={CompleteFirstTimeLogin} />
+					<Route path="/*" component={Login} />
+				</Switch>
+			</AuthContainer>
 		)
 	}
+	const [ home ] = channels
+
+	return (
+		<React.Fragment>
+			{isLegacyPath(path) && (
+				<Redirect to={transformLegacyPath(path)} />
+			)}
+
+			<Flex flex="1" style={{
+				height: '100%'
+			}}>
+				<PageTitle siteName={name} />
+				<HomeChannel channel={home}/>
+
+				<Switch>
+					<Route path="/oauth/:integration" component={Oauth} />
+					<Route path="/*" component={RouteHandler} />
+				</Switch>
+			</Flex>
+
+			{isChatWidgetOpen && (
+				<ChatWidgetSidebar
+					onClose={handleChatWidgetClose}
+				/>
+			)}
+		</React.Fragment>
+	)
 }
 
 const mapStateToProps = (state) => {

--- a/apps/ui/lib/JellyfishUI.jsx
+++ b/apps/ui/lib/JellyfishUI.jsx
@@ -20,6 +20,9 @@ import {
 	MarkdownWidget
 } from 'rendition/dist/extra/Form/markdown'
 import {
+	createClient, createNoopClient, createWebTracker
+} from 'analytics-client'
+import {
 	saveAs
 } from 'file-saver'
 import {
@@ -41,6 +44,7 @@ import {
 	selectors
 } from './core'
 import {
+	useLocation,
 	Route,
 	Redirect,
 	Switch
@@ -48,6 +52,9 @@ import {
 import {
 	name
 } from './manifest.json'
+import {
+	isProduction
+} from './environment'
 
 // Register the mermaid and markdown widgets for rendition forms
 // Register the extra format widgets to the Form component
@@ -71,9 +78,24 @@ const transformLegacyPath = (path) => {
 	return path.replace(LEGACY_PATH_REPLACE_RE, '')
 }
 
+const analyticsClient = isProduction()
+	? createClient({
+		projectName: 'jellyfish',
+		componentName: 'jellyfish-ui'
+	})
+	: createNoopClient(false)
+
+const webTracker = createWebTracker(analyticsClient, 'UI')
+
 const JellyfishUI = ({
 	actions, status, channels, isChatWidgetOpen
 }) => {
+	const location = useLocation()
+
+	React.useEffect(() => {
+		webTracker.trackPageView()
+	}, [ location.pathname ])
+
 	React.useEffect(() => {
 		// Add a utility to the window to dump the core state, this is useful for
 		// debugging

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -14,6 +14,11 @@
         "turntable-camera-controller": "^3.0.0"
       }
     },
+    "@amplitude/ua-parser-js": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-bmW++BLt1Hg+4HCExLXP+0Jhgy2eTsEevqkVc5o4yYbgwdP/gV3gEQXzyVrMVlWWNLgph/tFIkf5PVlSpCELEg=="
+    },
     "@ava/babel": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@ava/babel/-/babel-1.0.1.tgz",
@@ -2411,6 +2416,11 @@
         "ajv": "^6.9.1"
       }
     },
+    "@types/amplitude-js": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-5.11.0.tgz",
+      "integrity": "sha512-d+ELEiXtU8H/wVtmGPxTiPuyZW5HWEdKrOWGO99Y1eOvJuSLw3g/b6xlB9+snUOW5P8AYDhCHh8TzT6Vsz8jzQ=="
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -3117,6 +3127,51 @@
       "requires": {
         "alpha-complex": "^1.0.0",
         "simplicial-complex-boundary": "^1.0.0"
+      }
+    },
+    "amplitude-js": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-5.11.0.tgz",
+      "integrity": "sha512-rH5CqWvnKK9E6uVI7h1t/ikkQK4vhiS7iy2fncE4K56MY0ty/XVF9cNFBq2NAujMo1VXvu8oG80MdIETPG1zsA==",
+      "requires": {
+        "@amplitude/ua-parser-js": "0.7.20",
+        "blueimp-md5": "^2.10.0",
+        "query-string": "5"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
+      }
+    },
+    "analytics-client": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/analytics-client/-/analytics-client-0.11.2.tgz",
+      "integrity": "sha512-OTKKjjd7NlQwM9rgmT/XJ2eP53a3jaeehr6UIeilTbkJ5Dr8Nig3ekYWgkWh8K8NwrQtOmUn1Na4dSkJJDc9Ww==",
+      "requires": {
+        "@types/amplitude-js": "5.11.0",
+        "amplitude-js": "5.11.0",
+        "js-cookie": "^2.2.1",
+        "mixpanel-browser": "2.29.1"
+      },
+      "dependencies": {
+        "mixpanel-browser": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.29.1.tgz",
+          "integrity": "sha512-RSBqVBznOkKBz3MkCXRrkTEEXqoNNYAbASpjaCxvhpT5pykWhjh7JY54fAmOvtG9XNL3GHYA6XiB7Yos4ngNYQ=="
+        }
       }
     },
     "ansi-align": {
@@ -4204,8 +4259,7 @@
     "blueimp-md5": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
-      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==",
-      "dev": true
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
     },
     "bn.js": {
       "version": "4.11.9",
@@ -11243,6 +11297,11 @@
           }
         }
       }
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -44,6 +44,7 @@
     "@balena/jellyfish-core": "^0.1.76",
     "@balena/jellyfish-environment": "^2.2.39",
     "@balena/jellyfish-ui-components": "^2.2.0",
+    "analytics-client": "^0.11.2",
     "babel-loader": "^8.1.0",
     "bluebird": "^3.7.2",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Add UI Analytics to track page views

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This PR makes use of [analytics-client](https://github.com/balena-io-modules/analytics-client) to track page views in Jellyfish.

### Note:

I refactored the `JellyfishUI` component to be a functional component instead of a class. See [this commit](https://github.com/product-os/jellyfish/commit/1fee8b4d3845a838d27f8feade35b0da5b7ce496). The page-tracking changes relevant to this PR are in [this commit](https://github.com/product-os/jellyfish/commit/8830949568dde3ccce27412e1cfd81e2af92df19).
