### PR TITLE
Add data.tags to Support Thread lens

### DIFF
--- a/apps/ui/lib/lens/full/SupportThread/index.jsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.jsx
@@ -385,6 +385,10 @@ class SupportThreadBase extends React.Component {
 								tags={card.tags}
 								blacklist={[ 'status', 'summary', 'pendinguserresponse' ]}
 							/>
+
+							<TagList
+								tags={_.get(card, [ 'data', 'tags' ], [])}
+							/>
 						</Flex>
 
 						{status === 'open' && (


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR just adds the conversation-level tags to the Support Thread lens list of tags.

This is useful for Discourse-synced threads that often have helpful tags.
