### PR TITLE
Automatically select list lens options

### DIFF
--- a/apps/ui/lib/lens/common/BaseLens.jsx
+++ b/apps/ui/lib/lens/common/BaseLens.jsx
@@ -5,15 +5,109 @@
  */
 
 import React from 'react'
+import path from 'path'
+import _ from 'lodash'
 import {
+	v4 as uuid
+} from 'uuid'
+import {
+	addNotification,
 	helpers
 } from '@balena/jellyfish-ui-components'
+import {
+	linkConstraints
+} from '@balena/jellyfish-client-sdk'
+import {
+	analytics,
+	sdk
+} from '../../core'
 
 export default class BaseLens extends React.Component {
 	constructor (props) {
 		super(props)
 
+		this.state = {
+			creatingCard: false
+		}
+
+		this.onAddCard = this.onAddCard.bind(this)
+		this.appendChannel = this.appendChannel.bind(this)
+		this.addLinkedCard = this.addLinkedCard.bind(this)
 		this.openCreateChannel = this.openCreateChannel.bind(this)
+	}
+
+	onAddCard (event) {
+		event.preventDefault()
+		if (this.props.addLinkedCardType) {
+			this.addLinkedCard()
+		} else {
+			this.openCreateChannel()
+		}
+	}
+
+	addLinkedCard () {
+		if (!this.props.addLinkedCardType) {
+			console.warn('.addLinkedCard() called, but addLinkedCardType prop is not set')
+			return
+		}
+		const {
+			head
+		} = this.props.channel.data
+		if (!head) {
+			console.warn('.addLinkedCard() called, but there is no head card')
+			return
+		}
+		if (helpers.getTypeBase(head.type) === 'view') {
+			console.warn('.addLinkedCard() is only valid for views')
+			return
+		}
+
+		const cardData = this.getSeedData()
+
+		cardData.slug = `${this.props.addLinkedCardType}-${uuid()}`
+		cardData.type = this.props.addLinkedCardType
+		if (!cardData.data) {
+			cardData.data = {}
+		}
+		this.setState({
+			creatingCard: true
+		})
+		sdk.card.create(cardData)
+			.then(async (newCard) => {
+				if (newCard) {
+					this.appendChannel(newCard.slug || newCard.id)
+					const linkConstraint = _.find(linkConstraints, {
+						data: {
+							from: this.props.addLinkedCardType,
+							to: helpers.getTypeBase(head.type)
+						}
+					})
+					await sdk.card.link(newCard, head, linkConstraint.name)
+				}
+			})
+			.then(() => {
+				analytics.track('element.create', {
+					element: {
+						type: cardData.type
+					}
+				})
+			})
+			.catch((error) => {
+				addNotification('danger', error.message)
+			})
+			.finally(() => {
+				this.setState({
+					creatingCard: false
+				})
+			})
+	}
+
+	appendChannel (target) {
+		// Remove everything after the current channel, then append the target.
+		const current = this.props.channel.data.target
+		this.props.history.push(
+			path.join(window.location.pathname.split(current)[0], current, target)
+		)
 	}
 
 	openCreateChannel () {

--- a/apps/ui/lib/lens/common/ViewFooter.jsx
+++ b/apps/ui/lib/lens/common/ViewFooter.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Flex,
+	Button
+} from 'rendition'
+import styled from 'styled-components'
+
+const Footer = styled(Flex) `
+	border-top: 1px solid #eee;
+`
+
+export const ViewFooter = ({
+	type,
+	onAddCard
+}) => {
+	return (
+		<Footer
+			flex={0}
+			p={3}
+			justifyContent="flex-end"
+		>
+			<Button
+				success={true}
+				className={`btn--add-${type.slug}`}
+				onClick={onAddCard}
+			>
+				Add {type.name || type.slug}
+			</Button>
+		</Footer>
+	)
+}

--- a/apps/ui/lib/lens/common/index.js
+++ b/apps/ui/lib/lens/common/index.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as BaseLens
+} from './BaseLens'
+export {
+	default as Segment
+} from './Segment'
+export {
+	ViewFooter
+} from './ViewFooter'

--- a/apps/ui/lib/lens/full/Repository/Repository.jsx
+++ b/apps/ui/lib/lens/full/Repository/Repository.jsx
@@ -32,6 +32,10 @@ import {
 	getContextualThreadsQuery,
 	getLensBySlug
 } from '../../'
+import {
+	BaseLens,
+	ViewFooter
+} from '../../common'
 
 const SingleCardTabs = styled(Tabs) `
 	flex: 1
@@ -43,7 +47,7 @@ const SingleCardTabs = styled(Tabs) `
 
 const LIMIT = 30
 
-export default class RepositoryFull extends React.Component {
+export default class RepositoryFull extends BaseLens {
 	constructor (props) {
 		super(props)
 
@@ -61,11 +65,7 @@ export default class RepositoryFull extends React.Component {
 				page: 0,
 				totalPages: Infinity
 			},
-			searchTerm: '',
-			relationship: {
-				target: this.props.card,
-				name: 'is of'
-			}
+			searchTerm: ''
 		}
 
 		const messageType = helpers.getType('message', this.props.types)
@@ -175,6 +175,8 @@ export default class RepositoryFull extends React.Component {
 			slug: card.type.split('@')[0]
 		})
 
+		const threadType = helpers.getType('thread', types)
+
 		const relationships = _.get(type, [ 'data', 'meta', 'relationships' ])
 		const messages = _.sortBy(this.props.messages, 'created_at')
 
@@ -245,7 +247,8 @@ export default class RepositoryFull extends React.Component {
 					</SingleCardTabs>
 				)}
 
-				<Box
+				<Flex
+					flexDirection="column"
 					style={{
 						overflow: 'auto'
 					}}
@@ -254,12 +257,12 @@ export default class RepositoryFull extends React.Component {
 					<Interleaved
 						channel={channel}
 						tail={messages}
-						relationship={this.state.relationship}
 						setPage={this.setPage}
 						page={this.state.options.page}
 						totalPages={this.state.options.totalPages}
 					/>
-				</Box>
+					<ViewFooter type={threadType} onAddCard={this.onAddCard} />
+				</Flex>
 			</CardLayout>
 		)
 	}

--- a/apps/ui/lib/lens/full/Repository/index.jsx
+++ b/apps/ui/lib/lens/full/Repository/index.jsx
@@ -6,9 +6,13 @@
 
 import * as _ from 'lodash'
 import {
+	withRouter
+} from 'react-router-dom'
+import {
 	connect
 } from 'react-redux'
 import {
+	compose,
 	bindActionCreators
 } from 'redux'
 import {
@@ -24,6 +28,7 @@ const mapStateToProps = (state, ownProps) => {
 	const query = getContextualThreadsQuery(ownProps.card.id)
 
 	return {
+		addLinkedCardType: 'thread',
 		types: selectors.getTypes(state),
 		messages: selectors.getViewData(state, query, {
 			viewId: ownProps.card.id
@@ -55,7 +60,7 @@ const lens = {
 	data: {
 		format: 'full',
 		icon: 'address-card',
-		renderer: connect(mapStateToProps, mapDispatchToProps)(Repository),
+		renderer: compose(withRouter, connect(mapStateToProps, mapDispatchToProps))(Repository),
 		filter: {
 			type: 'object',
 			required: [ 'type' ],

--- a/apps/ui/lib/lens/full/View/Content.jsx
+++ b/apps/ui/lib/lens/full/View/Content.jsx
@@ -7,11 +7,16 @@
 import React from 'react'
 import _ from 'lodash'
 import {
-	Box
+	Box,
+	Flex,
+	Txt
 } from 'rendition'
 import {
 	Icon
 } from '@balena/jellyfish-ui-components'
+import {
+	ViewFooter
+} from '../../common/ViewFooter'
 
 const sortTail = (tail, options) => {
 	if (!tail) {
@@ -27,6 +32,7 @@ const sortTail = (tail, options) => {
 export default class Content extends React.Component {
 	render () {
 		const {
+			onAddCard,
 			lens,
 			activeLens,
 			tail,
@@ -40,24 +46,35 @@ export default class Content extends React.Component {
 		const sortedTail = sortTail(tail, options)
 
 		return (
-			<React.Fragment>
-				{!sortedTail && (
-					<Box p={3}>
-						<Icon spin name="cog"/>
-					</Box>
+			<Flex flex={1} flexDirection="column" minWidth="270px">
+				<Flex flex={1} flexDirection="column" data-test="inner-flex" style={{
+					overflowY: 'auto'
+				}}>
+					{!sortedTail && (
+						<Box p={3}>
+							<Icon spin name="cog"/>
+						</Box>
+					)}
+					{Boolean(tail) && tail.length === 0 && (
+						<Txt.p p={3}>No results found</Txt.p>
+					)}
+					{Boolean(tail) && Boolean(lens) && (
+						<lens.data.renderer
+							channel={channel}
+							tail={sortedTail}
+							setPage={setPage}
+							pageOptions={pageOptions}
+							page={pageOptions.page}
+							totalPages={pageOptions.totalPages}
+							type={tailType}
+						/>
+					)}
+				</Flex>
+
+				{Boolean(tailType) && (
+					<ViewFooter type={tailType} onAddCard={onAddCard} />
 				)}
-				{Boolean(tail) && Boolean(lens) && (
-					<lens.data.renderer
-						channel={channel}
-						tail={sortedTail}
-						setPage={setPage}
-						pageOptions={pageOptions}
-						page={pageOptions.page}
-						totalPages={pageOptions.totalPages}
-						type={tailType}
-					/>
-				)}
-			</React.Fragment>
+			</Flex>
 		)
 	}
 }

--- a/apps/ui/lib/lens/full/View/Header/LensSelection.jsx
+++ b/apps/ui/lib/lens/full/View/Header/LensSelection.jsx
@@ -28,21 +28,27 @@ export const LensSelection = ({
 }) => {
 	return (
 		<Box {...rest} minHeight={MIN_HEIGHT}>
-			<ButtonGroup>
-				{_.map(lenses, (item) => {
-					return (
-						<Button
-							key={item.slug}
-							active={lens && lens.slug === item.slug}
-							data-test={`lens-selector--${item.slug}`}
-							data-slug={item.slug}
-							onClick={setLens}
-							pt={11}
-							icon={<Icon name={item.data.icon}/>}
-						/>
-					)
-				})}
-			</ButtonGroup>
+			{ lenses.length > 1 && (
+				<ButtonGroup>
+					{_.map(lenses, (item) => {
+						return (
+							<Button
+								key={item.slug}
+								active={lens && lens.slug === item.slug}
+								data-test={`lens-selector--${item.slug}`}
+								data-slug={item.slug}
+								onClick={setLens}
+								pt={11}
+								tooltip={{
+									text: item.name,
+									placement: 'bottom'
+								}}
+								icon={<Icon name={item.data.icon}/>}
+							/>
+						)
+					})}
+				</ButtonGroup>
+			)}
 		</Box>
 	)
 }

--- a/apps/ui/lib/lens/index.js
+++ b/apps/ui/lib/lens/index.js
@@ -8,59 +8,21 @@ import _ from 'lodash'
 import skhema from 'skhema'
 import jsone from 'json-e'
 
-// TODO: Improve the way "utility" lenses are handled
-import CreateLens from './actions/CreateLens'
-import CreateUserLens from './actions/CreateUserLens'
-import CreateViewLens from './actions/CreateView'
-import EditLens from './actions/EditLens'
-import LinksGraphLens from './actions/LinksGraphLens'
-
-import Kanban from './misc/Kanban'
-import SupportAuditChart from './misc/SupportAuditChart'
-import Table from './misc/Table'
-import CRMTable from './misc/CRMTable'
-import Chart from './misc/Chart'
-
+import ActionLenses from './actions'
 import FullLenses from './full'
 import ListLenses from './list'
 import SnippetLenses from './snippet'
-import InboxLens from './misc/Inbox'
+import MiscLenses from './misc'
 
-const lenses = {
-	full: FullLenses,
-	list: ListLenses,
-	snippet: SnippetLenses,
+const allLenses = _.concat(
+	ActionLenses,
+	FullLenses,
+	ListLenses,
+	SnippetLenses,
+	MiscLenses
+)
 
-	edit: [
-		EditLens
-	],
-
-	inbox: [
-		InboxLens
-	],
-
-	create: [
-		CreateLens,
-		CreateUserLens
-	],
-
-	createView: [
-		CreateViewLens
-	],
-
-	visualizeLinks: [
-		LinksGraphLens
-	],
-
-	// TODO: Find a more meaningful way to represent these lenses
-	misc: [
-		Kanban,
-		SupportAuditChart,
-		Table,
-		CRMTable,
-		Chart
-	]
-}
+const lenses = _.groupBy(allLenses, 'data.format')
 
 // Returns an array of lenses that can be used to render `data`.
 // An optional onePer argument (dot-notation string) can be supplied

--- a/apps/ui/lib/lens/list/List.jsx
+++ b/apps/ui/lib/lens/list/List.jsx
@@ -24,10 +24,7 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
-	Flex,
-	Button,
 	Box,
-	Txt,
 	Divider
 } from 'rendition'
 import {
@@ -149,8 +146,7 @@ class CardList extends BaseLens {
 		const {
 			tail,
 			pageOptions,
-			totalPages,
-			type
+			totalPages
 		} = this.props
 
 		// TODO: remove this logic when totalPage returns a usefull number
@@ -203,31 +199,7 @@ class CardList extends BaseLens {
 							)}
 						</InfiniteLoader>
 					)}
-
-					{Boolean(tail) && tail.length === 0 && (
-						<Txt.p p={3}>No results found</Txt.p>
-					)}
 				</Box>
-
-				{Boolean(this.props.type) && (
-					<React.Fragment>
-						<Flex
-							p={3}
-							style={{
-								borderTop: '1px solid #eee'
-							}}
-							justifyContent="flex-end"
-						>
-							<Button
-								success={true}
-								className={`btn--add-${type.slug}`}
-								onClick={this.openCreateChannel}
-							>
-								Add {type.name || type.slug}
-							</Button>
-						</Flex>
-					</React.Fragment>
-				)}
 			</Column>
 		)
 	}
@@ -252,7 +224,7 @@ const lens = {
 	slug: 'lens-list',
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Default list lens',
+	name: 'List',
 	data: {
 		format: 'list',
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CardList),
@@ -263,6 +235,9 @@ const lens = {
 			items: {
 				type: 'object',
 				properties: {
+					id: {
+						type: 'string'
+					},
 					slug: {
 						type: 'string'
 					}

--- a/apps/ui/lib/lens/list/SupportThreads.jsx
+++ b/apps/ui/lib/lens/list/SupportThreads.jsx
@@ -246,7 +246,7 @@ export class SupportThreads extends React.Component {
 		} = this.state
 
 		return (
-			<Column data-test={`lens--${SLUG}`}>
+			<Column data-test={`lens--${SLUG}`} overflowY>
 				<StyledTabs
 					activeIndex={this.props.lensState.activeIndex}
 					onActive={this.setActiveIndex}
@@ -338,7 +338,7 @@ const lens = {
 	slug: SLUG,
 	type: 'lens',
 	version: '1.0.0',
-	name: 'SupportThreads lens',
+	name: 'Support/sales threads',
 	data: {
 		icon: 'address-card',
 		format: 'list',
@@ -351,13 +351,32 @@ const lens = {
 					id: {
 						type: 'string'
 					},
+					slug: {
+						type: 'string'
+					},
 					type: {
+						type: 'string',
 						enum: [
-							'support-thread@1.0.0',
-							'sales-thread@1.0.0'
+							'sales-thread@1.0.0',
+							'support-thread@1.0.0'
+						]
+					},
+					data: {
+						type: 'object',
+						properties: {
+							status: {
+								type: 'string'
+							}
+						},
+						required: [
+							'status'
 						]
 					}
-				}
+				},
+				required: [
+					'type',
+					'data'
+				]
 			}
 		},
 		queryOptions: {

--- a/apps/ui/lib/lens/list/SupportThreadsToAudit/index.js
+++ b/apps/ui/lib/lens/list/SupportThreadsToAudit/index.js
@@ -38,7 +38,7 @@ const lens = {
 	slug: SLUG,
 	type: 'lens',
 	version: '1.0.0',
-	name: 'SupportThreads lens',
+	name: 'Support/sales threads to audit',
 	data: {
 		icon: 'address-card',
 		format: 'list',
@@ -51,7 +51,11 @@ const lens = {
 					id: {
 						type: 'string'
 					},
+					slug: {
+						type: 'string'
+					},
 					type: {
+						type: 'string',
 						enum: [
 							'support-thread@1.0.0',
 							'sales-thread@1.0.0'
@@ -68,11 +72,12 @@ const lens = {
 						required: [
 							'status'
 						]
-					},
-					required: [
-						'data'
-					]
-				}
+					}
+				},
+				required: [
+					'type',
+					'data'
+				]
 			}
 		},
 		queryOptions: {

--- a/apps/ui/lib/lens/list/Timeline.jsx
+++ b/apps/ui/lib/lens/list/Timeline.jsx
@@ -54,10 +54,10 @@ const lens = {
 	slug: 'lens-timeline',
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Timeline lens',
+	name: 'Timeline',
 	data: {
-		format: 'list',
-		icon: 'address-card',
+		format: 'timeline',
+		icon: 'list',
 		renderer: compose(
 			withResponsiveContext,
 			connect(mapStateToProps, mapDispatchToProps),
@@ -70,6 +70,12 @@ const lens = {
 			items: {
 				type: 'object',
 				properties: {
+					type: {
+						type: 'string',
+						not: {
+							const: 'rating@1.0.0'
+						}
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -87,10 +93,15 @@ const lens = {
 						},
 						required: [
 							'timestamp',
-							'actor'
+							'actor',
+							'payload'
 						]
 					}
-				}
+				},
+				required: [
+					'type',
+					'data'
+				]
 			}
 		}
 	}

--- a/apps/ui/lib/lens/misc/CRMTable/index.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/index.jsx
@@ -57,7 +57,7 @@ const lens = {
 	slug: SLUG,
 	type: 'lens',
 	version: '1.0.0',
-	name: 'CRM table lens',
+	name: 'CRM table',
 	data: {
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CRMTable),
 		format: 'list',
@@ -70,8 +70,22 @@ const lens = {
 				properties: {
 					slug: {
 						type: 'string'
+					},
+					data: {
+						type: 'object',
+						properties: {
+							status: {
+								type: 'string'
+							}
+						},
+						required: [
+							'status'
+						]
 					}
-				}
+				},
+				required: [
+					'data'
+				]
 			}
 		}
 	}

--- a/apps/ui/lib/lens/misc/Chart/index.jsx
+++ b/apps/ui/lib/lens/misc/Chart/index.jsx
@@ -15,7 +15,7 @@ const lens = {
 	slug: 'lens-chart',
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Generic chart lens',
+	name: 'Chart',
 	data: {
 		icon: 'chart-bar',
 		format: 'list',

--- a/apps/ui/lib/lens/misc/Kanban.jsx
+++ b/apps/ui/lib/lens/misc/Kanban.jsx
@@ -18,7 +18,6 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
-	Button,
 	Flex
 } from 'rendition'
 import skhema from 'skhema'
@@ -171,12 +170,6 @@ class Kanban extends BaseLens {
 			lanes: this.getLanes()
 		}
 
-		const {
-			type
-		} = this.props
-
-		const typeName = type ? type.name || type.slug : ''
-
 		const components = {}
 
 		return (
@@ -197,23 +190,6 @@ class Kanban extends BaseLens {
 					handleDragEnd={this.handleDragEnd}
 					onCardClick={this.onCardClick}
 				/>
-
-				{Boolean(type) && (
-					<React.Fragment>
-						<Button
-							success
-							onClick={this.openCreateChannel}
-							m={3}
-							style={{
-								position: 'absolute',
-								bottom: 0,
-								right: 0
-							}}
-						>
-							Add {typeName}
-						</Button>
-					</React.Fragment>
-				)}
 			</Flex>
 		)
 	}
@@ -241,14 +217,22 @@ const lens = {
 	slug: 'lens-kanban',
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Kanban lens',
+	name: 'Kanban',
 	data: {
 		supportsSlices: true,
 		icon: 'columns',
 		format: 'list',
 		renderer: withRouter(connect(mapStateToProps, mapDispatchToProps)(Kanban)),
 		filter: {
-			type: 'array'
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string'
+					}
+				}
+			}
 		},
 		queryOptions: {
 			limit: 500,

--- a/apps/ui/lib/lens/misc/SupportAuditChart/index.jsx
+++ b/apps/ui/lib/lens/misc/SupportAuditChart/index.jsx
@@ -41,7 +41,7 @@ const lens = {
 	slug: 'lens-support-audit-chart',
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Support audit chart lens',
+	name: 'Support audit chart',
 	data: {
 		icon: 'chart-bar',
 		format: 'list',
@@ -53,8 +53,27 @@ const lens = {
 				properties: {
 					id: {
 						type: 'string'
+					},
+					type: {
+						type: 'string',
+						const: 'support-thread@1.0.0'
+					},
+					data: {
+						type: 'object',
+						properties: {
+							status: {
+								type: 'string',
+								const: 'closed'
+							}
+						},
+						required: [
+							'status'
+						]
 					}
-				}
+				},
+				required: [
+					'data'
+				]
 			}
 		},
 		queryOptions: {

--- a/apps/ui/lib/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.jsx
@@ -8,10 +8,8 @@ import _ from 'lodash'
 import React from 'react'
 import {
 	Box,
-	Button,
 	Flex,
 	Table,
-	Txt,
 	DropDownButton,
 	TextWithCopy
 } from 'rendition'
@@ -296,29 +294,7 @@ export default class CardTable extends BaseLens {
 							/>
 						</React.Fragment>
 					)}
-					{Boolean(data) && data.length === 0 &&
-							<Txt.p p={3}>No results found</Txt.p>}
 				</Box>
-
-				{Boolean(this.props.type) &&
-					<React.Fragment>
-						<Flex
-							p={3}
-							style={{
-								borderTop: '1px solid #eee'
-							}}
-							justifyContent="flex-end"
-						>
-							<Button
-								success
-								className={`btn--add-${this.props.type.slug}`}
-								onClick={this.openCreateChannel}
-							>
-								Add {this.props.type.name || this.props.type.slug}
-							</Button>
-						</Flex>
-					</React.Fragment>
-				}
 			</Column>
 		)
 	}

--- a/apps/ui/lib/lens/misc/Table/index.js
+++ b/apps/ui/lib/lens/misc/Table/index.js
@@ -44,7 +44,7 @@ const lens = {
 	slug: SLUG,
 	type: 'lens',
 	version: '1.0.0',
-	name: 'Default table lens',
+	name: 'Table',
 	data: {
 		renderer: connect(mapStateToProps, mapDispatchToProps)(CardTable),
 		icon: 'table',


### PR DESCRIPTION
Rather than getting the list of lenses from the hard-coded values in the type card, lenses will now be fetched based on their validity and scoring. All list lenses that are valid for the given data are grouped by lens 'icon' and the top-scoring valid lens for each icon is returned.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
