### PR TITLE
Abstract npm make commands to it's own file for shared logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,12 @@
 	npm-install \
 	push \
 	ssh \
-	npm-ci
+	npm-ci \
+	exec-apps
 
 # See https://stackoverflow.com/a/18137056
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+MAKEFILE_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
 
 # -----------------------------------------------
 # Runtime Configuration
@@ -258,18 +260,10 @@ endif
 # -----------------------------------------------
 
 npm-install:
-	npm install
-	cd apps/action-server && npm install
-	cd apps/livechat && npm install
-	cd apps/server && npm install
-	cd apps/ui && npm install
+	npm install && CMD="npm install" make exec-apps
 
 npm-ci:
-	npm ci
-	cd apps/action-server && npm ci
-	cd apps/livechat && npm ci
-	cd apps/server && npm ci
-	cd apps/ui && npm ci
+	npm ci && CMD="npm ci" make exec-apps
 
 .tmp:
 	mkdir -p $@
@@ -483,3 +477,7 @@ reset-state:
 
 deploy-%:
 	./scripts/deploy-package.js jellyfish-$(subst deploy-,,$@)
+
+# Execute a command under each app directory
+exec-apps:
+	for app in $(shell find $(MAKEFILE_DIR)/apps -maxdepth 1 -mindepth 1 -type d | sort -g); do cd $$app && echo - $$app: && $(CMD); done


### PR DESCRIPTION
After talking with @joshbwlng we discussed abstracting commands for every `apps/<service>` to a wrapper command.

This commit cleans up the two make commands to a .sh script. When we add more commands to our npm apps in the future a possible next step would be to abstract this to a properly clean API or CLI. Since Makefiles aren't mean to abitrairly pass commands from the CLI (https://stackoverflow.com/questions/2214575/passing-arguments-to-make-run)

Change-type: minor
Signed-off-by: Stef Kors stef@balena.io

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
