### PR TITLE
Improve CRM table with inline CardOwners and removing LinksProvider

### DIFF
--- a/apps/server/lib/default-cards/balena/view-all-opportunities.json
+++ b/apps/server/lib/default-cards/balena/view-all-opportunities.json
@@ -20,6 +20,14 @@
                     }
                   },
                   "additionalProperties": true
+                },
+                "is owned by": {
+                  "properties": {
+                    "type": {
+                      "const": "user@1.0.0"
+                    }
+                  },
+                  "additionalProperties": true
                 }
               }
             },
@@ -45,8 +53,8 @@
       }
     ],
     "lenses": [
-      "lens-list",
       "lens-crm-table",
+      "lens-list",
       "lens-kanban"
     ]
   }

--- a/apps/server/lib/default-cards/balena/view-my-opportunities.json
+++ b/apps/server/lib/default-cards/balena/view-my-opportunities.json
@@ -2,7 +2,9 @@
   "slug": "view-my-opportunities",
   "name": "My opportunities",
   "type": "view@1.0.0",
-  "markers": [ "org-balena" ],
+  "markers": [
+    "org-balena"
+  ],
   "data": {
     "namespace": "Sales",
     "allOf": [
@@ -60,8 +62,8 @@
       }
     ],
     "lenses": [
-      "lens-list",
       "lens-crm-table",
+      "lens-list",
       "lens-kanban"
     ]
   }

--- a/apps/server/lib/default-cards/contrib/opportunity.js
+++ b/apps/server/lib/default-cards/contrib/opportunity.js
@@ -94,9 +94,6 @@ module.exports = ({
 					}
 				}
 			},
-			slices: [
-				'properties.data.properties.status'
-			],
 			meta: {
 				relationships: [
 					{

--- a/apps/ui/lib/components/CardActions/CardActions.jsx
+++ b/apps/ui/lib/components/CardActions/CardActions.jsx
@@ -5,6 +5,7 @@
  */
 
 import copy from 'copy-to-clipboard'
+import _ from 'lodash'
 import React from 'react'
 import {
 	Button,
@@ -83,6 +84,8 @@ export default class CardActions extends React.Component {
 
 	render () {
 		const supportsOwnership = supportsLink(this.props.card.type, 'is owned by')
+		const owner = _.head(_.get(this.props.card, [ 'links', 'is owned by' ], null))
+
 		return (
 			<React.Fragment>
 				<Flex alignItems="center" justifyContent="flex-end">
@@ -92,7 +95,9 @@ export default class CardActions extends React.Component {
 							user={this.props.user}
 							types={this.props.types}
 							card={this.props.card}
+							channel={this.props.channel}
 							sdk={this.props.sdk}
+							cardOwner={owner}
 							actions={this.props.actions} />
 					)}
 					<Button

--- a/apps/ui/lib/components/CardOwner/CardOwner.jsx
+++ b/apps/ui/lib/components/CardOwner/CardOwner.jsx
@@ -80,10 +80,12 @@ export default class CardOwner extends React.Component {
 	handover (unassigned) {
 		const {
 			actions,
-			card
+			card,
+			channel
 		} = this.props
 		const flowState = {
 			isOpen: true,
+			type: FLOW_IDS.GUIDED_HANDOVER,
 			card,
 			unassigned,
 			statusDescription: _.get(card, [ 'data', 'statusDescription' ], '')
@@ -93,7 +95,7 @@ export default class CardOwner extends React.Component {
 			flowState.newOwner = null
 			flowState.userError = null
 		}
-		actions.setFlow(FLOW_IDS.GUIDED_HANDOVER, card.id, flowState)
+		actions.setFlow(channel.data.target, card.id, flowState)
 	}
 
 	unassign () {
@@ -137,7 +139,6 @@ export default class CardOwner extends React.Component {
 		} = this.props
 
 		const cardTypeName = helpers.getType(card.type, types).name
-
 		return (
 			<DropDownButton
 				data-test="card-owner-dropdown"

--- a/apps/ui/lib/components/CardOwner/CardOwner.jsx
+++ b/apps/ui/lib/components/CardOwner/CardOwner.jsx
@@ -56,10 +56,6 @@ export default class CardOwner extends React.Component {
 
 			await sdk.card.link(card, user, 'is owned by')
 
-			this.props.updateCardOwnerCache(user)
-
-			addNotification('success', `${cardTypeName} assigned to me`)
-
 			// Now generate a whisper in this card's timeline to detail the self-assignment
 			const whisper = handoverUtils.getHandoverWhisperEventCard(
 				card, cardOwner, user, null, _.get(card, [ 'data', 'statusDescription' ])
@@ -71,6 +67,7 @@ export default class CardOwner extends React.Component {
 						console.error('Failed to create whisper', err)
 					})
 			}
+			addNotification('success', `Assigned ${helpers.userDisplayName(user)} to ${cardTypeName} ${card.name}`)
 		} catch (err) {
 			addNotification('danger', `Failed to assign ${cardTypeName}`)
 			console.error('Failed to create link', err)

--- a/apps/ui/lib/components/CardOwner/index.js
+++ b/apps/ui/lib/components/CardOwner/index.js
@@ -11,11 +11,7 @@ import {
 	compose
 } from 'redux'
 import CardOwner from './CardOwner'
-import {
-	withLink
-} from '@balena/jellyfish-ui-components'
 
 export default compose(
-	withRouter,
-	withLink('is owned by', 'cardOwner')
+	withRouter
 )(CardOwner)

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
@@ -24,7 +24,6 @@ import {
 } from '../Steps'
 
 const HandoverFlowPanel = ({
-	flowId,
 	card,
 	channel,
 	flowState,

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/HandoverFlowPanel.jsx
@@ -27,6 +27,7 @@ export default function HandoverFlowPanel ({
 	card,
 	cardOwner,
 	updateCardOwnerCache,
+	channel,
 	flowState,
 	user,
 	types,
@@ -36,10 +37,10 @@ export default function HandoverFlowPanel ({
 	onClose
 }) {
 	const setFlow = (updatedFlowState) => {
-		return actions.setFlow(flowId, card.id, updatedFlowState)
+		return actions.setFlow(channel.data.target, card.id, updatedFlowState)
 	}
 	const removeFlow = () => {
-		return actions.removeFlow(flowId, card.id)
+		return actions.removeFlow(channel.data.target, card.id)
 	}
 	const transferOwnership = async () => {
 		const {

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/index.js
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/index.js
@@ -5,8 +5,5 @@
  */
 
 import HandoverFlowPanel from './HandoverFlowPanel'
-import {
-	withLink
-} from '@balena/jellyfish-ui-components'
 
-export default withLink('is owned by', 'cardOwner')(HandoverFlowPanel)
+export default HandoverFlowPanel

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
@@ -26,7 +26,6 @@ const SlideInFlowPanel = ({
 }) => {
 	const flowId = _.get(flowState, [ 'type' ])
 	const isOpen = _.get(flowState, [ 'isOpen' ], false)
-	console.log(flowState, flowPanel)
 
 	if (_.isArray(children)) {
 		throw new Error('SlideInFlowPanel only accepts a single child component')
@@ -45,7 +44,7 @@ const SlideInFlowPanel = ({
 			isOpen={isOpen}
 			onClose={close}
 		>
-			{hasMultipleFlowPanels && hasMultipleFlowPanels.map((panel, key) => {
+			{Boolean(flowState) && hasMultipleFlowPanels && hasMultipleFlowPanels.map((panel, key) => {
 				if (getPanelType(panel.type.name) === flowState.type) {
 					return (
 						React.cloneElement(panel, {

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
@@ -11,23 +11,25 @@ import {
 } from '@balena/jellyfish-ui-components'
 
 export default function SlideInFlowPanel ({
-	flowId,
 	card,
+	channel,
 	slideInPanelProps,
 	flowState,
 	actions,
 	children,
 	...rest
 }) {
+	const flowId = _.get(flowState, [ 'type' ])
+	const isOpen = _.get(flowState, [ 'isOpen' ], false)
+
 	if (_.isArray(children)) {
 		throw new Error('SlideInFlowPanel only accepts a single child component')
 	}
 	const close = () => {
-		actions.setFlow(flowId, card.id, {
+		actions.setFlow(channel.data.target, card.id, {
 			isOpen: false
 		})
 	}
-	const isOpen = _.get(flowState, [ 'isOpen' ], false)
 
 	return (
 		<SlideInPanel

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
@@ -10,15 +10,17 @@ import {
 	SlideInPanel
 } from '@balena/jellyfish-ui-components'
 
-export default function SlideInFlowPanel ({
+const SlideInFlowPanel = ({
+	sdk,
 	card,
 	channel,
 	slideInPanelProps,
 	flowState,
+	flowPanel,
 	actions,
 	children,
 	...rest
-}) {
+}) => {
 	const flowId = _.get(flowState, [ 'type' ])
 	const isOpen = _.get(flowState, [ 'isOpen' ], false)
 
@@ -39,9 +41,11 @@ export default function SlideInFlowPanel ({
 			isOpen={isOpen}
 			onClose={close}
 		>
-			{Boolean(flowState) && React.cloneElement(children, {
-				flowId,
+			{Boolean(flowState) && React.cloneElement(flowPanel, {
+				sdk,
 				card,
+				channel,
+				flowId,
 				flowState,
 				actions,
 				onClose: close,
@@ -50,3 +54,5 @@ export default function SlideInFlowPanel ({
 		</SlideInPanel>
 	)
 }
+
+export default SlideInFlowPanel

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/SlideInFlowPanel.jsx
@@ -9,6 +9,9 @@ import _ from 'lodash'
 import {
 	SlideInPanel
 } from '@balena/jellyfish-ui-components'
+import {
+	getPanelType
+} from '../flow-utils'
 
 const SlideInFlowPanel = ({
 	sdk,
@@ -23,6 +26,7 @@ const SlideInFlowPanel = ({
 }) => {
 	const flowId = _.get(flowState, [ 'type' ])
 	const isOpen = _.get(flowState, [ 'isOpen' ], false)
+	console.log(flowState, flowPanel)
 
 	if (_.isArray(children)) {
 		throw new Error('SlideInFlowPanel only accepts a single child component')
@@ -32,7 +36,7 @@ const SlideInFlowPanel = ({
 			isOpen: false
 		})
 	}
-
+	const hasMultipleFlowPanels = _.get(flowPanel, [ 'props', 'children' ])
 	return (
 		<SlideInPanel
 			height="50%"
@@ -41,7 +45,27 @@ const SlideInFlowPanel = ({
 			isOpen={isOpen}
 			onClose={close}
 		>
-			{Boolean(flowState) && React.cloneElement(flowPanel, {
+			{hasMultipleFlowPanels && hasMultipleFlowPanels.map((panel, key) => {
+				if (getPanelType(panel.type.name) === flowState.type) {
+					return (
+						React.cloneElement(panel, {
+							key,
+							sdk,
+							card,
+							channel,
+							flowId,
+							flowState,
+							actions,
+							onClose: close,
+							...rest
+						})
+					)
+				}
+
+				return null
+			})}
+
+			{Boolean(flowState) && !hasMultipleFlowPanels && React.cloneElement(flowPanel, {
 				sdk,
 				card,
 				channel,

--- a/apps/ui/lib/components/Flows/SlideInFlowPanel/index.jsx
+++ b/apps/ui/lib/components/Flows/SlideInFlowPanel/index.jsx
@@ -20,11 +20,14 @@ import {
 import SlideInFlowPanel from './SlideInFlowPanel'
 
 const mapStateToProps = (state, props) => {
+	const channelTarget = _.get(props, [ 'channel', 'data', 'target' ])
+
 	return {
 		sdk,
 		analytics,
 		types: selectors.getTypes(state),
-		flowState: selectors.getFlow(props.flowId, props.card.id)(state)
+		flowState: selectors.getFlow(channelTarget, _.get(props, [ 'card', 'id' ]))(state),
+		card: _.get(props, [ 'card' ]) || null
 	}
 }
 

--- a/apps/ui/lib/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
@@ -46,8 +46,7 @@ const getSummaryEvent = (target, summary) => {
 	}
 }
 
-export default function TeardownFlowPanel ({
-	flowId,
+const TeardownFlowPanel = ({
 	card,
 	channel,
 	flowState,
@@ -56,7 +55,7 @@ export default function TeardownFlowPanel ({
 	analytics,
 	sdk,
 	onClose
-}) {
+}) => {
 	const setFlow = (updatedFlowState) => {
 		return actions.setFlow(channel.data.target, card.id, updatedFlowState)
 	}
@@ -140,3 +139,5 @@ export default function TeardownFlowPanel ({
 		</StepsFlow>
 	)
 }
+
+export default TeardownFlowPanel

--- a/apps/ui/lib/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
+++ b/apps/ui/lib/components/Flows/TeardownFlowPanel/TeardownFlowPanel.jsx
@@ -49,6 +49,7 @@ const getSummaryEvent = (target, summary) => {
 export default function TeardownFlowPanel ({
 	flowId,
 	card,
+	channel,
 	flowState,
 	types,
 	actions,
@@ -57,10 +58,10 @@ export default function TeardownFlowPanel ({
 	onClose
 }) {
 	const setFlow = (updatedFlowState) => {
-		return actions.setFlow(flowId, card.id, updatedFlowState)
+		return actions.setFlow(channel.data.target, card.id, updatedFlowState)
 	}
 	const removeFlow = () => {
-		return actions.removeFlow(flowId, card.id)
+		return actions.removeFlow(channel.data.target, card.id)
 	}
 	const teardown = async () => {
 		const {

--- a/apps/ui/lib/components/Flows/TeardownFlowPanel/index.js
+++ b/apps/ui/lib/components/Flows/TeardownFlowPanel/index.js
@@ -4,30 +4,6 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash'
-import {
-	connect
-} from 'react-redux'
-import {
-	bindActionCreators
-} from 'redux'
-import {
-	actionCreators
-}	from '../../../core'
 import TeardownFlowPanel from './TeardownFlowPanel'
 
-const mapDispatchToProps = (dispatch, ownProps) => {
-	const teardownActions = bindActionCreators(
-		_.pick(actionCreators, [
-			'addChannel',
-			'createLink',
-			'getLinks'
-		]),
-		dispatch
-	)
-	return {
-		actions: Object.assign({}, ownProps.actions, teardownActions)
-	}
-}
-
-export default connect(null, mapDispatchToProps)(TeardownFlowPanel)
+export default TeardownFlowPanel

--- a/apps/ui/lib/components/Flows/flow-utils.js
+++ b/apps/ui/lib/components/Flows/flow-utils.js
@@ -18,3 +18,21 @@ export const FLOW_IDS = {
 export const stepStatus = (isComplete) => {
 	return isComplete ? 'completed' : 'pending'
 }
+
+/**
+ * Returns panel type based on component name
+ *
+ * @param {String} name - Name of component
+ * @returns {String | null}
+ */
+export const getPanelType = (name) => {
+	if (name === 'HandoverFlowPanel') {
+		return FLOW_IDS.GUIDED_HANDOVER
+	}
+
+	if (name === 'TeardownFlowPanel') {
+		return FLOW_IDS.GUIDED_TEARDOWN
+	}
+
+	return null
+}

--- a/apps/ui/lib/components/Flows/index.js
+++ b/apps/ui/lib/components/Flows/index.js
@@ -11,12 +11,6 @@ import {
 export {
 	default as SlideInFlowPanel
 } from './SlideInFlowPanel'
-export {
-	default as HandoverFlowPanel
-} from './HandoverFlowPanel'
-export {
-	default as TeardownFlowPanel
-} from './TeardownFlowPanel'
 
 export const Steps = allGenericSteps
 

--- a/apps/ui/lib/components/LayoutTitle/Header.jsx
+++ b/apps/ui/lib/components/LayoutTitle/Header.jsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Heading
+} from 'rendition'
+
+export const Header = (card) => {
+	return <Heading.h4>{card.name || card.slug || card.type}</Heading.h4>
+}

--- a/apps/ui/lib/components/LayoutTitle/Header.jsx
+++ b/apps/ui/lib/components/LayoutTitle/Header.jsx
@@ -9,6 +9,8 @@ import {
 	Heading
 } from 'rendition'
 
-export const Header = (card) => {
+export const Header = ({
+	card
+}) => {
 	return <Heading.h4>{card.name || card.slug || card.type}</Heading.h4>
 }

--- a/apps/ui/lib/components/LayoutTitle/LayoutTitle.jsx
+++ b/apps/ui/lib/components/LayoutTitle/LayoutTitle.jsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Flex, Box
+} from 'rendition'
+import {
+	Header
+} from './Header'
+import {
+	SubHeader
+} from './SubHeader'
+
+const LayoutTitle = ({
+	title, card
+}) => {
+	// If we have neither props, don't render
+	if (!title && !card) {
+		return null
+	}
+
+	return (
+		<Flex
+			flex={1}
+			alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]}
+			my={[ 2, 2, 0 ]}
+		>
+			{title}
+
+			{!title && Boolean(card) && (
+				<Box>
+					<Header card={card} />
+					<SubHeader card={card} />
+				</Box>
+			)}
+		</Flex>
+	)
+}
+
+export default LayoutTitle

--- a/apps/ui/lib/components/LayoutTitle/SubHeader.jsx
+++ b/apps/ui/lib/components/LayoutTitle/SubHeader.jsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import React from 'react'
+import {
+	useSelector
+} from 'react-redux'
+import {
+	Txt
+} from 'rendition'
+import {
+	selectors
+} from '../../core'
+
+export const SubHeader = (card) => {
+	const types = useSelector(selectors.getTypes)
+	const typeBase = card.type && card.type.split('@')[0]
+
+	const typeName = _.get(
+		_.find(types, {
+			slug: typeBase
+		}),
+		[ 'name' ],
+		null
+	)
+
+	return (
+		<Txt color="text.light" fontSize="0">
+			{typeName}
+		</Txt>
+	)
+}

--- a/apps/ui/lib/components/LayoutTitle/SubHeader.jsx
+++ b/apps/ui/lib/components/LayoutTitle/SubHeader.jsx
@@ -16,7 +16,9 @@ import {
 	selectors
 } from '../../core'
 
-export const SubHeader = (card) => {
+export const SubHeader = ({
+	card
+}) => {
 	const types = useSelector(selectors.getTypes)
 	const typeBase = card.type && card.type.split('@')[0]
 

--- a/apps/ui/lib/components/LayoutTitle/index.js
+++ b/apps/ui/lib/components/LayoutTitle/index.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import LayoutTitle from './LayoutTitle'
+
+export default LayoutTitle

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -38,6 +38,9 @@ import {
 import {
 	streamTyping
 } from './stream/typing'
+import {
+	getAllLinkQueries
+} from '../helpers'
 
 // Refresh the session token once every 3 hours
 const TOKEN_REFRESH_INTERVAL = 3 * 60 * 60 * 1000
@@ -515,14 +518,27 @@ export default class ActionCreator {
 
 			const identifier = isUUID(target) ? 'id' : 'slug'
 
+			let default$$Links = {
+				'has attached element': {
+					type: 'object',
+					additionalProperties: true
+				}
+			}
+
+			// If we have a channel that's not a view
+			if (_.get(channel, [ 'data', 'cardType' ]) !== 'view') {
+				// Go through all the link constraints and set as default $$Links
+				default$$Links = {
+					...default$$Links,
+					...getAllLinkQueries()
+				}
+			}
 			const query = {
 				type: 'object',
 				anyOf: [
 					{
 						$$links: {
-							'has attached element': {
-								type: 'object'
-							}
+							...default$$Links
 						}
 					},
 					true

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -145,7 +145,12 @@ const getViewId = (query) => {
 }
 
 export const selectors = {
-	getFlow: (flowId, cardId) => (state) => { return _.get(state.ui, [ 'flows', flowId, cardId ]) || null },
+	getFlow: (channelId, cardId) => (state) => {
+		return _.get(state.ui, [ 'flows', channelId, cardId ]) || null
+	},
+	getAllChannelFlows: (channelId) => (state) => {
+		return _.get(state.ui, [ 'flows', channelId ])
+	},
 	getCard: (id, type) => (state) => { return _.get(state.core, [ 'cards', type.split('@')[0], id ]) || null },
 	getAccounts: (state) => { return state.core.accounts },
 	getOrgs: (state) => { return state.core.orgs },
@@ -1528,12 +1533,12 @@ export default class ActionCreator {
 		}
 	}
 
-	setFlow (flowId, cardId, flowState) {
+	setFlow (channelId, cardId, flowState) {
 		return (dispatch) => {
 			return dispatch({
 				type: actions.SET_FLOW,
 				value: {
-					flowId,
+					channelId,
 					cardId,
 					flowState
 				}
@@ -1541,12 +1546,12 @@ export default class ActionCreator {
 		}
 	}
 
-	removeFlow (flowId, cardId) {
+	removeFlow (channelId, cardId) {
 		return (dispatch) => {
 			return dispatch({
 				type: actions.REMOVE_FLOW,
 				value: {
-					flowId,
+					channelId,
 					cardId
 				}
 			})

--- a/apps/ui/lib/core/store/helpers.js
+++ b/apps/ui/lib/core/store/helpers.js
@@ -6,6 +6,10 @@
 
 import _ from 'lodash'
 import update from 'immutability-helper'
+import {
+	constraints
+} from '@balena/jellyfish-client-sdk/lib/link-constraints'
+import memoize from 'memoize-one'
 
 /**
  * Given a target card id and a card that's been updated, finds all channels
@@ -76,3 +80,17 @@ export const mentionsUser = (card, user, groups) => {
 		return _.get(groups, [ groupName, 'isMine' ])
 	})
 }
+
+export const getAllLinkQueries = memoize(() => {
+	let links = {}
+	constraints.forEach((constraint) => {
+		links = {
+			...links,
+			[constraint.name]: {
+				type: 'object',
+				additionalProperties: true
+			}
+		}
+	})
+	return links
+})

--- a/apps/ui/lib/core/store/reducer.js
+++ b/apps/ui/lib/core/store/reducer.js
@@ -189,13 +189,13 @@ const uiReducer = (state = defaultState.ui, action = {}) => {
 		}
 		case actions.SET_FLOW: {
 			const {
-				flowId,
+				channelId,
 				cardId,
 				flowState
 			} = action.value
 			return update(state, {
 				flows: {
-					[flowId]: (flowsById) => update(flowsById || {}, {
+					[channelId]: (channelsById) => update(channelsById || {}, {
 						[cardId]: {
 							$apply: (existingFlowState) => {
 								return _.merge({}, existingFlowState || {}, flowState)
@@ -207,12 +207,12 @@ const uiReducer = (state = defaultState.ui, action = {}) => {
 		}
 		case actions.REMOVE_FLOW: {
 			const {
-				flowId,
+				channelId,
 				cardId
 			} = action.value
 			return update(state, {
 				flows: {
-					[flowId]: (flowsById) => update(flowsById || {}, {
+					[channelId]: (channelsById) => update(channelsById || {}, {
 						$unset: [ cardId ]
 					})
 				}

--- a/apps/ui/lib/core/store/reducer.spec.js
+++ b/apps/ui/lib/core/store/reducer.spec.js
@@ -473,7 +473,7 @@ ava('USER_STOPPED_TYPING action removes the user from the usersTyping for that c
 
 ava('SET_FLOW adds flow state if it doesn\'t already exist', (test) => {
 	const initialState = _.cloneDeep(defaultState)
-	const flowId = 'HANDOVER'
+	const channelId = 'view-all-opportunities'
 	const cardId = '3'
 	const flowStateUpdates = {
 		someItem: 'someValue'
@@ -482,14 +482,14 @@ ava('SET_FLOW adds flow state if it doesn\'t already exist', (test) => {
 	const newState = reducer(initialState, {
 		type: actions.SET_FLOW,
 		value: {
-			flowId,
+			channelId,
 			cardId,
 			flowState: flowStateUpdates
 		}
 	})
 
 	test.deepEqual(newState.ui.flows, {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: {
 				someItem: 'someValue'
 			}
@@ -499,14 +499,14 @@ ava('SET_FLOW adds flow state if it doesn\'t already exist', (test) => {
 
 ava('SET_FLOW merges an existing flow state', (test) => {
 	const initialState = _.cloneDeep(defaultState)
-	const flowId = 'HANDOVER'
+	const channelId = 'view-all-opportunities'
 	const cardId = '3'
 	const flowState = {
 		isOpen: true,
 		valA: 'initial'
 	}
 	initialState.ui.flows = {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: flowState
 		}
 	}
@@ -517,14 +517,14 @@ ava('SET_FLOW merges an existing flow state', (test) => {
 	const newState = reducer(initialState, {
 		type: actions.SET_FLOW,
 		value: {
-			flowId,
+			channelId,
 			cardId,
 			flowState: flowStateUpdates
 		}
 	})
 
 	test.deepEqual(newState.ui.flows, {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: {
 				isOpen: true,
 				valA: 'changed'
@@ -533,15 +533,45 @@ ava('SET_FLOW merges an existing flow state', (test) => {
 	})
 })
 
-ava('REMOVE_FLOW removes flow state', (test) => {
+ava('REMOVE_FLOW removes flow state from channel with multiple flows', (test) => {
 	const initialState = _.cloneDeep(defaultState)
-	const flowId = 'HANDOVER'
+	const channelId = 'view-all-opportunities'
+	const cardId = '3'
+	const card2Id = '22'
+	const flowState = {
+		isOpen: true
+	}
+	initialState.ui.flows = {
+		[channelId]: {
+			[cardId]: flowState,
+			[card2Id]: flowState
+		}
+	}
+
+	const newState = reducer(initialState, {
+		type: actions.REMOVE_FLOW,
+		value: {
+			channelId,
+			cardId
+		}
+	})
+
+	test.deepEqual(newState.ui.flows, {
+		[channelId]: {
+			[card2Id]: flowState
+		}
+	})
+})
+
+ava('REMOVE_FLOW removes flow state from channel with single flow', (test) => {
+	const initialState = _.cloneDeep(defaultState)
+	const channelId = 'view-all-opportunities'
 	const cardId = '3'
 	const flowState = {
 		isOpen: true
 	}
 	initialState.ui.flows = {
-		[flowId]: {
+		[channelId]: {
 			[cardId]: flowState
 		}
 	}
@@ -549,13 +579,13 @@ ava('REMOVE_FLOW removes flow state', (test) => {
 	const newState = reducer(initialState, {
 		type: actions.REMOVE_FLOW,
 		value: {
-			flowId,
+			channelId,
 			cardId
 		}
 	})
 
 	test.deepEqual(newState.ui.flows, {
-		[flowId]: {}
+		[channelId]: {}
 	})
 })
 

--- a/apps/ui/lib/layouts/CardLayout/CardLayout.jsx
+++ b/apps/ui/lib/layouts/CardLayout/CardLayout.jsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	CloseButton,
+	Column
+} from '@balena/jellyfish-ui-components'
+import * as _ from 'lodash'
+import React from 'react'
+import {
+	Flex,
+	Heading,
+	Txt
+} from 'rendition'
+import CardActions from '../../components/CardActions'
+import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
+import Markers from '../../components/Markers'
+
+const CardLayout = (props) => {
+	const {
+		inlineActionItems,
+		actionItems,
+		card,
+		channel,
+		children,
+		noActions,
+		overflowY,
+		title,
+		types,
+		flowId
+	} = props
+
+	const typeBase = card.type && card.type.split('@')[0]
+
+	const typeName = _.get(_.find(types, {
+		slug: typeBase
+	}), [ 'name' ], null)
+
+	return (
+		<Column
+			className={`column--${typeBase || 'unknown'} column--slug-${card.slug || 'unkown'}`}
+			overflowY={overflowY}
+			data-test={props['data-test']}
+		>
+			<Flex
+				p={3} pb={0}
+				flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
+				justifyContent="space-between"
+				alignItems="center">
+				<Flex flex={1} alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
+					{title}
+
+					{!title && (
+						<div>
+							<Heading.h4>
+								{card.name || card.slug || card.type}
+							</Heading.h4>
+
+							{Boolean(typeName) && (
+								<Txt color="text.light" fontSize="0">{typeName}</Txt>
+							)}
+						</div>
+					)}
+				</Flex>
+				<Flex alignSelf={[ 'flex-end', 'flex-end', 'flex-start' ]}>
+					{!noActions && (
+						<CardActions card={card} channel={channel} inlineActionItems={inlineActionItems}>
+							{actionItems}
+						</CardActions>
+					)}
+					<CloseButton
+						flex={0}
+						onClick={props.onClose}
+						channel={channel} />
+				</Flex>
+			</Flex>
+
+			<Markers card={card} />
+
+			{children}
+			<SlideInFlowPanel
+				slideInPanelProps={{
+					height: 480
+				}}
+				card={card}
+				channel={channel}
+				flowId={flowId} />
+		</Column>
+	)
+}
+
+export default CardLayout

--- a/apps/ui/lib/layouts/CardLayout/CardLayout.jsx
+++ b/apps/ui/lib/layouts/CardLayout/CardLayout.jsx
@@ -8,16 +8,14 @@ import {
 	CloseButton,
 	Column
 } from '@balena/jellyfish-ui-components'
-import * as _ from 'lodash'
 import React from 'react'
 import {
-	Flex,
-	Heading,
-	Txt
+	Flex
 } from 'rendition'
 import CardActions from '../../components/CardActions'
 import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
 import Markers from '../../components/Markers'
+import LayoutTitle from '../../components/LayoutTitle'
 
 const CardLayout = (props) => {
 	const {
@@ -29,15 +27,11 @@ const CardLayout = (props) => {
 		noActions,
 		overflowY,
 		title,
-		types,
-		flowId
+		flowId,
+		flowPanel
 	} = props
 
 	const typeBase = card.type && card.type.split('@')[0]
-
-	const typeName = _.get(_.find(types, {
-		slug: typeBase
-	}), [ 'name' ], null)
 
 	return (
 		<Column
@@ -50,21 +44,9 @@ const CardLayout = (props) => {
 				flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
 				justifyContent="space-between"
 				alignItems="center">
-				<Flex flex={1} alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
-					{title}
 
-					{!title && (
-						<div>
-							<Heading.h4>
-								{card.name || card.slug || card.type}
-							</Heading.h4>
+				<LayoutTitle title={title} card={card} />
 
-							{Boolean(typeName) && (
-								<Txt color="text.light" fontSize="0">{typeName}</Txt>
-							)}
-						</div>
-					)}
-				</Flex>
 				<Flex alignSelf={[ 'flex-end', 'flex-end', 'flex-start' ]}>
 					{!noActions && (
 						<CardActions card={card} channel={channel} inlineActionItems={inlineActionItems}>
@@ -81,13 +63,16 @@ const CardLayout = (props) => {
 			<Markers card={card} />
 
 			{children}
-			<SlideInFlowPanel
-				slideInPanelProps={{
-					height: 480
-				}}
-				card={card}
-				channel={channel}
-				flowId={flowId} />
+			{Boolean(flowId) && Boolean(flowPanel) && (
+				<SlideInFlowPanel
+					slideInPanelProps={{
+						height: 480
+					}}
+					card={card}
+					channel={channel}
+					flowPanel={flowPanel}
+					flowId={flowId} />
+			)}
 		</Column>
 	)
 }

--- a/apps/ui/lib/layouts/CardLayout/index.jsx
+++ b/apps/ui/lib/layouts/CardLayout/index.jsx
@@ -23,7 +23,6 @@ const mapStateToProps = (state, props) => {
 
 	return {
 		user: selectors.getCurrentUser(state),
-		types: selectors.getTypes(state),
 		flowId: props.flowId || FLOW_IDS.GUIDED_HANDOVER,
 		flowState: selectors.getFlow(props.flowId, channelTarget, _.get(flow, [ 'card', 'id' ]))(state)
 	}

--- a/apps/ui/lib/layouts/CardLayout/index.jsx
+++ b/apps/ui/lib/layouts/CardLayout/index.jsx
@@ -5,114 +5,27 @@
  */
 
 import * as _ from 'lodash'
-import React from 'react'
 import {
 	connect
 } from 'react-redux'
 import {
-	Flex,
-	Heading,
-	Txt
-} from 'rendition'
-import {
-	CloseButton,
-	Column,
-	LinksProvider
-} from '@balena/jellyfish-ui-components'
-import CardActions from '../../components/CardActions'
-import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
-import {
 	FLOW_IDS
 } from '../../components/Flows/flow-utils'
-import HandoverFlowPanel from '../../components/Flows/HandoverFlowPanel'
-import Markers from '../../components/Markers'
 import {
-	selectors,
-	sdk
+	selectors
 } from '../../core'
+import CardLayout from './CardLayout'
 
-const CardLayout = (props) => {
-	const {
-		inlineActionItems,
-		actionItems,
-		card,
-		channel,
-		children,
-		noActions,
-		overflowY,
-		title,
-		types,
-		user
-	} = props
+const mapStateToProps = (state, props) => {
+	const channelTarget = _.get(props, [ 'channel', 'data', 'target' ])
+	const flows = _.values(selectors.getAllChannelFlows(channelTarget)(state))
+	const flow = _.head(flows)
 
-	const typeBase = card.type && card.type.split('@')[0]
-
-	const typeName = _.get(_.find(types, {
-		slug: typeBase
-	}), [ 'name' ], null)
-
-	return (
-		<LinksProvider sdk={sdk} cards={typeBase ? [ card ] : []} link="is owned by">
-			<Column
-				className={`column--${typeBase || 'unknown'} column--slug-${card.slug || 'unkown'}`}
-				overflowY={overflowY}
-				data-test={props['data-test']}
-			>
-				<Flex
-					p={3} pb={0}
-					flexDirection={[ 'column-reverse', 'column-reverse', 'row' ]}
-					justifyContent="space-between"
-					alignItems="center">
-					<Flex flex={1} alignSelf={[ 'flex-start', 'flex-start', 'inherit' ]} my={[ 2, 2, 0 ]}>
-						{title}
-
-						{!title && (
-							<div>
-								<Heading.h4>
-									{card.name || card.slug || card.type}
-								</Heading.h4>
-
-								{Boolean(typeName) && (
-									<Txt color="text.light" fontSize="0">{typeName}</Txt>
-								)}
-							</div>
-						)}
-					</Flex>
-					<Flex alignSelf={[ 'flex-end', 'flex-end', 'flex-start' ]}>
-						{!noActions && (
-							<CardActions card={card} inlineActionItems={inlineActionItems}>
-								{actionItems}
-							</CardActions>
-						)}
-						<CloseButton
-							flex={0}
-							onClick={props.onClose}
-							channel={channel}
-						/>
-					</Flex>
-				</Flex>
-
-				<Markers card={card} />
-
-				{children}
-				<SlideInFlowPanel
-					slideInPanelProps={{
-						height: 480
-					}}
-					card={card}
-					flowId={FLOW_IDS.GUIDED_HANDOVER}
-				>
-					<HandoverFlowPanel user={user} />
-				</SlideInFlowPanel>
-			</Column>
-		</LinksProvider>
-	)
-}
-
-const mapStateToProps = (state) => {
 	return {
 		user: selectors.getCurrentUser(state),
-		types: selectors.getTypes(state)
+		types: selectors.getTypes(state),
+		flowId: props.flowId || FLOW_IDS.GUIDED_HANDOVER,
+		flowState: selectors.getFlow(props.flowId, channelTarget, _.get(flow, [ 'card', 'id' ]))(state)
 	}
 }
 

--- a/apps/ui/lib/layouts/LensLayout/LensLayout.jsx
+++ b/apps/ui/lib/layouts/LensLayout/LensLayout.jsx
@@ -7,9 +7,15 @@
 import _ from 'lodash'
 import * as React from 'react'
 import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
+import LayoutTitle from '../../components/LayoutTitle'
 
 const LensLayout = ({
-	sdk, channelFlows, children, channel, flowId, ...rest
+	channelFlows,
+	flowPanel,
+	children,
+	channel,
+	title,
+	card
 }) => {
 	const openFlows = _.values(channelFlows).filter((flow) => {
 		return flow.isOpen
@@ -18,14 +24,17 @@ const LensLayout = ({
 
 	return (
 		<React.Fragment>
+			<LayoutTitle title={title} card={card} />
+
 			{children}
 
-			{firstFlow && (
+			{Boolean(firstFlow) && Boolean(flowPanel) && (
 				<SlideInFlowPanel
 					slideInPanelProps={{
 						height: 480
 					}}
 					channel={channel}
+					flowPanel={flowPanel}
 					flowId={firstFlow.type}
 					card={firstFlow.card}
 				/>

--- a/apps/ui/lib/layouts/LensLayout/LensLayout.jsx
+++ b/apps/ui/lib/layouts/LensLayout/LensLayout.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import * as React from 'react'
+import SlideInFlowPanel from '../../components/Flows/SlideInFlowPanel'
+
+const LensLayout = ({
+	sdk, channelFlows, children, channel, flowId, ...rest
+}) => {
+	const openFlows = _.values(channelFlows).filter((flow) => {
+		return flow.isOpen
+	})
+	const firstFlow = _.head(openFlows)
+
+	return (
+		<React.Fragment>
+			{children}
+
+			{firstFlow && (
+				<SlideInFlowPanel
+					slideInPanelProps={{
+						height: 480
+					}}
+					channel={channel}
+					flowId={firstFlow.type}
+					card={firstFlow.card}
+				/>
+			)}
+		</React.Fragment>
+	)
+}
+
+export default LensLayout

--- a/apps/ui/lib/layouts/LensLayout/index.jsx
+++ b/apps/ui/lib/layouts/LensLayout/index.jsx
@@ -8,15 +8,13 @@ import {
 	connect
 } from 'react-redux'
 import {
-	sdk,
 	selectors
 } from '../../core'
 import LensLayout from './LensLayout'
 
 const mapStateToProps = (state, props) => {
 	return {
-		channelFlows: selectors.getAllChannelFlows(props.channel.data.target)(state),
-		sdk
+		channelFlows: selectors.getAllChannelFlows(props.channel.data.target)(state)
 	}
 }
 

--- a/apps/ui/lib/layouts/LensLayout/index.jsx
+++ b/apps/ui/lib/layouts/LensLayout/index.jsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	connect
+} from 'react-redux'
+import {
+	sdk,
+	selectors
+} from '../../core'
+import LensLayout from './LensLayout'
+
+const mapStateToProps = (state, props) => {
+	return {
+		channelFlows: selectors.getAllChannelFlows(props.channel.data.target)(state),
+		sdk
+	}
+}
+
+export default connect(mapStateToProps)(LensLayout)

--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
@@ -24,6 +24,7 @@ import Segment from '../../common/Segment'
 import CardFields from '../../../components/CardFields'
 import CardLayout from '../../../layouts/CardLayout'
 import Timeline from '../../list/Timeline'
+import HandoverFlowPanel from '../../../components/Flows/HandoverFlowPanel'
 
 const SingleCardTabs = styled(Tabs) `
 	flex: 1;
@@ -91,6 +92,7 @@ export default class SingleCardFull extends React.Component {
 				card={card}
 				channel={channel}
 				actionItems={actionItems}
+				flowPanel={(<HandoverFlowPanel />)}
 			>
 				<Divider width="100%" color={helpers.colorHash(card.type)} />
 

--- a/apps/ui/lib/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.jsx
@@ -44,8 +44,9 @@ import Timeline from '../../list/Timeline'
 import CardLayout from '../../../layouts/CardLayout'
 import CardFields from '../../../components/CardFields'
 import {
-	FLOW_IDS, TeardownFlowPanel
+	FLOW_IDS
 } from '../../../components/Flows'
+import HandoverFlowPanel from '../../../components/Flows/HandoverFlowPanel'
 import {
 	IssueOpenedIcon,
 	GitPullRequestIcon
@@ -351,7 +352,7 @@ class SupportThreadBase extends React.Component {
 						</ActionRouterLink>
 					</React.Fragment>
 				)}
-				flowPanel={(<TeardownFlowPanel />)}
+				flowPanel={(<HandoverFlowPanel />)}
 			>
 				<Box px={3}>
 					<Flex alignItems="center" mb={1} flexWrap="wrap">

--- a/apps/ui/lib/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.jsx
@@ -47,6 +47,7 @@ import {
 	FLOW_IDS
 } from '../../../components/Flows'
 import HandoverFlowPanel from '../../../components/Flows/HandoverFlowPanel'
+import TeardownFlowPanel from '../../../components/Flows/TeardownFlowPanel'
 import {
 	IssueOpenedIcon,
 	GitPullRequestIcon
@@ -352,7 +353,12 @@ class SupportThreadBase extends React.Component {
 						</ActionRouterLink>
 					</React.Fragment>
 				)}
-				flowPanel={(<HandoverFlowPanel />)}
+				flowPanel={(
+					<React.Fragment>
+						<HandoverFlowPanel />
+						<TeardownFlowPanel />
+					</React.Fragment>
+				)}
 			>
 				<Box px={3}>
 					<Flex alignItems="center" mb={1} flexWrap="wrap">

--- a/apps/ui/lib/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.jsx
@@ -44,7 +44,7 @@ import Timeline from '../../list/Timeline'
 import CardLayout from '../../../layouts/CardLayout'
 import CardFields from '../../../components/CardFields'
 import {
-	FLOW_IDS
+	FLOW_IDS, TeardownFlowPanel
 } from '../../../components/Flows'
 import {
 	IssueOpenedIcon,
@@ -351,6 +351,7 @@ class SupportThreadBase extends React.Component {
 						</ActionRouterLink>
 					</React.Fragment>
 				)}
+				flowPanel={(<TeardownFlowPanel />)}
 			>
 				<Box px={3}>
 					<Flex alignItems="center" mb={1} flexWrap="wrap">

--- a/apps/ui/lib/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.jsx
@@ -4,7 +4,6 @@
  * Proprietary and confidential.
  */
 
-import * as Bluebird from 'bluebird'
 import {
 	circularDeepEqual
 } from 'fast-equals'
@@ -41,13 +40,11 @@ import {
 	selectors,
 	sdk
 } from '../../../core'
-import SlideInFlowPanel from '../../../components/Flows/SlideInFlowPanel'
 import Timeline from '../../list/Timeline'
 import CardLayout from '../../../layouts/CardLayout'
 import CardFields from '../../../components/CardFields'
 import {
-	FLOW_IDS,
-	TeardownFlowPanel
+	FLOW_IDS
 } from '../../../components/Flows'
 import {
 	IssueOpenedIcon,
@@ -210,33 +207,12 @@ class SupportThreadBase extends React.Component {
 				})
 		}
 
-		this.removeLink = async (fromCard, toCard, verb) => {
-			try {
-				await sdk.card.unlink(fromCard, toCard, verb)
-			} catch (err) {
-				addNotification('danger', err.message)
-				return
-			}
-
-			addNotification('success', 'Link removed')
-
-			this.setState((state) => ({
-				linkedCardsMap: {
-					...state.linkedCardsMap,
-					[verb]: state.linkedCardsMap[verb].filter((linkedCard) => {
-						return linkedCard.id !== toCard.id
-					})
-				}
-			}))
-		}
-
 		this.state = {
 			actor: null,
 			isClosing: false,
 			linkedCardsMap: {},
 			flowId: FLOW_IDS.GUIDED_HANDOVER
 		}
-		this.loadLinks(props.card.id)
 	}
 
 	async componentDidMount () {
@@ -247,64 +223,8 @@ class SupportThreadBase extends React.Component {
 		})
 	}
 
-	async loadLinks (id) {
-		const baseSchema = {
-			type: 'object',
-			properties: {
-				id: {
-					type: 'string',
-					const: id
-				},
-				type: {
-					type: 'string',
-					const: 'support-thread@1.0.0'
-				}
-			},
-			additionalProperties: true
-		}
-
-		const linkedCardsMap = await Bluebird.props(LINKS.reduce((result, link) => {
-			return {
-				...result,
-				[link.verb]: (async () => {
-					const cardWithLinks = (await sdk.query({
-						$$links: {
-							[link.verb]: {
-								type: 'object',
-								additionalProperties: true
-							}
-						},
-						description: link.description({
-							id
-						}),
-						...baseSchema
-					}))[0]
-
-					if (!cardWithLinks) {
-						return []
-					}
-
-					return cardWithLinks.links[link.verb]
-				})()
-			}
-		}, {}))
-
-		this.setState({
-			linkedCardsMap
-		})
-	}
-
 	shouldComponentUpdate (nextProps, nextState) {
 		return !circularDeepEqual(nextProps, this.props) || !circularDeepEqual(nextState, this.state)
-	}
-
-	componentDidUpdate (prevProps) {
-		if (
-			(prevProps.card.id !== this.props.card.id) ||
-			LINKS.some((link) => prevProps.card.linked_at[link.verb] !== this.props.card.linked_at[link.verb])
-		) {
-			this.loadLinks(this.props.card.id)
-		}
 	}
 
 	render () {
@@ -313,9 +233,8 @@ class SupportThreadBase extends React.Component {
 			channel,
 			getActorHref
 		} = this.props
-		const {
-			linkedCardsMap
-		} = this.state
+
+		const linkedCardsMap = _.get(card, [ 'links' ])
 		const typeCard = _.find(this.props.types, {
 			slug: card.type.split('@')[0]
 		})
@@ -538,15 +457,6 @@ class SupportThreadBase extends React.Component {
 						tail={_.get(this.props.card.links, [ 'has attached element' ], [])}
 					/>
 				</Box>
-				<SlideInFlowPanel
-					slideInPanelProps={{
-						height: 500
-					}}
-					card={card}
-					flowId={FLOW_IDS.GUIDED_TEARDOWN}
-				>
-					<TeardownFlowPanel/>
-				</SlideInFlowPanel>
 			</CardLayout>
 		)
 	}

--- a/apps/ui/lib/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.jsx
@@ -144,6 +144,7 @@ class SupportThreadBase extends React.Component {
 		this.close = async () => {
 			const {
 				card,
+				channel,
 				actions: {
 					setFlow
 				}
@@ -177,11 +178,12 @@ class SupportThreadBase extends React.Component {
 			})
 
 			const flowState = {
+				type: FLOW_IDS.GUIDED_TEARDOWN,
 				isOpen: true,
 				card,
 				summary: _.get(summaryCard, [ 'data', 'payload', 'message' ], '')
 			}
-			setFlow(FLOW_IDS.GUIDED_TEARDOWN, card.id, flowState)
+			setFlow(channel.data.target, card.id, flowState)
 		}
 
 		this.archiveCard = () => {
@@ -231,7 +233,8 @@ class SupportThreadBase extends React.Component {
 		this.state = {
 			actor: null,
 			isClosing: false,
-			linkedCardsMap: {}
+			linkedCardsMap: {},
+			flowId: FLOW_IDS.GUIDED_HANDOVER
 		}
 		this.loadLinks(props.card.id)
 	}

--- a/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
@@ -19,6 +19,9 @@ import {
 } from 'rendition'
 import CardOwner from '../../../components/CardOwner'
 import {
+	HandoverFlowPanel
+} from '../../../components/Flows'
+import {
 	FLOW_IDS
 } from '../../../components/Flows/flow-utils'
 import LinkModal from '../../../components/LinkModal'
@@ -273,6 +276,7 @@ class CRMTable extends BaseLens {
 				user={user}
 				channel={channel}
 				flowId={FLOW_IDS.GUIDED_HANDOVER}
+				flowPanel={(<HandoverFlowPanel />)}
 			>
 				<CardTable
 					{...this.props}

--- a/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
@@ -4,17 +4,6 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash'
-import * as React from 'react'
-import {
-	Box,
-	Button,
-	Txt,
-	Badge
-} from 'rendition'
-import styled from 'styled-components'
-import SelectWrapper from './SelectWrapper'
-import BaseLens from '../../common/BaseLens'
 import {
 	ColorHashPill,
 	formatCurrency,
@@ -22,16 +11,48 @@ import {
 	helpers,
 	Link
 } from '@balena/jellyfish-ui-components'
+import _ from 'lodash'
+import * as React from 'react'
+import {
+	Badge, Box,
+	Txt
+} from 'rendition'
+import CardOwner from '../../../components/CardOwner'
+import {
+	FLOW_IDS
+} from '../../../components/Flows/flow-utils'
+import LinkModal from '../../../components/LinkModal'
+import LensLayout from '../../../layouts/LensLayout'
+import BaseLens from '../../common/BaseLens'
 import CardTable from '../Table/CardTable'
+import {
+	SingleLineSpan
+} from './helpers'
+import InlineLinkButton from './InlineLinkButton'
+import SelectWrapper from './SelectWrapper'
 
-const SingleLineSpan = styled.span `
-	whiteSpace: 'nowrap'
-`
 class CRMTable extends BaseLens {
 	constructor (props) {
 		super(props)
 		this.columns = this.initColumns()
+		this.showLinkModal = this.showLinkModal.bind(this)
+		this.hideLinkModal = this.hideLinkModal.bind(this)
 		this.generateTableData = this.generateTableData.bind(this)
+		this.state = {
+			showLinkModal: false
+		}
+	}
+
+	showLinkModal () {
+		this.setState({
+			showLinkModal: true
+		})
+	}
+
+	hideLinkModal () {
+		this.setState({
+			showLinkModal: false
+		})
 	}
 
 	initColumns () {
@@ -46,25 +67,35 @@ class CRMTable extends BaseLens {
 			{
 				field: 'Account',
 				sortable: true,
-				render: (account, item) => {
-					if (!account) {
-						return (
-							<Button
-								mr={2}
-								success
+				render: ({
+					accounts, opportunity
+				}) => {
+					const {
+						actions,
+						types
+					} = this.props
 
-								// TODO: This should open a linked account create modal
-								onClick={this.openCreateChannel}
-							>
-					Add new linked Account
-							</Button>
+					if (!accounts) {
+						const selectedCardTypes = types.filter((typeCard) => {
+							return typeCard.slug.includes('account')
+						})
+
+						return (
+							<InlineLinkButton mr={2} card={opportunity} actions={actions} types={selectedCardTypes} />
 						)
 					}
 
+					const linkedCardsCount = _.get(opportunity, [ 'links', 'is attached to' ]).length - 1
+					const account = _.find(accounts)
+					const typeName = linkedCardsCount >= 2 ? `${account.type.split('@')[0]}s` : account.type.split('@')[0]
+
 					return (
-						<Box>
+						<Box minWidth={200}>
 							<Link to={helpers.appendToChannelPath(this.props.channel, account)}>{account.name}</Link>
 							<Txt color="text.light" fontSize="0">{_.get(account, [ 'data', 'type' ])}</Txt>
+							{Boolean(linkedCardsCount) && (
+								<Txt color="text.light" fontSize="0">{`+${linkedCardsCount} linked ${typeName}`}</Txt>
+							)}
 						</Box>
 					)
 				}
@@ -114,9 +145,37 @@ class CRMTable extends BaseLens {
 				}
 			},
 			{
-				field: 'Stage',
+				field: 'Status',
 				sortable: true,
-				render: (value, item) => <SelectWrapper {...this.props} card={value} />
+				render: (card, item) => <SelectWrapper {...this.props} card={card} />
+			},
+			{
+				field: 'Owner',
+				sortable: true,
+				render: (card) => {
+					const {
+						sdk,
+						actions,
+						user,
+						types,
+						channel
+					} = this.props
+
+					const owner = _.head(_.get(card, [ 'links', 'is owned by' ], null))
+
+					return (
+						<Box minWidth={200}>
+							<CardOwner
+								user={user}
+								types={types}
+								card={card}
+								channel={channel}
+								sdk={sdk}
+								cardOwner={owner}
+								actions={actions} />
+						</Box>
+					)
+				}
 			},
 			{
 				field: 'Account Status',
@@ -147,7 +206,7 @@ class CRMTable extends BaseLens {
 				render: (tags, item) => {
 					if (!tags) return ''
 					return tags.map((value, index) => {
-						return <ColorHashPill key={index} value={value} mr={2} mb={1} color={'white'} />
+						return <ColorHashPill key={index} value={value} mr={2} mb={1} />
 					})
 				}
 			}
@@ -162,7 +221,8 @@ class CRMTable extends BaseLens {
 
 	generateTableData () {
 		return this.props.tail ? _.map(this.props.tail, (opportunity) => {
-			const account = _.find(_.get(opportunity, [ 'links', 'is attached to' ]))
+			const accounts = _.get(opportunity, [ 'links', 'is attached to' ])
+			const account = _.first(accounts)
 
 			const update = _.find(_.get(opportunity, [ 'links', 'has attached element' ]), (linkedCard) => {
 				return [ 'update', 'update@1.0.0' ].includes(linkedCard.type)
@@ -173,11 +233,14 @@ class CRMTable extends BaseLens {
 				slug: _.get(opportunity, [ 'slug' ]),
 
 				Opportunity: _.get(opportunity, [ 'name' ]),
-				Account: account,
+				Account: {
+					accounts, opportunity
+				},
 				'Due Date': _.get(opportunity, [ 'data', 'dueDate' ]),
 				Value: _.get(opportunity, [ 'data', 'value' ]),
 				'Estimated ARR': _.get(opportunity, [ 'data', 'totalValue' ]),
-				Stage: opportunity,
+				Status: opportunity,
+				Owner: opportunity,
 				'Account Status': _.get(account, [ 'data', 'status' ]),
 				Usecase: _.get(opportunity, [ 'data', 'usecase' ]),
 				'Device Type': opportunity.data.device,
@@ -192,13 +255,40 @@ class CRMTable extends BaseLens {
 	}
 
 	render () {
+		const {
+			user,
+			channel,
+			tail,
+			actions,
+			types
+		} = this.props
+		const {
+			checkedCards,
+			showLinkModal
+		} = this.state
+
 		return (
-			<CardTable
-				{...this.props}
-				rowKey="slug"
-				generateData={this.generateTableData}
-				columns={this.columns}
-			/>
+			<LensLayout
+				tail={tail}
+				user={user}
+				channel={channel}
+				flowId={FLOW_IDS.GUIDED_HANDOVER}
+			>
+				<CardTable
+					{...this.props}
+					rowKey="slug"
+					generateData={this.generateTableData}
+					columns={this.columns}
+				/>
+				{showLinkModal && (
+					<LinkModal
+						actions={actions}
+						cards={checkedCards}
+						types={types}
+						onHide={this.hideLinkModal}
+					/>
+				)}
+			</LensLayout>
 		)
 	}
 }

--- a/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
@@ -18,9 +18,7 @@ import {
 	Txt
 } from 'rendition'
 import CardOwner from '../../../components/CardOwner'
-import {
-	HandoverFlowPanel
-} from '../../../components/Flows'
+import HandoverFlowPanel from '../../../components/Flows/HandoverFlowPanel'
 import {
 	FLOW_IDS
 } from '../../../components/Flows/flow-utils'

--- a/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/CRMTable.jsx
@@ -19,9 +19,6 @@ import {
 } from 'rendition'
 import CardOwner from '../../../components/CardOwner'
 import HandoverFlowPanel from '../../../components/Flows/HandoverFlowPanel'
-import {
-	FLOW_IDS
-} from '../../../components/Flows/flow-utils'
 import LinkModal from '../../../components/LinkModal'
 import LensLayout from '../../../layouts/LensLayout'
 import BaseLens from '../../common/BaseLens'
@@ -273,7 +270,6 @@ class CRMTable extends BaseLens {
 				tail={tail}
 				user={user}
 				channel={channel}
-				flowId={FLOW_IDS.GUIDED_HANDOVER}
 				flowPanel={(<HandoverFlowPanel />)}
 			>
 				<CardTable

--- a/apps/ui/lib/lens/misc/CRMTable/InlineLinkButton.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/InlineLinkButton.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React, {
+	useState
+} from 'react'
+import {
+	Button
+} from 'rendition'
+import withCardUpdater from '@balena/jellyfish-ui-components/lib/HOC/with-card-updater'
+import LinkModal from '../../../components/LinkModal'
+import * as _ from 'lodash'
+import {
+	formatAsConjunction
+} from './helpers'
+
+const InlineLinkButton = (props) => {
+	const {
+		card, types, actions, ...rest
+	} = props
+
+	const [ isLinkModalVisible, setIsLinkModalVisible ] = useState(false)
+
+	const typeNames = _.compact(_.map(types, 'name'))
+
+	return (
+		<React.Fragment>
+			<Button
+				{...rest}
+				success
+				onClick={() => setIsLinkModalVisible(true)}
+			>Link to {formatAsConjunction(typeNames)}</Button>
+
+			{isLinkModalVisible && (
+				<LinkModal
+					actions={actions}
+					cards={[ card ]}
+					types={types}
+					onHide={() => setIsLinkModalVisible(false)}
+				/>
+			)}
+		</React.Fragment>
+	)
+}
+
+export default withCardUpdater()(InlineLinkButton)

--- a/apps/ui/lib/lens/misc/CRMTable/SelectWrapper.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/SelectWrapper.jsx
@@ -4,24 +4,21 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash'
-import React from 'react'
-import {
-	Select,
-	Badge
-} from 'rendition'
-import styled from 'styled-components'
 import {
 	helpers,
 	withCardUpdater
 } from '@balena/jellyfish-ui-components'
-
-const SingleLineSpan = styled.span `
-	whiteSpace: 'nowrap'
-`
+import _ from 'lodash'
+import React from 'react'
+import {
+	Badge, Select
+} from 'rendition'
+import {
+	SingleLineSpan
+} from './helpers'
 
 const SelectWrapper = ({
-	card, types, onUpdateCard
+	card, statusTypes, onUpdateCard
 }) => {
 	const setValue = ({
 		option
@@ -33,11 +30,11 @@ const SelectWrapper = ({
 	const label = _.get(card, [ 'data', 'status' ])
 	return (
 		<Select
-			options={types}
+			options={statusTypes}
 			onChange={setValue}
 			value={
 				<SingleLineSpan>
-					<Badge shade={types.indexOf(label)} xsmall m={1}>{label}</Badge>
+					<Badge shade={statusTypes.indexOf(label)} xsmall m={1}>{label}</Badge>
 				</SingleLineSpan>
 			}
 		>

--- a/apps/ui/lib/lens/misc/CRMTable/helpers.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/helpers.jsx
@@ -4,9 +4,10 @@
  * Proprietary and confidential.
  */
 
-import '@formatjs/intl-listformat/locale-data/en'
-import '@formatjs/intl-listformat/polyfill'
 import styled from 'styled-components'
+import {
+	oneLineCommaListsAnd
+} from 'common-tags'
 
 /**
  * Formats an array of words to a conjuction
@@ -15,9 +16,7 @@ import styled from 'styled-components'
  * @returns {String} - for example: Account, Org, and User
  */
 export const formatAsConjunction = (words = []) => {
-	return new Intl.ListFormat('en', {
-		style: 'long', type: 'conjunction'
-	}).format(words)
+	return oneLineCommaListsAnd `${words}`
 }
 
 /**

--- a/apps/ui/lib/lens/misc/CRMTable/helpers.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/helpers.jsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '@formatjs/intl-listformat/locale-data/en'
+import '@formatjs/intl-listformat/polyfill'
+import styled from 'styled-components'
+
+/**
+ * Formats an array of words to a conjuction
+ *
+ * @param {Array} words - for example: [ 'Account', 'Org', 'User' ]
+ * @returns {String} - for example: Account, Org, and User
+ */
+export const formatAsConjunction = (words = []) => {
+	return new Intl.ListFormat('en', {
+		style: 'long', type: 'conjunction'
+	}).format(words)
+}
+
+/**
+ * An inline span that doesn't line wrap
+ */
+export const SingleLineSpan = styled.span `
+	white-space: 'nowrap'
+`

--- a/apps/ui/lib/lens/misc/CRMTable/index.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/index.jsx
@@ -13,21 +13,21 @@ import {
 } from 'redux'
 import {
 	actionCreators,
-	selectors
+	selectors,
+	sdk
 } from '../../../core'
 import CRMTable from './CRMTable'
 
 const SLUG = 'lens-crm-table'
 
-const mapStateToProps = (state, ownProps) => {
-	const allTypes = selectors.getTypes(state)
-	const target = _.get(ownProps, [ 'channel', 'data', 'head', 'id' ])
+const mapStateToProps = (state, props) => {
+	const target = _.get(props, [ 'channel', 'data', 'head', 'id' ])
 	return {
+		sdk,
 		user: selectors.getCurrentUser(state),
-
-		allTypes,
-		types: _.get(
-			_.find(allTypes, [ 'slug', 'opportunity' ]), [
+		types: selectors.getTypes(state),
+		statusTypes: _.get(
+			_.find(selectors.getTypes(state), [ 'slug', 'opportunity' ]), [
 				'data',
 				'schema',
 				'properties',
@@ -47,8 +47,11 @@ const mapDispatchToProps = (dispatch) => {
 		actions: bindActionCreators(
 			_.pick(actionCreators, [
 				'addChannel',
+				'setLensState',
+				'addNotification',
 				'createLink',
-				'setLensState'
+				'setFlow',
+				'queryAPI'
 			]), dispatch)
 	}
 }


### PR DESCRIPTION
The LinksProvider logic is being split out to: https://github.com/product-os/jellyfish/pull/5490

----

This PR does the following:

## Add inline CardOwners component on the CRM table
The CardOwners component previously only used on single card lenses is now used on the CRMTable lens. For this to happen it needed to have a single slide in panel component on the Lens. I've created a LensLayout component which contains the slide in panel and I've refactored the `Flow` actions.

## Refactor flow actions and deprecate LinksProvider component
The LinksProvider component was designed to be used with a single SlideInFlowPanel and a single withLinks child component. Using it on a view wil multiple withLinks child components was not possible. This together with the introduction of optional link queries we have no reason to query for card links seperately. We can remove the LinksProvider logic and streamline our SlideInFlowPanel.

I've also refactored the `Flow` actions to be referenced on the channel target instead of just the card id. With this we can use a single SlideInFlowPanel component with multiple components controlling it's state.

## Screenshot:
<img width="1506" alt="Screen Shot 2020-09-22 at 6 22 04 PM" src="https://user-images.githubusercontent.com/11800807/93909842-89167880-fd00-11ea-9412-807906708565.png">

Depends-on: https://github.com/product-os/jellyfish/pull/5490
