### PR TITLE
Add support for restricting lenses based on a lens field

### DIFF
--- a/apps/ui/lib/lens/index.spec.js
+++ b/apps/ui/lib/lens/index.spec.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '../../test/ui-setup'
+import ava from 'ava'
+import {
+	getLenses
+} from './index'
+
+const user = {
+	id: 'u-1',
+	slug: 'user-1'
+}
+
+const data = [
+	{
+		id: 'st-1',
+		type: 'support-thread@1.0.0'
+	}
+]
+
+ava('getLenses can be used to return one lens per icon', (test) => {
+	let lenses = getLenses('list', data, user)
+	test.true(lenses.filter((lens) => lens.data.icon === 'address-card').length > 1)
+	lenses = getLenses('list', data, user, 'data.icon')
+	test.is(lenses.filter((lens) => lens.data.icon === 'address-card').length, 1)
+})


### PR DESCRIPTION
This optional argument can be used to group lenses by a lens field value and then ensure only the top-scoring lens per group is returned.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Preparatory PR for the lens reformat that is coming!