### PR TITLE
Add NPM_TOKEN auto inject/remove for Livepush

### DIFF
--- a/.balena/balena.yml
+++ b/.balena/balena.yml
@@ -3,8 +3,8 @@ build-variables:
     - SENTRY_DSN_UI=0
   services:
     ui:
-      - SERVER_HOST=http://api.ly.fish.local
+      - 'SERVER_HOST=http://api.ly.fish.local'
       - SERVER_PORT=80
     livechat:
-      - SERVER_HOST=http://api.ly.fish.local
+      - 'SERVER_HOST=http://api.ly.fish.local'
       - SERVER_PORT=80

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@
 	clean-github \
 	npm-install \
 	push \
-	ssh
+	ssh \
+	set-npm-token \
+	remove-npm-token
 
 # See https://stackoverflow.com/a/18137056
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -427,6 +429,7 @@ dev-%:
 	cd apps/$(subst dev-,,$@) && SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) make dev-$(subst dev-,,$@)
 
 push:
+	make set-npm-token
 	balena push jel.ly.fish.local \
 		--env INTEGRATION_DEFAULT_USER=$(INTEGRATION_DEFAULT_USER) \
 		--env INTEGRATION_GOOGLE_MEET_CREDENTIALS=$(INTEGRATION_GOOGLE_MEET_CREDENTIALS) \
@@ -460,3 +463,9 @@ ssh:
 
 deploy-%:
 	./scripts/deploy-package.js jellyfish-$(subst deploy-,,$@)
+
+set-npm-token:
+	./scripts/update-balena-config.js set-npm-token
+
+remove-npm-token:
+	./scripts/update-balena-config.js remove-npm-token

--- a/package-lock.json
+++ b/package-lock.json
@@ -15511,30 +15511,10 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
-      "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.8.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.9.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-          "dev": true
-        }
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yargs": {
       "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     ],
     "*.{js,jsx,sh}": [
       "./scripts/lint/check-licenses.sh"
+    ],
+    ".balena/balena.yml": [
+      "make remove-npm-token"
     ]
   },
   "author": "Balena.io. <hello@balena.io>",
@@ -98,6 +101,7 @@
     "front-sdk": "^0.8.1",
     "husky": "^4.3.0",
     "js-combinatorics": "^0.6.1",
+    "js-yaml": "^3.14.0",
     "jsonwebtoken": "^8.5.1",
     "lint-staged": "^10.5.2",
     "lodash": "^4.17.20",

--- a/scripts/update-balena-config.js
+++ b/scripts/update-balena-config.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/*
+ * This script is used to automatically add and remove a developer's
+ * npm token to and from our balena configuration file. Primarily to
+ * make the Livepush-based development more seemless.
+ * Add token: ./scripts/update-balena-config.js set-npm-token
+ * Remove token: ./scripts/update-balena-config.js remove-npm-token
+ */
+
+const _ = require('lodash')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const uuid = require('uuid')
+const yaml = require('js-yaml')
+
+// Assume that the balena config exists at the root of the repository
+const BALENA_CONFIG = path.join(process.cwd(), '.balena', 'balena.yml')
+
+/**
+ * @summary Output error message and exit script
+ * @function
+ *
+ * @param {String} msg - error message
+ */
+const abort = (msg) => {
+	console.error(`[${path.parse(__filename).name}] ${msg}`)
+	process.exit(1)
+}
+
+/**
+ * @summary Read in balena config
+ * @function
+ *
+ * @returns {Object} balena config in object form
+ */
+const getConfig = () => {
+	let config = {}
+	try {
+		config = yaml.safeLoad(fs.readFileSync(BALENA_CONFIG))
+	} catch (err) {
+		abort(`Failed to load balena config from ${BALENA_CONFIG}: ${err}`)
+	}
+	return config
+}
+
+/**
+ * @summary Get and return NPM_TOKEN from env var or npmrc file
+ * @function
+ *
+ * @returns {String} npm token
+ */
+const getToken = () => {
+	// First try to grab from environment variable
+	if (uuid.validate(process.env.NPM_TOKEN)) {
+		return process.env.NPM_TOKEN
+	}
+
+	// Now try to grab from .npmrc file
+	const npmrcPath = path.join(os.homedir(), '.npmrc')
+	if (!fs.existsSync(npmrcPath)) {
+		abort(`Could not find .npmrc file at ${npmrcPath}`)
+	}
+	const lines = fs.readFileSync(npmrcPath, 'utf8').split('\n').map((line) => {
+		return line.trim()
+	})
+	const tokenLine = lines.find((line) => {
+		return line.startsWith('//registry.npmjs.org/:') && line.includes('authToken=')
+	})
+	if (!tokenLine) {
+		abort(`Could not find npmjs registry token in ${npmrcPath}`)
+	}
+	const token = tokenLine.split('authToken=')[1]
+	if (!uuid.validate(token)) {
+		abort(`Found token, but not in proper UUID format: ${token}`)
+	}
+
+	return token
+}
+
+/**
+ * @summary Remove NPM_TOKEN global build variables from balena config
+ * @function
+ *
+ * @param {Object} config - balena config
+ */
+const removeToken = (config) => {
+	if (_.has(config, [ 'build-variables', 'global' ]) && _.isArray(config['build-variables'].global)) {
+		// Remove NPM_TOKEN entries
+		_.remove(config['build-variables'].global, (item) => {
+			return _.startsWith(item, 'NPM_TOKEN=')
+		})
+
+		// Remove 'build-variables' and 'build-variables.global' sections if empty
+		if (_.size(config['build-variables'].global) < 1) {
+			Reflect.deleteProperty(config['build-variables'], 'global')
+		}
+		if (_.size(config['build-variables']) < 1) {
+			Reflect.deleteProperty(config, 'build-variables')
+		}
+
+		// Save modified config
+		try {
+			fs.writeFileSync(BALENA_CONFIG, yaml.safeDump(config))
+		} catch (err) {
+			abort(`Failed to save balena config to ${BALENA_CONFIG}: ${err}`)
+		}
+	}
+}
+
+/**
+ * @summary Set npm token as global build variable in balena config
+ * @function
+ *
+ * @param {Object} config - balena config
+ * @param {String} token - npm token
+ */
+const setToken = (config, token) => {
+	// Remove any currently set npm tokens first
+	removeToken()
+
+	// Add parent sections if they do not already exist
+	if (!_.has(config, [ 'build-variables', 'global' ])) {
+		if (!_.has(config, [ 'build-variables' ])) {
+			config['build-variables'] = {}
+		}
+		config['build-variables'].global = []
+	}
+	config['build-variables'].global.push(`NPM_TOKEN=${token}`)
+	try {
+		fs.writeFileSync(BALENA_CONFIG, yaml.safeDump(config))
+	} catch (err) {
+		abort(`Failed to add token to balena config at ${BALENA_CONFIG}: ${err}`)
+	}
+}
+
+// Check expected argument
+const args = process.argv.slice(2)
+const action = args[0]
+if (!action.match(/^(set-npm-token|remove-npm-token)$/)) {
+	abort('Must pass argument of either set-npm-token or remove-npm-token')
+}
+
+// Execute action
+const config = getConfig()
+if (action === 'set-npm-token') {
+	setToken(config, getToken())
+} else {
+	removeToken(config)
+}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR adds a script that automagically adds and removes your npmjs registry `NPM_TOKEN` to and from the `.balena/balena.yml` file for Livepush-based development. It first checks for an `NPM_TOKEN` environment variable exported to the current shell and falls back to parsing `~/.npmrc`. Tokens are automatically set on `make push` and automatically removed through the use of a pre-commit githook on `git commit` so developers shouldn't have to worry about manually setting/removing `NPM_TOKEN`. Assuming you've already logged into npmjs on your local machine, this should *just work*™.
