### PR TITLE
Make mirrors field required when loading forums threads

### DIFF
--- a/apps/server/lib/default-cards/balena/view-all-forum-threads.json
+++ b/apps/server/lib/default-cards/balena/view-all-forum-threads.json
@@ -53,6 +53,9 @@
             },
             "data": {
               "type": "object",
+              "required": [
+                 "mirrors"
+              ],
               "properties": {
                 "mirrors": {
                   "type": "array",
@@ -73,7 +76,8 @@
           },
           "required": [
             "active",
-            "type"
+            "type",
+            "data"
           ],
           "additionalProperties": true
         }


### PR DESCRIPTION
If the `mirrors` field is not required, then cards that don't have the field will be returned.

Change-type: patch

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
