### PR TITLE
Bump test base image to 1.3.28

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Runtime
 ###########################################################
 
-FROM resinci/jellyfish-test:1.3.27
+FROM resinci/jellyfish-test:1.3.28
 
 WORKDIR /usr/src/jellyfish
 

--- a/test/containers/Dockerfile.test
+++ b/test/containers/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM resinci/jellyfish-test:1.3.27
+FROM resinci/jellyfish-test:1.3.28
 
 WORKDIR /usr/src/jellyfish
 ARG NPM_TOKEN


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
