### PR TITLE
Set image names in compose config

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: local_image_api
     build:
       context: .
       dockerfile: ./apps/server/Dockerfile
@@ -114,6 +115,7 @@ services:
     networks:
       - internal
   tick:
+    image: local_image_tick
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.tick
@@ -161,6 +163,7 @@ services:
       - internal
   {{#workers}}
   worker_{{idx}}:
+    image: local_image_worker_{{idx}}
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: local_image_api
     build:
       context: .
       dockerfile: ./apps/server/Dockerfile
@@ -113,6 +114,7 @@ services:
     networks:
       - internal
   tick:
+    image: local_image_tick
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.tick
@@ -159,6 +161,7 @@ services:
     networks:
       - internal
   worker_1:
+    image: local_image_worker_1
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.worker
@@ -219,6 +222,7 @@ services:
     networks:
       - internal
   worker_2:
+    image: local_image_worker_2
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.worker


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add `image` fields back to `docker-compose.yml`, but with names that Livepush expects so we don't run into [this bug](https://github.com/balena-io/balena-cli/issues/1874).
