### PR TITLE
Replace balena-redis with official redis images

### DIFF
--- a/deploy-templates/keyframe.tpl.yml
+++ b/deploy-templates/keyframe.tpl.yml
@@ -57,11 +57,11 @@ children:
               url: 'https://github.com/balena-io/jellyfish.git'
       jellyfish-redis:
         slug: jellyfish-redis
-        version: latest
+        version: 6.0.9
         type: sw.containerized-application
         data:
           assets:
             image:
-              url: 'balena/balena-redis:latest'
+              url: 'redis:6.0.9'
             repo:
-              url: 'https://github.com/balena-io/balena-redis.git'
+              url: 'https://github.com/redis/redis'

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -113,8 +113,7 @@ services:
     networks:
       - internal
   redis:
-    image: balena/balena-redis:0.0.3
-    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
+    image: redis:6.0.9
     restart: always
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,8 +112,7 @@ services:
     networks:
       - internal
   redis:
-    image: balena/balena-redis:0.0.3
-    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
+    image: redis:6.0.9
     restart: always
     networks:
       - internal


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Replace `balena-redis` image with official `redis` image, as we are deprecating [`balena-redis`](https://github.com/product-os/balena-redis). The biggest difference with these changes is that the `balena-redis` image we were using in compose and production was based on Redis 5.0.3 while this PR will change this to the most recent stable image based on 6.0.9.
