### PR TITLE
Revert "Replace balena-redis with official redis images"

### DIFF
--- a/deploy-templates/keyframe.tpl.yml
+++ b/deploy-templates/keyframe.tpl.yml
@@ -57,11 +57,11 @@ children:
               url: 'https://github.com/balena-io/jellyfish.git'
       jellyfish-redis:
         slug: jellyfish-redis
-        version: 6.0.9
+        version: latest
         type: sw.containerized-application
         data:
           assets:
             image:
-              url: 'redis:6.0.9'
+              url: 'balena/balena-redis:latest'
             repo:
-              url: 'https://github.com/redis/redis'
+              url: 'https://github.com/balena-io/balena-redis.git'

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -113,7 +113,8 @@ services:
     networks:
       - internal
   redis:
-    image: redis:6.0.9
+    image: balena/balena-redis:0.0.3
+    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
     restart: always
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,8 @@ services:
     networks:
       - internal
   redis:
-    image: redis:6.0.9
+    image: balena/balena-redis:0.0.3
+    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
     restart: always
     networks:
       - internal


### PR DESCRIPTION
Reverts product-os/jellyfish#5444

As Jellyfish went down at a similar time to when PR #5444 was merged, I'm predicting the problem stems from that PR.