### PR TITLE
Add a new view that only shows support threads from the balena forums

### DIFF
--- a/apps/server/lib/default-cards/balena/view-all-forum-threads.json
+++ b/apps/server/lib/default-cards/balena/view-all-forum-threads.json
@@ -1,0 +1,88 @@
+{
+  "slug": "view-all-forum-threads",
+  "name": "Forums",
+  "type": "view@1.0.0",
+  "markers": [ "org-balena" ],
+  "data": {
+    "namespace": "Support",
+    "allOf": [
+      {
+        "name": "Forum threads",
+        "schema": {
+          "anyOf": [
+            {
+             "$$links": {
+                "is owned by": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            true
+          ],
+          "$$links": {
+            "has attached element": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "enum": [
+                    "message@1.0.0",
+                    "create@1.0.0",
+                    "whisper@1.0.0",
+                    "update@1.0.0"
+                  ]
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "type": "object",
+          "properties": {
+            "active": {
+              "const": true,
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "const": "support-thread@1.0.0"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "mirrors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "forums.balena.io"
+                  }
+                },
+                "category": {
+                  "description": "This field is not required and should match cases where the field is not present OR is 'general'",
+                  "const": "general"
+                },
+                "product": {
+                  "const": "balenaCloud"
+                }
+              }
+            }
+          },
+          "required": [
+            "active",
+            "type"
+          ],
+          "additionalProperties": true
+        }
+      }
+    ],
+    "lenses": [
+      "lens-support-threads",
+      "lens-table",
+      "lens-kanban"
+    ]
+  }
+}

--- a/apps/server/lib/default-cards/index.js
+++ b/apps/server/lib/default-cards/index.js
@@ -140,6 +140,7 @@ module.exports = ({
 		viewBalenaChat: require('./balena/view-balena-chat.json'),
 		viewSupportKnowledgeBase: require('./balena/view-support-knowledge-base.json'),
 		viewSupportThreadsParticipation: require('./balena/view-support-threads-participation.json'),
+		viewAllForumThreads: require('./balena/view-all-forum-threads.json'),
 		viewAllSupportThreads: require('./balena/view-all-support-threads.json'),
 		viewAllUsers: require('./balena/view-all-users.json'),
 		viewChangelogs: require('./balena/view-changelogs.json'),


### PR DESCRIPTION
In the future this should be bundled into a forums "channel"

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
