### PR TITLE
Start tick before other backend services in compose

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -177,6 +177,7 @@ services:
       - postgres
       - redis
       - balena-mdns-publisher
+      - tick
     environment:
       - DATABASE={{DATABASE}}
       - LOGLEVEL=crit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,7 @@ services:
       - postgres
       - redis
       - balena-mdns-publisher
+      - tick
     environment:
       - DATABASE=postgres
       - LOGLEVEL=crit
@@ -236,6 +237,7 @@ services:
       - postgres
       - redis
       - balena-mdns-publisher
+      - tick
     environment:
       - DATABASE=postgres
       - LOGLEVEL=crit


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Testing if starting a single backend service before others improves the "CI fails because of Postgres deadlock" situation.
