### PR TITLE
Use NODE_ENV=production for compose JF services

### DIFF
--- a/apps/server/lib/bootstrap.js
+++ b/apps/server/lib/bootstrap.js
@@ -105,7 +105,8 @@ module.exports = async (context, options) => {
 			}
 		})
 
-	if (!environment.isProduction()) {
+	// Need test user during development and CI.
+	if (!environment.isProduction() || environment.isCI()) {
 		logger.info(context, 'Setting test user password', {
 			username: environment.test.user.username,
 			role: environment.test.user.role

--- a/apps/server/lib/card-loader.js
+++ b/apps/server/lib/card-loader.js
@@ -29,7 +29,9 @@ module.exports = async (context, jellyfish, worker, session) => {
 	logger.info(context, 'Setting default cards')
 
 	const cardsToSkip = [ 'user-guest' ]
-	if (environment.isProduction()) {
+
+	// Only need test user role during development and CI.
+	if (environment.isProduction() && !environment.isCI()) {
 		cardsToSkip.push('role-user-test')
 	}
 

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -22,7 +22,7 @@ services:
       - DATABASE={{DATABASE}}
       - LOGENTRIES_TOKEN
       - LOGLEVEL=crit
-      - NODE_ENV={{NODE_ENV}}
+      - NODE_ENV
       - POD_NAME={{POD_NAME}}
       - PORT={{PORT}}
       - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
@@ -126,7 +126,7 @@ services:
     environment:
       - DATABASE={{DATABASE}}
       - LOGENTRIES_TOKEN
-      - NODE_ENV={{NODE_ENV}}
+      - NODE_ENV
       - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker
@@ -154,8 +154,8 @@ services:
       - api
       - balena-mdns-publisher
     environment:
-      NGINX_PORT: 80
-      NODE_ENV: {{NODE_ENV}}
+      - NGINX_PORT=80
+      - NODE_ENV
     networks:
       - internal
   {{#workers}}
@@ -173,7 +173,7 @@ services:
     environment:
       - DATABASE={{DATABASE}}
       - LOGLEVEL=crit
-      - NODE_ENV={{NODE_ENV}}
+      - NODE_ENV
       - POSTGRES_DATABASE={{POSTGRES_DATABASE}}
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DATABASE=postgres
       - LOGENTRIES_TOKEN
       - LOGLEVEL=crit
-      - NODE_ENV=test
+      - NODE_ENV
       - POD_NAME=localhost
       - PORT=8000
       - POSTGRES_DATABASE=jellyfish
@@ -125,7 +125,7 @@ services:
     environment:
       - DATABASE=postgres
       - LOGENTRIES_TOKEN
-      - NODE_ENV=test
+      - NODE_ENV
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker
@@ -153,8 +153,8 @@ services:
       - api
       - balena-mdns-publisher
     environment:
-      NGINX_PORT: 80
-      NODE_ENV: test
+      - NGINX_PORT=80
+      - NODE_ENV
     networks:
       - internal
   worker_1:
@@ -171,7 +171,7 @@ services:
     environment:
       - DATABASE=postgres
       - LOGLEVEL=crit
-      - NODE_ENV=test
+      - NODE_ENV
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker
@@ -232,7 +232,7 @@ services:
     environment:
       - DATABASE=postgres
       - LOGLEVEL=crit
-      - NODE_ENV=test
+      - NODE_ENV
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Should be setting `NODE_ENV=production` for Jellyfish services during tests to match production.

However, we want the ability to change `NODE_ENV` to be `development` when developing using the compose config + livepush. For that reason I have set `NODE_ENV` to be `production` in the AWS parameter store that is used during balenaCI runs and we can control the `NODE_ENV` value when developing locally through the Makefile defaults or customizing using our dotenv files.

## ToDo
- [x] Double-check that the `CI` env var is not set in production containers and that `environment.isCI()` returns false