### PR TITLE
Fix link on SingleCard snippet lens

### DIFF
--- a/apps/ui/lib/components/ChannelRenderer.jsx
+++ b/apps/ui/lib/components/ChannelRenderer.jsx
@@ -21,6 +21,9 @@ import {
 	LinkModal
 } from './LinkModal'
 import ChannelNotFound from './ChannelNotFound'
+import {
+	ChannelContextProvider
+} from '../hooks'
 
 // Selects an appropriate renderer for a card
 class ChannelRenderer extends React.Component {
@@ -126,24 +129,26 @@ class ChannelRenderer extends React.Component {
 		const lens = getLens(_.get(channel.data, [ 'format' ], 'full'), head, user)
 
 		return (
-			<ErrorBoundary style={style}>
-				{
-					connectDropTarget(
-						<div style={style}>
-							<lens.data.renderer card={head} level={0} {...this.props}/>
-						</div>
-					)
-				}
+			<ChannelContextProvider channel={channel}>
+				<ErrorBoundary style={style}>
+					{
+						connectDropTarget(
+							<div style={style}>
+								<lens.data.renderer card={head} level={0} {...this.props}/>
+							</div>
+						)
+					}
 
-				{showLinkModal && (
-					<LinkModal
-						target={head}
-						cards={[ linkFrom ]}
-						types={types}
-						onHide={this.closeLinkModal}
-					/>
-				)}
-			</ErrorBoundary>
+					{showLinkModal && (
+						<LinkModal
+							target={head}
+							cards={[ linkFrom ]}
+							types={types}
+							onHide={this.closeLinkModal}
+						/>
+					)}
+				</ErrorBoundary>
+			</ChannelContextProvider>
 		)
 	}
 }

--- a/apps/ui/lib/hooks/channel-context.js
+++ b/apps/ui/lib/hooks/channel-context.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+
+const channelContext = React.createContext(null)
+
+export const ChannelContextProvider = ({
+	channel,
+	children
+}) => {
+	return (
+		<channelContext.Provider value={channel}>
+			{children}
+		</channelContext.Provider>
+	)
+}
+
+export const withChannelContext = (Component) => {
+	return (props) => {
+		return (
+			<channelContext.Consumer>
+				{(context) => {
+					return <Component channel={context} {...props} />
+				}}
+			</channelContext.Consumer>
+		)
+	}
+}
+
+export const useChannelContext = () => {
+	return React.useContext(channelContext)
+}

--- a/apps/ui/lib/hooks/index.js
+++ b/apps/ui/lib/hooks/index.js
@@ -7,3 +7,8 @@
 export {
 	default as useLabeledImage
 } from './use-labeled-image'
+export {
+	ChannelContextProvider,
+	useChannelContext,
+	withChannelContext
+} from './channel-context'

--- a/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
@@ -16,6 +16,7 @@ import {
 	Txt
 } from 'rendition'
 import {
+	helpers,
 	Icon,
 	Link,
 	TagList
@@ -46,6 +47,7 @@ export default class SingleCard extends React.Component {
 
 	render () {
 		const {
+			channel,
 			channels,
 			card
 		} = this.props
@@ -65,7 +67,7 @@ export default class SingleCard extends React.Component {
 			<CardBox active={active} p={3} data-test="snippet--card" data-test-id={`snippet-card-${card.id}`}>
 				<Flex justifyContent="space-between">
 					<Txt>
-						<Link append={card.slug || card.id}>
+						<Link to={helpers.appendToChannelPath(channel, card)}>
 							<strong>{card.name || card.slug}</strong>
 						</Link>
 					</Txt>

--- a/apps/ui/lib/lens/snippet/SingleCard/index.js
+++ b/apps/ui/lib/lens/snippet/SingleCard/index.js
@@ -5,11 +5,17 @@
  */
 
 import {
+	compose
+} from 'redux'
+import {
 	connect
 } from 'react-redux'
 import {
 	selectors
 } from '../../../core'
+import {
+	withChannelContext
+} from '../../../hooks/channel-context'
 import SingleCard from './SingleCard'
 
 const mapStateToProps = (state) => {
@@ -27,7 +33,7 @@ const lens = {
 	data: {
 		format: 'snippet',
 		icon: 'address-card',
-		renderer: connect(mapStateToProps)(SingleCard),
+		renderer: compose(connect(mapStateToProps), withChannelContext)(SingleCard),
 		filter: {
 			type: 'object'
 		}


### PR DESCRIPTION
The link should append the target channel to the current channel (i.e. replacing any existing content to the right of the current channel).

This change introduces a React context which supplies the channel value. This is useful for any components that need to know what channel they are being displayed in.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #5582

## Before

With a brainstorm call open, I choose a topic which opens on the right hand side of the screen (perfect), but when I choose a second topic, the first topic moves to the left and I end up with two topics open simultaneously. 

## After

With a brainstorm call open, I select a topic and have it appear on the right hand side of the screen, then choose a different topic and have the right hand side view switch to the new topic.


