### PR TITLE
Bump test/sidecar base images

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-test:v1.3.17
+FROM resinci/jellyfish-test:v1.3.19
 
 WORKDIR /usr/src/jellyfish
 

--- a/test/containers/Dockerfile.test
+++ b/test/containers/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM resinci/jellyfish-test:v1.3.16
+FROM resinci/jellyfish-test:v1.3.19
 
 WORKDIR /usr/src/jellyfish
 ARG NPM_TOKEN


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `jellyfish-test` and `jellyfish-sidecar` base images, which include:
- https://github.com/product-os/jellyfish-base-images/pull/25
- https://github.com/product-os/jellyfish-base-images/pull/26
