### PR TITLE
Fix AutoCompleteCardSelect bug inside modal

### DIFF
--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -17,6 +17,11 @@ import {
 	helpers
 } from '@balena/jellyfish-ui-components'
 
+const preventClickPropagation = (event) => {
+	event.stopPropagation()
+	event.preventDefault()
+}
+
 export default class AutoCompleteCardSelect extends React.Component {
 	constructor (props) {
 		super(props)
@@ -28,12 +33,26 @@ export default class AutoCompleteCardSelect extends React.Component {
 		this.onChange = this.onChange.bind(this)
 	}
 
+	createContainer () {
+		this.container = document.createElement('div')
+		this.container.addEventListener('mousedown', preventClickPropagation)
+		document.body.appendChild(this.container)
+	}
+
+	disposeContainer () {
+		this.container.parentNode.removeChild(this.container)
+		this.container.removeEventListener('mousedown', preventClickPropagation)
+		this.container = null
+	}
+
 	componentDidMount () {
 		this._isMounted = true
+		this.createContainer()
 	}
 
 	componentWillUnmount () {
 		this._isMounted = false
+		this.disposeContainer()
 	}
 
 	componentDidUpdate (prevProps) {
@@ -140,7 +159,7 @@ export default class AutoCompleteCardSelect extends React.Component {
 				defaultOptions
 				onChange={this.onChange}
 				loadOptions={this.getTargets}
-				menuPortalTarget={document.body}
+				menuPortalTarget={this.container}
 				styles={{
 					// Ensure the menu portal shows on top of a modal
 					menuPortal: (base) => {


### PR DESCRIPTION
Change-type: patch
Connects-to: #5333

***

Fixes #5333 

Reason:

When you put `AutoCompleteCardSelect` inside modal, it's options are rendered inside body and positioned absolutely to appear near the select input, so in dom options are not children of select, so they are not children of modal neither. This causes modal to think that it was clicked outside when clicking on autocomplete select option.

Workaround:

I created a div inside a body. Then used this div as a container for autocomplete select, instead of using directly body. Then I added mousedown event listener to this div and prevented propagation of the click event, so that event never gets to the modal.
