### PR TITLE
Use apparmor=unconfined for security-opt

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -228,7 +228,7 @@ services:
       - SYS_RESOURCE
       - SYS_ADMIN
     security_opt:
-      - 'apparmor:unconfined'
+      - 'apparmor=unconfined'
     tmpfs:
       - /run
       - /sys/fs/cgroup
@@ -247,7 +247,7 @@ services:
       - SYS_RESOURCE
       - SYS_ADMIN
     security_opt:
-      - 'apparmor:unconfined'
+      - 'apparmor=unconfined'
     tmpfs:
       - /run
       - /sys/fs/cgroup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,7 +285,7 @@ services:
       - SYS_RESOURCE
       - SYS_ADMIN
     security_opt:
-      - 'apparmor:unconfined'
+      - 'apparmor=unconfined'
     tmpfs:
       - /run
       - /sys/fs/cgroup
@@ -304,7 +304,7 @@ services:
       - SYS_RESOURCE
       - SYS_ADMIN
     security_opt:
-      - 'apparmor:unconfined'
+      - 'apparmor=unconfined'
     tmpfs:
       - /run
       - /sys/fs/cgroup


### PR DESCRIPTION
```
time="2020-11-30T12:16:01.576318912+01:00" level=warning msg="Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead."
```

Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>
