### PR TITLE
Fix view slices

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -198,6 +198,10 @@ export const selectors = {
 		const user = selectors.getCurrentUser(state)
 		return _.get(user, [ 'data', 'profile', 'viewSettings', viewId, 'lens' ], null)
 	},
+	getUsersViewSlice: (state, viewId) => {
+		const user = selectors.getCurrentUser(state)
+		return _.get(user, [ 'data', 'profile', 'viewSettings', viewId, 'slice' ], null)
+	},
 	getHomeView: (state) => {
 		const user = selectors.getCurrentUser(state)
 		return _.get(user, [ 'data', 'profile', 'homeView' ], null)
@@ -1345,6 +1349,20 @@ export const actionCreators = {
 				user,
 				[ 'data', 'profile', 'viewSettings', viewId, 'lens' ],
 				lensSlug
+			)
+
+			return actionCreators.updateUser(patches, null)(dispatch, getState, context)
+		}
+	},
+
+	setViewSlice (viewId, slice) {
+		return (dispatch, getState, context) => {
+			const user = selectors.getCurrentUser(getState())
+
+			const patches = helpers.patchPath(
+				user,
+				[ 'data', 'profile', 'viewSettings', viewId, 'slice' ],
+				slice
 			)
 
 			return actionCreators.updateUser(patches, null)(dispatch, getState, context)

--- a/apps/ui/lib/lens/full/View/index.jsx
+++ b/apps/ui/lib/lens/full/View/index.jsx
@@ -393,6 +393,8 @@ class ViewRenderer extends React.Component {
 		})
 
 		this.updateFilters(parsedFilters)
+
+		this.props.actions.setViewSlice(this.props.card.id, value)
 	}
 
 	setPage (page) {
@@ -500,7 +502,13 @@ class ViewRenderer extends React.Component {
 		const sliceOptions = getSliceOptions(head, this.props.types)
 
 		if (sliceOptions && sliceOptions.length) {
-			activeSlice = _.first(sliceOptions)
+			// Default to setting the active slice based on the user's preference
+			if (this.props.userActiveSlice) {
+				activeSlice = _.find(sliceOptions, this.props.userActiveSlice)
+			}
+
+			// Otherwise just select the first slice option
+			activeSlice = activeSlice || _.first(sliceOptions)
 
 			const filter = createSliceFilter(activeSlice)
 
@@ -757,7 +765,8 @@ const mapStateToProps = (state, ownProps) => {
 		tail,
 		types: selectors.getTypes(state),
 		user: selectors.getCurrentUser(state),
-		userActiveLens: selectors.getUsersViewLens(state, target)
+		userActiveLens: selectors.getUsersViewLens(state, target),
+		userActiveSlice: selectors.getUsersViewSlice(state, target)
 	}
 }
 
@@ -769,7 +778,8 @@ const mapDispatchToProps = (dispatch) => {
 				'loadViewData',
 				'loadMoreViewData',
 				'setViewData',
-				'setViewLens'
+				'setViewLens',
+				'setViewSlice'
 			]), dispatch)
 	}
 }

--- a/apps/ui/lib/lens/full/View/index.jsx
+++ b/apps/ui/lib/lens/full/View/index.jsx
@@ -225,7 +225,7 @@ const createEventSearchFilter = (types, term) => {
 	}
 }
 
-class ViewRenderer extends React.Component {
+export class ViewRenderer extends React.Component {
 	constructor (props) {
 		super(props)
 

--- a/apps/ui/lib/lens/full/View/index.jsx
+++ b/apps/ui/lib/lens/full/View/index.jsx
@@ -56,6 +56,23 @@ import {
 
 const getSearchViewId = (targetId) => `$$search-${targetId}`
 
+// Search the view card's filters for a slice filter. If one is found
+// that matches one of the slice options, return that slice option
+const getActiveSliceFromFilter = (sliceOptions, viewCard) => {
+	const viewFilters = _.get(viewCard, [ 'data', 'allOf' ], [])
+	for (const slice of sliceOptions) {
+		const sliceFilter = createSliceFilter(slice)
+		for (const viewFilter of viewFilters) {
+			const filterOptions = _.get(viewFilter, [ 'schema', 'anyOf' ])
+			const activeSliceFilter = _.find(filterOptions, sliceFilter)
+			if (activeSliceFilter) {
+				return slice
+			}
+		}
+	}
+	return null
+}
+
 const createSliceFilter = (slice) => {
 	const filter = {
 		// Use the slice path as a unique ID, as we don't want multiple slice constraints
@@ -506,6 +523,9 @@ class ViewRenderer extends React.Component {
 			if (this.props.userActiveSlice) {
 				activeSlice = _.find(sliceOptions, this.props.userActiveSlice)
 			}
+
+			// Check if the view defines a slice filter
+			activeSlice = activeSlice || getActiveSliceFromFilter(sliceOptions, head)
 
 			// Otherwise just select the first slice option
 			activeSlice = activeSlice || _.first(sliceOptions)

--- a/apps/ui/lib/lens/full/View/index.jsx
+++ b/apps/ui/lib/lens/full/View/index.jsx
@@ -387,15 +387,10 @@ class ViewRenderer extends React.Component {
 			return item.anyOf && item.anyOf[0].$id !== filter.$id
 		})
 
-		// The default slice represents the 'all' option (i.e. no actual filter)
-		// so only add the slice filter if it is not the default ('all') option.
-		const isAllFilter = _.isEqual(value, getDefaultSliceOption(this.state.sliceOptions))
-		if (!isAllFilter) {
-			parsedFilters.push({
-				$id: filter.$id,
-				anyOf: [ filter ]
-			})
-		}
+		parsedFilters.push({
+			$id: filter.$id,
+			anyOf: [ filter ]
+		})
 
 		this.updateFilters(parsedFilters)
 	}

--- a/apps/ui/lib/lens/full/View/tests/fixtures/archived-paid-support.json
+++ b/apps/ui/lib/lens/full/View/tests/fixtures/archived-paid-support.json
@@ -1,0 +1,308 @@
+{
+  "id": "c8c7ce79-82b4-4eb5-8712-998423d2a218",
+  "created_at": "2021-02-01T07:42:00.566Z",
+  "slug": "channel-c8c7ce79-82b4-4eb5-8712-998423d2a218",
+  "type": "channel",
+  "active": true,
+  "data": {
+    "target": "view-user-created-view-493216e2-6f30-4ace-a0b4-e2947ba5737f-archived-paid-support-threads",
+    "options": {},
+    "canonical": true,
+    "head": {
+      "id": "18541044-754d-40c7-827e-058c44c243ee",
+      "data": {
+        "actor": "304d1747-ccc5-4c43-8daa-57d002c9f6b5",
+        "allOf": [
+          {
+            "name": "Paid support threads",
+            "schema": {
+              "type": "object",
+              "anyOf": [
+                {
+                  "$$links": {
+                    "is owned by": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "type": {
+                          "const": "user@1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                true
+              ],
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "message@1.0.0",
+                        "create@1.0.0",
+                        "whisper@1.0.0",
+                        "update@1.0.0",
+                        "rating@1.0.0",
+                        "summary@1.0.0"
+                      ]
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "active",
+                "type",
+                "data"
+              ],
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "mirrors": {
+                      "type": "array",
+                      "items": {
+                        "not": {
+                          "pattern": "forums.balena.io"
+                        },
+                        "type": "string"
+                      }
+                    },
+                    "product": {
+                      "const": "balenaCloud"
+                    },
+                    "category": {
+                      "const": "general",
+                      "description": "This field is not required and should match cases where the field is not present OR is 'general'"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "const": "support-thread@1.0.0"
+                },
+                "active": {
+                  "type": "boolean",
+                  "const": true
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          {
+            "name": "user-generated-filter",
+            "schema": {
+              "$id": "properties.data.properties.status",
+              "type": "object",
+              "anyOf": [
+                {
+                  "$id": "properties.data.properties.status",
+                  "type": "object",
+                  "title": "user-generated-filter",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "const": "archived",
+                          "title": "status"
+                        }
+                      }
+                    }
+                  },
+                  "description": "Status: archived"
+                }
+              ]
+            }
+          }
+        ],
+        "lenses": [
+          "lens-support-threads",
+          "lens-table",
+          "lens-kanban",
+          "lens-chart"
+        ]
+      },
+      "name": "Archived paid support threads",
+      "slug": "view-user-created-view-493216e2-6f30-4ace-a0b4-e2947ba5737f-archived-paid-support-threads",
+      "tags": [],
+      "type": "view@1.0.0",
+      "links": {
+        "has attached element": [
+          {
+            "id": "4a214820-3d01-4cb8-8bde-0a143ea5209a",
+            "data": {
+              "actor": "304d1747-ccc5-4c43-8daa-57d002c9f6b5",
+              "target": "18541044-754d-40c7-827e-058c44c243ee",
+              "payload": {
+                "data": {
+                  "actor": "304d1747-ccc5-4c43-8daa-57d002c9f6b5",
+                  "allOf": [
+                    {
+                      "name": "Paid support threads",
+                      "schema": {
+                        "type": "object",
+                        "anyOf": [
+                          {
+                            "$$links": {
+                              "is owned by": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "const": "user@1.0.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          true
+                        ],
+                        "$$links": {
+                          "has attached element": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "message@1.0.0",
+                                  "create@1.0.0",
+                                  "whisper@1.0.0",
+                                  "update@1.0.0",
+                                  "rating@1.0.0",
+                                  "summary@1.0.0"
+                                ]
+                              }
+                            },
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": [
+                          "active",
+                          "type",
+                          "data"
+                        ],
+                        "properties": {
+                          "data": {
+                            "type": "object",
+                            "properties": {
+                              "mirrors": {
+                                "type": "array",
+                                "items": {
+                                  "not": {
+                                    "pattern": "forums.balena.io"
+                                  },
+                                  "type": "string"
+                                }
+                              },
+                              "product": {
+                                "const": "balenaCloud"
+                              },
+                              "category": {
+                                "const": "general",
+                                "description": "This field is not required and should match cases where the field is not present OR is 'general'"
+                              }
+                            }
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "support-thread@1.0.0"
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "const": true
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    {
+                      "name": "user-generated-filter",
+                      "schema": {
+                        "$id": "properties.data.properties.status",
+                        "type": "object",
+                        "anyOf": [
+                          {
+                            "$id": "properties.data.properties.status",
+                            "type": "object",
+                            "title": "user-generated-filter",
+                            "properties": {
+                              "data": {
+                                "type": "object",
+                                "properties": {
+                                  "status": {
+                                    "const": "archived",
+                                    "title": "status"
+                                  }
+                                }
+                              }
+                            },
+                            "description": "Status: archived"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "lenses": [
+                    "lens-support-threads",
+                    "lens-table",
+                    "lens-kanban",
+                    "lens-chart"
+                  ]
+                },
+                "name": "Archived paid support threads",
+                "slug": "view-user-created-view-493216e2-6f30-4ace-a0b4-e2947ba5737f-archived-paid-support-threads",
+                "tags": [],
+                "type": "view@1.0.0",
+                "links": {},
+                "active": true,
+                "markers": [
+                  "user-jellyfish"
+                ],
+                "version": "1.0.0",
+                "requires": [],
+                "linked_at": {},
+                "updated_at": "2021-01-31T08:59:38.655Z",
+                "capabilities": []
+              },
+              "timestamp": "2021-02-01T07:41:59.079Z"
+            },
+            "name": null,
+            "slug": "create-a5c03851-56b1-435b-8c01-fd9a2ad25708",
+            "tags": [],
+            "type": "create@1.0.0",
+            "links": {},
+            "active": true,
+            "markers": [
+              "user-jellyfish"
+            ],
+            "version": "1.0.0",
+            "requires": [],
+            "linked_at": {
+              "is attached to": "2021-02-01T07:41:59.204Z"
+            },
+            "created_at": "2021-02-01T07:41:59.175Z",
+            "updated_at": null,
+            "capabilities": []
+          }
+        ]
+      },
+      "active": true,
+      "markers": [
+        "user-jellyfish"
+      ],
+      "version": "1.0.0",
+      "requires": [],
+      "linked_at": {
+        "has attached element": "2021-02-01T07:41:59.204Z"
+      },
+      "created_at": "2021-02-01T07:41:59.119Z",
+      "updated_at": "2021-01-31T08:59:38.655Z",
+      "capabilities": []
+    }
+  }
+}

--- a/apps/ui/lib/lens/full/View/tests/fixtures/index.js
+++ b/apps/ui/lib/lens/full/View/tests/fixtures/index.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as archivedPaidSupport
+} from './archived-paid-support.json'
+export {
+	default as paidSupport
+} from './paid-support.json'
+export {
+	default as supportThreadType
+} from './support-thread.json'

--- a/apps/ui/lib/lens/full/View/tests/fixtures/paid-support.json
+++ b/apps/ui/lib/lens/full/View/tests/fixtures/paid-support.json
@@ -1,0 +1,120 @@
+{
+  "id": "045cf6b1-c615-4e6e-b877-2b42f5aff918",
+  "created_at": "2021-02-01T07:26:40.072Z",
+  "slug": "channel-045cf6b1-c615-4e6e-b877-2b42f5aff918",
+  "type": "channel",
+  "active": true,
+  "data": {
+    "target": "view-paid-support-threads",
+    "options": {},
+    "canonical": true,
+    "head": {
+      "id": "4bc4596b-1c97-4281-94c4-56ac0a483b93",
+      "data": {
+        "allOf": [
+          {
+            "name": "Paid support threads",
+            "schema": {
+              "type": "object",
+              "anyOf": [
+                {
+                  "$$links": {
+                    "is owned by": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "type": {
+                          "const": "user@1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                true
+              ],
+              "$$links": {
+                "has attached element": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "message@1.0.0",
+                        "create@1.0.0",
+                        "whisper@1.0.0",
+                        "update@1.0.0",
+                        "rating@1.0.0",
+                        "summary@1.0.0"
+                      ]
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "active",
+                "type",
+                "data"
+              ],
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "mirrors": {
+                      "type": "array",
+                      "items": {
+                        "not": {
+                          "pattern": "forums.balena.io"
+                        },
+                        "type": "string"
+                      }
+                    },
+                    "product": {
+                      "const": "balenaCloud"
+                    },
+                    "category": {
+                      "const": "general",
+                      "description": "This field is not required and should match cases where the field is not present OR is 'general'"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "const": "support-thread@1.0.0"
+                },
+                "active": {
+                  "type": "boolean",
+                  "const": true
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        ],
+        "lenses": [
+          "lens-support-threads",
+          "lens-table",
+          "lens-kanban",
+          "lens-chart"
+        ],
+        "namespace": "Support"
+      },
+      "name": "Paid support",
+      "slug": "view-paid-support-threads",
+      "tags": [],
+      "type": "view@1.0.0",
+      "links": {},
+      "active": true,
+      "markers": [
+        "org-balena"
+      ],
+      "version": "1.0.0",
+      "requires": [],
+      "linked_at": {},
+      "created_at": "2021-01-28T07:39:48.605Z",
+      "updated_at": "2021-01-31T08:59:38.655Z",
+      "capabilities": []
+    }
+  }
+}

--- a/apps/ui/lib/lens/full/View/tests/fixtures/support-thread.json
+++ b/apps/ui/lib/lens/full/View/tests/fixtures/support-thread.json
@@ -1,0 +1,125 @@
+{
+  "id": "00ba987f-e873-4298-a66b-20ddc78cdef5",
+  "data": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "fullTextSearch": true
+            },
+            "inbox": {
+              "type": "string",
+              "fullTextSearch": true
+            },
+            "status": {
+              "enum": [
+                "open",
+                "closed",
+                "archived"
+              ],
+              "type": "string",
+              "title": "Status",
+              "default": "open"
+            },
+            "mirrors": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "category": {
+              "enum": [
+                "general",
+                "customer-success",
+                "devices",
+                "fleetops",
+                "security"
+              ],
+              "type": "string",
+              "default": "general",
+              "fullTextSearch": true
+            },
+            "alertsUser": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.alertsUser')"
+            },
+            "alertsGroup": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.alertsGroup')"
+            },
+            "description": {
+              "type": "string",
+              "format": "markdown",
+              "fullTextSearch": true
+            },
+            "environment": {
+              "enum": [
+                "production"
+              ],
+              "type": "string",
+              "fullTextSearch": true
+            },
+            "mentionsUser": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.mentionsUser')"
+            },
+            "participants": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.actor')"
+            },
+            "mentionsGroup": {
+              "type": "array",
+              "$$formula": "AGGREGATE($events, 'data.payload.mentionsGroup')"
+            },
+            "statusDescription": {
+              "type": "string",
+              "title": "Current Status",
+              "fullTextSearch": true
+            }
+          }
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "fullTextSearch": true
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "$$formula": "AGGREGATE($events, 'tags')",
+          "fullTextSearch": true
+        }
+      }
+    },
+    "slices": [
+      "properties.data.properties.status"
+    ]
+  },
+  "name": "Support Thread",
+  "slug": "support-thread",
+  "tags": [],
+  "type": "type@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {},
+  "created_at": "2021-01-28T07:39:46.312Z",
+  "updated_at": null,
+  "capabilities": []
+}

--- a/apps/ui/lib/lens/full/View/tests/index.spec.jsx
+++ b/apps/ui/lib/lens/full/View/tests/index.spec.jsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '../../../../../test/ui-setup'
+import ava from 'ava'
+import sinon from 'sinon'
+import {
+	shallow
+} from 'enzyme'
+import React from 'react'
+import {
+	ViewRenderer
+} from '..'
+import {
+	paidSupport,
+	archivedPaidSupport,
+	supportThreadType
+} from './fixtures'
+
+const sandbox = sinon.createSandbox()
+
+const user = {
+	id: 'u1',
+	slug: 'user-1',
+	data: {
+		profile: {}
+	}
+}
+
+const types = [ supportThreadType ]
+
+ava.beforeEach((test) => {
+	test.context.commonProps = {
+		channel: paidSupport,
+		user,
+		types,
+		actions: {
+			clearViewData: sandbox.stub(),
+			loadViewData: sandbox.stub(),
+			loadMoreViewData: sandbox.stub(),
+			setViewData: sandbox.stub(),
+			setViewLens: sandbox.stub(),
+			setViewSlice: sandbox.stub()
+		}
+	}
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('Active slice is initialized to the user\'s view slice, if set', (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const userActiveSlice = {
+		title: 'Status: archived',
+		value: {
+			path: 'properties.data.properties.status', value: 'archived'
+		}
+	}
+
+	const wrapper = shallow(
+		<ViewRenderer {...commonProps} userActiveSlice={userActiveSlice} />
+	)
+
+	test.deepEqual(wrapper.state().activeSlice, userActiveSlice)
+})
+
+ava('Active slice is initialized to the slice specified by a custom view\'s filters, if set', (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const wrapper = shallow(
+		<ViewRenderer {...commonProps} channel={archivedPaidSupport} />
+	)
+
+	test.deepEqual(wrapper.state().activeSlice, {
+		title: 'Status: archived',
+		value: {
+			path: 'properties.data.properties.status', value: 'archived'
+		}
+	})
+
+	test.deepEqual(wrapper.state().filters, [ {
+		$id: 'properties.data.properties.status',
+		type: 'object',
+		anyOf: [ {
+			$id: 'properties.data.properties.status',
+			type: 'object',
+			title: 'user-generated-filter',
+			properties: {
+				data: {
+					type: 'object',
+					properties: {
+						status: {
+							const: 'archived', title: 'status'
+						}
+					}
+				}
+			},
+			description: 'Status: archived'
+		} ]
+	} ])
+})
+
+ava('Active slice is initialized to the first slice option if not set in user profile or view filter', (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const wrapper = shallow(
+		<ViewRenderer {...commonProps} />
+	)
+
+	test.deepEqual(wrapper.state().activeSlice, {
+		title: 'Status: open',
+		value: {
+			path: 'properties.data.properties.status', value: 'open'
+		}
+	})
+
+	test.deepEqual(wrapper.state().filters, [ {
+		$id: 'properties.data.properties.status',
+		anyOf: [ {
+			$id: 'properties.data.properties.status',
+			type: 'object',
+			title: 'user-generated-filter',
+			properties: {
+				data: {
+					type: 'object',
+					properties: {
+						status: {
+							const: 'open'
+						}
+					}
+				}
+			},
+			description: 'Status: open'
+		} ]
+	} ])
+})


### PR DESCRIPTION
Three related fixes that improve how slices are handled in views...

I've added three unit tests to verify the behaviour when loading the `ViewRenderer` component!

***

[Always display slice filter](https://github.com/product-os/jellyfish/commit/9529e6508492cd7ddf6a7533357c44296f5dcead)

Even if the selected slice option is 'All', we still want to display it in the filter summary so that we can create a custom view with the 'All' slice option selected.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

[Save previously selected slice to user's profile.](https://github.com/product-os/jellyfish/commit/503f5e370464a7dca758d84a4f70fe058dbfbcbd)

The most recently selected slice will be saved to a user's profile in the same way that the most recently selected lens currently is. This way if you always view a particular view with a slice other than the default first one, this will be preserved and you won't always have to re-select your preferred slice!

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

[Ensure active slice is initialized to view's slice filter if set](https://github.com/product-os/jellyfish/commit/434a082493d0d404dcb6ae44510570e0c87b9b06)

Fixes #5618

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

