### PR TITLE
Fix bug that stops data loading when the channel target is a slug

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -606,18 +606,7 @@ export default class ActionCreator {
 		target, query, queryOptions
 	}) {
 		return async (dispatch, getState) => {
-			const identifierType = isUUID(target) ? 'id' : 'slug'
-			let cardIdentifier = target
-
-			if (identifierType !== 'id') {
-				const card = await this.sdk.card.get(target)
-				if (_.isNil(card)) {
-					throw new Error(`Could not find card with ${identifierType} ${target}`)
-				}
-				cardIdentifier = card.id
-			}
-
-			const stream = streams[cardIdentifier]
+			const stream = streams[target]
 			if (!stream) {
 				throw new Error('Stream not found: Did you forget to call loadChannelData?')
 			}


### PR DESCRIPTION
This issue is caused by the stream logic assuming that stream
identifiers are normalized to use card IDs, but this is no longer the
case.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
