### PR TITLE
Fix D3 event calls in LinksGraphLens

### DIFF
--- a/apps/ui/lib/lens/actions/LinksGraphLens.jsx
+++ b/apps/ui/lib/lens/actions/LinksGraphLens.jsx
@@ -110,31 +110,31 @@ class CreateLens extends React.Component {
 			}
 		}
 
-		const dragsubject = () => {
-			return simulation.find(d3.event.x, d3.event.y)
+		const dragsubject = (event) => {
+			return simulation.find(event.x, event.y)
 		}
 
-		const dragstarted = () => {
-			if (!d3.event.active) {
+		const dragstarted = (event) => {
+			if (!event.active) {
 				simulation.alphaTarget(0.3).restart()
 			}
-			d3.event.subject.fx = d3.event.subject.x
-			d3.event.subject.fy = d3.event.subject.y
+			event.subject.fx = event.subject.x
+			event.subject.fy = event.subject.y
 
-			active = d3.event.subject
+			active = event.subject
 		}
 
-		const dragged = () => {
-			d3.event.subject.fx = d3.event.x
-			d3.event.subject.fy = d3.event.y
+		const dragged = (event) => {
+			event.subject.fx = event.x
+			event.subject.fy = event.y
 		}
 
-		const dragended = () => {
-			if (!d3.event.active) {
+		const dragended = (event) => {
+			if (!event.active) {
 				simulation.alphaTarget(0)
 			}
-			d3.event.subject.fx = null
-			d3.event.subject.fy = null
+			event.subject.fx = null
+			event.subject.fy = null
 
 			active = null
 		}


### PR DESCRIPTION
Broken in the update to D3 v6.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #4918

Tested manually and it a) removes the console errors and b) interactions with the links graph work again now!

See the 'Event Management' section of the [D3 v6 migration guide](https://observablehq.com/@d3/d3v6-migration-guide) for context.
