### PR TITLE
Fix upsert of messages in inbox

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
@@ -106,7 +106,8 @@ const InboxTab = ({
 		const messageIndex = _.findIndex(messagesRef.current, [ 'id', updatedMessage.id ])
 		const messageNotInState = messageIndex === -1
 		if (messageNotInState) {
-			return appendMessage(updatedMessage)
+			appendMessage(updatedMessage)
+			return
 		}
 		const updatedMessages = update(messagesRef.current, {
 			[messageIndex]: {


### PR DESCRIPTION
Turns out we were importing the update function from immutability-helpers incorrectly. Since we still had the append event, this wasn't obvious to us since we were still getting messages in the inbox. There were, however, errors being thrown all the time in the console.

I did some clean up as part of this PR. Changed the update function to an upsert since this is what it is doing. Also extracted the append function so we can reuse it.