### PR TITLE
Expand all links when streaming a single card

### DIFF
--- a/apps/ui/lib/components/CardActions/CardActions.jsx
+++ b/apps/ui/lib/components/CardActions/CardActions.jsx
@@ -5,6 +5,7 @@
  */
 
 import copy from 'copy-to-clipboard'
+import _ from 'lodash'
 import React from 'react'
 import {
 	Flex,
@@ -83,6 +84,8 @@ export default class CardActions extends React.Component {
 
 	render () {
 		const supportsOwnership = supportsLink(this.props.card.type, 'is owned by')
+		const owner = _.head(_.get(this.props.card, [ 'links', 'is owned by' ], null))
+
 		return (
 			<React.Fragment>
 				<Flex alignItems="center" justifyContent="flex-end">
@@ -92,7 +95,9 @@ export default class CardActions extends React.Component {
 							user={this.props.user}
 							types={this.props.types}
 							card={this.props.card}
+							channel={this.props.channel}
 							sdk={this.props.sdk}
+							cardOwner={owner}
 							actions={this.props.actions} />
 					)}
 					<PlainButton

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -508,7 +508,7 @@ export const actionCreators = {
 						channels[0],
 						{
 							arrayMerge: (destinationArray, sourceArray) => {
-								return _.union(destinationArray, sourceArray)
+								return _.unionBy(destinationArray, sourceArray, 'id')
 							}
 						}
 					)

--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -38,6 +38,9 @@ import {
 import {
 	streamTyping
 } from './stream/typing'
+import {
+	getAllLinkQueries
+} from '../helpers'
 
 // Refresh the session token once every 3 hours
 const TOKEN_REFRESH_INTERVAL = 3 * 60 * 60 * 1000
@@ -438,14 +441,27 @@ export const actionCreators = {
 
 			const identifier = isUUID(target) ? 'id' : 'slug'
 
+			let default$$Links = {
+				'has attached element': {
+					type: 'object',
+					additionalProperties: true
+				}
+			}
+
+			// If we have a channel that's not a view
+			if (_.get(channel, [ 'data', 'cardType' ]) !== 'view') {
+				// Go through all the link constraints and set as default $$Links
+				default$$Links = {
+					...default$$Links,
+					...getAllLinkQueries()
+				}
+			}
 			const query = {
 				type: 'object',
 				anyOf: [
 					{
 						$$links: {
-							'has attached element': {
-								type: 'object'
-							}
+							...default$$Links
 						}
 					},
 					true

--- a/apps/ui/lib/core/store/helpers.js
+++ b/apps/ui/lib/core/store/helpers.js
@@ -6,6 +6,10 @@
 
 import _ from 'lodash'
 import update from 'immutability-helper'
+import {
+	constraints
+} from '@balena/jellyfish-client-sdk/lib/link-constraints'
+import memoize from 'memoize-one'
 
 /**
  * Given a target card id and a card that's been updated, finds all channels
@@ -76,3 +80,17 @@ export const mentionsUser = (card, user, groups) => {
 		return _.get(groups, [ groupName, 'isMine' ])
 	})
 }
+
+export const getAllLinkQueries = memoize(() => {
+	let links = {}
+	constraints.forEach((constraint) => {
+		links = {
+			...links,
+			[constraint.name]: {
+				type: 'object',
+				additionalProperties: true
+			}
+		}
+	})
+	return links
+})

--- a/apps/ui/lib/lens/actions/CreateLens.jsx
+++ b/apps/ui/lib/lens/actions/CreateLens.jsx
@@ -476,7 +476,6 @@ const mapDispatchToProps = (dispatch) => {
 			_.pick(actionCreators, [
 				'createLink',
 				'removeChannel',
-				'getLinks',
 				'queryAPI'
 			]),
 			dispatch

--- a/apps/ui/lib/lens/actions/tests/CreateLens.spec.jsx
+++ b/apps/ui/lib/lens/actions/tests/CreateLens.spec.jsx
@@ -110,7 +110,6 @@ ava.beforeEach(async (test) => {
 			actions: {
 				removeChannel: sandbox.stub().resolves(null),
 				createLink: sandbox.stub().resolves(null),
-				getLinks: sandbox.stub().resolves([]),
 				queryAPI: sandbox.stub()
 			}
 		}

--- a/apps/ui/lib/lens/common/Segment.jsx
+++ b/apps/ui/lib/lens/common/Segment.jsx
@@ -4,11 +4,6 @@
  * Proprietary and confidential.
  */
 
-import Bluebird from 'bluebird'
-import clone from 'deep-copy'
-import {
-	circularDeepEqual
-} from 'fast-equals'
 import _ from 'lodash'
 import React from 'react'
 import {
@@ -31,31 +26,12 @@ class Segment extends React.Component {
 		super(props)
 
 		this.state = {
-			results: props.draftCards || null,
 			showLinkModal: false
 		}
 
 		this.openCreateChannel = this.openCreateChannel.bind(this)
 		this.openLinkModal = this.openLinkModal.bind(this)
 		this.hideLinkModal = this.hideLinkModal.bind(this)
-		this.updateResults = this.updateResults.bind(this)
-		this.getData = this.getData.bind(this)
-	}
-
-	componentDidUpdate (prevProps) {
-		if (
-			!circularDeepEqual(prevProps.segment, this.props.segment)
-		) {
-			this.setState({
-				results: null
-			})
-			this.getData()
-		} else if (
-			!circularDeepEqual(prevProps.card, this.props.card) ||
-			!circularDeepEqual(prevProps.draftCards, this.props.draftCards)
-		) {
-			this.getData()
-		}
 	}
 
 	openLinkModal () {
@@ -68,58 +44,6 @@ class Segment extends React.Component {
 		this.setState({
 			showLinkModal: false
 		})
-	}
-
-	componentDidMount () {
-		this.getData()
-	}
-
-	updateResults (results) {
-		const {
-			onCardsUpdated,
-			draftCards
-		} = this.props
-		this.setState({
-			results: _.unionBy(results, (draftCards || []), 'id')
-		}, () => {
-			if (onCardsUpdated) {
-				onCardsUpdated(results)
-			}
-		})
-	}
-
-	async getData () {
-		const {
-			card,
-			segment,
-			actions,
-			sdk
-		} = this.props
-
-		if (segment.link) {
-			const results = await	actions.getLinks({
-				sdk
-			}, card, segment.link)
-			this.updateResults(results)
-		} else if (segment.query) {
-			let context = [ card ]
-			for (const relation of _.castArray(segment.query)) {
-				if (relation.link) {
-					context = actions.getLinks({
-						sdk
-					}, card, relation.link)
-				} else {
-					const mapped = await Bluebird.map(context, (item) => {
-						return actions.queryAPI(helpers.evalSchema(clone(relation), {
-							result: item
-						}))
-					})
-					context = _.flatten(mapped)
-				}
-			}
-
-			this.updateResults(_.flatten(context))
-		}
 	}
 
 	openCreateChannel () {
@@ -139,11 +63,6 @@ class Segment extends React.Component {
 				}),
 				seed: {
 					markers: card.markers
-				},
-				onDone: {
-					action: 'link',
-					targets: [ card ],
-					callback: this.getData
 				}
 			},
 			format: 'create',
@@ -153,11 +72,11 @@ class Segment extends React.Component {
 
 	render () {
 		const {
-			results,
 			showLinkModal
 		} = this.state
 
 		const {
+			draftCards,
 			actions,
 			card,
 			segment,
@@ -165,6 +84,9 @@ class Segment extends React.Component {
 			onSave,
 			showLinkToExistingElementButton = true
 		} = this.props
+
+		const linkedCards = _.get(card, [ 'links', segment.link ], draftCards)
+		const results = _.unionBy(linkedCards, (draftCards || []), 'id')
 
 		const type = _.find(types, {
 			slug: helpers.getRelationshipTargetType(segment)
@@ -236,7 +158,6 @@ class Segment extends React.Component {
 						types={[ type ]}
 						onHide={this.hideLinkModal}
 						onSave={onSave}
-						onSaved={this.getData}
 					/>
 				)}
 			</Flex>

--- a/apps/ui/lib/lens/full/FormResponse/index.jsx
+++ b/apps/ui/lib/lens/full/FormResponse/index.jsx
@@ -29,7 +29,6 @@ const mapDispatchToProps = (dispatch) => {
 			_.pick(actionCreators, [
 				'createLink',
 				'addChannel',
-				'getLinks',
 				'queryAPI'
 			]), dispatch)
 	}

--- a/apps/ui/lib/lens/full/Repository/index.jsx
+++ b/apps/ui/lib/lens/full/Repository/index.jsx
@@ -38,7 +38,6 @@ const mapDispatchToProps = (dispatch) => {
 				'addChannel',
 				'clearViewData',
 				'createLink',
-				'getLinks',
 				'loadViewData',
 				'loadMoreViewData',
 				'queryAPI',

--- a/apps/ui/lib/lens/full/SingleCard/index.jsx
+++ b/apps/ui/lib/lens/full/SingleCard/index.jsx
@@ -33,7 +33,6 @@ const mapDispatchToProps = (dispatch) => {
 			_.pick(actionCreators, [
 				'createLink',
 				'addChannel',
-				'getLinks',
 				'queryAPI'
 			]), dispatch)
 	}


### PR DESCRIPTION
As far as possible, all data fetched from the server should be fetched by a stream.

- This will hugely improve the UX as front-end data will automatically be kept in sync with backend data.
- It will simplify the front-end code significantly as there will be no requirements for manual updating/syncing across sibling components.

The main risk is that the backend will be overloaded with the increased size of stream queries.

Expanding all links on the stream would still allow of pagination of for example the timeline `"has attached element"` links:
https://github.com/product-os/jellyfish/blob/179cc909726439439bd969665c78ff9684b5d26f/apps/ui/lib/core/store/actioncreators/index.js#L549-L562

and all other link verbs are currently not paginated. There is a separate thread of work ongoing to improve the Pagination API.