### PR TITLE
Kubernetes: Enable stdin & tty for logging to promtail/loki.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -236,6 +236,8 @@ spec:
             secretKeyRef:
               key: QUEUE_CONCURRENCY
               name: queue-concurrency
+        stdin: true
+        tty: true
         ports:
           - containerPort: {{{METRICS_PORT}}}
             name: prometheus-a

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -318,6 +318,8 @@ spec:
               key: REGISTRY_TOKEN_AUTH_JWT_ALGO
               name: registry-token-auth-jwt-algo
         {{/REGISTRY_TOKEN_AUTH_JWT_ALGO}}
+        stdin: true
+        tty: true
         ports:
         - containerPort: 8000
         - containerPort: 9229

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -54,6 +54,8 @@ spec:
             secretKeyRef:
               key: NODE_ENV
               name: node-env
+        stdin: true
+        tty: true
         ports:
         - containerPort: 80
       imagePullSecrets:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -60,6 +60,8 @@ spec:
           value: 'https://api.ly.fish'
         - name: SERVER_PORT
           value: '80'
+        stdin: true
+        tty: true
         ports:
         - containerPort: 80
       imagePullSecrets:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/tick-server-deployment.tpl.yml
@@ -197,6 +197,8 @@ spec:
             secretKeyRef:
               key: RESET_PASSWORD_SECRET_TOKEN
               name: reset-password-secret-token
+        stdin: true
+        tty: true
 
       imagePullSecrets:
         - name: com.docker.hub.travisciresin


### PR DESCRIPTION
This allows engineers to refer to Loki logs in monitor.balena-cloud.com.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
