### PR TITLE
Update the reason in the reopen and summary triggered actions to align with new designs for updates in the Timeline component

### DIFF
--- a/apps/server/lib/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -106,7 +106,7 @@
       }
     },
     "arguments": {
-      "reason": "Re-opened because linked issue was closed",
+      "reason": "Support Thread re-opened because linked Issue was closed",
       "patch": [
         {
           "op": "replace",

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-closed-pull-request-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-closed-pull-request-reopen.json
@@ -106,7 +106,7 @@
       }
     },
     "arguments": {
-      "reason": "Re-opened because linked pull request was closed",
+      "reason": "Support Thread re-opened because linked Pull Request was closed",
       "patch": [
         {
           "op": "replace",

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-reopen.json
@@ -54,7 +54,7 @@
     },
     "mode": "insert",
     "arguments": {
-      "reason": "Re-open because of activity",
+      "reason": "Support Thread re-opened because of activity",
       "patch": [
         {
           "op": "replace",

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-summary.json
@@ -71,7 +71,7 @@
       }
     },
     "arguments": {
-      "reason": "Closed with #summary tag",
+      "reason": "Support Thread closed with #summary tag",
       "patch": [
         {
           "op": "replace",


### PR DESCRIPTION
This doesn't perfectly align with the designs but we would need to make changes to how we store the reason (at the moment it's stored as a string in the name field of the resulting update card. This gets us 90% of the way there

<img width="436" alt="Screenshot 2020-11-06 at 15 50 29" src="https://user-images.githubusercontent.com/6325359/98380108-6d64f880-2048-11eb-97c0-b726212fae7a.png">


Change-type: patch
Signed-off-by: Lucy-Jane Walsh <Lucy-Jane@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
