### PR TITLE
Refactor lenses to use common view footer

### DIFF
--- a/apps/ui/lib/lens/actions/CreateView/CreateView.jsx
+++ b/apps/ui/lib/lens/actions/CreateView/CreateView.jsx
@@ -6,6 +6,7 @@
 
 import * as _ from 'lodash'
 import React from 'react'
+import skhema from 'skhema'
 import {
 	Redirect
 } from 'react-router-dom'
@@ -241,20 +242,19 @@ export default class CreateView extends React.Component {
 			}
 		}
 
-		const query = Object.assign(
-			searchTerm
-				? helpers.createFullTextSearchFilter(userType.data.schema, searchTerm)
-				: {
-					type: 'object',
-					properties: {
-						type: {
-							const: 'user@1.0.0'
-						}
-					},
-					additionalProperties: true
-				},
-			linksQuery
-		)
+		const query = skhema.merge([ linksQuery, {
+			type: 'object',
+			required: [ 'type' ],
+			properties: {
+				type: {
+					const: 'user@1.0.0'
+				}
+			},
+			additionalProperties: true
+		}, searchTerm
+			? helpers.createFullTextSearchFilter(userType.data.schema, searchTerm)
+			: {}
+		])
 
 		const users = await sdk.query(query)
 

--- a/apps/ui/lib/lens/common/ViewFooter/ViewFooter.jsx
+++ b/apps/ui/lib/lens/common/ViewFooter/ViewFooter.jsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Flex,
+	Button
+} from 'rendition'
+import styled from 'styled-components'
+import {
+	Icon
+} from '@balena/jellyfish-ui-components'
+
+const Footer = styled(Flex) `
+	border-top: 1px solid #eee;
+`
+
+export const ViewFooter = ({
+	channel,
+	type,
+	actions,
+	...rest
+}) => {
+	const [ isBusy, setIsBusy ] = React.useState(false)
+
+	const synchronous = React.useMemo(() => {
+		return type.slug === 'thread'
+	}, [ type.slug ])
+
+	const onAddCard = React.useCallback(async () => {
+		setIsBusy(true)
+		await actions.addCard(channel, type, {
+			synchronous
+		})
+		setIsBusy(false)
+	}, [ actions.addCard, synchronous, channel, type, synchronous ])
+	return (
+		<Footer
+			flex={0}
+			p={3}
+			{...rest}
+		>
+			<Button
+				disabled={isBusy}
+				success
+				className={`btn--add-${type.slug}`}
+				onClick={onAddCard}
+			>
+				{ isBusy ? <Icon spin name="cog"/> : `Add ${type.name || type.slug}`	}
+			</Button>
+		</Footer>
+	)
+}

--- a/apps/ui/lib/lens/common/ViewFooter/index.js
+++ b/apps/ui/lib/lens/common/ViewFooter/index.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash'
+import {
+	connect
+} from 'react-redux'
+import {
+	compose,
+	bindActionCreators
+} from 'redux'
+import {
+	actionCreators
+} from '../../../core'
+import {
+	ViewFooter as InnerViewFooter
+} from './ViewFooter'
+import {
+	withChannelContext
+} from '../../../hooks'
+
+const mapStateToProps = () => {
+	return {}
+}
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, [
+				'addCard'
+			]), dispatch)
+	}
+}
+
+export const ViewFooter = compose(
+	withChannelContext,
+	connect(mapStateToProps, mapDispatchToProps)
+)(InnerViewFooter)

--- a/apps/ui/lib/lens/common/index.js
+++ b/apps/ui/lib/lens/common/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as Segment
+} from './Segment'
+export {
+	ViewFooter
+} from './ViewFooter'

--- a/apps/ui/lib/lens/full/Repository/Repository.jsx
+++ b/apps/ui/lib/lens/full/Repository/Repository.jsx
@@ -32,6 +32,9 @@ import {
 	getContextualThreadsQuery,
 	getLensBySlug
 } from '../../'
+import {
+	ViewFooter
+} from '../../common'
 
 const SingleCardTabs = styled(Tabs) `
 	flex: 1
@@ -61,11 +64,7 @@ export default class RepositoryFull extends React.Component {
 				page: 0,
 				totalPages: Infinity
 			},
-			searchTerm: '',
-			relationship: {
-				target: this.props.card,
-				name: 'is of'
-			}
+			searchTerm: ''
 		}
 
 		const messageType = helpers.getType('message', this.props.types)
@@ -175,6 +174,7 @@ export default class RepositoryFull extends React.Component {
 			slug: card.type.split('@')[0]
 		})
 
+		const threadType = helpers.getType('thread', types)
 		const relationships = _.get(type, [ 'data', 'meta', 'relationships' ])
 		const messages = _.sortBy(this.props.messages, 'created_at')
 
@@ -245,7 +245,8 @@ export default class RepositoryFull extends React.Component {
 					</SingleCardTabs>
 				)}
 
-				<Box
+				<Flex
+					flexDirection="column"
 					style={{
 						overflow: 'auto'
 					}}
@@ -254,12 +255,12 @@ export default class RepositoryFull extends React.Component {
 					<Interleaved
 						channel={channel}
 						tail={messages}
-						relationship={this.state.relationship}
 						setPage={this.setPage}
 						page={this.state.options.page}
 						totalPages={this.state.options.totalPages}
 					/>
-				</Box>
+					<ViewFooter type={threadType} justifyContent="flex-end" />
+				</Flex>
 			</CardLayout>
 		)
 	}

--- a/apps/ui/lib/lens/full/View/Content.jsx
+++ b/apps/ui/lib/lens/full/View/Content.jsx
@@ -7,11 +7,16 @@
 import React from 'react'
 import _ from 'lodash'
 import {
-	Box
+	Box,
+	Flex,
+	Txt
 } from 'rendition'
 import {
 	Icon
 } from '@balena/jellyfish-ui-components'
+import {
+	ViewFooter
+} from '../../common/ViewFooter'
 
 const sortTail = (tail, options) => {
 	if (!tail) {
@@ -40,24 +45,34 @@ export default class Content extends React.Component {
 		const sortedTail = sortTail(tail, options)
 
 		return (
-			<React.Fragment>
-				{!sortedTail && (
-					<Box p={3}>
-						<Icon spin name="cog"/>
-					</Box>
+			<Flex flex={1} flexDirection="column" minWidth="270px">
+				<Flex flex={1} flexDirection="column" data-test="inner-flex" style={{
+					overflowY: 'auto'
+				}}>
+					{!sortedTail && (
+						<Box p={3}>
+							<Icon spin name="cog"/>
+						</Box>
+					)}
+					{Boolean(tail) && tail.length === 0 && (
+						<Txt.p p={3}>No results found</Txt.p>
+					)}
+					{Boolean(tail) && Boolean(lens) && (
+						<lens.data.renderer
+							channel={channel}
+							tail={sortedTail}
+							setPage={setPage}
+							pageOptions={pageOptions}
+							page={pageOptions.page}
+							totalPages={pageOptions.totalPages}
+							type={tailType}
+						/>
+					)}
+				</Flex>
+				{Boolean(tailType) && (
+					<ViewFooter type={tailType} justifyContent="flex-end" />
 				)}
-				{Boolean(tail) && Boolean(lens) && (
-					<lens.data.renderer
-						channel={channel}
-						tail={sortedTail}
-						setPage={setPage}
-						pageOptions={pageOptions}
-						page={pageOptions.page}
-						totalPages={pageOptions.totalPages}
-						type={tailType}
-					/>
-				)}
-			</React.Fragment>
+			</Flex>
 		)
 	}
 }

--- a/apps/ui/lib/lens/list/List.jsx
+++ b/apps/ui/lib/lens/list/List.jsx
@@ -24,10 +24,7 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
-	Flex,
-	Button,
 	Box,
-	Txt,
 	Divider
 } from 'rendition'
 import {
@@ -163,8 +160,7 @@ class CardList extends React.Component {
 		const {
 			tail,
 			pageOptions,
-			totalPages,
-			type
+			totalPages
 		} = this.props
 
 		// TODO: remove this logic when totalPage returns a usefull number
@@ -217,31 +213,7 @@ class CardList extends React.Component {
 							)}
 						</InfiniteLoader>
 					)}
-
-					{Boolean(tail) && tail.length === 0 && (
-						<Txt.p p={3}>No results found</Txt.p>
-					)}
 				</Box>
-
-				{Boolean(this.props.type) && (
-					<React.Fragment>
-						<Flex
-							p={3}
-							style={{
-								borderTop: '1px solid #eee'
-							}}
-							justifyContent="flex-end"
-						>
-							<Button
-								success={true}
-								className={`btn--add-${type.slug}`}
-								onClick={this.openCreateChannel}
-							>
-								Add {type.name || type.slug}
-							</Button>
-						</Flex>
-					</React.Fragment>
-				)}
 			</Column>
 		)
 	}

--- a/apps/ui/lib/lens/list/SupportThreads.jsx
+++ b/apps/ui/lib/lens/list/SupportThreads.jsx
@@ -65,7 +65,6 @@ export class SupportThreads extends React.Component {
 		super(props)
 
 		this.state = {
-			creatingCard: false,
 			newMessage: '',
 			showNewCardModal: false,
 			segments: []
@@ -246,7 +245,7 @@ export class SupportThreads extends React.Component {
 		} = this.state
 
 		return (
-			<Column data-test={`lens--${SLUG}`}>
+			<Column data-test={`lens--${SLUG}`} overflowY>
 				<StyledTabs
 					activeIndex={this.props.lensState.activeIndex}
 					onActive={this.setActiveIndex}

--- a/apps/ui/lib/lens/misc/Inbox/MessageList.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/MessageList.jsx
@@ -68,7 +68,6 @@ class MessageList extends React.Component {
 		}
 
 		this.state = {
-			creatingCard: false,
 			newMessage: '',
 			showNewCardModal: false,
 			loadingPage: false

--- a/apps/ui/lib/lens/misc/Kanban.jsx
+++ b/apps/ui/lib/lens/misc/Kanban.jsx
@@ -18,7 +18,6 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
-	Button,
 	Flex
 } from 'rendition'
 import skhema from 'skhema'
@@ -184,12 +183,6 @@ class Kanban extends React.Component {
 			lanes: this.getLanes()
 		}
 
-		const {
-			type
-		} = this.props
-
-		const typeName = type ? type.name || type.slug : ''
-
 		const components = {}
 
 		return (
@@ -210,23 +203,6 @@ class Kanban extends React.Component {
 					handleDragEnd={this.handleDragEnd}
 					onCardClick={this.onCardClick}
 				/>
-
-				{Boolean(type) && (
-					<React.Fragment>
-						<Button
-							success
-							onClick={this.openCreateChannel}
-							m={3}
-							style={{
-								position: 'absolute',
-								bottom: 0,
-								right: 0
-							}}
-						>
-							Add {typeName}
-						</Button>
-					</React.Fragment>
-				)}
 			</Flex>
 		)
 	}

--- a/apps/ui/lib/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.jsx
@@ -8,10 +8,8 @@ import _ from 'lodash'
 import React from 'react'
 import {
 	Box,
-	Button,
 	Flex,
 	Table,
-	Txt,
 	DropDownButton,
 	TextWithCopy
 } from 'rendition'
@@ -309,29 +307,7 @@ export default class CardTable extends React.Component {
 							/>
 						</React.Fragment>
 					)}
-					{Boolean(data) && data.length === 0 &&
-							<Txt.p p={3}>No results found</Txt.p>}
 				</Box>
-
-				{Boolean(this.props.type) &&
-					<React.Fragment>
-						<Flex
-							p={3}
-							style={{
-								borderTop: '1px solid #eee'
-							}}
-							justifyContent="flex-end"
-						>
-							<Button
-								success
-								className={`btn--add-${this.props.type.slug}`}
-								onClick={this.openCreateChannel}
-							>
-								Add {this.props.type.name || this.props.type.slug}
-							</Button>
-						</Flex>
-					</React.Fragment>
-				}
 			</Column>
 		)
 	}

--- a/scripts/lint/check-filenames.sh
+++ b/scripts/lint/check-filenames.sh
@@ -36,6 +36,7 @@ for file in $(find "${DIRECTORIES[@]}" -type f | grep -v -E node_modules); do
 	# components should only be defined in jellyfish-ui-components
 	COMPONENTS_DIRECTORIES="apps/ui/lib/layouts/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/components/"
+	COMPONENTS_DIRECTORIES+="|apps/ui/lib/lens/common/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/lens/misc/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/lens/full/"
 	COMPONENTS_DIRECTORIES+="|apps/ui/lib/lens/list/"


### PR DESCRIPTION
The `Add <type>` button has been removed from list lenses and is now included in the view (using a new `ViewFooter` component).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

I've tested this manually quite a lot, making sure the repository view, 1-2-1 custom views, segments, CreateLens, EditLens, CreateView etc all still behave as expected.