### PR TITLE
Add new Unlink modal component

### DIFF
--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -77,18 +77,19 @@ export default class AutoCompleteCardSelect extends React.Component {
 
 	async getTargets (value) {
 		const {
+			getQueryFilter,
 			cardFilter,
 			cardType: cardTypes,
 			types,
 			sdk
 		} = this.props
 
-		const queryFilter = {
+		const queryFilter = getQueryFilter ? getQueryFilter(value) : {
 			type: 'object',
 			anyOf: [].concat(cardTypes).map((cardType) => {
 				// Retrieve the target type of the selected link
 				const typeCard = _.find(types, {
-					slug: cardType.split('@')[0]
+					slug: helpers.getTypeBase(cardType)
 				})
 
 				// Create full text search query based on the target type and search term
@@ -126,7 +127,7 @@ export default class AutoCompleteCardSelect extends React.Component {
 		// Return the results in a format understood by the AsyncSelect component
 		return results.map((card) => {
 			const typeCardIndex = _.findIndex(types, {
-				slug: card.type.split('@')[0]
+				slug: helpers.getTypeBase(card.type)
 			})
 
 			return {

--- a/apps/ui/lib/components/CardLinker/CardLinker.jsx
+++ b/apps/ui/lib/components/CardLinker/CardLinker.jsx
@@ -19,7 +19,8 @@ import {
 	Icon
 } from '@balena/jellyfish-ui-components'
 import {
-	LinkModal
+	LinkModal,
+	UnlinkModal
 } from '../LinkModal'
 
 class CardLinker extends React.Component {
@@ -28,10 +29,11 @@ class CardLinker extends React.Component {
 
 		this.state = {
 			showMenu: false,
-			showLinkModal: false
+			showLinkModal: null
 		}
 
 		this.openLinkModal = this.openLinkModal.bind(this)
+		this.openUnlinkModal = this.openUnlinkModal.bind(this)
 		this.hideLinkModal = this.hideLinkModal.bind(this)
 		this.toggleMenu = this.toggleMenu.bind(this)
 		this.openCreateChannel = this.openCreateChannel.bind(this)
@@ -40,14 +42,21 @@ class CardLinker extends React.Component {
 
 	openLinkModal () {
 		this.setState({
-			showLinkModal: true,
+			showLinkModal: 'link',
+			showMenu: false
+		})
+	}
+
+	openUnlinkModal () {
+		this.setState({
+			showLinkModal: 'unlink',
 			showMenu: false
 		})
 	}
 
 	hideLinkModal () {
 		this.setState({
-			showLinkModal: false,
+			showLinkModal: null,
 			showMenu: false
 		})
 	}
@@ -129,7 +138,7 @@ class CardLinker extends React.Component {
 						onClick={this.toggleMenu}
 						tooltip={{
 							placement: 'left',
-							text: `Link this ${typeName} to another element`
+							text: `Manage links for this ${typeName}`
 						}}
 					>
 						<Icon name="bezier-curve"/>
@@ -158,6 +167,14 @@ class CardLinker extends React.Component {
 
 							<ActionButton
 								plain
+								onClick={this.openUnlinkModal}
+								data-test="card-linker-action--unlink"
+							>
+								Unlink from existing element
+							</ActionButton>
+
+							<ActionButton
+								plain
 								onClick={this.openVisualizeChannel}
 								data-test="card-linker-action--visualize"
 							>
@@ -167,10 +184,17 @@ class CardLinker extends React.Component {
 					)}
 				</span>
 
-				{showLinkModal && (
+				{showLinkModal === 'link' && (
 					<LinkModal
 						cards={[ card ]}
 						types={types}
+						onHide={this.hideLinkModal}
+					/>
+				)}
+
+				{showLinkModal === 'unlink' && (
+					<UnlinkModal
+						cards={[ card ]}
 						onHide={this.hideLinkModal}
 					/>
 				)}

--- a/apps/ui/lib/components/CardLinker/CardLinker.jsx
+++ b/apps/ui/lib/components/CardLinker/CardLinker.jsx
@@ -18,7 +18,9 @@ import {
 	PlainButton,
 	Icon
 } from '@balena/jellyfish-ui-components'
-import LinkModal from '../LinkModal'
+import {
+	LinkModal
+} from '../LinkModal'
 
 class CardLinker extends React.Component {
 	constructor (props) {
@@ -101,7 +103,6 @@ class CardLinker extends React.Component {
 
 	render () {
 		const {
-			actions,
 			card,
 			connectDragSource,
 			types
@@ -168,7 +169,6 @@ class CardLinker extends React.Component {
 
 				{showLinkModal && (
 					<LinkModal
-						actions={actions}
 						cards={[ card ]}
 						types={types}
 						onHide={this.hideLinkModal}

--- a/apps/ui/lib/components/CardOwner/CardOwner.jsx
+++ b/apps/ui/lib/components/CardOwner/CardOwner.jsx
@@ -45,9 +45,10 @@ export default class CardOwner extends React.Component {
 			cardOwner,
 			card,
 			sdk,
+			types,
 			user
 		} = this.props
-		const cardTypeName = helpers.getType(card.type).name
+		const cardTypeName = helpers.getType(card.type, types).name
 
 		try {
 			if (cardOwner) {

--- a/apps/ui/lib/components/ChannelRenderer.jsx
+++ b/apps/ui/lib/components/ChannelRenderer.jsx
@@ -17,7 +17,9 @@ import {
 	ErrorBoundary,
 	Icon
 } from '@balena/jellyfish-ui-components'
-import LinkModal from './LinkModal'
+import {
+	LinkModal
+} from './LinkModal'
 import ChannelNotFound from './ChannelNotFound'
 
 // Selects an appropriate renderer for a card
@@ -59,7 +61,6 @@ class ChannelRenderer extends React.Component {
 	render () {
 		const {
 			getLens,
-			actions,
 			channel,
 			connectDropTarget,
 			isOver,
@@ -136,7 +137,6 @@ class ChannelRenderer extends React.Component {
 
 				{showLinkModal && (
 					<LinkModal
-						actions={actions}
 						target={head}
 						cards={[ linkFrom ]}
 						types={types}

--- a/apps/ui/lib/components/LinkModal/LinkModal.jsx
+++ b/apps/ui/lib/components/LinkModal/LinkModal.jsx
@@ -23,26 +23,13 @@ import {
 	Icon
 } from '@balena/jellyfish-ui-components'
 import AutoCompleteCardSelect from '../AutoCompleteCardSelect'
+import {
+	getCommonTypeBase
+} from './util'
 
-const getTypes = memoize((inputCards) => {
-	return _.uniq(_.map(inputCards, 'type'))
-})
-
-export default class LinkModal extends React.Component {
+export class LinkModal extends React.Component {
 	constructor (props) {
 		super(props)
-
-		this.getFromType = memoize((cards) => {
-			const cardTypes = getTypes(cards)
-			if (cardTypes.length > 1) {
-				throw new Error('All cards must be of the same type')
-			}
-			let fromType = cards[0].type.split('@')[0]
-			if (fromType === 'type') {
-				fromType = cards[0].slug.split('@')[0]
-			}
-			return fromType
-		})
 
 		this.getAvailableTypeSlugs = memoize((types) => {
 			return _.reduce(types || [], (acc, type) => {
@@ -105,7 +92,7 @@ export default class LinkModal extends React.Component {
 			types
 		} = this.props
 
-		const fromType = this.getFromType(cards)
+		const fromType = getCommonTypeBase(cards)
 		const availableTypeSlugs = this.getAvailableTypeSlugs(types)
 		return this.filterLinks(linkVerb, availableTypeSlugs, target, fromType)
 	}
@@ -188,7 +175,7 @@ export default class LinkModal extends React.Component {
 			submitting
 		} = this.state
 
-		const fromType = this.getFromType(cards)
+		const fromType = getCommonTypeBase(cards)
 		const availableTypeSlugs = this.getAvailableTypeSlugs(types)
 		const linkTypeTargets = this.filterLinks(linkVerb, availableTypeSlugs, selectedTarget, fromType)
 
@@ -201,7 +188,7 @@ export default class LinkModal extends React.Component {
 		const typeCard = _.find(types, [ 'slug', fromType ])
 		const typeName = typeCard ? typeCard.name : fromType
 
-		const titleSource = `${cards.length > 1 ? 'these' : 'this'} ${pluralize(typeName, cards.length, cards.length > 1)}`
+		const titleSource = `${pluralize('this', cards.length)} ${pluralize(typeName, cards.length, cards.length > 1)}`
 		const titleTarget = linkTypeTargets.length === 1 ? linkTypeTargets[0].title : 'another element'
 		const title = `Link ${titleSource} to ${titleTarget}`
 

--- a/apps/ui/lib/components/LinkModal/UnlinkModal.jsx
+++ b/apps/ui/lib/components/LinkModal/UnlinkModal.jsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Flex,
+	Modal,
+	Txt
+} from 'rendition'
+import pluralize from 'pluralize'
+import {
+	constraints
+} from '@balena/jellyfish-client-sdk/lib/link-constraints'
+import {
+	addNotification,
+	Icon,
+	helpers
+} from '@balena/jellyfish-ui-components'
+import AutoCompleteCardSelect from '../AutoCompleteCardSelect'
+import {
+	getCommonTypeBase
+} from './util'
+
+export const UnlinkModal = ({
+	actions,
+	cards,
+	target,
+	types,
+	onHide
+}) => {
+	const [ submitting, setSubmitting ] = React.useState(false)
+	const [ selectedTarget, setSelectedTarget ] = React.useState(target || null)
+
+	const cardsTypeBase = getCommonTypeBase(cards)
+	const typeCard = helpers.getType(cardsTypeBase, types)
+	const typeName = typeCard ? typeCard.name : cardsTypeBase
+
+	const allLinkTypeTargets = React.useMemo(() => {
+		return constraints.reduce((acc, constraint) => {
+			if (constraint.data.to === cardsTypeBase) {
+				// Move the data.title property to the root of the object, as the rendition Select
+				// component can't use a non-root field for the `labelKey` prop
+				acc.push(Object.assign({}, constraint, {
+					title: constraint.data.title
+				}))
+			}
+			return acc
+		}, [])
+	}, [ cardsTypeBase ])
+
+	const linkTypeSlugs = React.useMemo(() => {
+		return _.map(allLinkTypeTargets, 'data.from')
+	}, [ allLinkTypeTargets ])
+
+	const targetTypeList = React.useMemo(() => {
+		return _.uniq(_.map(allLinkTypeTargets, 'title')).join(', ')
+	}, [ allLinkTypeTargets ])
+
+	const unlinkCards = React.useCallback(async () => {
+		setSubmitting(true)
+
+		const unlinkCard = async (card) => {
+			const constraint = _.find(constraints, {
+				data: {
+					from: helpers.getTypeBase(card.type),
+					to: helpers.getTypeBase(selectedTarget.type)
+				}
+			})
+			await actions.removeLink(card, selectedTarget, constraint.name, {
+				skipSuccessMessage: true
+			})
+		}
+
+		const unlinkTasks = cards.map(unlinkCard)
+		await Promise.all(unlinkTasks)
+		addNotification('success', `Removed ${pluralize('link', cards.length)}`)
+		setSubmitting(false)
+		onHide()
+	}, [ cards, selectedTarget ])
+
+	// Adapt the selectedTarget state variable into an object
+	// structured in a way that the AutoCompleteCardSelect component
+	// knows how to render.
+	const selectedTargetValue = React.useMemo(() => {
+		if (!selectedTarget) {
+			return null
+		}
+		const selectedTargetCardTypeIndex = _.findIndex(types, {
+			slug: helpers.getTypeBase(selectedTarget.type)
+		})
+
+		return {
+			value: selectedTarget.id,
+			label: selectedTarget.name || selectedTarget.slug,
+			type: types[selectedTargetCardTypeIndex].name,
+			shade: selectedTargetCardTypeIndex
+		}
+	}, [ selectedTarget, types ])
+
+	// We use a custom query callback for the AutoCompleteCardSelect
+	// as we need to filter on cards that are linked to all of the specified
+	// cards.
+	const getLinkedCardsQuery = React.useCallback((value) => {
+		return {
+			type: 'object',
+			anyOf: allLinkTypeTargets.map((constraint) => {
+				const fromType = helpers.getType(constraint.data.from, types)
+				const query = {
+					$$links: {
+						[constraint.name]: {
+							allOf: cards.map((card) => {
+								return {
+									type: 'object',
+									properties: {
+										id: {
+											const: card.id
+										}
+									}
+								}
+							})
+						}
+					},
+					properties: {
+						type: {
+							const: `${fromType.slug}@${fromType.version}`
+						}
+					}
+				}
+
+				// Add full-text-search for the typed text (if set)
+				if (value) {
+					const filter = helpers.createFullTextSearchFilter(fromType.data.schema, value)
+					_.merge(query, filter)
+				}
+				return query
+			})
+		}
+	}, [ cards ])
+
+	const titleSource = `${pluralize('this', cards.length)} ${pluralize(typeName, cards.length, cards.length > 1)}`
+
+	return (
+		<Modal
+			title={`Unlink ${titleSource} from another element`}
+			cancel={onHide}
+			primaryButtonProps={{
+				disabled: !selectedTarget || submitting,
+				'data-test': 'card-unlinker__submit'
+			}}
+			action={submitting ? <Icon spin name="cog"/> : 'OK'}
+			done={unlinkCards}
+		>
+			<Flex flexDirection="column">
+				<Txt>
+					Look for the card types: {targetTypeList}
+				</Txt>
+				<AutoCompleteCardSelect
+					getQueryFilter={getLinkedCardsQuery}
+					value={selectedTargetValue}
+					cardType={linkTypeSlugs}
+					types={types}
+					isDisabled={Boolean(target)}
+					onChange={setSelectedTarget}
+				/>
+			</Flex>
+		</Modal>
+	)
+}

--- a/apps/ui/lib/components/LinkModal/index.js
+++ b/apps/ui/lib/components/LinkModal/index.js
@@ -12,11 +12,15 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
-	actionCreators
+	actionCreators,
+	selectors
 }	from '../../core'
 import {
 	LinkModal as LinkModalInner
 } from './LinkModal'
+import {
+	UnlinkModal as UnlinkModalInner
+} from './UnlinkModal'
 
 export const LinkModal = connect(
 	null,
@@ -31,3 +35,21 @@ export const LinkModal = connect(
 		}
 	}
 )(LinkModalInner)
+
+export const UnlinkModal = connect(
+	(state) => {
+		return {
+			types: selectors.getTypes(state)
+		}
+	},
+	(dispatch) => {
+		return {
+			actions: bindActionCreators(
+				_.pick(actionCreators, [
+					'removeLink'
+				]),
+				dispatch
+			)
+		}
+	}
+)(UnlinkModalInner)

--- a/apps/ui/lib/components/LinkModal/index.js
+++ b/apps/ui/lib/components/LinkModal/index.js
@@ -4,6 +4,30 @@
  * Proprietary and confidential.
  */
 
-import LinkModal from './LinkModal'
+import {
+	connect
+} from 'react-redux'
+import _ from 'lodash'
+import {
+	bindActionCreators
+} from 'redux'
+import {
+	actionCreators
+}	from '../../core'
+import {
+	LinkModal as LinkModalInner
+} from './LinkModal'
 
-export default LinkModal
+export const LinkModal = connect(
+	null,
+	(dispatch) => {
+		return {
+			actions: bindActionCreators(
+				_.pick(actionCreators, [
+					'createLink'
+				]),
+				dispatch
+			)
+		}
+	}
+)(LinkModalInner)

--- a/apps/ui/lib/components/LinkModal/tests/LinkModal.spec.jsx
+++ b/apps/ui/lib/components/LinkModal/tests/LinkModal.spec.jsx
@@ -14,7 +14,9 @@ import {
 } from 'enzyme'
 import sinon from 'sinon'
 import React from 'react'
-import LinkModal from '../LinkModal'
+import {
+	LinkModal
+} from '../LinkModal'
 import * as AutoCompleteCardSelect from '../../AutoCompleteCardSelect'
 import user from './fixtures/user.json'
 import org from './fixtures/org.json'

--- a/apps/ui/lib/components/LinkModal/tests/UnlinkModal.spec.jsx
+++ b/apps/ui/lib/components/LinkModal/tests/UnlinkModal.spec.jsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getPromiseResolver,
+	getWrapper
+} from '../../../../test/ui-setup'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import {
+	UnlinkModal
+} from '../UnlinkModal'
+import * as AutoCompleteCardSelect from '../../AutoCompleteCardSelect'
+import user from './fixtures/user.json'
+import org from './fixtures/org.json'
+
+const sandbox = sinon.createSandbox()
+
+const {
+	wrapper: Wrapper
+} = getWrapper()
+
+const card = {
+	id: 'U1',
+	slug: 'user-1',
+	type: 'user@1.0.0'
+}
+
+const card2 = {
+	id: 'U2',
+	slug: 'user-2',
+	type: 'user@1.0.0'
+}
+
+const orgInstanceCard = {
+	id: 'O2',
+	slug: 'org-1',
+	type: 'org@1.0.0'
+}
+
+const types = [
+	user,
+	org
+]
+
+const targets = [
+	{
+		id: 'R1',
+		slug: 'org-balena',
+		name: 'Balena',
+		type: 'org@1.0.0'
+	},
+	{
+		id: 'R2',
+		slug: 'org-google',
+		name: 'Google',
+		type: 'org@1.0.0'
+	}
+]
+
+const selectedTarget = targets[0]
+
+// Mock the AutoCompleteCardSelect as it doesn't work well outside of the real browser environment
+const mockAutoCompleteCardSelect = () => {
+	const callbacks = {}
+	const FakeAutoCompleteCardSelect = ({
+		onChange
+	}) => {
+		callbacks.onChange = onChange
+		return null
+	}
+	const autoCompleteCardSelectComponentStub = sandbox.stub(AutoCompleteCardSelect, 'default')
+	autoCompleteCardSelectComponentStub.callsFake((props) => FakeAutoCompleteCardSelect(props))
+	return callbacks
+}
+
+const submit = (unlinkModalComponent) => {
+	const button = unlinkModalComponent.find('button[data-test="card-unlinker__submit"]')
+	button.simulate('click')
+}
+
+// TBD: This code assumes that Promise.all in UnlinkModal will call the async removeLink methods
+// in the same order as the cards are provided in the cards prop.
+const verifyCard = (test, commonProps, callIndex, expectedCard) => {
+	const [ theCard, theSelectedTarget, linkTypeName ] = commonProps.actions.removeLink.args[callIndex]
+	test.deepEqual(theCard, expectedCard)
+	test.deepEqual(theSelectedTarget, selectedTarget)
+	test.deepEqual(linkTypeName, 'is member of')
+}
+
+ava.beforeEach(async (test) => {
+	const onHidePromise = getPromiseResolver()
+	const onHide = () => {
+		onHidePromise.resolver()
+	}
+	test.context = {
+		...test.context,
+		onHidePromise,
+		autoCompleteCallbacks: mockAutoCompleteCardSelect(),
+		commonProps: {
+			onHide,
+			actions: {
+				removeLink: sandbox.stub().resolves(null)
+			}
+		}
+	}
+})
+
+ava.afterEach(async (test) => {
+	sandbox.restore()
+})
+
+ava('UnlinkModal can unlink one card from another card', async (test) => {
+	const {
+		commonProps,
+		onHidePromise,
+		autoCompleteCallbacks
+	} = test.context
+
+	const unlinkModalComponent = await mount((
+		<UnlinkModal
+			{...commonProps}
+			cards={[ card ]}
+			types={types}
+		/>
+	), {
+		wrappingComponent: Wrapper
+	})
+
+	autoCompleteCallbacks.onChange(selectedTarget)
+
+	submit(unlinkModalComponent)
+
+	await onHidePromise.promise
+
+	test.is(commonProps.actions.removeLink.callCount, 1)
+
+	verifyCard(test, commonProps, 0, card)
+})
+
+ava('UnlinkModal can unlink multiple cards from another card', async (test) => {
+	const {
+		commonProps,
+		onHidePromise,
+		autoCompleteCallbacks
+	} = test.context
+
+	const unlinkModalComponent = await mount((
+		<UnlinkModal
+			{...commonProps}
+			cards={[ card, card2 ]}
+			types={types}
+		/>
+	), {
+		wrappingComponent: Wrapper
+	})
+
+	autoCompleteCallbacks.onChange(selectedTarget)
+
+	submit(unlinkModalComponent)
+
+	await onHidePromise.promise
+
+	test.is(commonProps.actions.removeLink.callCount, 2)
+
+	verifyCard(test, commonProps, 0, card)
+	verifyCard(test, commonProps, 1, card2)
+})
+
+ava('UnlinkModal throws exception if card types are different', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	test.throws(() => {
+		mount((
+			<UnlinkModal
+				{...commonProps}
+				cards={[ card, orgInstanceCard ]}
+				types={types}
+			/>
+		), {
+			wrappingComponent: Wrapper
+		})
+	}, {
+		message: 'All cards must be of the same type'
+	})
+})

--- a/apps/ui/lib/components/LinkModal/util.js
+++ b/apps/ui/lib/components/LinkModal/util.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import memoize from 'memoize-one'
+
+const getTypes = memoize((inputCards) => {
+	return _.uniq(_.map(inputCards, 'type'))
+})
+
+export const getCommonTypeBase = memoize((cards) => {
+	const cardTypes = getTypes(cards)
+	if (cardTypes.length > 1) {
+		throw new Error('All cards must be of the same type')
+	}
+	let fromType = cards[0].type.split('@')[0]
+	if (fromType === 'type') {
+		fromType = cards[0].slug.split('@')[0]
+	}
+	return fromType
+})

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -1142,6 +1142,21 @@ export const actionCreators = {
 		}
 	},
 
+	removeLink (fromCard, toCard, verb, options = {}) {
+		return async (dispatch, getState, {
+			sdk
+		}) => {
+			try {
+				await sdk.card.unlink(fromCard, toCard, verb)
+				if (!options.skipSuccessMessage) {
+					addNotification('success', 'Removed link')
+				}
+			} catch (error) {
+				addNotification('danger', error.message)
+			}
+		}
+	},
+
 	dumpState () {
 		return async (dispatch, getState) => {
 			const state = clone(getState())

--- a/apps/ui/lib/lens/common/Segment.jsx
+++ b/apps/ui/lib/lens/common/Segment.jsx
@@ -24,7 +24,9 @@ import {
 	Icon,
 	withSetup
 } from '@balena/jellyfish-ui-components'
-import LinkModal from '../../components/LinkModal'
+import {
+	LinkModal
+} from '../../components/LinkModal'
 
 class Segment extends React.Component {
 	constructor (props) {
@@ -158,7 +160,6 @@ class Segment extends React.Component {
 		} = this.state
 
 		const {
-			actions,
 			card,
 			segment,
 			types,
@@ -231,7 +232,6 @@ class Segment extends React.Component {
 				{showLinkModal && (
 					<LinkModal
 						linkVerb={segment.link}
-						actions={actions}
 						cards={[ card ]}
 						types={[ type ]}
 						onHide={this.hideLinkModal}

--- a/apps/ui/lib/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.jsx
@@ -26,7 +26,8 @@ import parseISO from 'date-fns/parseISO'
 import flatten from 'flat'
 import BaseLens from '../../common/BaseLens'
 import {
-	LinkModal
+	LinkModal,
+	UnlinkModal
 } from '../../../components/LinkModal'
 import {
 	ColumnHider
@@ -74,11 +75,12 @@ export default class CardTable extends BaseLens {
 		this.generateTableColumns = this.generateTableColumns.bind(this)
 		this.state = {
 			checkedCards: [],
-			showLinkModal: false,
+			showLinkModal: null,
 			tableColumns: props.columns || this.generateTableColumns()
 		}
 		this.onChecked = this.onChecked.bind(this)
 		this.showLinkModal = this.showLinkModal.bind(this)
+		this.showUnlinkModal = this.showUnlinkModal.bind(this)
 		this.hideLinkModal = this.hideLinkModal.bind(this)
 		this.toggleColumns = this.toggleColumns.bind(this)
 		this.openCreateChannelForLinking = this.openCreateChannelForLinking.bind(this)
@@ -101,13 +103,19 @@ export default class CardTable extends BaseLens {
 
 	showLinkModal () {
 		this.setState({
-			showLinkModal: true
+			showLinkModal: 'link'
+		})
+	}
+
+	showUnlinkModal () {
+		this.setState({
+			showLinkModal: 'unlink'
 		})
 	}
 
 	hideLinkModal () {
 		this.setState({
-			showLinkModal: false
+			showLinkModal: null
 		})
 	}
 
@@ -222,10 +230,17 @@ export default class CardTable extends BaseLens {
 				<Box flex="1" style={{
 					position: 'relative'
 				}}>
-					{showLinkModal && (
+					{showLinkModal === 'link' && (
 						<LinkModal
 							cards={checkedCards}
 							types={allTypes}
+							onHide={this.hideLinkModal}
+						/>
+					)}
+
+					{showLinkModal === 'unlink' && (
+						<UnlinkModal
+							cards={checkedCards}
 							onHide={this.hideLinkModal}
 						/>
 					)}
@@ -251,6 +266,12 @@ export default class CardTable extends BaseLens {
 										onClick={this.openCreateChannelForLinking}
 									>
 										Create a new element to link to
+									</ActionLink>
+									<ActionLink
+										data-test="cardTableActions__unlink-existing"
+										onClick={this.showUnlinkModal}
+									>
+										Unlink from existing element
 									</ActionLink>
 								</DropDownButton>
 

--- a/apps/ui/lib/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.jsx
@@ -25,7 +25,9 @@ import format from 'date-fns/format'
 import parseISO from 'date-fns/parseISO'
 import flatten from 'flat'
 import BaseLens from '../../common/BaseLens'
-import LinkModal from '../../../components/LinkModal'
+import {
+	LinkModal
+} from '../../../components/LinkModal'
 import {
 	ColumnHider
 } from './ColumnHider'
@@ -205,7 +207,6 @@ export default class CardTable extends BaseLens {
 
 	render () {
 		const {
-			actions,
 			allTypes,
 			generateData
 		} = this.props
@@ -223,7 +224,6 @@ export default class CardTable extends BaseLens {
 				}}>
 					{showLinkModal && (
 						<LinkModal
-							actions={actions}
 							cards={checkedCards}
 							types={allTypes}
 							onHide={this.hideLinkModal}

--- a/apps/ui/lib/lens/misc/Table/tests/CardTable.spec.jsx
+++ b/apps/ui/lib/lens/misc/Table/tests/CardTable.spec.jsx
@@ -192,5 +192,5 @@ ava('It should let you link multiple selected cards to an existing card', async 
 	openActions(cardTableComponent)
 	takeAction(cardTableComponent, 'link-existing')
 
-	test.true(cardTableComponent.state().showLinkModal)
+	test.is(cardTableComponent.state().showLinkModal, 'link')
 })


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![Unlinking Demo](https://user-images.githubusercontent.com/2925657/104404936-68fc1500-558e-11eb-9344-f6dd02bf99d6.gif)

(This modal can also be accessed from the table lens, allowing you to unlink multiple cards from a particular card at the same time).

Note: this PR is split into several commits - do review them separately to make life easier for yourself!

Fixes #5370
