### PR TITLE
Optimize webpack dev configs

### DIFF
--- a/apps/livechat/lib/webpack.config.js
+++ b/apps/livechat/lib/webpack.config.js
@@ -40,7 +40,8 @@ const config = {
 					{
 						loader: 'babel-loader',
 						options: {
-							presets: [ '@babel/preset-react' ]
+							presets: [ '@babel/preset-react' ],
+							cacheDirectory: true
 						}
 					}
 				]
@@ -120,7 +121,6 @@ if (process.env.NODE_ENV === 'production') {
 	config.optimization = {
 		minimize: true
 	}
-} else {
 	config.plugins.push(
 		new BundleAnalyzerPlugin({
 			analyzerMode: 'static',

--- a/apps/ui/lib/webpack.config.js
+++ b/apps/ui/lib/webpack.config.js
@@ -51,7 +51,8 @@ const config = {
 					{
 						loader: 'babel-loader',
 						options: {
-							presets: [ '@babel/preset-react' ]
+							presets: [ '@babel/preset-react' ],
+							cacheDirectory: true
 						}
 					}
 				]
@@ -180,7 +181,6 @@ if (process.env.NODE_ENV === 'production') {
 	config.optimization = {
 		minimize: true
 	}
-} else {
 	config.plugins.push(
 		new BundleAnalyzerPlugin({
 			analyzerMode: 'static',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Tweak webpack `optimization` config used during `make dev-ui` and `make dev-livechat`. Pulled tips from:
- https://webpack.js.org/guides/caching/
- https://blog.box.com/how-we-improved-webpack-build-performance-95

Also think it would be better to stop using `BundleAnalyzerPlugin`? If it's something that the frontend developers make use of quite often, it should stay, otherwise I doubt we need to generate the report every time.

**The point of this PR is to find a way to optimize webpack builds during development so builds don't die from OOM errors so if anyone has other ideas on how to do this don't hesitate to let me know or push commits!**