### PR TITLE
Fix ci task dependencies

### DIFF
--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -34,6 +34,8 @@ tasks:
     environment:
       - name: 'FILES'
         value: './test/e2e/sync/front-mirror.spec.js'
+    dependencies:
+      - 'wait-for-api'
   - name: 'discourse-mirror'
     description: 'Discourse Mirror Tests'
     command: 'make test'
@@ -60,7 +62,7 @@ tasks:
     cwd: '/usr/src/jellyfish'
     required: true
     dependencies:
-      - 'front-mirror'
+      - 'wait-for-api'
   - name: 'e2e-ui'
     description: 'E2E UI Tests'
     command: 'make test-e2e-ui'
@@ -71,6 +73,13 @@ tasks:
         value: ''
     dependencies:
       - 'e2e-livechat'
+  - name: 'e2e-server'
+    description: 'E2E Server Tests'
+    command: 'make test-e2e-server'
+    cwd: '/usr/src/jellyfish'
+    required: true
+    dependencies:
+      - 'e2e-ui'
   - name: 'integration-server'
     description: 'Server Integration Tests'
     command: 'make test-integration-server'
@@ -91,19 +100,14 @@ tasks:
         value: ''
     dependencies:
       - 'integration-server'
-  - name: 'e2e-server'
-    description: 'E2E Server Tests'
-    command: 'make test-e2e-server'
-    cwd: '/usr/src/jellyfish'
-    required: true
-    dependencies:
-      - 'e2e-ui'
   - name: 'postgres-export'
     description: 'Export Postgres dump'
     command: './scripts/ci/postgres/export.js e2e-server'
     cwd: '/usr/src/jellyfish'
     required: true
     dependencies:
+      - 'github-mirror'
+      - 'integration-worker'
       - 'e2e-server'
   - name: 'postgres-import'
     description: 'Import Postgres dump from most recently merged commit'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

There are some cases in which all mirror tests do not complete before the postgres-import step executes, resulting in errors. Need to make sure all non-"previous-dump" tests complete before importing the previous pg dump.
