### PR TITLE
Add the view name (if set) to the view header

### DIFF
--- a/apps/ui/lib/lens/full/View/Header/index.jsx
+++ b/apps/ui/lib/lens/full/View/Header/index.jsx
@@ -6,7 +6,8 @@
 
 import React from 'react'
 import {
-	Flex
+	Flex,
+	Heading
 } from 'rendition'
 import {
 	CloseButton,
@@ -63,6 +64,7 @@ export default class Header extends React.Component {
 							mt={[ 2, 2, 0 ]}
 							flexWrap={[ 'wrap', 'wrap', 'nowrap' ]}
 							flexDirection="row-reverse"
+							justifyContent="space-between"
 							alignItems={[ 'flex-start', 'flex-start', 'center' ]}
 						>
 							<Flex mb={3} alignItems="center" justifyContent="flex-end" minWidth={[ '100%', '100%', 'auto' ]}>
@@ -78,6 +80,9 @@ export default class Header extends React.Component {
 									setLens={setLens}
 								/>
 							</Flex>
+							{ !isMobile && channel.data.head.name && (
+								<Heading.h4 mb={3}>{channel.data.head.name}</Heading.h4>
+							)}
 						</Flex>
 						<ViewFilters
 							tailType={tailType}


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before:
![image](https://user-images.githubusercontent.com/2925657/106696213-cecc4180-660e-11eb-9ca2-501740d1f219.png)

After:
![image](https://user-images.githubusercontent.com/2925657/106696036-6aa97d80-660e-11eb-86ad-1754120d5048.png)

_Note: the view name is not shown on small screens as this takes up valuable screen real-estate. We can revisit this decision later if it is deemed necessary to have the view name on the mobile view as well._

![image](https://user-images.githubusercontent.com/2925657/106696133-a7757480-660e-11eb-9ab0-8afc42e9451d.png)

