### PR TITLE
Ensure stream attempts to reconnect indefinitely when the connection has dropped

### DIFF
--- a/apps/ui/lens/misc/Inbox/InboxTab.jsx
+++ b/apps/ui/lens/misc/Inbox/InboxTab.jsx
@@ -102,12 +102,14 @@ const InboxTab = ({
 
 	const updateMessage = (updatedMessage) => {
 		const messageIndex = _.findIndex(messagesRef.current, [ 'id', updatedMessage.id ])
-		const updatedMessages = update(messages, {
-			[messageIndex]: {
-				$set: updatedMessage
-			}
-		})
-		setMessages(updatedMessages)
+		if (messages.length === messagesRef.current.ref) {
+			const updatedMessages = update(messages, {
+				[messageIndex]: {
+					$set: updatedMessage
+				}
+			})
+			setMessages(updatedMessages)
+		}
 	}
 
 	const viewHandlers = {


### PR DESCRIPTION
At the moment, when the connection is dropped we only attempt to reconnect a couple of times. If the socket doesn't come available in time we never reconnect and thus stop getting streaming updates on a page.

This can be reproduced locally through the following steps:
1. Open a local version of Jellyfish and navigating to the inbox
2. Open a private window and log into Jellyfish with another account. Ping the user whose inbox you have open
3. Ping should appear in first browser window
4. Now shutdown the server, wait a minute, and start it up again
5. Pin the same user from your private window
6. Before this change, the new message would not appear in the inbox. After this change, it does