### PR TITLE
Revert balena-redis version from latest to 0.0.3

### DIFF
--- a/deploy-templates/keyframe.tpl.yml
+++ b/deploy-templates/keyframe.tpl.yml
@@ -62,6 +62,6 @@ children:
         data:
           assets:
             image:
-              url: 'balena/balena-redis:latest'
+              url: 'balena/balena-redis:0.0.3'
             repo:
               url: 'https://github.com/balena-io/balena-redis.git'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Changed from `balena/balena-redis:latest` to `redis:6.0.9` with https://github.com/product-os/jellyfish/pull/5444. This caused the following error to occur when backend service clients attempted to connect: `Uncaught ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?` We then reverted this PR to use `balena/balena-redis:latest` instead of `redis:6.0.9`. The problem is that `balena/balena-redis:latest` is now based on Redis 6.0.9, so the same errors kept occurring. This led us to this PR where we are explicitly setting the `balena-redis` image version to `0.0.3`, which is the version we were using before.

Once this is handled, we need to:
- Figure out what configuration changes are necessary for JF to work with Redis 6.0.9
- NEVER use `latest` tag when defining which images to use, always use explicit versions