### PR TITLE
Test: mentions count should be equal to messages in inbox

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.jsx
@@ -600,6 +600,7 @@ export default class HomeChannel extends React.Component {
 										bottom: '10px'
 									}}
 									tooltip={`${mentions.length} notifications`}
+									data-test="homechannel-mentions-count"
 									>
 										{(mentions.length >= 100) ? '99+' : mentions.length}
 									</MentionsCount>

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -260,15 +260,13 @@ ava.serial('Messages that alert a user should appear in their inbox and in the h
 
 	// Navigate to the inbox page
 	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
-
+	await incognitoPage.waitForSelector('[data-test="homechannel-mentions-count"]')
 	const inboxmessages = await incognitoPage.$$('[data-test="event-card__message"]')
 	const mentionscount = await macros.getElementText(incognitoPage, '[data-test="homechannel-mentions-count"]')
 
 	// Assert that they are equal count
 	test.deepEqual(inboxmessages.length, 2)
 	test.deepEqual(mentionscount, '2')
-
-	test.pass()
 })
 
 ava.serial('Messages that mention a user\'s group should appear in their inbox', async (test) => {

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -260,13 +260,15 @@ ava.serial('Messages that alert a user should appear in their inbox and in the h
 
 	// Navigate to the inbox page
 	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
-	await incognitoPage.waitForSelector('[data-test="homechannel-mentions-count"]')
+
+	await incognitoPage.waitForSelector('[data-test="event-card__message"]')
 	const inboxmessages = await incognitoPage.$$('[data-test="event-card__message"]')
+
+	await incognitoPage.waitForSelector('[data-test="homechannel-mentions-count"]')
 	const mentionscount = await macros.getElementText(incognitoPage, '[data-test="homechannel-mentions-count"]')
 
 	// Assert that they are equal count
-	test.deepEqual(inboxmessages.length, 2)
-	test.deepEqual(mentionscount, '2')
+	test.deepEqual(Number(mentionscount), inboxmessages.length)
 })
 
 ava.serial('Messages that mention a user\'s group should appear in their inbox', async (test) => {

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -233,6 +233,44 @@ ava.serial('Messages that alert a user should appear in their inbox', async (tes
 	test.pass()
 })
 
+ava.serial('Messages that alert a user should appear in their inbox and in the homechannel mentions count', async (test) => {
+	const {
+		user2,
+		page,
+		incognitoPage
+	} = context
+
+	const thread = await page.evaluate(() => {
+		return window.sdk.card.create({
+			type: 'thread@1.0.0'
+		})
+	})
+
+	// Navigate to the thread page
+	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+
+	const columnSelector = `.column--slug-${thread.slug}`
+	await page.waitForSelector(columnSelector)
+
+	const msg = `@${user2.slug.slice(5)} ${uuid()}`
+
+	await page.waitForSelector('.new-message-input')
+	await macros.createChatMessage(page, columnSelector, msg)
+	await macros.createChatMessage(page, columnSelector, msg)
+
+	// Navigate to the inbox page
+	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+
+	const inboxmessages = await incognitoPage.$$('[data-test="event-card__message"]')
+	const mentionscount = await macros.getElementText(incognitoPage, '[data-test="homechannel-mentions-count"]')
+
+	// Assert that they are equal count
+	test.deepEqual(inboxmessages.length, 2)
+	test.deepEqual(mentionscount, '2')
+
+	test.pass()
+})
+
 ava.serial('Messages that mention a user\'s group should appear in their inbox', async (test) => {
 	const {
 		user2,


### PR DESCRIPTION
This test checks if the inbox and homechannel mentions have the same count. It's part of investigating issue #4625 

Related-to: https://github.com/product-os/jellyfish/issues/4625
Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
