### PR TITLE
Allow setting FILES for make test in apps/ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ test: scrub
 
 test-unit:
 	cd apps/ui && make test
-	cd apps/server && FILES="'./test/unit/**/*.spec.js'" make test
+	cd apps/server && make test-unit
 
 test-integration:
 	FILES="'./test/integration/**/*.spec.js'" make test
@@ -335,7 +335,7 @@ test-unit-ui:
 	cd apps/ui && make test
 
 test-integration-server:
-	cd apps/server && FILES="'./test/integration/**/*.spec.js'" make test
+	cd apps/server && make test-integration
 
 test-integration-%:
 	FILES="'./test/integration/$(subst test-integration-,,$@)/**/*.spec.js'" make test

--- a/apps/server/Makefile
+++ b/apps/server/Makefile
@@ -36,6 +36,8 @@ else
 ESLINT_OPTION_FIX = --fix
 endif
 
+FILES ?= "'./test/**/*.spec.js'"
+
 .PHONY: lint
 lint:
 	npx eslint --ext .js $(ESLINT_OPTION_FIX) lib test
@@ -44,6 +46,14 @@ lint:
 .PHONY: test
 test:
 	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) $(FILES)
+
+.PHONY: test-unit
+test-unit:
+	make test FILES="'./test/unit/**/*.spec.js'"
+
+.PHONY: test-integration
+test-integration:
+	make test FILES="'./test/integration/**/*.spec.js'"
 
 .PHONY: start-server
 start-server: LOGLEVEL = info

--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -47,10 +47,12 @@ else
 ESLINT_OPTION_FIX = --fix
 endif
 
+FILES ?= "'./{lib,test}/**/*.spec.{js,jsx}'"
+
 .PHONY: test
 test: LOGLEVEL = warning
 test:
-	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) "'./{test,lib}/**/*.spec.{js,jsx}'"
+	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) $(FILES)
 
 .PHONY: dev-ui
 dev-ui:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Allow setting `FILES` when running `make test` under `apps/ui`, defaulting to `"'./{lib,test}/**/*.spec.{js,jsx}'"`.
Also setting a default value for `FILES` in `apps/server/Makefile` along with a couple convenience make commands:
- `make test-unit`
- `make test-integration`
