### PR TITLE
Add balena.yml NPM_TOKEN step to Livepush steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Add endpoints to local hosts file:
 ```
 
 If you are going to be working with any libraries, clone them under `.libs` and checkout your branches.
+
+Then, add your npm token to `.balena/balena.yml` under `build-variables.global` in the form of
+`- NPM_TOKEN=xxxxx` so image builds on the device will have access to our private libraries.
+**Remember to remove this token before committing and pushing your changes!**
+
 Finally, deploy everything to the device by executing `make push` from the repository root.
 
 Once deployed, app and library source changes will cause quick service reloads. Adding and removing


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR adds instructions about adding and removing `NPM_TOKEN` to `.balena/balena.yml` for Livepush-based development.

I'm currently looking into if we can remove this manual process by adding support for the `--buildArg` to `balena push`, etc.