### PR TITLE
Reduce to two workers for compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - tick
       - worker_1
       - worker_2
-      - worker_3
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres
@@ -280,67 +279,6 @@ services:
     restart: always
     networks:
       - internal
-  worker_3:
-    image: balena/jellyfish-action-server
-    build:
-      context: .
-      dockerfile: apps/action-server/Dockerfile.worker
-      args:
-        - NPM_TOKEN
-    depends_on:
-      - postgres
-      - redis
-      - balena-mdns-publisher
-    environment:
-      - DATABASE=postgres
-      - LOGLEVEL=crit
-      - NODE_ENV=test
-      - POSTGRES_DATABASE=jellyfish
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_PORT=5432
-      - POSTGRES_USER=docker
-      - REDIS_HOST=redis
-      - REDIS_PASSWORD=
-      - REDIS_PORT=6379
-      - SENTRY_DSN_SERVER
-      - LOGENTRIES_TOKEN
-      - FS_DRIVER
-      - AWS_ACCESS_KEY_ID
-      - AWS_S3_BUCKET_NAME
-      - AWS_SECRET_ACCESS_KEY
-      - INTEGRATION_BALENA_API_APP_SECRET=foobar
-      - INTEGRATION_BALENA_API_OAUTH_BASE_URL=https://api.balena-cloud.com
-      - INTEGRATION_BALENA_API_PRIVATE_KEY
-      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
-      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING=foobar
-      - INTEGRATION_DEFAULT_USER
-      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
-      - INTEGRATION_DISCOURSE_TOKEN
-      - INTEGRATION_DISCOURSE_USERNAME
-      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
-      - INTEGRATION_FLOWDOCK_TOKEN
-      - INTEGRATION_FRONT_TOKEN
-      - INTEGRATION_GITHUB_APP_ID
-      - INTEGRATION_GITHUB_PRIVATE_KEY
-      - INTEGRATION_GITHUB_SIGNATURE_KEY
-      - INTEGRATION_GITHUB_TOKEN
-      - INTEGRATION_GOOGLE_MEET_CREDENTIALS="{}"
-      - INTEGRATION_INTERCOM_TOKEN
-      - INTEGRATION_OUTREACH_APP_ID
-      - INTEGRATION_OUTREACH_APP_SECRET
-      - INTEGRATION_OUTREACH_SIGNATURE_KEY
-      - INTEGRATION_TYPEFORM_SIGNATURE_KEY
-      - MAILGUN_DOMAIN
-      - MAILGUN_BASE_URL
-      - MAILGUN_TOKEN
-      - MONITOR_SECRET_TOKEN
-      - NPM_TOKEN
-      - RESET_PASSWORD_SECRET_TOKEN
-      - CI
-    restart: always
-    networks:
-      - internal
   balena-mdns-publisher:
     image: 'balena/balena-mdns-publisher:master'
     network_mode: host
@@ -374,7 +312,6 @@ services:
     depends_on:
       - worker_1
       - worker_2
-      - worker_3
       - ui
       - tick
       - livechat

--- a/scripts/template/index.js
+++ b/scripts/template/index.js
@@ -21,8 +21,6 @@ console.log(mustache.render(contents, Object.assign({}, process.env, {
 		idx: 1
 	}, {
 		idx: 2
-	}, {
-		idx: 3
 	} ]
 })))
 console.error(`Done rendering ${TEMPLATE}`)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Wanting to see if dropping the number of workers from 3 to 2 has a negative impact on our CI times. If not, we could possible remove one to speed to reduce overall cluster resource usage.
