### PR TITLE
renovate: Ignore node version bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,8 @@
   ],
   "ignoreDeps": [
     "monaco-editor",
-    "monaco-editor-webpack-plugin"
+    "monaco-editor-webpack-plugin",
+    "node"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

We need to ignore node version bumps because balenaCI will currently fail engine version check as it currently only has v14.2.0:
```
npm ERR! notsup Required: {"node":">=v14.15.1"}
npm ERR! notsup Actual:   {"npm":"6.14.5","node":"14.2.0"}
```
