### PR TITLE
Remove sentry info logs from livechat

### DIFF
--- a/apps/livechat/lib/components/AuthenticationTask.jsx
+++ b/apps/livechat/lib/components/AuthenticationTask.jsx
@@ -16,7 +16,7 @@ import {
 } from '@balena/jellyfish-ui-components/lib/SetupProvider'
 
 const authenticate = async ({
-	sdk, errorReporter
+	sdk
 }, userSlug, oauthUrl) => {
 	const user = await sdk.auth.whoami()
 
@@ -29,11 +29,6 @@ const authenticate = async ({
 	}
 
 	if (user.slug !== userSlug) {
-		errorReporter.reportInfo(
-			`Logged in user "${user.slug}" does not match authorizing user "${userSlug}", reauthorizing`,
-			user
-		)
-
 		window.location.href = oauthUrl
 	}
 }
@@ -42,15 +37,15 @@ export const AuthenticationTask = ({
 	userSlug, oauthUrl, children
 }) => {
 	const {
-		sdk, errorReporter
+		sdk
 	} = useSetup()
 	const authenticationTask = useTask(authenticate)
 
 	React.useEffect(() => {
 		authenticationTask.exec({
-			sdk, errorReporter
+			sdk
 		}, userSlug, oauthUrl)
-	}, [ sdk, errorReporter, userSlug, oauthUrl ])
+	}, [ sdk, userSlug, oauthUrl ])
 
 	return (
 		<Task task={authenticationTask}>{children}</Task>

--- a/apps/livechat/lib/components/OauthCallbackTask.jsx
+++ b/apps/livechat/lib/components/OauthCallbackTask.jsx
@@ -16,7 +16,7 @@ import {
 } from '@balena/jellyfish-ui-components/lib/SetupProvider'
 
 const exchangeCode = async ({
-	sdk, errorReporter
+	sdk
 }, userSlug, code, oauthProvider) => {
 	if (!code) {
 		throw new Error('Auth code missing')
@@ -37,10 +37,6 @@ const exchangeCode = async ({
 		throw new Error('Could not fetch auth token')
 	}
 
-	errorReporter.reportInfo(
-		`Oauth with ${oauthProvider} was successful for the user "${userSlug}", setting token`
-	)
-
 	localStorage.setItem('token', token)
 	sdk.setAuthToken(token)
 }
@@ -49,16 +45,16 @@ export const OauthCallbackTask = ({
 	userSlug, location, oauthProvider, children
 }) => {
 	const {
-		sdk, errorReporter
+		sdk
 	} = useSetup()
 	const exchangeCodeTask = useTask(exchangeCode)
 
 	React.useEffect(() => {
 		const code = new URLSearchParams(location.search).get('code')
 		exchangeCodeTask.exec({
-			sdk, errorReporter
+			sdk
 		}, userSlug, code, oauthProvider)
-	}, [ sdk, errorReporter, location.search, userSlug, oauthProvider ])
+	}, [ sdk, location.search, userSlug, oauthProvider ])
 
 	return (
 		<Task task={exchangeCodeTask} px={2}>


### PR DESCRIPTION
Change-type: minor

***

Sentry displayed a notification saying that we are not receiving events any more, because we exceeded the quota.

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
