### PR TITLE
Share Puppeteer browser options

### DIFF
--- a/test/e2e/livechat/helpers.js
+++ b/test/e2e/livechat/helpers.js
@@ -5,7 +5,6 @@
  */
 
 const puppeteer = require('puppeteer')
-const environment = require('@balena/jellyfish-environment')
 const helpers = require('../sdk/helpers')
 const uiHelpers = require('../ui/helpers')
 const screenshot = require('../screenshot')
@@ -31,26 +30,14 @@ exports.browser = {
 		await helpers.before(test)
 		await helpers.beforeEach(test)
 
-		const options = {
-			headless: !environment.flags.visual,
-			dumpio: true,
-			args: [
-				'--window-size=1366,768',
-
-				// Set extra flags so puppeteer runs on docker
-				'--no-sandbox',
-				'--disable-setuid-sandbox'
-			]
-		}
-
-		test.context.browser = await puppeteer.launch(options)
+		test.context.browser = await puppeteer.launch(uiHelpers.puppeteerOptions)
 		test.context.page = await test.context.browser.newPage()
 		test.context.page.setViewport({
 			width: 1366,
 			height: 768
 		})
 
-		uiHelpers.addPageHandlers(test.context.page, options.headless)
+		uiHelpers.addPageHandlers(test.context.page, uiHelpers.puppeteerOptions.headless)
 	},
 
 	afterEach: async (test) => {

--- a/test/e2e/ui/helpers.js
+++ b/test/e2e/ui/helpers.js
@@ -12,6 +12,18 @@ const environment = require('@balena/jellyfish-environment')
 const helpers = require('../sdk/helpers')
 const screenshot = require('../screenshot')
 
+exports.puppeteerOptions = {
+	headless: !environment.flags.visual,
+	dumpio: true,
+	args: [
+		'--window-size=1366,768',
+
+		// Set extra flags so puppeteer runs on docker
+		'--no-sandbox',
+		'--disable-setuid-sandbox'
+	]
+}
+
 exports.generateUserDetails = () => {
 	return {
 		username: `johndoe-${uuid()}`,
@@ -63,19 +75,7 @@ exports.browser = {
 		await helpers.before(test)
 		await helpers.beforeEach(test)
 
-		const options = {
-			headless: !environment.flags.visual,
-			dumpio: true,
-			args: [
-				'--window-size=1366,768',
-
-				// Set extra flags so puppeteer runs on docker
-				'--no-sandbox',
-				'--disable-setuid-sandbox'
-			]
-		}
-
-		test.context.browser = await puppeteer.launch(options)
+		test.context.browser = await puppeteer.launch(exports.puppeteerOptions)
 		const browserContext = test.context.browser.defaultBrowserContext()
 
 		// Allow the clipboard API to be accessed so we can easily test
@@ -88,7 +88,7 @@ exports.browser = {
 			height: 768
 		})
 
-		this.addPageHandlers(test.context.page, options.headless)
+		this.addPageHandlers(test.context.page, exports.puppeteerOptions.headless)
 
 		test.context.createUser = async (user) => {
 			const result = await test.context.sdk.action({


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Simple PR that shares the options used to create Puppeteer instances during tests in order to reduce duplicate code. The options are the exact same for both `e2e-ui` and `e2e-livechat` tests. 
