### PR TITLE
Restrict filtering to fullTextSearch indexed fields

### DIFF
--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -86,14 +86,18 @@ export default class AutoCompleteCardSelect extends React.Component {
 
 		const queryFilter = getQueryFilter ? getQueryFilter(value) : {
 			type: 'object',
-			anyOf: [].concat(cardTypes).map((cardType) => {
+			anyOf: _.compact([].concat(cardTypes).map((cardType) => {
 				// Retrieve the target type of the selected link
 				const typeCard = _.find(types, {
 					slug: helpers.getTypeBase(cardType)
 				})
 
 				// Create full text search query based on the target type and search term
-				const filter = helpers.createFullTextSearchFilter(typeCard.data.schema, value)
+				const filter = helpers.createFullTextSearchFilter(typeCard.data.schema, value, {
+					fullTextSearchFieldsOnly: true
+				}) || {
+					type: 'object'
+				}
 
 				// Additionally, restrict the query to only filter for cards of the chosen
 				// type
@@ -104,7 +108,7 @@ export default class AutoCompleteCardSelect extends React.Component {
 
 				// Merge with the provided filter (if given)
 				return _.merge(filter, cardFilter)
-			})
+			}))
 		}
 
 		// Query the API for results and set them to state so they can be accessed

--- a/apps/ui/lib/components/LinkModal/UnlinkModal.jsx
+++ b/apps/ui/lib/components/LinkModal/UnlinkModal.jsx
@@ -138,8 +138,12 @@ export const UnlinkModal = ({
 
 				// Add full-text-search for the typed text (if set)
 				if (value) {
-					const filter = helpers.createFullTextSearchFilter(toType.data.schema, value)
-					_.merge(query, filter)
+					const filter = helpers.createFullTextSearchFilter(toType.data.schema, value, {
+						fullTextSearchFieldsOnly: true
+					})
+					if (filter) {
+						_.merge(query, filter)
+					}
 				}
 				return query
 			})

--- a/apps/ui/lib/lens/actions/CreateView/CreateView.jsx
+++ b/apps/ui/lib/lens/actions/CreateView/CreateView.jsx
@@ -252,7 +252,9 @@ export default class CreateView extends React.Component {
 			},
 			additionalProperties: true
 		}, searchTerm
-			? helpers.createFullTextSearchFilter(userType.data.schema, searchTerm)
+			? helpers.createFullTextSearchFilter(userType.data.schema, searchTerm, {
+				fullTextSearchFieldsOnly: true
+			}) || {}
 			: {}
 		])
 

--- a/apps/ui/lib/lens/full/Repository/Repository.jsx
+++ b/apps/ui/lib/lens/full/Repository/Repository.jsx
@@ -80,8 +80,12 @@ export default class RepositoryFull extends React.Component {
 	async loadThreadData (page, searchTerm = '') {
 		const query = getContextualThreadsQuery(this.props.card.id)
 		if (searchTerm) {
-			const searchQuery = helpers.createFullTextSearchFilter(this.eventSchema, searchTerm)
-			query.anyOf = (query.anyOf || []).concat(searchQuery.anyOf)
+			const searchQuery = helpers.createFullTextSearchFilter(this.eventSchema, searchTerm, {
+				fullTextSearchFieldsOnly: true
+			})
+			if (searchQuery) {
+				query.anyOf = (query.anyOf || []).concat(searchQuery.anyOf)
+			}
 		}
 		const options = {
 			viewId: this.props.card.id,

--- a/apps/ui/lib/lens/full/View/index.jsx
+++ b/apps/ui/lib/lens/full/View/index.jsx
@@ -224,11 +224,10 @@ const createEventSearchFilter = (types, term) => {
 		return null
 	}
 	const messageType = helpers.getType('message', types)
-	if (!messageType) {
-		return null
-	}
 	const eventSchema = messageType.data.schema
-	const attachedElementSearchFilter = helpers.createFullTextSearchFilter(eventSchema, term)
+	const attachedElementSearchFilter = helpers.createFullTextSearchFilter(eventSchema, term, {
+		fullTextSearchFieldsOnly: true
+	})
 	if (!attachedElementSearchFilter) {
 		return null
 	}


### PR DESCRIPTION
This should speed up searches quite a lot as we will only be filtering on fullTextSearch indexed fields.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

