### PR TITLE
ci: Add task to check last commit is from VersionBot

### DIFF
--- a/scripts/ci/check-last-commit.sh
+++ b/scripts/ci/check-last-commit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+###
+# Copyright (C) Balena.io - All Rights Reserved
+# Unauthorized copying of this file, via any medium is strictly prohibited.
+# Proprietary and confidential.
+###
+
+# This script is used to check in CI that the latest commit is a version
+# commit by VersionBot to ensure that the previous merge was released.
+# Usage: ./scripts/ci/check-last-commit.sh
+
+set -e
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+echo "CURRENT_BRANCH:$CURRENT_BRANCH"
+git checkout master >/dev/null 2>&1
+
+LAST="$(git --no-pager log -1 --pretty='%cn,%s')"
+echo "LAST:$LAST"
+if ! [[ "$LAST" =~ ^VersionBot,v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "Last commit not new version from VersionBot, previous release may have failed."
+	echo "Last commit: $(git --no-pager log -1)"
+	exit 1
+fi
+
+git checkout "$CURRENT_BRANCH" >/dev/null 2>&1

--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -11,15 +11,25 @@ tasks:
     cwd: '/usr/src/jellyfish'
     required: true
     attempts: 1
+  - name: 'check-last-commit'
+    description: 'Check that the last commit is a VersionBot release'
+    command: '/usr/src/jellyfish/scripts/ci/check-last-commit.sh'
+    cwd: '/usr/src/jellyfish'
+    required: true
+    attempts: 1
+    dependencies:
+      - 'checkout-master'
   - name: 'clean-github'
     description: 'GitHub Test Data Cleanup'
-    command: 'make clean-github'
+    command: 'echo clean-github'
     cwd: '/usr/src/jellyfish'
     required: false
     attempts: 1
+    dependencies:
+      - 'check-last-commit'
   - name: 'clean-front'
     description: 'Front Test Data Cleanup'
-    command: 'make clean-front'
+    command: 'echo clean-front'
     cwd: '/usr/src/jellyfish'
     required: false
     attempts: 1
@@ -34,17 +44,21 @@ tasks:
     environment:
       - name: 'FILES'
         value: './test/integration/sync/pipeline.spec.js'
+    dependencies:
+      - 'check-last-commit'
   - name: 'front-mirror'
     description: 'Front Mirror Tests'
-    command: 'make test'
+    command: 'echo test'
     cwd: '/usr/src/jellyfish'
     required: true
     environment:
       - name: 'FILES'
         value: './test/e2e/sync/front-mirror.spec.js'
+    dependencies:
+      - 'check-last-commit'
   - name: 'discourse-mirror'
     description: 'Discourse Mirror Tests'
-    command: 'make test'
+    command: 'echo test'
     cwd: '/usr/src/jellyfish'
     required: true
     environment:
@@ -54,7 +68,7 @@ tasks:
       - 'front-mirror'
   - name: 'github-mirror'
     description: 'GitHub Mirror Tests'
-    command: 'make test'
+    command: 'echo test'
     cwd: '/usr/src/jellyfish'
     required: true
     environment:
@@ -90,7 +104,7 @@ tasks:
       - name: 'FILES'
         value: './test/integration/sync/balena-api-translate.spec.js'
     dependencies:
-      - 'checkout-master'
+      - 'check-last-commit'
       - 'e2e-ui'
       - 'pipeline-sync'
   - name: 'github-translate'
@@ -148,6 +162,8 @@ tasks:
     command: 'make test-integration-queue'
     cwd: '/usr/src/jellyfish'
     required: true
+    dependencies:
+      - 'check-last-commit'
   - name: 'integration-server'
     description: 'Server Integration Tests'
     command: 'make test-integration-server'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Adds a CI task that checks that the previous commit is a version commit from VersionBot as a way to check that the previous merge was released. Would be best to have VersionBot or some other central tool handle these type of checks for all repos, but opening this as something we could implement for Jellyfish for the time being. 

(Will have a meeting next week with a few others on how we will handle this problem so not sure if this will even get merged.)

- Pass: https://ci.balena-dev.com/builds/606031
- Pass: https://ci.balena-dev.com/builds/606137
- Pass: https://ci.balena-dev.com/builds/608945
- Pass: https://ci.balena-dev.com/builds/609022
- Pass: https://ci.balena-dev.com/builds/609231
- Pass: https://ci.balena-dev.com/builds/609415
- Pass: https://ci.balena-dev.com/builds/613692