### PR TITLE
ci: Stop running front-mirror tests in parallel with other tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,6 +8,7 @@ WORKDIR /usr/src/jellyfish
 
 COPY ./.git ./.git
 COPY ./scripts ./scripts
+RUN /usr/src/jellyfish/scripts/ci/checkout-master.sh
 COPY package.json package-lock.json /usr/src/jellyfish/
 COPY ./apps ./apps
 ARG NPM_TOKEN

--- a/scripts/ci/wait-for-api.sh
+++ b/scripts/ci/wait-for-api.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+###
+# Copyright (C) Balena.io - All Rights Reserved
+# Unauthorized copying of this file, via any medium is strictly prohibited.
+# Proprietary and confidential.
+###
+
+# This script is used in the sut container for the balenaCI docker pipeline.
+# This is necessary to make "master" accessible, which is needed to run scripts/ci/skip_tests_if_only.sh.
+
+set -eu
+
+ENDPOINT="$SERVER_HOST:$SERVER_PORT/ping"
+while :
+do
+	echo "Waiting for API at $ENDPOINT..."
+	if [ "$(curl -LI "$ENDPOINT" -o /dev/null -w '%{http_code}\n' -s)" == "200" ]; then
+		exit 0
+	fi
+	sleep 2
+done

--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -5,9 +5,9 @@ environment:
   - name: 'AVA_OPTS'
     value: '--fail-fast'
 tasks:
-  - name: 'checkout-master'
-    description: 'Checkout master branch'
-    command: '/usr/src/jellyfish/scripts/ci/checkout-master.sh'
+  - name: 'wait-for-api'
+    description: 'Wait for API to be available'
+    command: '/usr/src/jellyfish/scripts/ci/wait-for-api.sh'
     cwd: '/usr/src/jellyfish'
     required: true
     attempts: 1
@@ -34,6 +34,8 @@ tasks:
     environment:
       - name: 'FILES'
         value: './test/integration/sync/pipeline.spec.js'
+    dependencies:
+      - 'wait-for-api'
   - name: 'front-mirror'
     description: 'Front Mirror Tests'
     command: 'make test'
@@ -42,6 +44,8 @@ tasks:
     environment:
       - name: 'FILES'
         value: './test/e2e/sync/front-mirror.spec.js'
+    dependencies:
+      - 'pipeline-sync'
   - name: 'discourse-mirror'
     description: 'Discourse Mirror Tests'
     command: 'make test'
@@ -68,7 +72,7 @@ tasks:
     cwd: '/usr/src/jellyfish'
     required: true
     dependencies:
-      - 'pipeline-sync'
+      - 'front-mirror'
   - name: 'e2e-ui'
     description: 'E2E UI Tests'
     command: 'make test-e2e-ui'
@@ -90,9 +94,8 @@ tasks:
       - name: 'FILES'
         value: './test/integration/sync/balena-api-translate.spec.js'
     dependencies:
-      - 'checkout-master'
       - 'e2e-ui'
-      - 'pipeline-sync'
+      - 'front-mirror'
   - name: 'github-translate'
     description: 'GitHub Translate Tests'
     command: './scripts/ci/skip_tests_if_only.sh ui livechat || make test'
@@ -151,6 +154,8 @@ tasks:
     environment:
       - name: 'SERVER_HOST'
         value: 'http://localhost'
+    dependencies:
+      - 'front-mirror'
   - name: 'integration-worker'
     description: 'Worker Integration Tests'
     command: 'make test-integration-worker'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Try moving `front-mirror` tests to run earlier in the pipeline and not in parallel with other tests to see if they pass more frequently.