### PR TITLE
Group select frontend dependency bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,22 @@
         "patch"
       ],
       "automerge": true
+    },
+    {
+      "groupName": "non-major-frontend",
+      "packageNames": [
+        "@balena/jellyfish-ui-components",
+        "@balena/jellyfish-chat-widget",
+        "rendition",
+        "react",
+        "react-dom",
+        "styled-components"
+      ],
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
     }
   ],
   "encrypted": {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Group the following frontend dependencies into their own PR grouping:
- `@balena/jellyfish-ui-components`
- `@balena/jellyfish-chat-widget`
- `rendition`
- `react`
- `react-dom`
- `styled-components`

This should help when there is some kind of `react` dependency conflict etc that causes `e2e-ui` or `e2e-livechat` tests to fail and blocks unrelated dependency bumps from getting through CI.
