### PR TITLE
Stop using SupportThreadsToAudit lens for viewing non-support-thread cards

### DIFF
--- a/apps/ui/lib/lens/common/Segment.jsx
+++ b/apps/ui/lib/lens/common/Segment.jsx
@@ -183,11 +183,16 @@ class Segment extends React.Component {
 
 		return (
 			<Flex flexDirection='column' style={{
-				height: '100%'
+				flex: 1
 			}}>
-				<Box flex={1} style={{
+				<Box flex={1} mt={3} style={{
 					minHeight: 0
 				}}>
+					{results.length === 0 && (
+						<Box px={3}>
+							<strong>No results found</strong>
+						</Box>
+					)}
 					{Boolean(results.length) && (
 						<lens.data.renderer
 							tail={results}
@@ -195,14 +200,8 @@ class Segment extends React.Component {
 					)}
 				</Box>
 
-				{results.length === 0 && (
-					<Box px={3} mt={2}>
-						<strong>There are no results</strong>
-					</Box>
-				)}
-
 				{segment.link && (
-					<Flex px={3} pb={2} flexWrap="wrap">
+					<Flex px={3} pb={3} flexWrap="wrap">
 
 						{!onSave &&
 							<Button

--- a/apps/ui/lib/lens/common/Segment.jsx
+++ b/apps/ui/lib/lens/common/Segment.jsx
@@ -196,6 +196,13 @@ class Segment extends React.Component {
 					{Boolean(results.length) && (
 						<lens.data.renderer
 							tail={results}
+							page={1}
+							totalPages={1}
+							setPage={_.noop}
+							pageOptions={{
+								limit: 30,
+								sortBy: [ 'created_at' ]
+							}}
 						/>
 					)}
 				</Box>

--- a/apps/ui/lib/lens/list/List.jsx
+++ b/apps/ui/lib/lens/list/List.jsx
@@ -67,11 +67,8 @@ class CardList extends BaseLens {
 
 		this.rowRenderer = (rowProps) => {
 			const {
-				tail, channel: {
-					data: {
-						head
-					}
-				}
+				tail,
+				channel
 			} = this.props
 			const card = tail[rowProps.index]
 
@@ -83,7 +80,7 @@ class CardList extends BaseLens {
 			const lens = getLens('snippet', card, {})
 
 			// Don't show the card if its the head, this can happen on view types
-			if (card.id === head.id) {
+			if (card.id === _.get(channel, [ 'data', 'head', 'id' ])) {
 				return null
 			}
 

--- a/apps/ui/lib/lens/list/List.jsx
+++ b/apps/ui/lib/lens/list/List.jsx
@@ -67,6 +67,7 @@ class CardList extends BaseLens {
 
 		this.rowRenderer = (rowProps) => {
 			const {
+				user,
 				tail,
 				channel
 			} = this.props
@@ -77,7 +78,7 @@ class CardList extends BaseLens {
 				return null
 			}
 
-			const lens = getLens('snippet', card, {})
+			const lens = getLens('snippet', card, user)
 
 			// Don't show the card if its the head, this can happen on view types
 			if (card.id === _.get(channel, [ 'data', 'head', 'id' ])) {

--- a/apps/ui/lib/lens/list/List.jsx
+++ b/apps/ui/lib/lens/list/List.jsx
@@ -95,7 +95,7 @@ class CardList extends BaseLens {
 					columnIndex={0}
 					rowIndex={rowProps.index}
 				>
-					<Box px={3} pb={3} style={rowProps.style}>
+					<Box style={rowProps.style}>
 						<lens.data.renderer card={card}/>
 						<Divider color="#eee" m={0} style={{
 							height: 1
@@ -167,7 +167,8 @@ class CardList extends BaseLens {
 		return (
 			<Column flex="1" overflowY>
 				<Box flex="1" style={{
-					position: 'relative'
+					position: 'relative',
+					minHeight: 80
 				}}>
 					<ReactResizeObserver onResize={this.clearCellCache}/>
 					{Boolean(tail) && tail.length > 0 && (

--- a/apps/ui/lib/lens/list/List.jsx
+++ b/apps/ui/lib/lens/list/List.jsx
@@ -196,6 +196,7 @@ class CardList extends BaseLens {
 												rowRenderer={this.rowRenderer}
 												sortBy={sortBy}
 												scrollToIndex={this.state.scrollToIndex}
+												tail={tail}
 											/>
 										)
 									}}

--- a/apps/ui/lib/lens/list/SupportThreads.jsx
+++ b/apps/ui/lib/lens/list/SupportThreads.jsx
@@ -350,6 +350,12 @@ const lens = {
 				properties: {
 					id: {
 						type: 'string'
+					},
+					type: {
+						enum: [
+							'support-thread@1.0.0',
+							'sales-thread@1.0.0'
+						]
 					}
 				}
 			}

--- a/apps/ui/lib/lens/list/SupportThreadsToAudit/SupportThreadsToAudit.jsx
+++ b/apps/ui/lib/lens/list/SupportThreadsToAudit/SupportThreadsToAudit.jsx
@@ -73,6 +73,7 @@ export default class SupportThreadsToAudit extends React.Component {
 					ref={this.bindScrollArea}
 					onScroll={this.handleScroll}
 					style={{
+						flex: 1,
 						height: '100%',
 						paddingBottom: 16,
 						overflowY: 'auto'

--- a/apps/ui/lib/lens/list/SupportThreadsToAudit/index.js
+++ b/apps/ui/lib/lens/list/SupportThreadsToAudit/index.js
@@ -50,7 +50,28 @@ const lens = {
 				properties: {
 					id: {
 						type: 'string'
-					}
+					},
+					type: {
+						enum: [
+							'support-thread@1.0.0',
+							'sales-thread@1.0.0'
+						]
+					},
+					data: {
+						type: 'object',
+						properties: {
+							status: {
+								type: 'string',
+								const: 'closed'
+							}
+						},
+						required: [
+							'status'
+						]
+					},
+					required: [
+						'data'
+					]
 				}
 			}
 		},

--- a/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
@@ -9,6 +9,7 @@ import {
 } from 'fast-equals'
 import _ from 'lodash'
 import React from 'react'
+import styled from 'styled-components'
 import {
 	Box,
 	Flex,
@@ -24,6 +25,20 @@ import {
 	UI_SCHEMA_MODE
 } from '../../schema-util'
 
+const CardBox = styled(Box) `
+	border-left-style: solid;
+	border-left-width: 4px;
+	${(props) => {
+		return props.active ? `
+			background: ${props.theme.colors.info.light};
+			border-left-color: ${props.theme.colors.info.main};
+		` : `
+			background: white;
+			border-left-color: transparent;
+		`
+	}}
+`
+
 export default class SingleCard extends React.Component {
 	shouldComponentUpdate (nextProps) {
 		return !circularDeepEqual(nextProps, this.props)
@@ -31,11 +46,15 @@ export default class SingleCard extends React.Component {
 
 	render () {
 		const {
+			channels,
 			card
 		} = this.props
 		const typeCard = _.find(this.props.types, {
 			slug: card.type.split('@')[0]
 		})
+		const threadTargets = _.map(channels, 'data.target')
+
+		const active = _.includes(threadTargets, card.slug) || _.includes(threadTargets, card.id)
 
 		// Count the number of non-event links the card has
 		const numLinks = _.reduce(card.links, (carry, value, key) => {
@@ -43,7 +62,7 @@ export default class SingleCard extends React.Component {
 		}, 0)
 
 		return (
-			<Box p={3} data-test="snippet--card" data-test-id={`snippet-card-${card.id}`}>
+			<CardBox active={active} p={3} data-test="snippet--card" data-test-id={`snippet-card-${card.id}`}>
 				<Flex justifyContent="space-between">
 					<Txt>
 						<Link append={card.slug || card.id}>
@@ -70,7 +89,7 @@ export default class SingleCard extends React.Component {
 					type={typeCard}
 					viewMode={UI_SCHEMA_MODE.snippet}
 				/>
-			</Box>
+			</CardBox>
 		)
 	}
 }

--- a/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
@@ -43,7 +43,7 @@ export default class SingleCard extends React.Component {
 		}, 0)
 
 		return (
-			<Box pb={3} data-test="snippet--card" data-test-id={`snippet-card-${card.id}`}>
+			<Box p={3} data-test="snippet--card" data-test-id={`snippet-card-${card.id}`}>
 				<Flex justifyContent="space-between">
 					<Txt>
 						<Link append={card.slug || card.id}>

--- a/apps/ui/lib/lens/snippet/SingleCard/index.js
+++ b/apps/ui/lib/lens/snippet/SingleCard/index.js
@@ -14,6 +14,7 @@ import SingleCard from './SingleCard'
 
 const mapStateToProps = (state) => {
 	return {
+		channels: selectors.getChannels(state),
 		types: selectors.getTypes(state)
 	}
 }

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -26,7 +26,7 @@ const selectors = {
 	closedBadge: '.column--support-thread span[data-test="status-closed"]',
 	addProductImprovement: '[data-test="add-product-improvement"]',
 	linkProductImprovement: '[data-test="link-to-product-improvement"]',
-	linkedProductImprovements: '[data-test="segment-card--product-improvements"] [data-test-component="card-chat-summary"]',
+	linkedProductImprovements: '[data-test="segment-card--product-improvements"] [data-test="snippet--card"]',
 	summaryProductImprovements: '[data-test="summary--product-improvements"] ul li',
 	summaryTextArea: '[data-test="gf__ta-summary"]',
 	summary: '.event-card--summary [data-test="event-card__message"]'
@@ -121,7 +121,7 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 	await page.keyboard.press('Enter')
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__submit"]:not(:disabled)')
 
-	const pi1CardChatSummary = `[data-test-component="card-chat-summary"][data-test-id="${productImprovement1.id}"]`
+	const pi1CardChatSummary = `[data-test="snippet--card"][data-test-id="snippet-card-${productImprovement1.id}"]`
 	await page.waitForSelector(`[data-test="segment-card--product-improvements"] ${pi1CardChatSummary}`)
 	linkedProductImprovements = await page.$$(selectors.linkedProductImprovements)
 	test.is(linkedProductImprovements.length, 2)

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -146,7 +146,13 @@ ava.serial('should let users create new opportunities', async (test) => {
 		page
 	} = context
 
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-opportunities"]')
+	// Navigate to view all opportunities
+	await macros.navigateToHomeChannelItem(page, [
+		'[data-test="home-channel__group-toggle--org-balena"]',
+		'[data-test="home-channel__group-toggle--Sales"]',
+		'[data-test="home-channel__item--view-all-opportunities"]'
+	])
+
 	await macros.waitForThenClickSelector(page, '.btn--add-opportunity')
 
 	const name = `test opportunity ${uuid()}`
@@ -167,7 +173,11 @@ ava.serial('should let users create new opportunities and directly link existing
 	} = context
 
 	// Navigate to view all opportunities
-	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-opportunities"]')
+	await macros.navigateToHomeChannelItem(page, [
+		'[data-test="home-channel__group-toggle--org-balena"]',
+		'[data-test="home-channel__group-toggle--Sales"]',
+		'[data-test="home-channel__item--view-all-opportunities"]'
+	])
 
 	// Open CreateLens for opportunities
 	await macros.waitForThenClickSelector(page, '.btn--add-opportunity')
@@ -186,7 +196,7 @@ ava.serial('should let users create new opportunities and directly link existing
 	await page.keyboard.press('Enter')
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__submit"]:not(:disabled)')
 
-	await page.waitForSelector('[data-test="segment-card--account"] [data-test-component="card-chat-summary"]')
+	await page.waitForSelector('[data-test="segment-card--account"] [data-test="snippet--card"]')
 
 	// Submit CreateLens
 	await macros.waitForThenClickSelector(page, '[data-test="card-creator__submit"]')


### PR DESCRIPTION
This PR fixes a super-old bug where `lens-support-threads-to-audit` was incorrectly being used to render lists of cards that were not support-threads or sales-threads.

Before:
![Brainstorm Calls Topic Segment - before](https://user-images.githubusercontent.com/2925657/105801373-9653b480-5fcb-11eb-93b7-820a2846a68f.png)

After:
![Brainstorm Calls Topic Segment - after](https://user-images.githubusercontent.com/2925657/105801379-994ea500-5fcb-11eb-9e3e-f60df7f64b94.png)

The easy part of fixing this bug was adding details to the `filter` property for `lens-support-threads` and `lens-support-threads-to-audit`. 

Significantly, the `Segment` component now typically uses the `lens-list` to render the list of cards (instead of `lens-support-threads-to-audit`!). Before this was possible I had to make a few tweaks to `Segment` and `List` to get them to play nicely together. The exception is, of course, tabs displaying support-threads or sales-threads. These are now rendered using the `lens-support-threads` (instead of `lens-support-threads-to-audit` - which requires that all threads are closed).

The code changes are separated out into several distinct commits so you can see _why_ each change was made. 

### Note
One slightly hacky part of all this is that the `List` component auto-sizes based on it's parents size. This is fine when the list is located within a `flex: 1` div that will always have a relatively large height (at least several times the height of an item in the list). But if the `List` component is in a 'normal' layout (i.e. not expanding to fill a flexbox container), we need to specify a hard-coded min height to ensure it renders with that height and doesn't collapse to zero height. What would be much better is if the `List` could increase in size based on it's item and you just specify an optional _max_ height for the `List` instead. PRs to fix this are welcome! 😆 