### PR TITLE
Reopen support threads when a linked pull request is closed

### DIFF
--- a/apps/server/lib/default-cards/contrib/triggered-action-support-closed-pull-request-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-closed-pull-request-reopen.json
@@ -1,0 +1,119 @@
+{
+  "slug": "triggered-action-support-closed-pull-request-reopen",
+  "type": "triggered-action@1.0.0",
+  "name": "Triggered action for reopening support threads when pull requests are closed",
+  "markers": [],
+  "data": {
+    "async": false,
+    "filter": {
+      "$$links": {
+        "is attached to": {
+          "$$links": {
+            "pull request has attached support thread": {
+              "type": "object",
+              "required": [ "type", "data" ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "support-thread@1.0.0"
+                },
+                "data": {
+                  "type": "object",
+                  "required": [ "status" ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "not": {
+                        "const": "open"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "type": "object",
+          "required": [ "active", "type", "data" ],
+          "properties": {
+            "active": {
+              "type": "boolean",
+              "const": true
+            },
+            "type": {
+              "type": "string",
+              "const": "pull-request@1.0.0"
+            },
+            "data": {
+              "type": "object",
+              "required": [ "status" ],
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "const": "closed"
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [ "active", "type", "data" ],
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "const": true
+        },
+        "type": {
+          "type": "string",
+          "const": "update@1.0.0"
+        },
+        "data": {
+          "type": "object",
+          "required": [ "payload" ],
+          "properties": {
+            "payload": {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "required": [ "op", "path", "value" ],
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "replace"
+                  },
+                  "path": {
+                    "type": "string",
+                    "const": "/data/status"
+                  },
+                  "value": {
+                    "type": "string",
+                    "const": "closed"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "action": "action-update-card@1.0.0",
+    "target": {
+      "$map": {
+        "$eval": "source.links['is attached to'][0].links['pull request has attached support thread'][0:]"
+      },
+      "each(link)": {
+        "$eval": "link.id"
+      }
+    },
+    "arguments": {
+      "reason": "Re-opened because linked pull request was closed",
+      "patch": [
+        {
+          "op": "replace",
+          "path": "/data/status",
+          "value": "open"
+        }
+      ]
+    }
+  }
+}

--- a/apps/server/lib/default-cards/index.js
+++ b/apps/server/lib/default-cards/index.js
@@ -94,6 +94,8 @@ module.exports = ({
 		triggeredActionSupportSummary: require('./contrib/triggered-action-support-summary.json'),
 		triggeredActionSupportReopen: require('./contrib/triggered-action-support-reopen.json'),
 		triggeredActionSupportClosedIssueReopen: require('./contrib/triggered-action-support-closed-issue-reopen.json'),
+		triggeredActionSupportClosedPullRequestReopen:
+			require('./contrib/triggered-action-support-closed-pull-request-reopen.json'),
 		triggeredActionSyncThreadPostLinkWhisper: require(
 			'./contrib/triggered-action-sync-thread-post-link-whisper.json'),
 		triggeredActionUpdateEventEditedAt: require('./contrib/triggered-action-update-event-edited-at.json'),


### PR DESCRIPTION
This is a very similar triggered action to the one that relates to GitHub issues

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes #4998 
