### PR TITLE
Add `data.format` field to all lenses

### DIFF
--- a/apps/ui/lib/lens/actions/CreateLens.jsx
+++ b/apps/ui/lib/lens/actions/CreateLens.jsx
@@ -490,6 +490,7 @@ export default {
 	version: '1.0.0',
 	name: 'Default list lens',
 	data: {
+		format: 'create',
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CreateLens),
 		icon: 'address-card',
 		type: '*',

--- a/apps/ui/lib/lens/actions/CreateUserLens/index.jsx
+++ b/apps/ui/lib/lens/actions/CreateUserLens/index.jsx
@@ -40,6 +40,7 @@ export default {
 	version: '1.0.0',
 	name: 'Create user lens',
 	data: {
+		format: 'create',
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CreateUserLens),
 		icon: 'address-card',
 		type: '*',

--- a/apps/ui/lib/lens/actions/CreateView/index.jsx
+++ b/apps/ui/lib/lens/actions/CreateView/index.jsx
@@ -41,6 +41,7 @@ export default {
 	version: '1.0.0',
 	name: 'View creation lens',
 	data: {
+		format: 'createView',
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CreateView),
 		icon: 'address-card',
 		type: '*',

--- a/apps/ui/lib/lens/actions/EditLens.jsx
+++ b/apps/ui/lib/lens/actions/EditLens.jsx
@@ -251,6 +251,7 @@ export default {
 	version: '1.0.0',
 	name: 'Default list lens',
 	data: {
+		format: 'edit',
 		renderer: connect(null, mapDispatchToProps)(EditLens),
 		icon: 'pencil',
 		type: '*',

--- a/apps/ui/lib/lens/actions/LinksGraphLens.jsx
+++ b/apps/ui/lib/lens/actions/LinksGraphLens.jsx
@@ -242,6 +242,7 @@ export default {
 	version: '1.0.0',
 	name: 'Default list lens',
 	data: {
+		format: 'visualizeLinks',
 		renderer: connect(null, mapDispatchToProps)(CreateLens),
 		icon: 'address-card',
 		type: '*',

--- a/apps/ui/lib/lens/actions/index.js
+++ b/apps/ui/lib/lens/actions/index.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import CreateLens from './CreateLens'
+import CreateUserLens from './CreateUserLens'
+import CreateViewLens from './CreateView'
+import EditLens from './EditLens'
+import LinksGraphLens from './LinksGraphLens'
+
+export default [
+	CreateLens,
+	CreateUserLens,
+	CreateViewLens,
+	EditLens,
+	LinksGraphLens
+]

--- a/apps/ui/lib/lens/misc/CRMTable/index.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/index.jsx
@@ -60,7 +60,7 @@ const lens = {
 	name: 'CRM table lens',
 	data: {
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CRMTable),
-		format: 'full',
+		format: 'list',
 		icon: 'table',
 		type: '*',
 		filter: {

--- a/apps/ui/lib/lens/misc/Inbox/index.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/index.jsx
@@ -33,6 +33,7 @@ export default {
 	version: '1.0.0',
 	name: 'Inbox lens',
 	data: {
+		format: 'inbox',
 		renderer: connect(null, mapDispatchToProps)(Inbox),
 		icon: 'address-card',
 		type: '*',

--- a/apps/ui/lib/lens/misc/Kanban.jsx
+++ b/apps/ui/lib/lens/misc/Kanban.jsx
@@ -245,6 +245,7 @@ const lens = {
 	data: {
 		supportsSlices: true,
 		icon: 'columns',
+		format: 'list',
 		renderer: withRouter(connect(mapStateToProps, mapDispatchToProps)(Kanban)),
 		filter: {
 			type: 'array'

--- a/apps/ui/lib/lens/misc/Table/index.js
+++ b/apps/ui/lib/lens/misc/Table/index.js
@@ -48,6 +48,7 @@ const lens = {
 	data: {
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CardTable),
 		icon: 'table',
+		format: 'list',
 		type: '*',
 		filter: {
 			type: 'array',

--- a/apps/ui/lib/lens/misc/index.js
+++ b/apps/ui/lib/lens/misc/index.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import Kanban from './Kanban'
+import SupportAuditChart from './SupportAuditChart'
+import Table from './Table'
+import CRMTable from './CRMTable'
+import Chart from './Chart'
+import Inbox from './Inbox'
+
+export default [
+	Kanban,
+	SupportAuditChart,
+	Table,
+	CRMTable,
+	Chart,
+	Inbox
+]

--- a/apps/ui/lib/lens/snippet/Contact/index.js
+++ b/apps/ui/lib/lens/snippet/Contact/index.js
@@ -24,7 +24,7 @@ const lens = {
 	version: '1.0.0',
 	name: 'Default lens',
 	data: {
-		format: 'full',
+		format: 'snippet',
 		icon: 'address-card',
 		renderer: connect(mapStateToProps)(Contact),
 		filter: {

--- a/apps/ui/lib/lens/snippet/SingleCard/index.js
+++ b/apps/ui/lib/lens/snippet/SingleCard/index.js
@@ -24,7 +24,7 @@ const lens = {
 	version: '1.0.0',
 	name: 'Default lens',
 	data: {
-		format: 'full',
+		format: 'snippet',
 		icon: 'address-card',
 		renderer: connect(mapStateToProps)(SingleCard),
 		filter: {

--- a/apps/ui/lib/lens/snippet/SingleResponse/index.js
+++ b/apps/ui/lib/lens/snippet/SingleResponse/index.js
@@ -24,7 +24,7 @@ const lens = {
 	version: '1.0.0',
 	name: 'Default lens',
 	data: {
-		format: 'full',
+		format: 'snippet',
 		icon: 'address-card',
 		renderer: connect(mapStateToProps)(SingleResponse),
 		filter: {

--- a/apps/ui/lib/lens/snippet/Specification/index.js
+++ b/apps/ui/lib/lens/snippet/Specification/index.js
@@ -24,7 +24,7 @@ const lens = {
 	version: '1.0.0',
 	name: 'Specification snippet',
 	data: {
-		format: 'full',
+		format: 'snippet',
 		icon: 'address-card',
 		renderer: connect(mapStateToProps)(Specification),
 		filter: {


### PR DESCRIPTION
This field will be used for grouping lenses.

Some lenses had the wrong format set so this has been fixed too.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***


Preparatory PR for the lens reformat that is coming!