### PR TITLE
Fetch thread owners with threads if they exist

### DIFF
--- a/apps/server/lib/default-cards/balena/view-all-jellyfish-support-threads.json
+++ b/apps/server/lib/default-cards/balena/view-all-jellyfish-support-threads.json
@@ -9,6 +9,22 @@
         {
           "name": "Active cards",
           "schema": {
+            "anyOf": [
+              {
+              "$$links": {
+                  "is owned by": {
+                    "type": "object",
+                    "required": [ "type" ],
+                    "properties": {
+                      "type": {
+                        "const": "user@1.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              true
+            ],
             "$$links": {
               "has attached element": {
                 "type": "object",

--- a/apps/server/lib/default-cards/balena/view-all-sales-threads.json
+++ b/apps/server/lib/default-cards/balena/view-all-sales-threads.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-all-support-threads.json
+++ b/apps/server/lib/default-cards/balena/view-all-support-threads.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+             "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-customer-success-support-threads.json
+++ b/apps/server/lib/default-cards/balena/view-customer-success-support-threads.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-devices-support-threads.json
+++ b/apps/server/lib/default-cards/balena/view-devices-support-threads.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-fleetops-support-threads.json
+++ b/apps/server/lib/default-cards/balena/view-fleetops-support-threads.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-security-support-threads.json
+++ b/apps/server/lib/default-cards/balena/view-security-support-threads.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-support-threads-participation.json
+++ b/apps/server/lib/default-cards/balena/view-support-threads-participation.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-support-threads-pending-update.json
+++ b/apps/server/lib/default-cards/balena/view-support-threads-pending-update.json
@@ -8,6 +8,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/balena/view-support-threads-to-audit.json
+++ b/apps/server/lib/default-cards/balena/view-support-threads-to-audit.json
@@ -9,6 +9,22 @@
       {
         "name": "Active cards",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "has attached element": {
               "type": "object",

--- a/apps/server/lib/default-cards/contrib/view-my-conversations.json
+++ b/apps/server/lib/default-cards/contrib/view-my-conversations.json
@@ -8,6 +8,22 @@
       {
         "name": "My conversations",
         "schema": {
+          "anyOf": [
+            {
+            "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
           "$$links": {
             "is owned by": {
               "type": "object",


### PR DESCRIPTION
Note - I haven't used a mixin here because most of these views will actually be replaced with Support V2. At this point we'll add the optional fetching of thread owners to the Support V2 support thread view mixin.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR is a pre-cursor to #4994 - I'm just splitting out the backend work to a separate PR so I can test the new PR against production data.
