### PR TITLE
Refactor: Split out stream events

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/stream/helpers.js
+++ b/apps/ui/lib/core/store/actioncreators/stream/helpers.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	helpers
+} from '@balena/jellyfish-ui-components'
+import * as _ from 'lodash'
+import {
+	selectors
+} from '..'
+import {
+	mentionsUser
+} from '../../helpers'
+import {
+	createNotification
+} from '../../../../services/notifications'
+import {
+	push
+} from 'connected-react-router'
+
+const notifySchema = [
+	{
+		type: 'message',
+		update: [ 'insert' ]
+	},
+	{
+		type: 'whisper',
+		update: [ 'insert' ]
+	},
+	{
+		type: 'summary',
+		update: [ 'insert' ]
+	}
+]
+
+/**
+ * A method in the stream to trigger notifications. This handles the logic for which update events should trigger notifications.
+ *
+ * @param {Object} update - stream event update object
+ * @param {Function} getState - store getState function
+ * @param {Function} dispatch - store dispatch function
+ * @param {Object} user - the current user card
+ * @param {Array} types - list of all known card types
+ */
+export const triggerNotification = (update, getState, dispatch, user, types) => {
+	const card = update.after
+	const groupsState = selectors.getGroups(getState())
+
+	const event = {
+		type: card.type.split('@')[0],
+		update: [ update.type ]
+	}
+
+	const matchNotifySchema = _.some(notifySchema, event)
+	const isOwnMessage = _.get(card, [ 'data', 'actor' ]) === user.id
+	const isMentioned = mentionsUser(card, user, groupsState)
+	const isRead = _.includes(_.get(card, [ 'data', 'readBy' ]), user.slug)
+	console.log('helpers.getType(card.type, types)', helpers.getType(card.type, types))
+	console.log('card.type', card.type)
+	if (matchNotifySchema && !isOwnMessage && isMentioned && !isRead) {
+		handleNotification({
+			card,
+			cardType: helpers.getType(card.type, types)
+		})(dispatch, getState)
+	}
+}
+
+/**
+ * Create a notification by calling this function with a card and card type
+ *
+ * @param {Object} props - Function props object
+ * @param {Object} props.card - Card type card that should be shown in the notification
+ * @param {String} props.cardType - The Card type
+ * @returns {null}
+ */
+export const handleNotification = ({
+	card,
+	cardType
+}) => {
+	return (dispatch, getState) => {
+		// Skip notifications if the user's status is set to 'Do Not Disturb'
+		const userStatus = selectors.getCurrentUserStatus(getState())
+		if (_.get(userStatus, [ 'value' ]) === 'DoNotDisturb') {
+			return
+		}
+
+		const baseType = card.type.split('@')[0]
+		const title = `New ${_.get(cardType, [ 'name' ], baseType)}`
+		const body = _.get(card, [ 'data', 'payload', 'message' ])
+		const target = _.get(card, [ 'data', 'target' ])
+
+		createNotification({
+			title,
+			body,
+			target,
+			tag: card.id,
+			historyPush: (path, pathState) => dispatch(push(path, pathState))
+		})
+	}
+}

--- a/apps/ui/lib/core/store/actioncreators/stream/typing.js
+++ b/apps/ui/lib/core/store/actioncreators/stream/typing.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as _ from 'lodash'
+import actions from '../../actions'
+const typingTimeouts = {}
+
+export const streamTyping = (dispatch, payload) => {
+	if (typingTimeouts[payload.card] && typingTimeouts[payload.card][payload.user]) {
+		clearTimeout(typingTimeouts[payload.card][payload.user])
+	}
+
+	dispatch({
+		type: actions.USER_STARTED_TYPING,
+		value: {
+			card: payload.card,
+			user: payload.user
+		}
+	})
+
+	_.set(typingTimeouts, [ payload.card, payload.user ], setTimeout(() => {
+		dispatch({
+			type: actions.USER_STOPPED_TYPING,
+			value: {
+				card: payload.card,
+				user: payload.user
+			}
+		})
+	}, 2 * 1000))
+}

--- a/apps/ui/lib/core/store/actioncreators/stream/update.js
+++ b/apps/ui/lib/core/store/actioncreators/stream/update.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as _ from 'lodash'
+import actions from '../../actions'
+import {
+	updateThreadChannels
+} from '../../helpers'
+import {
+	selectors
+} from '../'
+import {
+	triggerNotification
+} from './helpers'
+
+export const streamUpdate = async (payload, getState, dispatch, user, types) => {
+	const update = payload.data
+	if (update.after) {
+		const card = update.after
+		const allChannels = selectors.getChannels(getState())
+
+		// Create a desktop notification if an unread message ping appears
+		// BUG: we don't get notified on message updates
+		// Notify of any of these card types:
+		triggerNotification(update, getState, dispatch, user, types)
+
+		// If we receive a card that targets another card...
+		const targetId = _.get(card, [ 'data', 'target' ])
+		if (targetId) {
+			// ...update all channels that have this card in their links
+			const channelsToUpdate = updateThreadChannels(
+				targetId,
+				card,
+				allChannels
+			)
+			for (const updatedChannel of channelsToUpdate) {
+				dispatch({
+					type: actions.UPDATE_CHANNEL,
+					value: updatedChannel
+				})
+			}
+
+			// TODO (FUTURE): Also update view channels that have a list of threads in them
+		}
+
+		// If we receive a user card...
+		if (card.type.split('@')[0] === 'user') {
+			// ...and we have a corresponding card already cached in our Redux store
+			if (selectors.getCard(getState(), card.id, card.type)) {
+				// ...then update the card
+				dispatch({
+					type: actions.SET_CARD,
+					value: card
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
This splits out the streaming logic it separate files. It's a first pass to clean up the streaming logic for readability

Change-type: minor
Signed-off-by: Stef Kors <stef@balena.io>
