### PR TITLE
Revert "Kubernetes: Updates use recommended labels for Jellyfish API."

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -5,18 +5,10 @@ metadata:
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   labels:
     app.kubernetes.io/name: jellyfish-api
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/component: api
-    app.kubernetes.io/part-of: product-os
-    app.kubernetes.io/managed-by: devops
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: jellyfish-api
-      app.kubernetes.io/instance: jellyfish-api
-      app.kubernetes.io/component: api
-      app.kubernetes.io/part-of: product-os
-      app.kubernetes.io/managed-by: devops
+      app: jellyfish
   replicas: 16
   strategy:
     type: RollingUpdate
@@ -26,11 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: jellyfish-api
-        app.kubernetes.io/instance: jellyfish-api
-        app.kubernetes.io/component: api
-        app.kubernetes.io/part-of: product-os
-        app.kubernetes.io/managed-by: devops
+        app: jellyfish
     spec:
       terminationGracePeriodSeconds: 120
       readinessGates:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -2,11 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    app.kubernetes.io/name: jellyfish-api
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/component: api
-    app.kubernetes.io/part-of: product-os
-    app.kubernetes.io/managed-by: devops
+    name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -2,20 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: jellyfish-api
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/component: api
-    app.kubernetes.io/part-of: product-os
-    app.kubernetes.io/managed-by: devops
+    name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
 spec:
   selector:
-    app.kubernetes.io/name: jellyfish-api
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/component: api
-    app.kubernetes.io/part-of: product-os
-    app.kubernetes.io/managed-by: devops
+    app: jellyfish
   ports:
   - port: 8000
   sessionAffinity: ClientIP


### PR DESCRIPTION
This reverts commit a9de2c21c2678f6d4c7e0a6ba9327c5bff47cf5a.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
