### PR TITLE
Bump jellyfish-test image version

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-test:v1.3.19
+FROM resinci/jellyfish-test:v1.3.21
 
 WORKDIR /usr/src/jellyfish
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bumping `jellyfish-test` image to latest version, testing that the leaner image with less packages installed still passes CI. This new version includes these changes: https://github.com/product-os/jellyfish-base-images/pull/27
