### PR TITLE
Fix check for re-opened support thread

### DIFF
--- a/apps/ui/lib/lens/list/SupportThreads.jsx
+++ b/apps/ui/lib/lens/list/SupportThreads.jsx
@@ -43,8 +43,8 @@ const StyledTabs = styled(Tabs) `
 
 const SLUG = 'lens-support-threads'
 
-// This name is added to update events that reopen issues
-const THREAD_REOPEN_NAME = 'Re-opened because linked issue was closed'
+// This name is added to update events that reopen issues/pull requests
+const THREAD_REOPEN_NAME_RE = /Support Thread re-opened because linked (Issue|Pull Request) was closed/
 
 // One day in milliseconds
 const ENGINEER_RESPONSE_TIMEOUT = 1000 * 60 * 60 * 24
@@ -139,7 +139,7 @@ export class SupportThreads extends React.Component {
 
 				// If the thread has re-opened then the we are waiting on action
 				// from the agent and can break out of the loop
-				if (typeBase === 'update' && event.name === THREAD_REOPEN_NAME) {
+				if (typeBase === 'update' && THREAD_REOPEN_NAME_RE.test(event.name)) {
 					break
 				}
 


### PR DESCRIPTION
The wording of the update event's name created by the triggered action has changed. This fix also accounts for threads re-opened because a pull request was closed.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #5759

See [triggered-action-support-closed-issue-reopen](https://github.com/product-os/jellyfish-plugin-default/blob/4c9b46a1d1ad3c2220891653e402b97b26009927/lib/cards/contrib/triggered-action-support-closed-issue-reopen.json#L109) and [triggered-action-support-closed-pull-request-reopen](https://github.com/product-os/jellyfish-plugin-default/blob/4c9b46a1d1ad3c2220891653e402b97b26009927/lib/cards/contrib/triggered-action-support-closed-pull-request-reopen.json#L109)