### PR TITLE
Use schedule field instead of async field in triggered actions

### DIFF
--- a/apps/action-server/lib/bootstrap.js
+++ b/apps/action-server/lib/bootstrap.js
@@ -63,10 +63,10 @@ const transformTriggerCard = (trigger) => {
 	}
 
 	// Triggered actions default to being asynchronous
-	if (_.has(trigger.data, [ 'async' ])) {
-		object.async = trigger.data.async
+	if (_.has(trigger.data, [ 'schedule' ])) {
+		object.schedule = trigger.data.schedule
 	} else {
-		object.async = true
+		object.schedule = 'async'
 	}
 
 	return object

--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -203,9 +203,9 @@
       }
     },
     "@balena/jellyfish-jellyscript": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-1.0.42.tgz",
-      "integrity": "sha512-X1BvcGy7n64vRgHnfrfvlcKBbpsDR2fAY9bFxAzV2t2Zjgl7vSqnk/eVRNumEGslqlGrPvHC6VF5Pn/DrEzHIg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-2.0.0.tgz",
+      "integrity": "sha512-QO52nLs42qxUQbaWsAcOawfTafhPA3gXhJEKj7XI8fGkve+XCNbAzo6QpGDXRVtEENHuGGeQtby1yVaor4dm0Q==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
         "@formulajs/formulajs": "^2.6.1",
@@ -332,12 +332,12 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "1.0.200",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-1.0.200.tgz",
-      "integrity": "sha512-wJOb+NySiHzG6qWw3vxVTWP6FQzNXQCLo5L2UCEJDOTL6yrKcnbjZvsun++S1KAL+gg/7szGNE88Oq/7S5egMg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-2.0.0.tgz",
+      "integrity": "sha512-GvGmO9cBW2e5xiUCZLwHg8u7estfTpeuDu10/k0V94VM6UCU5ypBnYV4aUzVUUKfxKmQKFPMvLbYPfi5Ia72eA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
-        "@balena/jellyfish-jellyscript": "^1.0.42",
+        "@balena/jellyfish-jellyscript": "^2.0.0",
         "@balena/jellyfish-logger": "^0.0.148",
         "@balena/jellyfish-uuid": "^1.0.31",
         "bluebird": "^3.7.2",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -17,7 +17,7 @@
     "@balena/jellyfish-metrics": "^0.0.175",
     "@balena/jellyfish-queue": "^0.0.219",
     "@balena/jellyfish-uuid": "^1.0.31",
-    "@balena/jellyfish-worker": "^1.0.200",
+    "@balena/jellyfish-worker": "^2.0.0",
     "bluebird": "^3.7.2",
     "lodash": "^4.17.20"
   },

--- a/apps/server/lib/default-cards/contrib/triggered-action-github-issue-link.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-github-issue-link.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for broadcasting links from a support thread to GitHub issue or pull request",
   "markers": [],
   "data": {
-    "async": true,
+    "schedule": "async",
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-hangouts-link.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-hangouts-link.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for creating messages with Hangouts link",
   "markers": [],
   "data": {
-    "async": true,
+    "schedule": "async",
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-increment-tag.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-increment-tag.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for incrementing count value of a tag",
   "markers": [],
   "data": {
-    "async": true,
+    "schedule": "async",
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-integration-discourse-mirror-event.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for Discourse mirrors",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "anyOf": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-integration-front-mirror-event.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-integration-front-mirror-event.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for Front mirrors",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "anyOf": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-integration-github-mirror-event.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-integration-github-mirror-event.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for GitHub mirrors",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-integration-import-event.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-integration-import-event.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for external service import events",
   "markers": [],
   "data": {
-    "async": true,
+    "schedule": "async",
     "filter": {
       "type": "object",
       "required": [

--- a/apps/server/lib/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-integration-outreach-mirror-event.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for Outreach mirrors",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "required": [ "type" ],

--- a/apps/server/lib/default-cards/contrib/triggered-action-set-user-avatar.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-set-user-avatar.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for user avatars",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "required": [ "type" ],

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-closed-issue-reopen.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for reopening support threads when issues are closed",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "$$links": {
         "is attached to": {

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-closed-pull-request-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-closed-pull-request-reopen.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for reopening support threads when pull requests are closed",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "$$links": {
         "is attached to": {

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-reopen.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-reopen.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for reopening support threads because of activity",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "$$links": {
         "is attached to": {

--- a/apps/server/lib/default-cards/contrib/triggered-action-support-summary.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-support-summary.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for support summaries",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "$$links": {

--- a/apps/server/lib/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-sync-thread-post-link-whisper.json
@@ -4,6 +4,7 @@
   "name": "Triggered action for creating a whisper with link on thread sync",
   "markers": [],
   "data": {
+    "schedule": "async",
     "filter": {
       "title": "Support threads created with a 'mirrors' field",
       "$$links": {

--- a/apps/server/lib/default-cards/contrib/triggered-action-update-event-edited-at.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-update-event-edited-at.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for updating the event's edited_at field when the payload is updated",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "$$links": {
         "is attached to": {

--- a/apps/server/lib/default-cards/contrib/triggered-action-user-contact.json
+++ b/apps/server/lib/default-cards/contrib/triggered-action-user-contact.json
@@ -4,7 +4,7 @@
   "name": "Triggered action for maintaining user contact information",
   "markers": [],
   "data": {
-    "async": false,
+    "schedule": "sync",
     "filter": {
       "type": "object",
       "required": [ "type" ],

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -324,9 +324,9 @@
       }
     },
     "@balena/jellyfish-jellyscript": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-1.0.42.tgz",
-      "integrity": "sha512-X1BvcGy7n64vRgHnfrfvlcKBbpsDR2fAY9bFxAzV2t2Zjgl7vSqnk/eVRNumEGslqlGrPvHC6VF5Pn/DrEzHIg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-2.0.0.tgz",
+      "integrity": "sha512-QO52nLs42qxUQbaWsAcOawfTafhPA3gXhJEKj7XI8fGkve+XCNbAzo6QpGDXRVtEENHuGGeQtby1yVaor4dm0Q==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
         "@formulajs/formulajs": "^2.6.1",
@@ -441,12 +441,12 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "1.0.200",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-1.0.200.tgz",
-      "integrity": "sha512-wJOb+NySiHzG6qWw3vxVTWP6FQzNXQCLo5L2UCEJDOTL6yrKcnbjZvsun++S1KAL+gg/7szGNE88Oq/7S5egMg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-2.0.0.tgz",
+      "integrity": "sha512-GvGmO9cBW2e5xiUCZLwHg8u7estfTpeuDu10/k0V94VM6UCU5ypBnYV4aUzVUUKfxKmQKFPMvLbYPfi5Ia72eA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
-        "@balena/jellyfish-jellyscript": "^1.0.42",
+        "@balena/jellyfish-jellyscript": "^2.0.0",
         "@balena/jellyfish-logger": "^0.0.148",
         "@balena/jellyfish-uuid": "^1.0.31",
         "bluebird": "^3.7.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-queue": "^0.0.219",
     "@balena/jellyfish-sync": "^3.0.106",
     "@balena/jellyfish-uuid": "^1.0.31",
-    "@balena/jellyfish-worker": "^1.0.200",
+    "@balena/jellyfish-worker": "^2.0.0",
     "aws-sdk": "^2.798.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -475,9 +475,9 @@
       }
     },
     "@balena/jellyfish-jellyscript": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-1.0.42.tgz",
-      "integrity": "sha512-X1BvcGy7n64vRgHnfrfvlcKBbpsDR2fAY9bFxAzV2t2Zjgl7vSqnk/eVRNumEGslqlGrPvHC6VF5Pn/DrEzHIg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-jellyscript/-/jellyfish-jellyscript-2.0.0.tgz",
+      "integrity": "sha512-QO52nLs42qxUQbaWsAcOawfTafhPA3gXhJEKj7XI8fGkve+XCNbAzo6QpGDXRVtEENHuGGeQtby1yVaor4dm0Q==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
@@ -660,13 +660,13 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "1.0.200",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-1.0.200.tgz",
-      "integrity": "sha512-wJOb+NySiHzG6qWw3vxVTWP6FQzNXQCLo5L2UCEJDOTL6yrKcnbjZvsun++S1KAL+gg/7szGNE88Oq/7S5egMg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-2.0.0.tgz",
+      "integrity": "sha512-GvGmO9cBW2e5xiUCZLwHg8u7estfTpeuDu10/k0V94VM6UCU5ypBnYV4aUzVUUKfxKmQKFPMvLbYPfi5Ia72eA==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.0.29",
-        "@balena/jellyfish-jellyscript": "^1.0.42",
+        "@balena/jellyfish-jellyscript": "^2.0.0",
         "@balena/jellyfish-logger": "^0.0.148",
         "@balena/jellyfish-uuid": "^1.0.31",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@balena/jellyfish-queue": "^0.0.219",
     "@balena/jellyfish-sync": "^3.0.106",
     "@balena/jellyfish-uuid": "^1.0.31",
-    "@balena/jellyfish-worker": "^1.0.200",
+    "@balena/jellyfish-worker": "^2.0.0",
     "@octokit/plugin-retry": "^3.0.4",
     "@octokit/plugin-throttling": "^3.3.3",
     "@octokit/rest": "^18.0.9",

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -55,7 +55,7 @@ ava.serial('should be able to run high privilege triggers in response to common 
 		data: {
 			action: 'action-create-card@1.0.0',
 			mode: 'insert',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				properties: {

--- a/test/integration/worker/executor.spec.js
+++ b/test/integration/worker/executor.spec.js
@@ -622,7 +622,7 @@ ava('.insertCard() should pass a triggered action as an action originator', asyn
 					slug: command
 				}
 			},
-			async: false
+			schedule: 'sync'
 		}
 	]
 
@@ -671,7 +671,7 @@ ava('.insertCard() should be able to override a triggered action originator', as
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -745,7 +745,7 @@ ava('.insertCard() should execute one matching triggered action', async (test) =
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -830,7 +830,7 @@ ava('.insertCard() should not execute non-matching triggered actions', async (te
 	const command = test.context.generateRandomSlug()
 	const triggers = [
 		{
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -891,7 +891,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -919,7 +919,7 @@ ava('.insertCard() should execute more than one matching triggered action', asyn
 		},
 		{
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -988,7 +988,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 	const triggers = [
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1016,7 +1016,7 @@ ava('.insertCard() should execute the matching triggered actions given more than
 		},
 		{
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -1433,7 +1433,7 @@ ava('.insertCard() should add a triggered action given a type with an AGGREGATE 
 		requires: [],
 		capabilities: [],
 		data: {
-			async: true,
+			schedule: 'async',
 			type: trigger.data.type,
 			target: trigger.data.target,
 			action: trigger.data.action,
@@ -1489,7 +1489,7 @@ ava('.insertCard() should pre-register a triggered action if using AGGREGATE', a
 
 	test.deepEqual(localTriggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: localTriggers[0].id,
 			slug: `triggered-action-${slug}-data-mentions`,
 			action: 'action-set-add@1.0.0',

--- a/test/integration/worker/insert-card.spec.js
+++ b/test/integration/worker/insert-card.spec.js
@@ -23,7 +23,7 @@ ava('.insertCard() should pass a triggered action originator', async (test) => {
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],
@@ -78,7 +78,7 @@ ava('.insertCard() should take an originator option', async (test) => {
 		{
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
-			async: false,
+			schedule: 'sync',
 			filter: {
 				type: 'object',
 				required: [ 'data' ],

--- a/test/integration/worker/trigger-updates.spec.js
+++ b/test/integration/worker/trigger-updates.spec.js
@@ -17,7 +17,7 @@ ava.after(helpers.worker.after)
 ava('.setTriggers() should be able to set a trigger with a start date', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -36,7 +36,7 @@ ava('.setTriggers() should be able to set a trigger with a start date', (test) =
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -55,7 +55,7 @@ ava('.setTriggers() should be able to set a trigger with a start date', (test) =
 ava('.setTriggers() should be able to set a trigger with an interval', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -71,7 +71,7 @@ ava('.setTriggers() should be able to set a trigger with an interval', (test) =>
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -87,7 +87,7 @@ ava('.setTriggers() should be able to set a trigger with an interval', (test) =>
 ava('.setTriggers() should be able to set triggers', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -100,7 +100,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 			}
 		},
 		{
-			async: true,
+			schedule: 'async',
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -119,7 +119,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -132,7 +132,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 			}
 		},
 		{
-			async: true,
+			schedule: 'async',
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -150,7 +150,7 @@ ava('.setTriggers() should be able to set triggers', (test) => {
 ava('.setTriggers() should not store extra properties', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			foo: 'bar',
@@ -170,7 +170,7 @@ ava('.setTriggers() should not store extra properties', (test) => {
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -188,7 +188,7 @@ ava('.setTriggers() should not store extra properties', (test) => {
 ava('.setTriggers() should store a mode', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			mode: 'update',
@@ -207,7 +207,7 @@ ava('.setTriggers() should store a mode', (test) => {
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -227,7 +227,7 @@ ava('.setTriggers() should throw if no interval nor filter', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -247,7 +247,7 @@ ava('.setTriggers() should throw if mode is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-foo-bar@1.0.0',
@@ -270,7 +270,7 @@ ava('.setTriggers() should throw if both interval and filter', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -294,7 +294,7 @@ ava('.setTriggers() should throw if no id', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -316,7 +316,7 @@ ava('.setTriggers() should throw if no slug', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
 				action: 'action-create-card@1.0.0',
@@ -338,7 +338,7 @@ ava('.setTriggers() should throw if id is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 999,
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -361,7 +361,7 @@ ava('.setTriggers() should throw if interval is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -382,7 +382,7 @@ ava('.setTriggers() should throw if no action', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				target: '4a962ad9-20b5-4dd8-a707-bf819593cc84',
@@ -403,7 +403,7 @@ ava('.setTriggers() should throw if action is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 1,
@@ -425,7 +425,7 @@ ava('.setTriggers() should throw if no target', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -447,7 +447,7 @@ ava('.setTriggers() should throw if target is not a string', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -470,7 +470,7 @@ ava('.setTriggers() should throw if no filter', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -490,7 +490,7 @@ ava('.setTriggers() should throw if filter is not an object', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -511,7 +511,7 @@ ava('.setTriggers() should throw if no arguments', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -530,7 +530,7 @@ ava('.setTriggers() should throw if arguments is not an object', (test) => {
 	test.throws(() => {
 		test.context.worker.setTriggers(test.context.context, [
 			{
-				async: true,
+				schedule: 'async',
 				id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 				slug: 'triggered-action-foo-bar',
 				action: 'action-create-card@1.0.0',
@@ -549,7 +549,7 @@ ava('.setTriggers() should throw if arguments is not an object', (test) => {
 ava('.upsertTrigger() should be able to add a trigger', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -564,7 +564,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 	])
 
 	test.context.worker.upsertTrigger(test.context.context, {
-		async: true,
+		schedule: 'async',
 		id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 		slug: 'triggered-action-foo-baz',
 		action: 'action-foo-bar@1.0.0',
@@ -582,7 +582,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -595,7 +595,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 			}
 		},
 		{
-			async: true,
+			schedule: 'async',
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -613,7 +613,7 @@ ava('.upsertTrigger() should be able to add a trigger', (test) => {
 ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 	test.context.worker.setTriggers(test.context.context, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -626,7 +626,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 			}
 		},
 		{
-			async: true,
+			schedule: 'async',
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -642,7 +642,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 	])
 
 	test.context.worker.upsertTrigger(test.context.context, {
-		async: true,
+		schedule: 'async',
 		id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 		slug: 'triggered-action-foo-baz',
 		action: 'action-foo-bar@1.0.0',
@@ -660,7 +660,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 
 	test.deepEqual(triggers, [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -673,7 +673,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 			}
 		},
 		{
-			async: true,
+			schedule: 'async',
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',
@@ -691,7 +691,7 @@ ava('.upsertTrigger() should be able to modify an existing trigger', (test) => {
 ava('.removeTrigger() should be able to remove an existing trigger', (test) => {
 	const cards = [
 		{
-			async: true,
+			schedule: 'async',
 			id: 'cb3523c5-b37d-41c8-ae32-9e7cc9309165',
 			slug: 'triggered-action-foo-bar',
 			action: 'action-foo-bar@1.0.0',
@@ -704,7 +704,7 @@ ava('.removeTrigger() should be able to remove an existing trigger', (test) => {
 			}
 		},
 		{
-			async: true,
+			schedule: 'async',
 			id: 'd6cacdef-f53b-4b5b-8aa2-8476e48248a4',
 			slug: 'triggered-action-foo-baz',
 			action: 'action-foo-bar@1.0.0',


### PR DESCRIPTION
Triggered actions now have a 'schedule' field which can currently take one of three string values - 'sync', 'async' or 'enqueue'.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: https://github.com/product-os/jellyfish-worker/pull/242
Relates to: https://github.com/product-os/jellyfish-jellyscript/pull/131