### PR TITLE
Add runtime env vars to UI container deployment

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -14,7 +14,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
        maxSurge: 1
-       maxUnavailable: 0 
+       maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -54,6 +54,12 @@ spec:
             secretKeyRef:
               key: NODE_ENV
               name: node-env
+        - name: SENTRY_DSN_UI
+          value: 'https://ff836b1e4abc4d0699bcaaf07ce4ea08@sentry.io/1366139'
+        - name: SERVER_HOST
+          value: 'https://api.ly.fish'
+        - name: SERVER_PORT
+          value: '80'
         ports:
         - containerPort: 80
       imagePullSecrets:


### PR DESCRIPTION
This is a pre-requisite for making UI containers parameterizable at runtime.
Connects to https://github.com/product-os/jellyfish/pull/5281

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
