### PR TITLE
Remove the prepended "|" to fix sed from failing

### DIFF
--- a/scripts/lint/check-filenames.sh
+++ b/scripts/lint/check-filenames.sh
@@ -34,7 +34,7 @@ for file in $(find "${DIRECTORIES[@]}" -type f | grep -v -E node_modules); do
 
 	# TODO: This whole list of exceptions shouldn't exist as React
 	# components should only be defined in jellyfish-ui-components
-	COMPONENTS_DIRECTORIES="|apps/ui/lib/layouts/"
+	COMPONENTS_DIRECTORIES="apps/ui/lib/layouts/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/components/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/lens/misc/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/lens/full/"


### PR DESCRIPTION
Running the check-filesnames.sh script on my macbook fails because of the following error:
```
❯ make lint FIX=1
./node_modules/.bin/eslint --ext .js,.jsx --fix scripts test
./scripts/lint/check-filenames.sh
sed: 1: "s#^(|apps/ui/lib/layout ...": RE error: empty (sub)expression
```
Specifically due to sed not being able to handle the empty (sub)expression. e.g. this fails:
```
sed -E 's#^(|apps/ui/lib/layouts)##g'
```
this succeeds:
```
sed -E 's#^(apps/ui/lib/layouts)##g'
```

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
