### PR TITLE
Add test to confirm the 'user-community' role is added to a user when send-first-time-time-login action is fired and their roles field contains a value that is not 'user-community'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -360,14 +360,14 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-5.1.8.tgz",
-      "integrity": "sha512-V6qEHSibGRnpRGHbwQnvcjblT1j2KWXYlEDV1r2a8By/BthUe1u4dVU24PLlKc06bDnqygEI4rqKVLyCDYr9RQ==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-5.1.9.tgz",
+      "integrity": "sha512-0GgoFN9ZQQRf54t13XxmFE367KNJHPKd4EPqbT1OzZrNFSmhs8m8fQwKRsEqbV2NjxUwVXVyBDbU2jY7V70PZQ==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.0.18",
         "@balena/jellyfish-environment": "^2.2.41",
-        "@balena/jellyfish-logger": "^0.0.117",
+        "@balena/jellyfish-logger": "^0.0.118",
         "@balena/jellyfish-mail": "^0.0.89",
         "@balena/jellyfish-metrics": "^0.0.133",
         "@balena/jellyfish-sync": "^3.0.39",
@@ -383,6 +383,105 @@
         "request-promise": "^4.2.6",
         "skhema": "^5.3.3",
         "typed-errors": "^1.1.0"
+      },
+      "dependencies": {
+        "@balena/jellyfish-logger": {
+          "version": "0.0.118",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-0.0.118.tgz",
+          "integrity": "sha512-guONN0UwYf6Om/ssku5vIksa16kwxL25du3uMerqeY1N7V5ku5R8M6vpo/rJNna615zlzU2JLaFhxKAd+sRwSA==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.0.18",
+            "@balena/jellyfish-environment": "^2.2.41",
+            "@sentry/node": "^5.27.2",
+            "errio": "^1.2.2",
+            "le_node": "^1.8.0",
+            "lodash": "^4.17.20",
+            "typed-errors": "^1.1.0",
+            "winston": "^3.3.3"
+          }
+        },
+        "@sentry/core": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.2.tgz",
+          "integrity": "sha512-FMX0Aignhi9Rk4tZkjwSXCsFFQc8FIOgUTvfIKCdayLhKxfbY0H37b0fFNzaQ9v15SFzIZJ9uzw4PTmjzEh6Uw==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "5.27.2",
+            "@sentry/minimal": "5.27.2",
+            "@sentry/types": "5.27.2",
+            "@sentry/utils": "5.27.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.2.tgz",
+          "integrity": "sha512-KCAWF5oDXd/Pjzbcmfj53F5ZzOX53Rzi23a2mWyUXMdPXoXIiMrIcdC/DqrqKV787LvOJcSFaTychJCH3t15/A==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "5.27.2",
+            "@sentry/utils": "5.27.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.2.tgz",
+          "integrity": "sha512-n9SssI30rpS1tw6hH0ylxVlONdmZCqiPy60fotxUzql6mCo/nW7tcADsW15fvQlUQ160VaGf3iMj+hpHkRBerw==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "5.27.2",
+            "@sentry/types": "5.27.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/node": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.27.2.tgz",
+          "integrity": "sha512-JHY+EYjq3iqVnTPIow7KzKX+lIqJXZGVT0xHdPrhaVcfBtUUBYTpjO7SSCkINPt6dPKVRq0QDzIfevd5nybR7A==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "5.27.2",
+            "@sentry/hub": "5.27.2",
+            "@sentry/tracing": "5.27.2",
+            "@sentry/types": "5.27.2",
+            "@sentry/utils": "5.27.2",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.27.2.tgz",
+          "integrity": "sha512-5Lptd32VtKBzIzTmFqcKgcetTMRraMvjPFTX8kFVX4aGDaUGOx0cCZeAURNoHDfHfjCazYK8yV6BkJfi6YJNww==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "5.27.2",
+            "@sentry/minimal": "5.27.2",
+            "@sentry/types": "5.27.2",
+            "@sentry/utils": "5.27.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+          "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "5.27.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.2.tgz",
+          "integrity": "sha512-ZrdRgcFapi1NACbtvnPLOIXKjBPVTlhGzmXNCVao0uRBBRNJa5i2Mjp/U/Xy/fT0K1MGJQ+F9YZjZPnAMsDNbw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "5.27.2",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@balena/jellyfish-assert": {

--- a/test/integration/worker/actions/send-first-time-login-link.spec.js
+++ b/test/integration/worker/actions/send-first-time-login-link.spec.js
@@ -752,3 +752,61 @@ ava('a community role is added to a supplied user with no role set', async (test
 
 	test.deepEqual(updatedUser.data.roles, [ 'user-community' ])
 })
+
+ava('a community role is added to a supplied user when it is not present in the roles field', async (test) => {
+	const {
+		session,
+		context,
+		processAction,
+		userCard,
+		org,
+		jellyfish,
+		worker,
+		nockRequest
+	} = test.context
+
+	nockRequest()
+
+	const createUserAction = await worker.pre(session, {
+		action: 'action-create-card@1.0.0',
+		context,
+		card: userCard.id,
+		type: userCard.type,
+		arguments: {
+			reason: 'for testing',
+			properties: {
+				slug: test.context.generateRandomSlug({
+					prefix: 'user'
+				}),
+				data: {
+					hash: 'fake-hash',
+					email: 'fake@email.com',
+					roles: [ 'user-external-support' ]
+				}
+			}
+		}
+	})
+
+	const userWithoutRole = await processAction(session, createUserAction)
+	test.false(userWithoutRole.error)
+
+	const linkAction = await createOrgLinkAction({
+		toId: userWithoutRole.data.id,
+		fromId: org.data.id,
+		context
+	})
+
+	await processAction(session, linkAction)
+
+	await processAction(session, {
+		action: 'action-send-first-time-login-link@1.0.0',
+		context,
+		card: userWithoutRole.data.id,
+		type: userWithoutRole.data.type,
+		arguments: {}
+	})
+
+	const updatedUser = await jellyfish.getCardById(context, session, userWithoutRole.data.id)
+
+	test.deepEqual(updatedUser.data.roles, [ 'user-external-support', 'user-community' ])
+})


### PR DESCRIPTION
This is to solve the case where the user already has a role like 'external-support-agent'. Before we were only adding the user-community role when the roles field was an empty list. Now we check that the list includes user-community and add its if it doesn't