### PR TITLE
Add missing .npmrc files for apps

### DIFF
--- a/apps/action-server/.npmrc
+++ b/apps/action-server/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/livechat/.npmrc
+++ b/apps/livechat/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/server/.npmrc
+++ b/apps/server/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/ui/.npmrc
+++ b/apps/ui/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Forgot to add the `.npmrc` file with `engine-strict=true` for all apps. This is needed to perform the node version check defined in each `package.json`:
```
...
"engines": {
  "node": ">=12.15.0"
},
...
```