### PR TITLE
Add withRelationships mixin to cards from link constraints

### DIFF
--- a/apps/server/lib/default-cards/contrib/account.js
+++ b/apps/server/lib/default-cards/contrib/account.js
@@ -7,9 +7,9 @@
 /* eslint-disable max-len */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withRelationships, uiSchemaDef
 }) => {
-	return {
+	return mixin(withRelationships('account'))({
 		slug: 'account',
 		type: 'type@1.0.0',
 		name: 'Account',
@@ -157,31 +157,7 @@ module.exports = ({
 			},
 			slices: [
 				'properties.data.properties.profile.properties.status'
-			],
-			meta: {
-				relationships: [
-					{
-						title: 'Opportunities',
-						link: 'has attached',
-						type: 'opportunity'
-					},
-					{
-						title: 'Contacts',
-						link: 'has',
-						type: 'contact'
-					},
-					{
-						title: 'Owner',
-						link: 'is owned by',
-						type: 'user'
-					},
-					{
-						title: 'Backup owners',
-						link: 'has backup owner',
-						type: 'user'
-					}
-				]
-			}
+			]
 		}
-	}
+	})
 }

--- a/apps/server/lib/default-cards/contrib/account.js
+++ b/apps/server/lib/default-cards/contrib/account.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable max-len */
+const SLUG = 'account'
 
 module.exports = ({
 	mixin, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withRelationships('account'))({
-		slug: 'account',
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
 		type: 'type@1.0.0',
 		name: 'Account',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/blog-post.js
+++ b/apps/server/lib/default-cards/contrib/blog-post.js
@@ -7,9 +7,9 @@
 /* eslint-disable max-len */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withRelationships, uiSchemaDef
 }) => {
-	return {
+	return mixin(withRelationships('blog-post'))({
 		slug: 'blog-post',
 		name: 'Blog post',
 		type: 'type@1.0.0',
@@ -257,21 +257,7 @@ module.exports = ({
 					}
 				}
 			},
-			meta: {
-				relationships: [
-					{
-						title: 'Author',
-						link: 'authored by',
-						type: 'user'
-					},
-					{
-						title: 'Related content',
-						link: 'is related to',
-						type: 'blog-post'
-					}
-				]
-			},
 			fieldOrder: [ 'post_header_meta', 'subheader', 'content', 'post_promo' ]
 		}
-	}
+	})
 }

--- a/apps/server/lib/default-cards/contrib/blog-post.js
+++ b/apps/server/lib/default-cards/contrib/blog-post.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable max-len */
+const SLUG = 'blog-post'
 
 module.exports = ({
 	mixin, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withRelationships('blog-post'))({
-		slug: 'blog-post',
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Blog post',
 		type: 'type@1.0.0',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/changelog.js
+++ b/apps/server/lib/default-cards/contrib/changelog.js
@@ -7,9 +7,9 @@
 /* eslint-disable max-len */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withRelationships, uiSchemaDef
 }) => {
-	return {
+	return mixin(withRelationships('changelog'))({
 		slug: 'changelog',
 		name: 'Changelog',
 		type: 'type@1.0.0',
@@ -66,5 +66,5 @@ module.exports = ({
 				}
 			}
 		}
-	}
+	})
 }

--- a/apps/server/lib/default-cards/contrib/changelog.js
+++ b/apps/server/lib/default-cards/contrib/changelog.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable max-len */
+const SLUG = 'changelog'
 
 module.exports = ({
 	mixin, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withRelationships('changelog'))({
-		slug: 'changelog',
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Changelog',
 		type: 'type@1.0.0',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/checkin.js
+++ b/apps/server/lib/default-cards/contrib/checkin.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable no-template-curly-in-string */
+const SLUG = 'checkin'
 
 module.exports = ({
 	mixin, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withRelationships('checkin'))({
-		slug: 'checkin',
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Checkin',
 		type: 'type@1.0.0',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/checkin.js
+++ b/apps/server/lib/default-cards/contrib/checkin.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withRelationships, uiSchemaDef
 }) => {
-	return {
+	return mixin(withRelationships('checkin'))({
 		slug: 'checkin',
 		name: 'Checkin',
 		type: 'type@1.0.0',
@@ -201,21 +201,7 @@ module.exports = ({
 						}
 					}
 				}
-			},
-			meta: {
-				relationships: [
-					{
-						title: 'Attendees',
-						link: 'is attended by',
-						type: 'user'
-					},
-					{
-						title: 'Project',
-						link: 'is of',
-						type: 'project'
-					}
-				]
 			}
 		}
-	}
+	})
 }

--- a/apps/server/lib/default-cards/contrib/issue.js
+++ b/apps/server/lib/default-cards/contrib/issue.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable no-template-curly-in-string */
+const SLUG = 'issue'
 
 module.exports = ({
 	mixin, withEvents, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withEvents, withRelationships('issue'))({
-		slug: 'issue',
+	return mixin(withEvents, withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'GitHub Issue',
 		type: 'type@1.0.0',
 		data: {

--- a/apps/server/lib/default-cards/contrib/issue.js
+++ b/apps/server/lib/default-cards/contrib/issue.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	mixin, withEvents, uiSchemaDef
+	mixin, withEvents, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withEvents)({
+	return mixin(withEvents, withRelationships('issue'))({
 		slug: 'issue',
 		name: 'GitHub Issue',
 		type: 'type@1.0.0',

--- a/apps/server/lib/default-cards/contrib/opportunity.js
+++ b/apps/server/lib/default-cards/contrib/opportunity.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withRelationships, uiSchemaDef
 }) => {
-	return {
+	return mixin(withRelationships('opportunity'))({
 		slug: 'opportunity',
 		name: 'Opportunity',
 		type: 'type@1.0.0',
@@ -96,31 +96,7 @@ module.exports = ({
 			},
 			slices: [
 				'properties.data.properties.status'
-			],
-			meta: {
-				relationships: [
-					{
-						title: 'Account',
-						link: 'is attached to',
-						type: 'account'
-					},
-					{
-						title: 'Owner',
-						link: 'is owned by',
-						type: 'user'
-					},
-					{
-						title: 'Backup owners',
-						link: 'has backup owner',
-						type: 'user'
-					},
-					{
-						title: 'Sales Thread',
-						link: 'has attached',
-						type: 'sales-thread'
-					}
-				]
-			}
+			]
 		}
-	}
+	})
 }

--- a/apps/server/lib/default-cards/contrib/opportunity.js
+++ b/apps/server/lib/default-cards/contrib/opportunity.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable no-template-curly-in-string */
+const SLUG = 'opportunity'
 
 module.exports = ({
 	mixin, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withRelationships('opportunity'))({
-		slug: 'opportunity',
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Opportunity',
 		type: 'type@1.0.0',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/pattern.js
+++ b/apps/server/lib/default-cards/contrib/pattern.js
@@ -5,9 +5,9 @@
  */
 
 module.exports = ({
-	mixin, withEvents
+	mixin, withEvents, withRelationships
 }) => {
-	return mixin(withEvents)({
+	return mixin(withEvents, withRelationships('pattern'))({
 		slug: 'pattern',
 		name: 'Pattern',
 		type: 'type@1.0.0',
@@ -32,15 +32,6 @@ module.exports = ({
 				},
 				required: [
 					'name'
-				]
-			},
-			meta: {
-				relationships: [
-					{
-						title: 'Product improvements',
-						link: 'has attached',
-						type: 'product-improvement'
-					}
 				]
 			}
 		}

--- a/apps/server/lib/default-cards/contrib/pattern.js
+++ b/apps/server/lib/default-cards/contrib/pattern.js
@@ -3,12 +3,13 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited.
  * Proprietary and confidential.
  */
+const SLUG = 'pattern'
 
 module.exports = ({
 	mixin, withEvents, withRelationships
 }) => {
-	return mixin(withEvents, withRelationships('pattern'))({
-		slug: 'pattern',
+	return mixin(withEvents, withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Pattern',
 		type: 'type@1.0.0',
 		data: {

--- a/apps/server/lib/default-cards/contrib/repository.js
+++ b/apps/server/lib/default-cards/contrib/repository.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	uiSchemaDef
+	mixin, withRelationships, uiSchemaDef
 }) => {
-	return {
+	return mixin(withRelationships('repository'))({
 		slug: 'repository',
 		name: 'Github Repository',
 		type: 'type@1.0.0',
@@ -56,5 +56,5 @@ module.exports = ({
 				[ 'data.name' ]
 			]
 		}
-	}
+	})
 }

--- a/apps/server/lib/default-cards/contrib/repository.js
+++ b/apps/server/lib/default-cards/contrib/repository.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable no-template-curly-in-string */
+const SLUG = 'repository'
 
 module.exports = ({
 	mixin, withRelationships, uiSchemaDef
 }) => {
-	return mixin(withRelationships('repository'))({
-		slug: 'repository',
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Github Repository',
 		type: 'type@1.0.0',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/sales-thread.js
+++ b/apps/server/lib/default-cards/contrib/sales-thread.js
@@ -5,12 +5,13 @@
  */
 
 /* eslint-disable no-template-curly-in-string */
+const SLUG = 'sales-thread'
 
 module.exports = ({
 	mixin, uiSchemaDef, asPipelineItem, withRelationships
 }) => {
-	return mixin(asPipelineItem, withRelationships('sales-thread'))({
-		slug: 'sales-thread',
+	return mixin(asPipelineItem, withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Sales Thread',
 		type: 'type@1.0.0',
 		markers: [],

--- a/apps/server/lib/default-cards/contrib/sales-thread.js
+++ b/apps/server/lib/default-cards/contrib/sales-thread.js
@@ -7,9 +7,9 @@
 /* eslint-disable no-template-curly-in-string */
 
 module.exports = ({
-	mixin, uiSchemaDef, asPipelineItem
+	mixin, uiSchemaDef, asPipelineItem, withRelationships
 }) => {
-	return mixin(asPipelineItem)({
+	return mixin(asPipelineItem, withRelationships('sales-thread'))({
 		slug: 'sales-thread',
 		name: 'Sales Thread',
 		type: 'type@1.0.0',
@@ -88,15 +88,6 @@ module.exports = ({
 						}
 					}
 				}
-			},
-			meta: {
-				relationships: [
-					{
-						title: 'Opportunity',
-						link: 'is attached to',
-						type: 'opportunity'
-					}
-				]
 			}
 		}
 	})

--- a/apps/server/lib/default-cards/mixins/index.js
+++ b/apps/server/lib/default-cards/mixins/index.js
@@ -5,6 +5,7 @@
  */
 
 const withEvents = require('./with-events')
+const withRelationships = require('./with-relationships')
 const asPipelineItem = require('./as-pipeline-item')
 
 const uiSchemaDef = (key) => {
@@ -16,5 +17,6 @@ module.exports = {
 	asPipelineItem,
 	withEvents: withEvents({
 		uiSchemaDef
-	})
+	}),
+	withRelationships
 }

--- a/apps/server/lib/default-cards/mixins/with-relationships.js
+++ b/apps/server/lib/default-cards/mixins/with-relationships.js
@@ -5,6 +5,7 @@
  */
 
 // This mixin adds all relationships defined in the SDK links-constraints.js
+const pluralize = require('pluralize')
 const _ = require('lodash')
 const {
 	constraints
@@ -20,7 +21,7 @@ const getRelationships = (slug) => {
 	}) => {
 		if (data.from === slug) {
 			return {
-				title: data.title,
+				title: pluralize(data.title),
 				link: name,
 				type: data.to
 			}

--- a/apps/server/lib/default-cards/mixins/with-relationships.js
+++ b/apps/server/lib/default-cards/mixins/with-relationships.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// This mixin adds all relationships defined in the SDK links-constraints.js
+const _ = require('lodash')
+const {
+	constraints
+} = require('@balena/jellyfish-client-sdk/lib/link-constraints')
+
+const getRelationships = (slug) => {
+	if (!slug) {
+		return []
+	}
+
+	return _.compact(constraints.map(({
+		name, data
+	}) => {
+		if (data.from === slug) {
+			return {
+				title: data.title,
+				link: name,
+				type: data.to
+			}
+		}
+
+		return null
+	}))
+}
+
+module.exports = (slug) => {
+	return {
+		data: {
+			meta: {
+				relationships: getRelationships(slug)
+			}
+		}
+	}
+}

--- a/apps/server/test/unit/test/01.json
+++ b/apps/server/test/unit/test/01.json
@@ -1,0 +1,233 @@
+{
+  "id": "d3fde464-1e89-451b-b8fb-732698c5c42e",
+  "data": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "repository"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "type": "string",
+              "title": "Status"
+            },
+            "mirrors": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "archived": {
+              "type": "boolean",
+              "default": false
+            },
+            "alertsUser": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.alertsUser')"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "alertsGroup": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.alertsGroup')"
+            },
+            "description": {
+              "type": "string",
+              "format": "markdown"
+            },
+            "mentionsUser": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.mentionsUser')"
+            },
+            "participants": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.actor')"
+            },
+            "mentionsGroup": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.mentionsGroup')"
+            }
+          }
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^.*\\S.*$"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "$$formula": "AGGREGATE($events, 'tags')",
+          "fullTextSearch": true
+        }
+      }
+    },
+    "slices": [
+      "properties.data.properties.status"
+    ],
+    "uiSchema": {
+      "edit": {
+        "data": {
+          "repository": {
+            "ui:widget": "AutoCompleteWidget",
+            "ui:options": {
+              "keyPath": "data.repository",
+              "resource": "issue"
+            }
+          }
+        }
+      },
+      "create": {
+        "data": {
+          "repository": {
+            "ui:widget": "AutoCompleteWidget",
+            "ui:options": {
+              "keyPath": "data.repository",
+              "resource": "issue"
+            }
+          }
+        }
+      },
+      "fields": {
+        "id": null,
+        "data": {
+          "origin": null,
+          "status": {
+            "ui:widget": "Badge"
+          },
+          "mirrors": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "${fns.getMirror(source)}",
+                "blank": true
+              }
+            }
+          },
+          "archived": {
+            "ui:title": null,
+            "ui:value": {
+              "$if": "source",
+              "else": null,
+              "then": "Archived"
+            },
+            "ui:widget": "Badge"
+          },
+          "ui:order": [
+            "repository",
+            "mirrors",
+            "description",
+            "status",
+            "archived",
+            "mentionsUser",
+            "alertsUser",
+            "mentionsGroup",
+            "alertsGroup",
+            "participants"
+          ],
+          "ui:title": null,
+          "alertsUser": {
+            "items": {
+              "ui:value": "${source[5:]},",
+              "ui:widget": "Link",
+              "ui:options": {
+                "mr": 1,
+                "href": "https://jel.ly.fish/${source}"
+              }
+            },
+            "ui:options": {
+              "orientation": "horizontal"
+            }
+          },
+          "repository": {
+            "ui:widget": "Link",
+            "ui:options": {
+              "href": "https://github.com/${source}",
+              "blank": true
+            }
+          },
+          "alertsGroup": {
+            "ui:widget": "Txt"
+          },
+          "mentionsUser": {
+            "items": {
+              "ui:value": "${source[5:]},",
+              "ui:widget": "Link",
+              "ui:options": {
+                "mr": 1,
+                "href": "https://jel.ly.fish/${source}"
+              }
+            },
+            "ui:options": {
+              "orientation": "horizontal"
+            }
+          },
+          "participants": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "https://jel.ly.fish/${source}"
+              }
+            }
+          },
+          "$$localSchema": null,
+          "mentionsGroup": {
+            "ui:widget": "Txt"
+          },
+          "translateDate": null
+        },
+        "name": null,
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": null,
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      },
+      "definitions": {
+        "form": {
+          "data": {
+            "repository": {
+              "ui:widget": "AutoCompleteWidget",
+              "ui:options": {
+                "keyPath": "data.repository",
+                "resource": "issue"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "name": "GitHub Issue",
+  "slug": "issue",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-09-21T10:59:14.946Z",
+  "updated_at": "2020-12-07T13:37:15.064Z",
+  "capabilities": []
+}

--- a/apps/server/test/unit/test/constraints-subset.js
+++ b/apps/server/test/unit/test/constraints-subset.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = [
+	{
+		slug: 'link-constraint-account-has-contact',
+		name: 'has',
+		data: {
+			title: 'Contact',
+			from: 'account',
+			to: 'contact',
+			inverse: 'link-constraint-contact-is-member-of-account'
+		}
+	},
+	{
+		slug: 'link-constraint-account-is-owned-by-user',
+		name: 'is owned by',
+		data: {
+			title: 'Owner',
+			from: 'account',
+			to: 'user',
+			inverse: 'link-constraint-user-owns-account'
+		}
+	},
+	{
+		slug: 'link-constraint-account-has-backup-owner',
+		name: 'has backup owner',
+		data: {
+			title: 'Backup owner',
+			from: 'account',
+			to: 'user',
+			inverse: 'link-constraint-user-is-backup-owner-of-account'
+		}
+	},
+	{
+		slug: 'link-constraint-account-has-attached-opportunity',
+		name: 'has attached',
+		data: {
+			title: 'Opportunity',
+			from: 'account',
+			to: 'opportunity',
+			inverse: 'link-constraint-opportunity-is-attached-to-account'
+		}
+	},
+	{
+		slug: 'link-constraint-issue-has-attached-support-thread',
+		name: 'issue has attached support thread',
+		data: {
+			title: 'Support thread',
+			from: 'issue',
+			to: 'support-thread',
+			inverse: 'link-constraint-support-thread-is-attached-to-issue'
+		}
+	},
+	{
+		slug: 'link-constraint-issue-has-attached-support-issue',
+		name: 'issue has attached support issue',
+		data: {
+			title: 'Support issue',
+			from: 'issue',
+			to: 'support-issue',
+			inverse: 'link-constraint-support-issue-is-attached-to-issue'
+		}
+	},
+	{
+		slug: 'link-constraint-issue-is-attached-to-brainstorm-topic',
+		name: 'is attached to',
+		data: {
+			title: 'Brainstorm topic',
+			from: 'issue',
+			to: 'brainstorm-topic',
+			inverse: 'link-constraint-brainstorm-topic-has-attached-issue'
+		}
+	},
+	{
+		slug: 'link-constraint-issue-comes-from-specification',
+		name: 'comes from',
+		data: {
+			title: 'Specification',
+			from: 'issue',
+			to: 'specification',
+			inverse: 'link-constraint-specification-is-source-for-issue'
+		}
+	},
+	{
+		slug: 'link-constraint-issue-is-attached-to-form-response',
+		name: 'is attached',
+		data: {
+			title: 'Form Response',
+			from: 'issue',
+			to: 'form-response',
+			inverse: 'link-constraint-form-response-has-attached-issue'
+		}
+	},
+	{
+		slug: 'link-constraint-issue-is-attached-to-user-feedback',
+		name: 'is attached to',
+		data: {
+			title: 'User Feedback',
+			from: 'issue',
+			to: 'user-feedback',
+			inverse: 'link-constraint-user-feedback-has-attached-issue'
+		}
+	}
+]

--- a/apps/server/test/unit/test/expected.json
+++ b/apps/server/test/unit/test/expected.json
@@ -1,0 +1,267 @@
+{
+  "id": "d3fde464-1e89-451b-b8fb-732698c5c42e",
+  "data": {
+    "meta": {
+      "relationships": [
+        {
+          "link": "issue has attached support thread",
+          "type": "support-thread",
+          "title": "Support thread"
+        },
+        {
+          "link": "issue has attached support issue",
+          "type": "support-issue",
+          "title": "Support issue"
+        },
+        {
+          "link": "is attached to",
+          "type": "brainstorm-topic",
+          "title": "Brainstorm topic"
+        },
+        {
+          "link": "comes from",
+          "type": "specification",
+          "title": "Specification"
+        },
+        {
+          "link": "is attached",
+          "type": "form-response",
+          "title": "Form Response"
+        },
+        {
+          "link": "is attached to",
+          "type": "user-feedback",
+          "title": "User Feedback"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "required": [
+            "repository"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "type": "string",
+              "title": "Status"
+            },
+            "mirrors": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "archived": {
+              "type": "boolean",
+              "default": false
+            },
+            "alertsUser": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.alertsUser')"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "alertsGroup": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.alertsGroup')"
+            },
+            "description": {
+              "type": "string",
+              "format": "markdown"
+            },
+            "mentionsUser": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.mentionsUser')"
+            },
+            "participants": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.actor')"
+            },
+            "mentionsGroup": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.mentionsGroup')"
+            }
+          }
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^.*\\S.*$"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "$$formula": "AGGREGATE($events, 'tags')",
+          "fullTextSearch": true
+        }
+      }
+    },
+    "slices": [
+      "properties.data.properties.status"
+    ],
+    "uiSchema": {
+      "edit": {
+        "data": {
+          "repository": {
+            "ui:widget": "AutoCompleteWidget",
+            "ui:options": {
+              "keyPath": "data.repository",
+              "resource": "issue"
+            }
+          }
+        }
+      },
+      "create": {
+        "data": {
+          "repository": {
+            "ui:widget": "AutoCompleteWidget",
+            "ui:options": {
+              "keyPath": "data.repository",
+              "resource": "issue"
+            }
+          }
+        }
+      },
+      "fields": {
+        "id": null,
+        "data": {
+          "origin": null,
+          "status": {
+            "ui:widget": "Badge"
+          },
+          "mirrors": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "${fns.getMirror(source)}",
+                "blank": true
+              }
+            }
+          },
+          "archived": {
+            "ui:title": null,
+            "ui:value": {
+              "$if": "source",
+              "else": null,
+              "then": "Archived"
+            },
+            "ui:widget": "Badge"
+          },
+          "ui:order": [
+            "repository",
+            "mirrors",
+            "description",
+            "status",
+            "archived",
+            "mentionsUser",
+            "alertsUser",
+            "mentionsGroup",
+            "alertsGroup",
+            "participants"
+          ],
+          "ui:title": null,
+          "alertsUser": {
+            "items": {
+              "ui:value": "${source[5:]},",
+              "ui:widget": "Link",
+              "ui:options": {
+                "mr": 1,
+                "href": "https://jel.ly.fish/${source}"
+              }
+            },
+            "ui:options": {
+              "orientation": "horizontal"
+            }
+          },
+          "repository": {
+            "ui:widget": "Link",
+            "ui:options": {
+              "href": "https://github.com/${source}",
+              "blank": true
+            }
+          },
+          "alertsGroup": {
+            "ui:widget": "Txt"
+          },
+          "mentionsUser": {
+            "items": {
+              "ui:value": "${source[5:]},",
+              "ui:widget": "Link",
+              "ui:options": {
+                "mr": 1,
+                "href": "https://jel.ly.fish/${source}"
+              }
+            },
+            "ui:options": {
+              "orientation": "horizontal"
+            }
+          },
+          "participants": {
+            "items": {
+              "ui:widget": "Link",
+              "ui:options": {
+                "href": "https://jel.ly.fish/${source}"
+              }
+            }
+          },
+          "$$localSchema": null,
+          "mentionsGroup": {
+            "ui:widget": "Txt"
+          },
+          "translateDate": null
+        },
+        "name": null,
+        "slug": null,
+        "tags": null,
+        "type": null,
+        "links": null,
+        "active": null,
+        "markers": null,
+        "version": null,
+        "requires": null,
+        "linked_at": null,
+        "created_at": null,
+        "updated_at": null,
+        "capabilities": null
+      },
+      "definitions": {
+        "form": {
+          "data": {
+            "repository": {
+              "ui:widget": "AutoCompleteWidget",
+              "ui:options": {
+                "keyPath": "data.repository",
+                "resource": "issue"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "name": "GitHub Issue",
+  "slug": "issue",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2020-09-21T10:59:14.946Z",
+  "updated_at": "2020-12-07T13:37:15.064Z",
+  "capabilities": []
+}

--- a/apps/server/test/unit/test/expected.json
+++ b/apps/server/test/unit/test/expected.json
@@ -6,32 +6,32 @@
         {
           "link": "issue has attached support thread",
           "type": "support-thread",
-          "title": "Support thread"
+          "title": "Support threads"
         },
         {
           "link": "issue has attached support issue",
           "type": "support-issue",
-          "title": "Support issue"
+          "title": "Support issues"
         },
         {
           "link": "is attached to",
           "type": "brainstorm-topic",
-          "title": "Brainstorm topic"
+          "title": "Brainstorm topics"
         },
         {
           "link": "comes from",
           "type": "specification",
-          "title": "Specification"
+          "title": "Specifications"
         },
         {
           "link": "is attached",
           "type": "form-response",
-          "title": "Form Response"
+          "title": "Form Responses"
         },
         {
           "link": "is attached to",
           "type": "user-feedback",
-          "title": "User Feedback"
+          "title": "User Feedbacks"
         }
       ]
     },

--- a/apps/server/test/unit/with-relationships.spec.js
+++ b/apps/server/test/unit/with-relationships.spec.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const ava = require('ava')
+const sinon = require('sinon')
+const withRelationships = require('../../lib/default-cards/mixins/with-relationships')
+const linkConstraints = require('@balena/jellyfish-client-sdk/lib/link-constraints')
+
+const expected = require('./test/expected.json')
+const card = require('./test/01.json')
+const fakeConstraints = require('./test/constraints-subset')
+
+ava('withRelationships adds correct relations to card', async (test) => {
+	sinon.stub(linkConstraints, 'constraints').returns(fakeConstraints)
+	const relationships = withRelationships(card.slug)
+	const cardWithRelationships = _.merge(card, relationships)
+
+	test.deepEqual(cardWithRelationships, expected)
+})

--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
@@ -121,7 +121,11 @@ export default class SingleCardFull extends React.Component {
 
 					{_.map(relationships, (segment, index) => {
 						return (
-							<Tab title={segment.title} key={segment.title}>
+							<Tab
+								title={segment.title}
+								key={segment.title}
+								data-test={`card-relationship-tab-${helpers.slugify(segment.title)}`}
+							>
 								<Segment
 									card={card}
 									segment={segment}

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -80,7 +80,7 @@ ava.serial('should let users create new contacts attached to accounts', async (t
 		page
 	} = context
 
-	await macros.waitForThenClickSelector(page, '[role="tablist"] button:nth-of-type(4)')
+	await macros.waitForThenClickSelector(page, '[role="tablist"] [data-test="card-relationship-tab-contacts"]')
 	await macros.waitForThenClickSelector(page, '[data-test="add-contact"]')
 
 	const name = `test contact ${uuid()}`


### PR DESCRIPTION
The following cards now have the mixin `with-relationships`:

- account.js
- blog-post.js
- changelog.js
- checkin.js
- issue.js
- opportunity.js
- pattern.js
- repository.js
- sales-thread.js

Change-type: minor
Signed-off-by: Stef Kors <stef@balena.io>