### PR TITLE
Enable Renovate Dockerfile bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,12 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:enableMajor"
   ],
   "ignorePaths": [],
   "enabledManagers": [
-    "npm"
+    "npm",
+    "dockerfile"
   ],
   "pruneStaleBranches": false,
   "rangeStrategy": "bump",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Update Renovate config to also bump Dockerfile base image versions
