### PR TITLE
Add transformer and task type cards

### DIFF
--- a/apps/server/lib/default-cards/index.js
+++ b/apps/server/lib/default-cards/index.js
@@ -158,8 +158,11 @@ module.exports = ({
 		viewWorkflows: require('./balena/view-workflows.json'),
 
 		// ProductOS
+		task: require('./product-os/task'),
+		transformer: require('./product-os/transformer.json'),
 		transformerWorker: require('./product-os/transformer-worker.json'),
-		viewTransformerWorkers: require('./product-os/view-all-transformer-workers.json')
+		viewTransformerWorkers: require('./product-os/view-all-transformer-workers.json'),
+		viewTransformers: require('./product-os/view-all-transformers.json')
 	}
 
 	return _.mapValues(defaultCards, initialize)

--- a/apps/server/lib/default-cards/product-os/task.js
+++ b/apps/server/lib/default-cards/product-os/task.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'task',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object'
+		}
+	}
+}

--- a/apps/server/lib/default-cards/product-os/transformer.json
+++ b/apps/server/lib/default-cards/product-os/transformer.json
@@ -1,0 +1,71 @@
+{
+  "slug": "transformer",
+  "name": "Transformer",
+  "type": "type@1.0.0",
+  "markers": [],
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "requirements": {
+              "type": "object",
+              "properties": {
+                "os": {
+                  "type": "string"
+                },
+                "architecture": {
+                  "type": "string"
+                }
+              }
+            },
+            "trigger": {
+              "type": "object",
+              "properties": {
+                "before": {
+                  "anyOf": [
+                    {
+                      "type": "object"
+                    }, {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "after": {
+                  "anyOf": [
+                    {
+                      "type": "object"
+                    }, {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            },
+            "workerFilter": {
+              "type": "object"
+            },
+            "image": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": [
+            "requirements",
+            "trigger",
+            "image"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data"
+    ]
+  }
+}

--- a/apps/server/lib/default-cards/product-os/view-all-transformers.json
+++ b/apps/server/lib/default-cards/product-os/view-all-transformers.json
@@ -1,0 +1,30 @@
+{
+  "slug": "view-all-transformers",
+  "name": "All transformers",
+  "type": "view@1.0.0",
+  "markers": [ "org-balena" ],
+  "data": {
+    "namespace": "Transformers",
+    "allOf": [
+      {
+        "name": "All transformers",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "transformer@1.0.0"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type"
+          ]
+        }
+      }
+    ],
+    "lenses": [
+      "lens-table"
+    ]
+  }
+}


### PR DESCRIPTION
This adds the contract representation for transformers, that can match an
input contract and create and output contract, and tasks, which describe
a discrete unit of work that needs to be done.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
