### PR TITLE
Registry auth uses slug instead of ID of cards

### DIFF
--- a/test/e2e/server/registry.spec.js
+++ b/test/e2e/server/registry.spec.js
@@ -135,7 +135,7 @@ ava.serial('/api/v2/registry should return a JWT with correct access permissions
 
 	const result = await test.context.http(
 		'GET',
-		`/api/v2/registry?account=${actor.slug}&scope=repository%3A${thread.id}%3Apush%2Cpull&service=registry.ly.fish.local`,
+		`/api/v2/registry?account=${actor.slug}&scope=repository%3A${thread.slug}%3Apush%2Cpull&service=registry.ly.fish.local`,
 		null,
 		{
 			authorization: `Basic ${b64Auth}`

--- a/test/e2e/server/registry.spec.js
+++ b/test/e2e/server/registry.spec.js
@@ -150,6 +150,6 @@ ava.serial('/api/v2/registry should return a JWT with correct access permissions
 	})
 
 	test.is(decoded.access.length, 1, 'The access array should contain 1 entry')
-	test.is(decoded.access[0].name, thread.id, 'Access should be provided to the card id')
+	test.is(decoded.access[0].name, thread.slug, 'Access should be provided to the card slug')
 	test.deepEqual(decoded.access[0].actions, [ 'push', 'pull' ], 'Pull and push actions should be authorized')
 })


### PR DESCRIPTION
This changes the Docker Registry authentication to check for access to an artifact by validating access to a card with the artifact's name as the slug.

Due to Docker Auth API constraints, no auth based on version is possible, but we decided to accept this limitation: https://www.flowdock.com/app/rulemotion/transformer/threads/5ZFZIfltE5kQ9r2vTnLHhUBJxVB