### PR TITLE
Use official Redis 6 image

### DIFF
--- a/deploy-templates/keyframe.tpl.yml
+++ b/deploy-templates/keyframe.tpl.yml
@@ -57,11 +57,11 @@ children:
               url: 'https://github.com/balena-io/jellyfish.git'
       jellyfish-redis:
         slug: jellyfish-redis
-        version: latest
+        version: 6.0.10
         type: sw.containerized-application
         data:
           assets:
             image:
-              url: 'balena/balena-redis:0.0.3'
+              url: 'redis:6.0.10'
             repo:
-              url: 'https://github.com/balena-io/balena-redis.git'
+              url: 'https://github.com/docker-library/redis.git'

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -30,7 +30,7 @@ services:
       - POSTGRES_PORT={{POSTGRES_PORT}}
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT={{REDIS_PORT}}
       - SENTRY_DSN_SERVER
       - SERVER_DATABASE={{SERVER_DATABASE}}
@@ -113,8 +113,10 @@ services:
     networks:
       - internal
   redis:
-    image: balena/balena-redis:0.0.3
-    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
+    image: redis:6.0.10
+    environment:
+      - REDIS_PASSWORD
+    command: [sh, -c, "redis-server --requirepass \"$REDIS_PASSWORD\" --save ''"]
     restart: always
     networks:
       - internal
@@ -138,7 +140,7 @@ services:
       - POSTGRES_PORT={{POSTGRES_PORT}}
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT={{REDIS_PORT}}
       - LOGLEVEL=crit
       - SENTRY_DSN_SERVER
@@ -185,7 +187,7 @@ services:
       - POSTGRES_PORT={{POSTGRES_PORT}}
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT={{REDIS_PORT}}
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - SERVER_DATABASE=jellyfish
@@ -112,8 +112,10 @@ services:
     networks:
       - internal
   redis:
-    image: balena/balena-redis:0.0.3
-    command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
+    image: redis:6.0.10
+    environment:
+      - REDIS_PASSWORD
+    command: [sh, -c, "redis-server --requirepass \"$REDIS_PASSWORD\" --save ''"]
     restart: always
     networks:
       - internal
@@ -137,7 +139,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT=6379
       - LOGLEVEL=crit
       - SENTRY_DSN_SERVER
@@ -183,7 +185,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN
@@ -243,7 +245,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
-      - REDIS_PASSWORD=
+      - REDIS_PASSWORD
       - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - LOGENTRIES_TOKEN


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Another attempt to switch from the deprecated `balena-redis` image based on Redis 5 to the official Redis 6 image. Found that the main difference between devenv and prod is that prod has a password set while devenv doesn't. `balena-redis` has a custom config baked into the image, but I believe we can get away with not doing this and just set customized config values with command flags (`requirepass`).
