### PR TITLE
Disable Renovate pruneStaleBranches option

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,8 +6,10 @@
   "enabledManagers": [
     "npm"
   ],
+  "pruneStaleBranches": false,
   "rangeStrategy": "bump",
   "commitMessagePrefix": "patch:",
+  "commitBody": "Change-type: patch",
   "prHourlyLimit": 0,
   "labels": [
     "dependencies"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Disable `pruneStaleBranches` option so we get proper versionbot version bumps.
Also add `Change-type: patch` to the commit body. Not necessary for versionbot to work, but is closer to what we expect in our commit messages.
