### PR TITLE
Update dev cmds to work with webpack-cli v4

### DIFF
--- a/apps/livechat/Makefile
+++ b/apps/livechat/Makefile
@@ -16,7 +16,7 @@ endif
 dev-livechat:
 	API_URL=$(SERVER_HOST):$(SERVER_PORT) \
 	NODE_ENV=development \
-	./node_modules/.bin/webpack-dev-server \
+	./node_modules/.bin/webpack serve \
 		--config=./lib/webpack.config.js \
 		--color
 

--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -56,7 +56,7 @@ test:
 dev-ui:
 	API_URL=$(SERVER_HOST):$(SERVER_PORT) \
 	NODE_ENV=development \
-	./node_modules/.bin/webpack-dev-server \
+	./node_modules/.bin/webpack serve \
 		--config=./lib/webpack.config.js \
 		--color
 


### PR DESCRIPTION
Need to use a different command now that webpack-cli v4 is being used.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

After [updating to webpack-cli v4](https://github.com/product-os/jellyfish/commit/9b7503f6b131027dcd2a8a6d12957a5a8c869513) we need to update the `dev-ui` and `dev-livechat` commands to use `webpack serve` rather than `webpack-dev-server`.

Without this we get the following error when running `dev-ui` or `dev-livechat`:
```
Error: Cannot find module 'webpack-cli/bin/config-yargs'
```

See [this issue](https://github.com/webpack/webpack-dev-server/issues/2029) and in particular [this comment](https://github.com/webpack/webpack-dev-server/issues/2029#issuecomment-707034614).
