### PR TITLE
Speed up lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,22 @@
     }
   },
   "lint-staged": {
+    "*": [
+      "./scripts/lint/check-filenames.sh"
+    ],
+    "apps/*": [
+      "./scripts/lint/check-descriptions.sh",
+      "./scripts/lint/check-apps.sh"
+    ],
     "*.{js,jsx}": [
-      "make lint FIX=1"
+      "eslint --cache --fix",
+      "deplint"
+    ],
+    "*.sh": [
+      "shellcheck"
+    ],
+    "*.{js,jsx,sh}": [
+      "./scripts/lint/check-licenses.sh"
     ]
   },
   "author": "Balena.io. <hello@balena.io>",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***
Instead of running all lint checks with `make lint`, which ends up checking *ALL* files in the repository, directly call `eslint` through `lint-staged` to only check files that have been staged. Still checking for a few things repository-wide using linting scripts (`./scripts/lint/check-filenames.sh` etc), but limiting when those are executed by setting multiple lint-staged rules.

These changes sped up the lint-staged check from 35 seconds to 5 seconds on my machine when editing a single file under `apps/server/lib`.

Note: Wasn't able to call `depcheck` on staged files, it throws an error about the file not having a `package.json`.