### PR TITLE
Restrict CRM table to opportunity type cards

### DIFF
--- a/apps/ui/lib/lens/misc/CRMTable/index.jsx
+++ b/apps/ui/lib/lens/misc/CRMTable/index.jsx
@@ -73,6 +73,10 @@ const lens = {
 					slug: {
 						type: 'string'
 					},
+					type: {
+						type: 'string',
+						const: 'opportunity@1.0.0'
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -86,7 +90,8 @@ const lens = {
 					}
 				},
 				required: [
-					'data'
+					'data',
+					'type'
 				]
 			}
 		}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

