### PR TITLE
Add transformer-worker lens

### DIFF
--- a/apps/server/lib/default-cards/product-os/task.js
+++ b/apps/server/lib/default-cards/product-os/task.js
@@ -6,10 +6,12 @@
 
 module.exports = {
 	slug: 'task',
+	name: 'Task',
 	type: 'type@1.0.0',
 	data: {
 		schema: {
-			type: 'object'
+			type: 'object',
+			properties: {}
 		}
 	}
 }

--- a/apps/server/lib/default-cards/product-os/transformer-worker.json
+++ b/apps/server/lib/default-cards/product-os/transformer-worker.json
@@ -74,6 +74,15 @@
         }
       }
     },
+    "meta": {
+			"relationships": [
+				{
+					"title": "Tasks",
+					"link": "owns",
+					"type": "task"
+        }
+      ]
+    },
     "required": [
       "data"
     ]

--- a/apps/ui/lib/components/Metrics/DeviceMetrics.jsx
+++ b/apps/ui/lib/components/Metrics/DeviceMetrics.jsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/* eslint-disable no-undefined */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Box,
+	Flex,
+	ProgressBar,
+	Txt,
+	Card
+} from 'rendition'
+import {
+	Icon
+} from '@balena/jellyfish-ui-components'
+
+// TODO: Move all this code into Rendition!
+
+// https://gist.github.com/thomseddon/3511330
+const formatSize = (bytes, base = 1000) => {
+	if (typeof bytes !== 'number' || bytes < 0) {
+		return null
+	}
+	const units = [ 'bytes', 'KB', 'MB', 'GB', 'TB', 'PB' ]
+	let order = Math.floor(Math.log(bytes) / Math.log(base))
+	if (order >= units.length) {
+		order = units.length - 1
+	}
+	const size = bytes / Math.pow(base, order)
+	let result = null
+	if (order < 0) {
+		result = bytes
+		order = 0
+	} else if (order >= 3 && size !== Math.floor(size)) {
+		result = size.toFixed(1)
+	} else {
+		result = size.toFixed()
+	}
+	return `${result} ${units[order]}`
+}
+
+const formatMb = (mb) => {
+	if (mb === null) {
+		return '-'
+	}
+
+	return formatSize(mb * 1024 * 1024, 1024) || '-'
+}
+
+const getDiscreteBarValue = (
+	value,
+	numSlices,
+	index
+) => {
+	const highlightedNumSlices = Math.ceil(value / (100 / numSlices))
+	if (numSlices <= 1) {
+		return value
+	}
+
+	return highlightedNumSlices > index ? 100 : 0
+}
+
+const ValueWithMaxTitle = ({
+	value, max
+}) => (
+	<React.Fragment>
+		<Txt.span>{value}</Txt.span>/
+		<Txt.span color="tertiary.main">{max}</Txt.span>
+	</React.Fragment>
+)
+
+const DiscreteBar = ({
+	value, numSlices, ...props
+}) => {
+	return (
+		<Flex flexDirection="row">
+			{_.range(numSlices).map((idx) => {
+				return (
+					<Box key={idx} flex={1} mr={idx === numSlices - 1 ? 0 : 2}>
+						<ProgressBar
+							value={getDiscreteBarValue(value, numSlices, idx)}
+							{...props}
+						/>
+					</Box>
+				)
+			})}
+		</Flex>
+	)
+}
+
+const StatsBar = ({
+	title,
+	statsLabel,
+	value,
+	max,
+	numSlices,
+	...props
+}) => {
+	const percentage = (value / (max || 100)) * 100
+
+	// ProgressBar checks for the existence of a field rather than checking for true/false, so we have to do it this way.
+	const bg = {
+		...(percentage <= 60 ? {
+			success: true
+		} : {}),
+		...(percentage > 60 && percentage <= 80 ? {
+			warning: true
+		} : {}),
+		...(percentage > 80 ? {
+			danger: true
+		} : {})
+	}
+
+	return (
+		<Flex flex={1} minWidth={152} flexDirection="column" {...props}>
+			<Flex
+				mb={2}
+				flexDirection="row"
+				alignItems="flex-start"
+				justifyContent="space-between"
+			>
+				<Txt.span>{title}</Txt.span>
+				<Txt.span>{statsLabel}</Txt.span>
+			</Flex>
+			<DiscreteBar numSlices={numSlices || 1} value={percentage} {...bg} />
+		</Flex>
+	)
+}
+
+const StatsTitle = ({
+	icon,
+	title,
+	description
+}) => {
+	return (
+		<Flex
+			flexDirection="column"
+			alignItems="flex-start"
+			justifyContent="flex-start"
+		>
+			<Box>
+				<Txt.span mr={1} color="tertiary.semilight">
+					<Icon name={icon} />
+				</Txt.span>
+				<Txt.span>{title}</Txt.span>
+			</Box>
+			{/* We add a zero-width character so the span always keeps its size */}
+			<Txt.span color="tertiary.main" style={{
+				lineHeight: 1
+			}} fontSize={0}>
+				{description || '\u200b'}
+			</Txt.span>
+		</Flex>
+	)
+}
+
+export const DeviceMetrics = ({
+	metrics
+}) => {
+	const hasSomeMetrics =
+		metrics.cpu_usage !== null ||
+		metrics.cpu_temp !== null ||
+		metrics.memory_usage !== null ||
+		metrics.storage_usage
+
+	if (!metrics || !hasSomeMetrics) {
+		return null
+	}
+
+	return (
+		<Card small mb={3}>
+			<Flex flexDirection={'row'} flexWrap="wrap">
+				<Flex flex={1} flexDirection="row">
+					{metrics.cpu_usage !== null && (
+						<StatsBar
+							mx={2}
+							my={1}
+							title={<StatsTitle icon="microchip" title="CPU" />}
+							statsLabel={`~${metrics.cpu_usage}%`}
+							value={metrics.cpu_usage}
+							max={100}
+							numSlices={5}
+						/>
+					)}
+					{metrics.cpu_temp && (
+						<StatsBar
+							mx={2}
+							my={1}
+							title={<StatsTitle icon="microchip" title="Temperature" />}
+							statsLabel={`~${metrics.cpu_temp}C`}
+							value={metrics.cpu_temp}
+							max={100}
+						/>
+					)}
+				</Flex>
+				<Flex flex={1} flexDirection="row">
+					{metrics.memory_usage && (
+						<StatsBar
+							mx={2}
+							my={1}
+							title={<StatsTitle icon="memory" title="Memory" />}
+							statsLabel={
+								<ValueWithMaxTitle
+									value={formatMb(metrics.memory_usage)}
+									max={formatMb(metrics.memory_total)}
+								/>
+							}
+							value={metrics.memory_usage}
+							max={metrics.memory_total}
+						/>
+					)}
+					{metrics.storage_usage && (
+						<StatsBar
+							mx={2}
+							my={1}
+							title={
+								<StatsTitle
+									icon="hdd"
+									title="Storage"
+									description={
+										metrics.storage_block_device
+											? `(${metrics.storage_block_device})`
+											: undefined
+									}
+								/>
+							}
+							statsLabel={
+								<ValueWithMaxTitle
+									value={formatMb(metrics.storage_usage)}
+									max={formatMb(metrics.storage_total)}
+								/>
+							}
+							value={metrics.storage_usage}
+							max={metrics.storage_total}
+						/>
+					)}
+				</Flex>
+			</Flex>
+		</Card>
+	)
+}

--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
@@ -25,7 +25,7 @@ import CardFields from '../../../components/CardFields'
 import CardLayout from '../../../layouts/CardLayout'
 import Timeline from '../../list/Timeline'
 
-const SingleCardTabs = styled(Tabs) `
+export const SingleCardTabs = styled(Tabs) `
 	flex: 1;
 	> [ role="tablist"]{
 	  height: 100%;

--- a/apps/ui/lib/lens/full/TransformerWorker/TransformerWorker.jsx
+++ b/apps/ui/lib/lens/full/TransformerWorker/TransformerWorker.jsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/* eslint-disable camelcase */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Box,
+	Heading,
+	Flex,
+	Tab,
+	Table,
+	Txt,
+	Divider
+} from 'rendition'
+import {
+	helpers
+} from '@balena/jellyfish-ui-components'
+import Segment from '../../common/Segment'
+import CardLayout from '../../../layouts/CardLayout'
+import {
+	DeviceMetrics
+} from '../../../components/Metrics/DeviceMetrics'
+import {
+	SingleCardTabs
+} from '../SingleCard'
+
+export const SLUG = 'lens-full-transformer-worker'
+
+const TRANSFORMER_COLUMNS = [
+	{
+		label: 'ID',
+		field: 'id',
+		sortable: true
+	},
+	{
+		label: 'Ref',
+		field: 'ref',
+		sortable: true
+	},
+	{
+		label: 'Count',
+		field: 'count',
+		sortable: true
+	}
+]
+
+const Field = ({
+	label, value, ...rest
+}) => {
+	if (!value) {
+		return null
+	}
+	return (
+		<Box {...rest}>
+			<Heading.h5>{label}</Heading.h5>
+			<Txt>{value}</Txt>
+		</Box>
+	)
+}
+
+export const TransformerWorker = ({
+	actions, actionItems, card, channel, types
+}) => {
+	const [ activeIndex, setActiveIndex ] = React.useState(0)
+
+	const type = _.find(types, {
+		slug: card.type.split('@')[0]
+	})
+
+	const os = _.get(card, [ 'data', 'os' ])
+	const architecture = _.get(card, [ 'data', 'architecture' ])
+	const relationships = _.get(type, [ 'data', 'meta', 'relationships' ])
+
+	const metrics = React.useMemo(() => {
+		const cpuUsage = _.get(card, [ 'data', 'cpu_load' ])
+		const memoryTotal = _.get(card, [ 'data', 'ram', 'total_mb' ])
+		const memoryAvailable = _.get(card, [ 'data', 'ram', 'available' ])
+		const storageTotal = _.get(card, [ 'data', 'storage', 'total_mb' ])
+		const storageAvailable = _.get(card, [ 'data', 'storage', 'available' ])
+		return {
+			cpu_usage: cpuUsage,
+			cpu_temp: null,
+			memory_usage: memoryAvailable - memoryTotal,
+			memory_total: memoryAvailable,
+			storage_usage: storageAvailable - storageTotal,
+			storage_total: storageAvailable
+		}
+	}, [ card ])
+
+	return (
+		<CardLayout
+			data-test={`lens--${SLUG}`}
+			card={card}
+			overflowY
+			channel={channel}
+			actionItems={actionItems}
+			title={(
+				<Heading.h4>
+					{card.name || card.slug}
+				</Heading.h4>
+			)}
+		>
+			<Divider width="100%" color={helpers.colorHash(card.type)} />
+
+			<SingleCardTabs activeIndex={activeIndex}	onActive={setActiveIndex}>
+				<Tab title="Metrics">
+					<Box flex={1} p={3}>
+						<Field label="Operating System" value={os} mb={3} />
+						<Field label="Architecture" value={architecture} mb={3} />
+						<Flex flex={1} my={3} flexDirection="column" justifyContent="stretch">
+							<DeviceMetrics metrics={metrics} />
+						</Flex>
+					</Box>
+				</Tab>
+				<Tab title="Transformers">
+					<Flex flex={1} p={3} flexDirection="column" justifyContent="stretch">
+						<Table
+							data={_.get(card, [ 'data', 'transformers' ], [])}
+							columns={TRANSFORMER_COLUMNS}
+						/>
+					</Flex>
+				</Tab>
+				{_.map(relationships, (segment, index) => {
+					return (
+						<Tab title={segment.title} key={segment.title}>
+							<Segment
+								card={card}
+								segment={segment}
+								types={types}
+								actions={actions}
+							/>
+						</Tab>
+					)
+				})}
+			</SingleCardTabs>
+		</CardLayout>
+	)
+}

--- a/apps/ui/lib/lens/full/TransformerWorker/index.jsx
+++ b/apps/ui/lib/lens/full/TransformerWorker/index.jsx
@@ -15,11 +15,10 @@ import {
 	actionCreators,
 	selectors
 } from '../../../core'
-import SingleCard from './SingleCard'
-
-export {
-	SingleCardTabs
-} from './SingleCard'
+import {
+	TransformerWorker,
+	SLUG
+} from './TransformerWorker'
 
 const mapStateToProps = (state) => {
 	return {
@@ -40,16 +39,22 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 const lens = {
-	slug: 'lens-full-default',
+	slug: SLUG,
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Default lens',
+	name: 'Transformer Worker lens',
 	data: {
 		format: 'full',
 		icon: 'address-card',
-		renderer: connect(mapStateToProps, mapDispatchToProps)(SingleCard),
+		renderer: connect(mapStateToProps, mapDispatchToProps)(TransformerWorker),
 		filter: {
-			type: 'object'
+			type: 'object',
+			properties: {
+				type: {
+					type: 'string',
+					const: 'transformer-worker@1.0.0'
+				}
+			}
 		}
 	}
 }

--- a/apps/ui/lib/lens/full/index.js
+++ b/apps/ui/lib/lens/full/index.js
@@ -12,6 +12,7 @@ import Thread from './Thread'
 import View from './View'
 import User from './User'
 import FormResponse from './FormResponse'
+import TransformerWorker from './TransformerWorker'
 
 export default [
 	MyUser,
@@ -21,5 +22,6 @@ export default [
 	User,
 	Thread,
 	View,
-	FormResponse
+	FormResponse,
+	TransformerWorker
 ]


### PR DESCRIPTION
Note - the `DeviceMetrics` code will be moved to Rendition shortly

BTW I think we could greatly reduce the amount of duplicate code here if we introduce a concept of a 'Tabs' lens type that allows a card type to define extra tabs to display in the Full Card lens. 

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
![image](https://user-images.githubusercontent.com/2925657/101915958-e1229400-3bf8-11eb-95c1-521651d6d774.png)


