### PR TITLE
Kubernetes: Updates use recommended labels for Jellyfish API.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -5,10 +5,18 @@ metadata:
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   labels:
     app.kubernetes.io/name: jellyfish-api
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
 spec:
   selector:
     matchLabels:
-      app: jellyfish
+      app.kubernetes.io/name: jellyfish-api
+      app.kubernetes.io/instance: jellyfish-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: product-os
+      app.kubernetes.io/managed-by: devops
   replicas: 16
   strategy:
     type: RollingUpdate
@@ -18,7 +26,11 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish
+        app.kubernetes.io/name: jellyfish-api
+        app.kubernetes.io/instance: jellyfish-api
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: product-os
+        app.kubernetes.io/managed-by: devops
     spec:
       terminationGracePeriodSeconds: 120
       readinessGates:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -2,7 +2,11 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -2,12 +2,20 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
 spec:
   selector:
-    app: jellyfish
+    app.kubernetes.io/name: jellyfish-api
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   ports:
   - port: 8000
   sessionAffinity: ClientIP


### PR DESCRIPTION
Standardizes the labels used for resources in Kubernetes.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
