### PR TITLE
Fix home channel user avatar

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.jsx
@@ -564,16 +564,16 @@ export default class HomeChannel extends React.Component {
 						<Flex position='relative' justifyContent="space-between" style={{
 							borderBottom: '1px solid #eee'
 						}}>
-							<Button
-								plain={true}
+							<Flex
 								className="user-menu-toggle"
 								py={3}
 								pl={3}
 								pr={2}
+								alignItems="center"
+								maxWidth="100%"
 								onClick={this.showMenu}
 								style={{
-									display: 'flex',
-									maxWidth: '100%',
+									cursor: 'pointer',
 									position: 'relative'
 								}}>
 								<UserAvatarLive
@@ -585,6 +585,7 @@ export default class HomeChannel extends React.Component {
 								{Boolean(username) && <Txt mx={2} style={{
 									textOverflow: 'ellipsis',
 									flex: '1 1 0%',
+									fontWeight: 600,
 									whiteSpace: 'nowrap',
 									overflow: 'hidden'
 								}}>{username}</Txt>}
@@ -602,7 +603,7 @@ export default class HomeChannel extends React.Component {
 										{(mentions.length >= 100) ? '99+' : mentions.length}
 									</MentionsCount>
 								)}
-							</Button>
+							</Flex>
 						</Flex>
 
 						{this.state.showMenu && (


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before:
![Home Channel User Avatar before](https://user-images.githubusercontent.com/2925657/98762243-d1e9d400-2409-11eb-81c1-91a48bc5f6ff.jpg)

After:
![Home Channel User Avatar after](https://user-images.githubusercontent.com/2925657/98762478-4ae92b80-240a-11eb-8b6c-31f92954ed2d.png)

