### PR TITLE
Adjust query to include links in the loadChannelData action in the ui

### DIFF
--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -47,10 +47,12 @@ else
 ESLINT_OPTION_FIX = --fix
 endif
 
+FILES ?= "'./lib/**/*.spec.{js,jsx}'"
+
 .PHONY: test
 test: LOGLEVEL = warning
 test:
-	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) "'./**/*.spec.{js,jsx}'"
+	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) $(FILES)
 
 .PHONY: dev-ui
 dev-ui:

--- a/apps/ui/lib/core/queries.js
+++ b/apps/ui/lib/core/queries.js
@@ -135,3 +135,92 @@ export const getUnreadQuery = (user, groupNames, searchTerm) => {
 		}
 	})
 }
+
+export const getChannelQuery = (cardId) => {
+	const cardQuery = getCardQuery(cardId)
+	const cardWithLinksQuery = getCardWithLinksQuery(cardId)
+	const linksQuery = getLinksQuery(cardId)
+	return {
+		type: 'object',
+		anyOf: [ cardQuery, cardWithLinksQuery, linksQuery ]
+	}
+}
+
+export const getCardQuery = (cardId) => ({
+	properties: {
+		id: {
+			const: cardId
+		}
+	}
+})
+
+export const getCardWithLinksQuery = (cardId) => ({
+	properties: {
+		id: {
+			const: cardId
+		}
+	},
+	$$links: {
+		'has attached element': {
+			type: 'object'
+		}
+	}
+})
+
+export const getLinksQuery = (cardId) => {
+	const toLinkSchema = {
+		properties: {
+			to: {
+				type: 'object',
+				properties: {
+					id: {
+						const: cardId
+					},
+					type: {
+						type: 'string'
+					},
+					slug: {
+						type: 'string'
+					}
+				}
+			}
+		}
+	}
+
+	const fromLinkSchema = {
+		properties: {
+			from: {
+				type: 'object',
+				properties: {
+					id: {
+						const: cardId
+					},
+					type: {
+						type: 'string'
+					},
+					slug: {
+						type: 'string'
+					}
+				}
+			}
+		}
+	}
+
+	return {
+		required: [ 'type', 'data' ],
+		properties: {
+			type: {
+				const: 'link@1.0.0'
+			},
+			name: {
+				not: {
+					enum: [ 'has attached element', 'is attached to' ]
+				}
+			},
+			data: {
+				type: 'object',
+				anyOf: [ toLinkSchema, fromLinkSchema ]
+			}
+		}
+	}
+}

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -514,41 +514,36 @@ export default class ActionCreator {
 			} = channel.data
 
 			const identifier = isUUID(target) ? 'id' : 'slug'
+			const targetCard = await this.sdk.card.get(target)
+			const cardId = _.get(targetCard, [ 'id' ])
+			if (!cardId) {
+				throw new Error(`Couldn't find card with ${identifier}: ${target}`)
+			}
 
-			let query = {
+			const query = {
 				type: 'object',
-				properties: {
-					[identifier]: {
-						type: 'string',
-						const: target
+				anyOf: [ {
+					properties: {
+						id: {
+							const: cardId
+						}
 					}
 				},
-				$$links: {
-					'has attached element': {
-						type: 'object'
+				{
+					properties: {
+						id: {
+							const: cardId
+						}
+					},
+					$$links: {
+						'has attached element': {
+							type: 'object'
+						}
 					}
-				},
-				required: [ identifier ]
+				} ]
 			}
 
-			// TODO: Clean up when we have optional links
-			// OR make sure default cards have attached items
-			// Checks to see if we can query for the card with
-			// attached elements. If we can't, remove the
-			// $$links from the query
-			let cards = await this.sdk.query(query)
-
-			if (cards.length === 0) {
-				query = _.omit(query, [ '$$links' ])
-				cards = [ await this.sdk.card.get(target) ]
-			}
-
-			const [ card ] = cards
-			if (_.isNil(card)) {
-				throw new Error(`Could not find card with ${identifier} target`)
-			}
-
-			const stream = await this.getStream(cards[0].id, query)
+			const stream = await this.getStream(cardId, query)
 
 			stream.on('dataset', ({
 				data: {

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -517,7 +517,7 @@ export default class ActionCreator {
 			const targetCard = await this.sdk.card.get(target)
 			const cardId = _.get(targetCard, [ 'id' ])
 			if (!cardId) {
-				throw new Error(`Couldn't find card with ${identifier}: ${target}`)
+				throw new Error(`Couldn't find channel with ${identifier}: ${target}`)
 			}
 
 			const query = {
@@ -543,70 +543,42 @@ export default class ActionCreator {
 				} ]
 			}
 
-			const stream = await this.getStream(cardId, query)
-
-			stream.on('dataset', ({
-				data: {
-					cards: channels
-				}
-			}) => {
-				const currentChannel = _.find(selectors.getChannels(getState()), {
-					id: channel.id
-				})
-
-				const clonedChannel = clone(currentChannel)
-
-				if (channels.length > 0) {
-					// Merge required in the event that this is a pagination query
-					clonedChannel.data.head = merge(clonedChannel.data.head, channels[0])
-				}
-
-				dispatch({
-					type: actions.UPDATE_CHANNEL,
-					value: clonedChannel
-				})
-			})
-
-			stream.on('update', ({
-				data: {
-					after: newHead
-				}
-			}) => {
-				const currentChannel = _.find(selectors.getChannels(getState()), {
-					id: channel.id
-				})
-				if (!currentChannel) {
-					return null
-				}
-				const clonedChannel = clone(currentChannel)
-
-				// Don't bother is the channel head card hasn't changed
-				if (newHead && fastEquals.deepEqual(clonedChannel.data.head, newHead)) {
-					return null
-				}
-
-				// If head is null, this indicates a 404 not found error
-				clonedChannel.data.head = newHead
-				return dispatch({
-					type: actions.UPDATE_CHANNEL,
-					value: clonedChannel
-				})
-			})
-
-			stream.emit('queryDataset', {
-				data: {
-					schema: query,
-					options: {
-						links: {
-							'has attached element': {
-								limit: 20,
-								sortBy: 'created_at',
-								sortDir: 'desc'
-							}
-						}
+			const streamHandlers = {
+				remove: _.noop,
+				append: _.noop,
+				upsert: (newHead) => {
+					const currentChannel = _.find(selectors.getChannels(getState()), {
+						id: channel.id
+					})
+					if (!currentChannel) {
+						return null
 					}
+					const clonedChannel = clone(currentChannel)
+
+					const headHasntChanged = fastEquals.deepEqual(clonedChannel.data.head, newHead)
+					if (headHasntChanged) {
+						return null
+					}
+
+					clonedChannel.data.head = newHead
+					return dispatch({
+						type: actions.UPDATE_CHANNEL,
+						value: clonedChannel
+					})
+				},
+				set: ([ newChannel ]) => {
+					const currentChannel = _.find(selectors.getChannels(getState()), {
+						id: channel.id
+					})
+					const clonedChannel = clone(currentChannel)
+					clonedChannel.data.head = merge(clonedChannel.data.head, newChannel)
+					return dispatch({
+						type: actions.UPDATE_CHANNEL,
+						value: clonedChannel
+					})
 				}
-			})
+			}
+			this.setupStream(cardId, query, streamHandlers)(dispatch, getState)
 		}
 	}
 
@@ -1201,7 +1173,7 @@ export default class ActionCreator {
 		})
 	}
 
-	setupStream (streamId, query, options, handlers) {
+	setupStream (streamId, query, handlers, options = {}) {
 		return async (dispatch, getState) => {
 			const stream = await this.getStream(streamId, query)
 
@@ -1239,13 +1211,7 @@ export default class ActionCreator {
 			stream.emit('queryDataset', {
 				id: uuid(),
 				data: {
-					schema: query,
-					options: {
-						limit: options.limit,
-						skip: options.limit * options.page,
-						sortBy: options.sortBy,
-						sortDir: options.sortDir
-					}
+					schema: query
 				}
 			})
 
@@ -1320,7 +1286,14 @@ export default class ActionCreator {
 				set: (cards) => dispatch(this.setViewData(query, cards, commonOptions))
 			}
 
-			return this.setupStream(viewId, schema, options, streamHandlers)(dispatch, getState)
+			const queryOptions = {
+				limit: options.limit,
+				skip: options.limit * options.page,
+				sortBy: options.sortBy,
+				sortDir: options.sortDir
+			}
+
+			return this.setupStream(viewId, schema, streamHandlers, queryOptions)(dispatch, getState)
 		}
 	}
 

--- a/apps/ui/lib/core/store/actioncreators/tests/add-user.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/tests/add-user.spec.js
@@ -6,7 +6,7 @@
 
 import ava from 'ava'
 import sinon from 'sinon'
-import ActionCreator from './'
+import ActionCreator from '../'
 
 const sandbox = sinon.createSandbox()
 

--- a/apps/ui/lib/core/store/actioncreators/tests/construct-channel-data.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/tests/construct-channel-data.spec.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import sinon from 'sinon'
+import ActionCreator from '../'
+
+const sandbox = sinon.createSandbox()
+
+ava.beforeEach((test) => {
+	const sdk = {
+		card: {
+			get: sandbox.stub()
+		}
+	}
+
+	const actionCreator = new ActionCreator({
+		sdk,
+		analytics: {
+			track: sandbox.stub()
+		}
+	})
+	actionCreator.analytics.track.resolves()
+
+	const dispatch = (fn) => {
+		return fn(dispatch)
+	}
+
+	test.context = {
+		...test.context,
+		actionCreator,
+		sdk,
+		dispatch
+	}
+})
+
+ava('constructChannelData adds the card to the head of the channel', async (test) => {
+	const {
+		actionCreator
+	} = test.context
+
+	const headCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstName: 'fake',
+				lastName: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-message',
+				type: 'message@1.0.0',
+				name: 'fake message'
+			} ]
+		}
+	}
+
+	const channel = {
+		id: 'test-channel',
+		data: {
+			fake: 'data'
+		}
+	}
+
+	const constructedChannel = actionCreator.constructChannelData(channel, [ headCard ])
+	test.deepEqual(constructedChannel, {
+		...channel,
+		data: {
+			...channel.data,
+			head: headCard
+		}
+	})
+})
+
+ava('constructChannelData separates out the links from the channel card and ' +
+	'adds the links to the \'has linked element\' array in the channel', async (test) => {
+	const {
+		actionCreator
+	} = test.context
+
+	const headCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstName: 'fake',
+				lastName: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-message',
+				type: 'message@1.0.0',
+				name: 'fake message'
+			} ]
+		}
+	}
+
+	const linkCard = {
+		id: 'link-card',
+		type: 'link@1.0.0'
+	}
+
+	const channel = {
+		id: 'test-channel',
+		data: {
+			fake: 'data'
+		}
+	}
+
+	const constructedChannel = actionCreator.constructChannelData(channel, [ headCard, linkCard ])
+
+	const expectedResult = {
+		id: 'test-channel',
+		data: {
+			fake: 'data',
+			head: {
+				id: 'fake-user',
+				type: 'user@1.0.0',
+				data: {
+					profile: {
+						firstName: 'fake',
+						lastName: 'user'
+					}
+				},
+				links: {
+					'has attached element': [ {
+						id: 'fake-message',
+						type: 'message@1.0.0',
+						name: 'fake message'
+					}, linkCard ]
+				}
+			}
+		}
+	}
+
+	test.deepEqual(constructedChannel, expectedResult)
+})

--- a/apps/ui/lib/core/store/actioncreators/tests/index.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/tests/index.spec.js
@@ -8,8 +8,8 @@ import ava from 'ava'
 import sinon from 'sinon'
 import _ from 'lodash'
 import Bluebird from 'bluebird'
-import actions from '../actions'
-import ActionCreator from './'
+import actions from '../../actions'
+import ActionCreator from '../'
 
 const sandbox = sinon.createSandbox()
 

--- a/apps/ui/lib/core/store/actioncreators/tests/load-channel-data.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/tests/load-channel-data.spec.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import sinon from 'sinon'
+import ActionCreator from '../'
+
+const sandbox = sinon.createSandbox()
+
+ava.beforeEach((test) => {
+	const sdk = {
+		card: {
+			get: sandbox.stub()
+		}
+	}
+
+	const actionCreator = new ActionCreator({
+		sdk,
+		analytics: {
+			track: sandbox.stub()
+		}
+	})
+	actionCreator.analytics.track.resolves()
+
+	const dispatch = (fn) => {
+		return fn(dispatch)
+	}
+
+	test.context = {
+		...test.context,
+		actionCreator,
+		sdk,
+		dispatch
+	}
+})
+
+ava('loadChannelData throws an error when the card does not exist', async (test) => {
+	const {
+		actionCreator, sdk, dispatch
+	} = test.context
+	sdk.card.get.resolves(null)
+
+	const channel = {
+		data: {
+			target: 'view-all-users',
+			canonical: true
+		}
+	}
+
+	await test.throwsAsync(actionCreator.loadChannelData(channel)(dispatch), {
+		instanceOf: Error,
+		message: 'Couldn\'t find channel with slug: view-all-users'
+	})
+})

--- a/apps/ui/lib/core/store/actioncreators/tests/send-first-time-login-link.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/tests/send-first-time-login-link.spec.js
@@ -12,8 +12,8 @@ import * as notifications from '@balena/jellyfish-ui-components/lib/services/not
 import {
 	// eslint-disable-next-line no-unused-vars
 	store
-} from '../../'
-import ActionCreator from './'
+} from '../../../'
+import ActionCreator from '../'
 
 const sandbox = sinon.createSandbox()
 

--- a/apps/ui/lib/core/store/actioncreators/tests/update-channel-on-upsert.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/tests/update-channel-on-upsert.spec.js
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ava from 'ava'
+import sinon from 'sinon'
+import ActionCreator from '../'
+
+const sandbox = sinon.createSandbox()
+
+ava.beforeEach((test) => {
+	const sdk = {
+		card: {
+			get: sandbox.stub()
+		}
+	}
+
+	const actionCreator = new ActionCreator({
+		sdk,
+		analytics: {
+			track: sandbox.stub()
+		}
+	})
+	actionCreator.analytics.track.resolves()
+
+	const dispatch = (fn) => {
+		return fn(dispatch)
+	}
+
+	test.context = {
+		...test.context,
+		actionCreator,
+		sdk,
+		dispatch
+	}
+})
+
+ava('updateChannelOnUpsert returns null when the upserted card matches the head card in our channel', async (test) => {
+	const {
+		actionCreator
+	} = test.context
+
+	const headCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstName: 'fake',
+				lastName: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-message',
+				type: 'message@1.0.0',
+				name: 'fake message'
+			} ]
+		}
+	}
+
+	const channel = {
+		data: {
+			head: headCard
+		}
+	}
+
+	const updatedChannel = actionCreator.updateChannelOnUpsert(channel, headCard)
+	test.is(updatedChannel, null)
+})
+
+ava('updateChannelOnUpdate returns a channel with a fresh head' +
+' when the upserted card matches our head card and it has been updated', async (test) => {
+	const {
+		actionCreator
+	} = test.context
+
+	const headCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstname: 'fake',
+				lastname: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-org',
+				type: 'org@1.0.0',
+				name: 'fake org'
+			} ]
+		}
+	}
+
+	const channel = {
+		data: {
+			head: headCard
+		}
+	}
+
+	const updatedCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstname: 'fake',
+				lastname: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-message',
+				type: 'message@1.0.0'
+			}, {
+				id: 'fake-whisper',
+				type: 'whisper@1.0.0'
+			} ]
+		}
+	}
+
+	const updatedChannel = actionCreator.updateChannelOnUpsert(channel, updatedCard)
+	test.deepEqual(updatedChannel, {
+		...channel,
+		data: {
+			head: updatedCard
+		}
+	})
+})
+
+ava('updateChannelOnUpdate adds a link card to the list of attached elements ' +
+'stored on the head of the channel', async (test) => {
+	const {
+		actionCreator
+	} = test.context
+
+	const headCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstname: 'fake',
+				lastname: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-org',
+				type: 'org@1.0.0',
+				name: 'fake org'
+			} ]
+		}
+	}
+
+	const channel = {
+		data: {
+			head: headCard
+		}
+	}
+
+	const linkCard = {
+		id: 'fake-link',
+		type: 'link@1.0.0',
+		data: {
+			to: {
+				id: headCard.id
+			}
+		}
+	}
+
+	const updatedChannel = actionCreator.updateChannelOnUpsert(channel, linkCard)
+	test.deepEqual(updatedChannel, {
+		...channel,
+		data: {
+			head: {
+				...headCard,
+				links: {
+					'has attached element': [ ...headCard.links['has attached element'], linkCard ]
+				}
+			}
+		}
+	})
+})
+
+ava('Existing link cards in the \'has attached element\' list on the head card ' +
+'are maintained when the head card is upserted', async (test) => {
+	const {
+		actionCreator
+	} = test.context
+
+	const headCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstname: 'fake',
+				lastname: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-message',
+				type: 'message@1.0.0'
+			}, {
+				id: 'fake-link',
+				type: 'link@1.0.0'
+			} ]
+		}
+	}
+
+	const channel = {
+		data: {
+			head: headCard
+		}
+	}
+
+	const updatedCard = {
+		id: 'fake-user',
+		type: 'user@1.0.0',
+		data: {
+			profile: {
+				firstname: 'fake',
+				lastname: 'user'
+			}
+		},
+		links: {
+			'has attached element': [ {
+				id: 'fake-message',
+				type: 'message@1.0.0'
+			}, {
+				id: 'fake-whisper',
+				type: 'whisper@1.0.0'
+			} ]
+		}
+	}
+
+	const updatedChannel = actionCreator.updateChannelOnUpsert(channel, updatedCard)
+
+	const expectedResult = {
+		data: {
+			head: {
+				id: 'fake-user',
+				type: 'user@1.0.0',
+				data: {
+					profile: {
+						firstname: 'fake',
+						lastname: 'user'
+					}
+				},
+				links: {
+					'has attached element': [ {
+						id: 'fake-message',
+						type: 'message@1.0.0'
+					}, {
+						id: 'fake-whisper',
+						type: 'whisper@1.0.0'
+					},
+					{
+						id: 'fake-link',
+						type: 'link@1.0.0'
+					} ]
+				}
+			}
+		}
+	}
+
+	test.deepEqual(updatedChannel, expectedResult)
+})

--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
@@ -128,7 +128,7 @@ const InboxTab = ({
 	const loadViewData = async () => {
 		setLoading(true)
 		const query = getQuery(user, groupNames, searchTerm)
-		const currentMessages = await setupStream(STREAM_ID, query, DEFAULT_OPTIONS, viewHandlers)
+		const currentMessages = await setupStream(STREAM_ID, query, viewHandlers, DEFAULT_OPTIONS)
 		setMessages(currentMessages)
 		setLoading(false)
 	}


### PR DESCRIPTION
*Important*: We need to merge [this PR](https://github.com/product-os/jellyfish-ui-components/pull/199) before this one so that the Timeline knows how to display links.

This PR updates the loadChannelData ui action. Previously the action would search for the card plus any events (whispers, messages, updates, creates) that are linked to that card. Using an optional query, we have now expanded the query to also look for link cards that either have a toId or a fromId that match our cardId. This allows us to surface links in our redux and thus our Timeline component.

In our stream handlers i am adding the links to the 'has attached element' array. I've extracted out these functions and added some unit tests