### PR TITLE
Hide inactive group users

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -51,8 +51,12 @@ const allGroupsWithUsersQuery = {
 	$$links: {
 		'has group member': {
 			type: 'object',
-			required: [ 'slug' ],
+			required: [ 'slug', 'active' ],
 			properties: {
+				active: {
+					type: 'boolean',
+					const: true
+				},
 				slug: {
 					type: 'string'
 				}


### PR DESCRIPTION
Inactive group users were still being fetched when retrieving groups with members.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
