### PR TITLE
Use mock data in a View when selecting a lens and canonical data hasn't loaded

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -11709,9 +11709,9 @@
       }
     },
     "json-schema-faker": {
-      "version": "0.5.0-rcv.29",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.29.tgz",
-      "integrity": "sha512-oc1Jlep1+4HqWEfSOIEzT5630yfe8xSbTSdWcQ18+tbyoEIdSAeyGVH+qh0kIJkFnapAU2VFW7vqJr7WAu4KwQ==",
+      "version": "0.5.0-rcv.33",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.33.tgz",
+      "integrity": "sha512-DZs0rAP1N6vJlyb19bpFXGBzAdgNiCY+H4L9/tQegDavpfkYuBfpwascA57H+OjBtQBoij4cZOxKewDzJaiaEw==",
       "requires": {
         "json-schema-ref-parser": "^6.1.0",
         "jsonpath-plus": "^3.0.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -68,6 +68,7 @@
     "immutability-helper": "^3.1.1",
     "is-uuid": "^1.0.2",
     "json-e": "^4.3.0",
+    "json-schema-faker": "^0.5.0-rcv.33",
     "localforage": "^1.9.0",
     "lodash": "^4.17.20",
     "memoize-one": "^5.1.1",


### PR DESCRIPTION
Previously, when loading a view, the lenses could not be selected until
the view results are known, as the view results are used to find the
lenses (using their "filters"). This creates problems where lenses can't
be rendered ahead of time, which can be a problem if the lens provides
some kind of query override, and also leads to a jumpy UI as the
available lenses disappear and reappear.
This change uses json-schema-faker to create a mock data object based on
the view query schema, which is then used to select a set of lenses.
This mocking only happens if there are no results available from the
view query.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
