### PR TITLE
Kubernetes: Update labels for Livechat, UI, Redis components.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -5,10 +5,18 @@ metadata:
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   labels:
     app.kubernetes.io/name: jellyfish-livechat
+    app.kubernetes.io/instance: jellyfish-livechat
+    app.kubernetes.io/component: livechat
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
 spec:
   selector:
     matchLabels:
-      app: jellyfish-livechat
+      app.kubernetes.io/name: jellyfish-livechat
+      app.kubernetes.io/instance: jellyfish-livechat
+      app.kubernetes.io/component: livechat
+      app.kubernetes.io/part-of: product-os
+      app.kubernetes.io/managed-by: devops
   replicas: 4
   strategy:
     type: RollingUpdate
@@ -18,7 +26,11 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish-livechat
+        app.kubernetes.io/name: jellyfish-livechat
+        app.kubernetes.io/instance: jellyfish-livechat
+        app.kubernetes.io/component: livechat
+        app.kubernetes.io/part-of: product-os
+        app.kubernetes.io/managed-by: devops
     spec:
       readinessGates:
       # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-ingress.tpl.yml
@@ -2,7 +2,11 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-livechat
+    app.kubernetes.io/name: jellyfish-livechat
+    app.kubernetes.io/instance: jellyfish-livechat
+    app.kubernetes.io/component: livechat
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-livechat
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
@@ -2,12 +2,20 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-livechat
+    app.kubernetes.io/name: jellyfish-livechat
+    app.kubernetes.io/instance: jellyfish-livechat
+    app.kubernetes.io/component: livechat
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-livechat
 spec:
   selector:
-    app: jellyfish-livechat
+    app.kubernetes.io/name: jellyfish-livechat
+    app.kubernetes.io/instance: jellyfish-livechat
+    app.kubernetes.io/component: livechat
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   ports:
   - port: 80
   sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -5,10 +5,18 @@ metadata:
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   labels:
     app.kubernetes.io/name: jellyfish-ui
+    app.kubernetes.io/instance: jellyfish-ui
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
 spec:
   selector:
     matchLabels:
-      app: jellyfish-ui
+      app.kubernetes.io/name: jellyfish-ui
+      app.kubernetes.io/instance: jellyfish-ui
+      app.kubernetes.io/component: ui
+      app.kubernetes.io/part-of: product-os
+      app.kubernetes.io/managed-by: devops
   replicas: 4
   strategy:
     type: RollingUpdate
@@ -18,7 +26,11 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish-ui
+        app.kubernetes.io/name: jellyfish-ui
+        app.kubernetes.io/instance: jellyfish-ui
+        app.kubernetes.io/component: ui
+        app.kubernetes.io/part-of: product-os
+        app.kubernetes.io/managed-by: devops
     spec:
       readinessGates:
       # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-ingress.tpl.yml
@@ -2,7 +2,11 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-ui
+    app.kubernetes.io/name: jellyfish-ui
+    app.kubernetes.io/instance: jellyfish-ui
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-ui
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
@@ -2,12 +2,20 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-ui
+    app.kubernetes.io/name: jellyfish-ui
+    app.kubernetes.io/instance: jellyfish-ui
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-ui
 spec:
   selector:
-    app: jellyfish-ui
+    app.kubernetes.io/name: jellyfish-ui
+    app.kubernetes.io/instance: jellyfish-ui
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   ports:
   - port: 80
   sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-deployment.tpl.yml
@@ -5,14 +5,26 @@ metadata:
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   labels:
     app.kubernetes.io/name: jellyfish-redis
+    app.kubernetes.io/instance: jellyfish-redis
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
 spec:
   selector:
     matchLabels:
-      app: redis
+      app.kubernetes.io/name: jellyfish-redis
+      app.kubernetes.io/instance: jellyfish-redis
+      app.kubernetes.io/component: redis
+      app.kubernetes.io/part-of: product-os
+      app.kubernetes.io/managed-by: devops
   template:
     metadata:
       labels:
-        app: redis
+        app.kubernetes.io/name: jellyfish-redis
+        app.kubernetes.io/instance: jellyfish-redis
+        app.kubernetes.io/component: redis
+        app.kubernetes.io/part-of: product-os
+        app.kubernetes.io/managed-by: devops
     spec:
       containers:
         - image: <<%&children.sw.containerized-application.jellyfish-redis.data.assets.image.url%>>

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/redis-service.tpl.yml
@@ -2,11 +2,19 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: redis
+    app.kubernetes.io/name: jellyfish-redis
+    app.kubernetes.io/instance: jellyfish-redis
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   name: redis
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
 spec:
   selector:
-    app: redis
+    app.kubernetes.io/name: jellyfish-redis
+    app.kubernetes.io/instance: jellyfish-redis
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: product-os
+    app.kubernetes.io/managed-by: devops
   ports:
     - port: 6379


### PR DESCRIPTION
The labels now use the recommended labels for Kubernetes deployments.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
