### PR TITLE
Add support in ViewRenderer for tails of multiple card types

### DIFF
--- a/apps/ui/lib/lens/common/ViewFooter/ViewFooter.spec.jsx
+++ b/apps/ui/lib/lens/common/ViewFooter/ViewFooter.spec.jsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getWrapper
+} from '../../../../test/ui-setup'
+import ava from 'ava'
+import sinon from 'sinon'
+import React from 'react'
+import {
+	mount
+} from 'enzyme'
+import {
+	ViewFooter
+} from './ViewFooter'
+
+const wrappingComponent = getWrapper().wrapper
+
+const type1 = {
+	slug: 'user',
+	name: 'User'
+}
+
+const type2 = {
+	slug: 'org',
+	name: 'Organization'
+}
+
+const types = [ type1, type2 ]
+
+const sandbox = sinon.createSandbox()
+
+ava.beforeEach((test) => {
+	test.context.defaultProps = {
+		actions: {
+			addCard: sandbox.stub()
+		},
+		channel: {}
+	}
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('ViewFooter renders a single button if only one type is supplied', (test) => {
+	const {
+		defaultProps
+	} = test.context
+	const component = mount((
+		<ViewFooter types={[ type1 ]} {...defaultProps} />
+	), {
+		wrappingComponent
+	})
+
+	const singleButton = component.find('button[data-test="viewfooter__add-btn--user"]').first()
+	test.is(singleButton.text(), 'Add User')
+
+	singleButton.simulate('click')
+	test.true(defaultProps.actions.addCard.calledOnce)
+})
+
+ava('ViewFooter renders a drop-down button if multiple types are supplied', (test) => {
+	const {
+		defaultProps
+	} = test.context
+	const component = mount((
+		<ViewFooter types={types} {...defaultProps} />
+	), {
+		wrappingComponent
+	})
+
+	const dropDownButton = component.find('button[data-test="viewfooter__add-dropdown"]').first()
+	test.is(dropDownButton.text(), 'Add User')
+
+	dropDownButton.simulate('click')
+	test.true(defaultProps.actions.addCard.calledOnce)
+})
+
+ava('ViewFooter calls addCard action when a dropdown option is clicked', (test) => {
+	const {
+		defaultProps
+	} = test.context
+	const component = mount((
+		<ViewFooter types={types} {...defaultProps} />
+	), {
+		wrappingComponent
+	})
+
+	const dropDownExpand = component.find('button[data-test="viewfooter__add-dropdown"]').at(1)
+	dropDownExpand.simulate('click')
+	component.update()
+
+	const dropDownOption = component.find('[data-test="viewfooter__add-link--org"]').first()
+	test.is(dropDownOption.text(), 'Add Organization')
+
+	dropDownOption.simulate('click')
+	test.true(defaultProps.actions.addCard.calledOnce)
+})

--- a/apps/ui/lib/lens/full/Repository/Repository.jsx
+++ b/apps/ui/lib/lens/full/Repository/Repository.jsx
@@ -259,7 +259,7 @@ export default class RepositoryFull extends React.Component {
 						page={this.state.options.page}
 						totalPages={this.state.options.totalPages}
 					/>
-					<ViewFooter type={threadType} justifyContent="flex-end" />
+					<ViewFooter types={[ threadType ]} justifyContent="flex-end" />
 				</Flex>
 			</CardLayout>
 		)

--- a/apps/ui/lib/lens/full/View/Content.jsx
+++ b/apps/ui/lib/lens/full/View/Content.jsx
@@ -37,7 +37,7 @@ export default class Content extends React.Component {
 			tail,
 			channel,
 			getQueryOptions,
-			tailType,
+			tailTypes,
 			setPage,
 			pageOptions
 		} = this.props
@@ -65,12 +65,12 @@ export default class Content extends React.Component {
 							pageOptions={pageOptions}
 							page={pageOptions.page}
 							totalPages={pageOptions.totalPages}
-							type={tailType}
+							tailTypes={tailTypes}
 						/>
 					)}
 				</Flex>
-				{Boolean(tailType) && (
-					<ViewFooter type={tailType} justifyContent="flex-end" />
+				{tailTypes.length && (
+					<ViewFooter types={tailTypes} justifyContent="flex-end" />
 				)}
 			</Flex>
 		)

--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/index.jsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/index.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react'
 import _ from 'lodash'
+import skhema from 'skhema'
 import clone from 'deep-copy'
 import {
 	Box,
@@ -16,9 +17,14 @@ import {
 } from 'rendition'
 import SortByButton from './SortByButton'
 
-const getSchemaForFilters = (tailType, timelineFilter) => {
+const getSchemaForFilters = (tailTypes, timelineFilter) => {
+	const tailSchemas = _.map(tailTypes, (tailType) => {
+		return clone(_.get(tailType, [ 'data', 'schema' ], {}))
+	})
+
+	const schemaForFilters = skhema.merge(tailSchemas)
+
 	// Always expose the created_at and updated_at field for filtering
-	const schemaForFilters = _.get(clone(tailType), [ 'data', 'schema' ], {})
 	_.set(schemaForFilters, [ 'properties', 'created_at' ], {
 		title: 'Created at',
 		type: 'string',
@@ -57,7 +63,7 @@ const getSchemaForFilters = (tailType, timelineFilter) => {
 }
 
 const ViewFilters = ({
-	tailType,
+	tailTypes,
 	filters,
 	searchFilter,
 	updateFilters,
@@ -69,13 +75,9 @@ const ViewFilters = ({
 	setSortByField,
 	timelineFilter
 }) => {
-	const isView = Boolean(tailType) && tailType.slug !== 'view'
-	if (!isView) {
-		return null
-	}
 	const summaryFilters = _.compact([ ...filters, searchFilter ])
 
-	const schemaForFilters = getSchemaForFilters(tailType, timelineFilter)
+	const schemaForFilters = getSchemaForFilters(tailTypes, timelineFilter)
 
 	// Only render filters in compact mode for the first breakpoint
 	const FiltersBreakpointSettings = _.sortBy(Theme.breakpoints).map((breakpoint, index) => Boolean(index <= 0))
@@ -102,7 +104,7 @@ const ViewFilters = ({
 						<SortByButton
 							pageOptions={pageOptions}
 							setSortByField={setSortByField}
-							tailType={tailType}
+							tailTypes={tailTypes}
 							ml={2}
 							mb={3}
 							minWidth="150px"

--- a/apps/ui/lib/lens/full/View/Header/index.jsx
+++ b/apps/ui/lib/lens/full/View/Header/index.jsx
@@ -31,7 +31,7 @@ export default class Header extends React.Component {
 			setLens,
 			lens,
 			filters,
-			tailType,
+			tailTypes,
 			updateFilters,
 			saveView,
 			channel,
@@ -57,8 +57,9 @@ export default class Header extends React.Component {
 						title="Filters and Lenses"
 						maxContentHeight="70vh"
 						flex={1}
+						minWidth={0}
 						collapsible={isMobile}
-						data-test="filters-and-lense"
+						data-test="filters-and-lenses"
 					>
 						<Flex
 							mt={[ 2, 2, 0 ]}
@@ -85,7 +86,7 @@ export default class Header extends React.Component {
 							)}
 						</Flex>
 						<ViewFilters
-							tailType={tailType}
+							tailTypes={tailTypes}
 							filters={filters}
 							searchFilter={searchFilter}
 							updateFilters={updateFilters}

--- a/apps/ui/lib/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.jsx
@@ -6,6 +6,7 @@
 
 import _ from 'lodash'
 import React from 'react'
+import skhema from 'skhema'
 import {
 	Box,
 	Flex,
@@ -180,12 +181,10 @@ export default class CardTable extends React.Component {
 		const {
 			allTypes,
 			lensState,
-			type: {
-				data: {
-					schema
-				}
-			}
+			tailTypes
 		} = this.props
+
+		const typesSchemas = _.map(tailTypes, 'data.schema', {})
 
 		const baseCardSchema = _.find(allTypes, {
 			slug: 'card'
@@ -201,7 +200,7 @@ export default class CardTable extends React.Component {
 			'properties.updated_at'
 		])
 
-		const paths = helpers.getPathsInSchema(_.merge(defaultSchema, schema), OMISSIONS)
+		const paths = helpers.getPathsInSchema(skhema.merge([ defaultSchema, ...typesSchemas ]), OMISSIONS)
 
 		return _.map(paths, ({
 			title, path

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -118,7 +118,7 @@ ava.serial('core: should stop users from seeing messages attached to cards they 
 	])
 
 	await page.waitForSelector('.column--view-all-support-issues')
-	await macros.waitForThenClickSelector(page, '.btn--add-support-issue')
+	await macros.waitForThenClickSelector(page, '[data-test="viewfooter__add-btn--support-issue"]')
 
 	await page.waitForSelector('.rendition-form__field--root_name', WAIT_OPTS)
 	await macros.setInputValue(
@@ -578,7 +578,7 @@ ava.serial('workflows: Should be able to create a new workflow', async (test) =>
 	// Navigate to the workflows view
 	await page.goto(`${environment.ui.host}:${environment.ui.port}/view-workflows`)
 
-	await macros.waitForThenClickSelector(page, '.btn--add-workflow')
+	await macros.waitForThenClickSelector(page, '[data-test="viewfooter__add-btn--workflow"]')
 
 	const name = `test-workflow-${uuid()}`
 

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -61,7 +61,7 @@ ava.serial('should let users create new accounts', async (test) => {
 		'[data-test="home-channel__item--view-all-customers"]'
 	])
 
-	await macros.waitForThenClickSelector(page, '.btn--add-account')
+	await macros.waitForThenClickSelector(page, '[data-test="viewfooter__add-btn--account"]')
 
 	const name = `test account ${uuid()}`
 
@@ -127,7 +127,7 @@ ava.serial('should let users create new contacts', async (test) => {
 	} = context
 
 	await macros.waitForThenClickSelector(page, '[data-test="home-channel__item--view-all-contacts"]')
-	await macros.waitForThenClickSelector(page, '.btn--add-contact')
+	await macros.waitForThenClickSelector(page, '[data-test="viewfooter__add-btn--contact"]')
 
 	const name = `test contact ${uuid()}`
 
@@ -153,7 +153,7 @@ ava.serial('should let users create new opportunities', async (test) => {
 		'[data-test="home-channel__item--view-all-opportunities"]'
 	])
 
-	await macros.waitForThenClickSelector(page, '.btn--add-opportunity')
+	await macros.waitForThenClickSelector(page, '[data-test="viewfooter__add-btn--opportunity"]')
 
 	const name = `test opportunity ${uuid()}`
 
@@ -180,7 +180,7 @@ ava.serial('should let users create new opportunities and directly link existing
 	])
 
 	// Open CreateLens for opportunities
-	await macros.waitForThenClickSelector(page, '.btn--add-opportunity')
+	await macros.waitForThenClickSelector(page, '[data-test="viewfooter__add-btn--opportunity"]')
 
 	const name = `test opportunity ${uuid()}`
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This is a necessary pre-requisite for omni-search - as this will create a view that is designed to return a list of cards of different types. 

The `ViewFooter` component has been refactored to accept multiple types. If the `types` prop contains more than one type, a `DropDownButton` is displayed, allowing you to create a new card of any of the types passed. I've added unit tests to verify the new behaviour of `ViewFooter`.