### PR TITLE
Prevent lens selection component collapsing

### DIFF
--- a/apps/ui/lib/lens/full/View/Header/LensSelection.jsx
+++ b/apps/ui/lib/lens/full/View/Header/LensSelection.jsx
@@ -7,6 +7,7 @@
 import React from 'react'
 import _ from 'lodash'
 import {
+	Box,
 	Button,
 	ButtonGroup
 } from 'rendition'
@@ -14,31 +15,34 @@ import {
 	Icon
 } from '@balena/jellyfish-ui-components'
 
-const LensSelection = ({
+// HACK: set min height to the height of a button group
+// this prevents the component collapsing vertically if
+// there are no lenses provided.
+const MIN_HEIGHT = '38px'
+
+export const LensSelection = ({
 	lenses,
 	lens,
-	setLens
+	setLens,
+	...rest
 }) => {
-	if (!lenses.length > 1 && !lens) {
-		return null
-	}
 	return (
-		<ButtonGroup ml={3}>
-			{_.map(lenses, (item) => {
-				return (
-					<Button
-						key={item.slug}
-						active={lens && lens.slug === item.slug}
-						data-test={`lens-selector--${item.slug}`}
-						data-slug={item.slug}
-						onClick={setLens}
-						pt={11}
-						icon={<Icon name={item.data.icon}/>}
-					/>
-				)
-			})}
-		</ButtonGroup>
+		<Box {...rest} minHeight={MIN_HEIGHT}>
+			<ButtonGroup>
+				{_.map(lenses, (item) => {
+					return (
+						<Button
+							key={item.slug}
+							active={lens && lens.slug === item.slug}
+							data-test={`lens-selector--${item.slug}`}
+							data-slug={item.slug}
+							onClick={setLens}
+							pt={11}
+							icon={<Icon name={item.data.icon}/>}
+						/>
+					)
+				})}
+			</ButtonGroup>
+		</Box>
 	)
 }
-
-export default LensSelection

--- a/apps/ui/lib/lens/full/View/Header/index.jsx
+++ b/apps/ui/lib/lens/full/View/Header/index.jsx
@@ -13,7 +13,9 @@ import {
 	Collapsible
 } from '@balena/jellyfish-ui-components'
 import Markers from '../../../../components/Markers'
-import LensSelection from './LensSelection'
+import {
+	LensSelection
+} from './LensSelection'
 import SliceOptions from './SliceOptions'
 import ViewFilters from './ViewFilters'
 
@@ -70,6 +72,7 @@ export default class Header extends React.Component {
 									setSlice={setSlice}
 								/>
 								<LensSelection
+									ml={3}
 									lenses={lenses}
 									lens={lens}
 									setLens={setLens}


### PR DESCRIPTION
This change ensures that the lens selection component does not collapse it's height if there are no lenses passed to it. This prevents the UI from jumping around.

The component is also exported as a named export now and the spacing is passed in as a prop now.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Preparatory PR for the lens reformat that is coming!
