### PR TITLE
Kuberentes: Remove readiness gates from K8s deployment manifests.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -21,9 +21,6 @@ spec:
         app: jellyfish
     spec:
       terminationGracePeriodSeconds: 120
-      readinessGates:
-      # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
-      - conditionType: target-health.alb.ingress.k8s.aws/jellyfish-api_jellyfish-api_8000
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-api.data.assets.image.url%>>
         name: jellyfish

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -20,9 +20,6 @@ spec:
       labels:
         app: jellyfish-livechat
     spec:
-      readinessGates:
-      # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
-      - conditionType: target-health.alb.ingress.k8s.aws/jellyfish-livechat_jellyfish-livechat_80
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-livechat.data.assets.image.url%>>
         name: jellyfish-livechat

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -20,9 +20,6 @@ spec:
       labels:
         app: jellyfish-ui
     spec:
-      readinessGates:
-      # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
-      - conditionType: target-health.alb.ingress.k8s.aws/jellyfish-ui_jellyfish-ui_80
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-ui.data.assets.image.url%>>
         name: jellyfish-ui


### PR DESCRIPTION
The new AWS Load Balancer Controller recommends removing the old
podReadinessGates from the deployment manifests since it is not
anymore in use.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
