### PR TITLE
Require Node 14

### DIFF
--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "The Jellyfish Action Server App",
   "engines": {
-    "node": ">=12.15.0"
+    "node": ">=14.2.0"
   },
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "The Jellyfish Livechat App",
   "engines": {
-    "node": ">=12.15.0"
+    "node": ">=14.2.0"
   },
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "The Jellyfish Server App",
   "engines": {
-    "node": ">=12.15.0"
+    "node": ">=14.2.0"
   },
   "ava": {
     "timeout": "10m",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "The Jellyfish UI App",
   "engines": {
-    "node": ">=12.15.0"
+    "node": ">=14.2.0"
   },
   "ava": {
     "timeout": "10m",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:product-os/jellyfish.git"
   },
   "engines": {
-    "node": ">=12.15.0"
+    "node": ">=14.2.0"
   },
   "deplint": {
     "files": [


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Require Node v14 instead of v12 to match what we're running in CI and production