### PR TITLE
Add contracts for image and image source

### DIFF
--- a/apps/server/lib/default-cards/index.js
+++ b/apps/server/lib/default-cards/index.js
@@ -158,6 +158,8 @@ module.exports = ({
 		viewWorkflows: require('./balena/view-workflows.json'),
 
 		// ProductOS
+		image: require('./product-os/image.json'),
+		imageSource: require('./product-os/image-source.json'),
 		task: require('./product-os/task'),
 		transformer: require('./product-os/transformer.json'),
 		transformerWorker: require('./product-os/transformer-worker.json'),

--- a/apps/server/lib/default-cards/product-os/image-source.json
+++ b/apps/server/lib/default-cards/product-os/image-source.json
@@ -1,0 +1,38 @@
+{
+  "slug": "image-source",
+  "name": "Image source contract",
+  "type": "type@1.0.0",
+  "markers": [],
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "artefact": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "should_trigger": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "should_trigger"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data"
+    ]
+  }
+}

--- a/apps/server/lib/default-cards/product-os/image.json
+++ b/apps/server/lib/default-cards/product-os/image.json
@@ -1,0 +1,38 @@
+{
+  "slug": "image",
+  "name": "Container image contract",
+  "type": "type@1.0.0",
+  "markers": [],
+  "data": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "artefact": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "should_trigger": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "should_trigger"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data"
+    ]
+  }
+}


### PR DESCRIPTION
Image source represents a source repo that will build a container image, the image contract is the contract for that

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
