### PR TITLE
HOTFIX: In views, set the default number of items per page to 100

### DIFF
--- a/apps/ui/lib/lens/full/View/index.jsx
+++ b/apps/ui/lib/lens/full/View/index.jsx
@@ -277,7 +277,7 @@ export class ViewRenderer extends React.Component {
 			options: {
 				page: 0,
 				totalPages: Infinity,
-				limit: 30,
+				limit: 100,
 				sortBy: [ 'created_at' ]
 			}
 		}


### PR DESCRIPTION
The lens queryoptions should be overriding the default query options on
the view, but this is not happening on initial load since the active
lens is still unknown while the data is loading.
This hotfix sets the default limit value to 100 as a temporary measure
whilst a root-cause fix is prepared.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
