### PR TITLE
Omni-search

### DIFF
--- a/apps/ui/lib/components/ChannelRenderer.jsx
+++ b/apps/ui/lib/components/ChannelRenderer.jsx
@@ -24,6 +24,9 @@ import ChannelNotFound from './ChannelNotFound'
 import {
 	ChannelContextProvider
 } from '../hooks'
+import {
+	getLens
+} from '../lens'
 
 // Selects an appropriate renderer for a card
 class ChannelRenderer extends React.Component {
@@ -63,7 +66,6 @@ class ChannelRenderer extends React.Component {
 
 	render () {
 		const {
-			getLens,
 			channel,
 			connectDropTarget,
 			isOver,

--- a/apps/ui/lib/components/HomeChannel/HomeChannel.jsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.jsx
@@ -36,6 +36,7 @@ import {
 import TreeMenu from './TreeMenu'
 import UserStatusMenuItem from '../UserStatusMenuItem'
 import ViewLink from '../ViewLink'
+import OmniSearch from '../OmniSearch'
 import {
 	registerForNotifications
 } from '../../services/notifications'
@@ -559,9 +560,13 @@ export default class HomeChannel extends React.Component {
 						flexDirection="column"
 						data-test='home-channel__content'
 					>
-						<Flex position='relative' justifyContent="space-between" style={{
-							borderBottom: '1px solid #eee'
-						}}>
+						<Flex
+							position='relative'
+							flexDirection="column"
+							style={{
+								borderBottom: '1px solid #eee'
+							}}
+						>
 							<Flex
 								className="user-menu-toggle"
 								py={3}
@@ -601,6 +606,7 @@ export default class HomeChannel extends React.Component {
 									</MentionsCount>
 								)}
 							</Flex>
+							<OmniSearch ml={3} mr={2} />
 						</Flex>
 
 						{this.state.showMenu && (

--- a/apps/ui/lib/components/HomeChannel/tests/HomeChannel.spec.jsx
+++ b/apps/ui/lib/components/HomeChannel/tests/HomeChannel.spec.jsx
@@ -21,6 +21,10 @@ const context = {}
 
 const sandbox = sinon.createSandbox()
 
+const initialState = {
+	core: {}
+}
+
 ava.beforeEach(async () => {
 	context.actions = _.reduce([
 		'addChannel',
@@ -53,7 +57,7 @@ ava.afterEach(async () => {
 ava('Starred views appear in their own menu section', async (test) => {
 	const {
 		wrapper
-	} = getWrapper()
+	} = getWrapper(initialState)
 	const homeChannel = await mount((
 		<HomeChannel
 			{...homeChannelProps}
@@ -84,7 +88,7 @@ ava('The home view is loaded on mount if set', async (test) => {
 	const homeView = 'view-123'
 	const {
 		wrapper
-	} = getWrapper()
+	} = getWrapper(initialState)
 	await mount((
 		<HomeChannel
 			{...homeChannelProps}

--- a/apps/ui/lib/components/OmniSearch/OmniSearch.jsx
+++ b/apps/ui/lib/components/OmniSearch/OmniSearch.jsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import path from 'path'
+import _ from 'lodash'
+import classnames from 'classnames'
+import {
+	Box,
+	Input,
+	Txt
+} from 'rendition'
+import styled from 'styled-components'
+import {
+	Icon
+} from '@balena/jellyfish-ui-components'
+
+const TipTxt = styled(Txt) `
+  opacity: 0;
+  transition: opacity ease-in-out 300ms;
+  &.active {
+    opacity: 1;
+  }
+`
+
+const SearchWrapper = styled(Box) `
+	position: relative;
+`
+
+const IconWrapper = styled(Box) `
+	position: absolute;
+	left: 8px;
+  top: 50%;
+	transform: translateY(-50%);
+`
+
+const SearchInput = styled(Input) `
+	padding-left: 26px;
+`
+
+export const OmniSearch = ({
+	actions,
+	channels,
+	types,
+	history,
+	...rest
+}) => {
+	const [ searchTerm, setSearchTerm ] = React.useState('')
+	const tipCN = classnames({
+		active: Boolean(searchTerm)
+	})
+	const onKeyPress = (event) => {
+		if (searchTerm && event.key === 'Enter') {
+			const searchChannel = _.find(channels, {
+				data: {
+					target: 'search'
+				}
+			})
+			if (searchChannel) {
+				actions.updateChannel(_.merge({}, searchChannel, {
+					data: {
+						seed: {
+							searchTerm
+						}
+					}
+				}))
+			} else {
+				actions.addChannel({
+					format: 'search',
+					target: 'search',
+					options: {},
+					head: {},
+					seed: {
+						searchTerm
+					},
+					canonical: false
+				})
+				history.push(path.join(window.location.pathname, 'search'))
+			}
+			setSearchTerm('')
+		}
+	}
+	return (
+		<Box {...rest}>
+			<SearchWrapper alignItems="center">
+				<IconWrapper>
+					<Icon name="search" />
+				</IconWrapper>
+				<SearchInput
+					value={searchTerm}
+					onKeyPress={onKeyPress}
+					onChange={(event) => {
+						setSearchTerm(event.target.value)
+					}}
+					placeholder="Search Jellyfish..."
+				/>
+			</SearchWrapper>
+			<TipTxt className={tipCN} fontSize="10px">Press enter to search</TipTxt>
+		</Box>
+	)
+}

--- a/apps/ui/lib/components/OmniSearch/index.js
+++ b/apps/ui/lib/components/OmniSearch/index.js
@@ -6,42 +6,38 @@
 
 import _ from 'lodash'
 import {
+	withRouter
+} from 'react-router-dom'
+import {
 	connect
 } from 'react-redux'
-import {
-	compose,
-	bindActionCreators
-} from 'redux'
-import {
-	withResponsiveContext
-} from '@balena/jellyfish-ui-components'
+import * as redux from 'redux'
 import {
 	actionCreators,
 	selectors
 } from '../../core'
-import RouteHandler from './RouteHandler'
+import {
+	OmniSearch
+} from './OmniSearch'
 
 const mapStateToProps = (state) => {
 	return {
-		types: selectors.getTypes(state),
 		channels: selectors.getChannels(state),
-		status: selectors.getStatus(state),
-		user: selectors.getCurrentUser(state)
+		types: selectors.getTypes(state)
 	}
 }
 
 const mapDispatchToProps = (dispatch) => {
 	return {
-		actions: bindActionCreators(
+		actions: redux.bindActionCreators(
 			_.pick(actionCreators, [
-				'setChannels',
-				'queryAPI',
-				'createLink'
+				'addChannel',
+				'updateChannel'
 			]), dispatch)
 	}
 }
 
-export default compose(
-	connect(mapStateToProps, mapDispatchToProps),
-	withResponsiveContext
-)(RouteHandler)
+export default redux.compose(
+	withRouter,
+	connect(mapStateToProps, mapDispatchToProps)
+)(OmniSearch)

--- a/apps/ui/lib/components/RouteHandler/RouteHandler.jsx
+++ b/apps/ui/lib/components/RouteHandler/RouteHandler.jsx
@@ -13,6 +13,9 @@ import ReactResizeObserver from 'react-resize-observer'
 import {
 	Flex
 } from 'rendition'
+import {
+	getLensForTarget
+} from '../../lens'
 import ChannelRenderer from '../ChannelRenderer'
 
 const PATH_SEPARATOR = '...'
@@ -141,13 +144,12 @@ export default class RouteHandler extends React.Component {
 				return existingChannel
 			}
 
-			// TODO: Remove this special case handling for the inbox and use a generic
-			// solution
-			if (target === 'inbox') {
+			const lensForTarget = getLensForTarget(target)
+			if (lensForTarget) {
 				return {
-					target: 'inbox',
+					target,
 					canonical: false,
-					format: 'inbox',
+					format: lensForTarget.data.format,
 					head: {},
 					options: {}
 				}
@@ -166,7 +168,6 @@ export default class RouteHandler extends React.Component {
 
 	render () {
 		const {
-			getLens,
 			types,
 			actions,
 			channels,
@@ -201,7 +202,6 @@ export default class RouteHandler extends React.Component {
 				{_.map(channels.slice(1), (channel, index) => {
 					return (
 						<ChannelRenderer
-							getLens={getLens}
 							types={types}
 							actions={actions}
 							user={user}

--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/SortByButton.jsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/SortByButton.jsx
@@ -50,7 +50,10 @@ const getSortByOptions = (cardSchema, tailTypes) => {
 	})
 
 	// Merge generic card schema with current card schema to get top-level and data fields
-	const fullSchema = skhema.merge([ cardSchema, ...tailSchemas ])
+	// TODO: Improve safety of skhema.merge so that it doesn't throw if the
+	// skhemas can't be merged. That way we can merge all the typesSchemas
+	// instead of just the first one.
+	const fullSchema = skhema.merge([ cardSchema, _.first(tailSchemas) ])
 
 	const dataFieldPaths = helpers.getPathsInSchema(fullSchema, FIELDS_TO_OMIT)
 

--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/index.jsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react'
 import _ from 'lodash'
-import skhema from 'skhema'
 import clone from 'deep-copy'
 import {
 	Box,
@@ -22,7 +21,10 @@ const getSchemaForFilters = (tailTypes, timelineFilter) => {
 		return clone(_.get(tailType, [ 'data', 'schema' ], {}))
 	})
 
-	const schemaForFilters = skhema.merge(tailSchemas)
+	const schemaForFilters = {
+		type: 'object',
+		anyOf: tailSchemas
+	}
 
 	// Always expose the created_at and updated_at field for filtering
 	_.set(schemaForFilters, [ 'properties', 'created_at' ], {

--- a/apps/ui/lib/lens/index.js
+++ b/apps/ui/lib/lens/index.js
@@ -74,6 +74,12 @@ export const getLensBySlug = (slug) => {
 	}) || null
 }
 
+export const getLensForTarget = (target) => {
+	return _.find(allLenses, (lens) => {
+		return lens.data.pathRegExp && new RegExp(lens.data.pathRegExp).test(target)
+	})
+}
+
 // Generate a query that will get all the contextual threads and their attached
 // messages and whispers
 export const getContextualThreadsQuery = (id) => {

--- a/apps/ui/lib/lens/index.spec.js
+++ b/apps/ui/lib/lens/index.spec.js
@@ -8,7 +8,8 @@ import '../../test/ui-setup'
 import ava from 'ava'
 import _ from 'lodash'
 import {
-	getLenses
+	getLenses,
+	getLensForTarget
 } from './index'
 
 const user = {
@@ -53,4 +54,14 @@ ava('getLenses returns the support-threads-to-audit and support-audit-chart lens
 	test.true(lensSlugs.includes('lens-support-threads-to-audit'))
 	test.true(lensSlugs.includes('lens-support-audit-chart'))
 	test.false(lensSlugs.includes('lens-support-threads'))
+})
+
+ava('getLensForTarget returns the omni-search lens for the path \'search\'', (test) => {
+	const lens = getLensForTarget('search')
+	test.is(lens.slug, 'lens-omni-search')
+})
+
+ava('getLensForTarget returns the inbox lens for the path \'inbox\'', (test) => {
+	const lens = getLensForTarget('inbox')
+	test.is(lens.slug, 'lens-inbox')
 })

--- a/apps/ui/lib/lens/list/Interleaved.jsx
+++ b/apps/ui/lib/lens/list/Interleaved.jsx
@@ -259,6 +259,7 @@ const lens = {
 			type: 'array',
 			items: {
 				type: 'object',
+				required: [ 'id', 'type' ],
 				properties: {
 					id: {
 						type: 'string'

--- a/apps/ui/lib/lens/misc/Inbox/Inbox.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/Inbox.jsx
@@ -18,6 +18,7 @@ import {
 	Tab
 } from 'rendition'
 import {
+	CloseButton,
 	Column
 } from '@balena/jellyfish-ui-components'
 import InboxTab from './InboxTab'
@@ -32,6 +33,7 @@ const InboxColumn = styled(Column) `
 `
 
 const Inbox = ({
+	channel,
 	setupStream,
 	clearViewData,
 	paginateStream
@@ -53,6 +55,7 @@ const Inbox = ({
 				<Heading.h4>
 					Inbox
 				</Heading.h4>
+				<CloseButton flex={0} mt={-1} channel={channel} />
 			</Flex>
 
 			<Tabs

--- a/apps/ui/lib/lens/misc/Inbox/index.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/index.jsx
@@ -33,6 +33,7 @@ export default {
 	version: '1.0.0',
 	name: 'Inbox lens',
 	data: {
+		pathRegExp: '^inbox$',
 		format: 'inbox',
 		renderer: connect(null, mapDispatchToProps)(Inbox),
 		icon: 'address-card',

--- a/apps/ui/lib/lens/misc/OmniSearch.jsx
+++ b/apps/ui/lib/lens/misc/OmniSearch.jsx
@@ -48,24 +48,20 @@ const generateOmniSearchView = memoize((typeSlugs) => {
 		type: 'view@1.0.0',
 		markers: [ 'org-balena' ],
 		data: {
+			types: typeSlugs,
 			allOf: [
 				{
-					name: 'Active searchable cards',
+					name: 'Active cards',
 					schema: {
 						type: 'object',
 						properties: {
 							active: {
 								const: true,
 								type: 'boolean'
-							},
-							type: {
-								type: 'string',
-								enum: typeSlugs || [ 'card@1.0.0' ]
 							}
 						},
 						required: [
-							'active',
-							'type'
+							'active'
 						],
 						additionalProperties: true
 					}

--- a/apps/ui/lib/lens/misc/OmniSearch.jsx
+++ b/apps/ui/lib/lens/misc/OmniSearch.jsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	v4 as uuid
+} from 'uuid'
+import memoize from 'memoize-one'
+import {
+	SchemaSieve
+} from 'rendition'
+import {
+	getLens
+} from '..'
+
+const typesToExclude = [
+	'rating',
+	'summary',
+	'message',
+	'whisper'
+]
+
+const getFullTextSearchTypes = memoize((types) => {
+	return types.reduce((fullTextSearchTypes, type) => {
+		if (typesToExclude.includes(type.slug)) {
+			return fullTextSearchTypes
+		}
+		const flatSchema = SchemaSieve.flattenSchema(type.data.schema)
+		const fullTextSearchFieldFound = _.find(flatSchema.properties, {
+			fullTextSearch: true
+		})
+		if (fullTextSearchFieldFound) {
+			fullTextSearchTypes.push(`${type.slug}@${type.version}`)
+		}
+		return fullTextSearchTypes
+	}, [])
+})
+
+const generateOmniSearchView = memoize((typeSlugs) => {
+	return {
+		id: uuid(),
+		slug: 'search',
+		name: 'Search Jellyfish',
+		type: 'view@1.0.0',
+		markers: [ 'org-balena' ],
+		data: {
+			allOf: [
+				{
+					name: 'Active searchable cards',
+					schema: {
+						type: 'object',
+						properties: {
+							active: {
+								const: true,
+								type: 'boolean'
+							},
+							type: {
+								type: 'string',
+								enum: typeSlugs || [ 'card@1.0.0' ]
+							}
+						},
+						required: [
+							'active',
+							'type'
+						],
+						additionalProperties: true
+					}
+				}
+			],
+			lenses: [
+				'lens-list'
+			]
+		}
+	}
+})
+
+const OmniSearchLens = (props) => {
+	const fullTextSearchTypes = getFullTextSearchTypes(props.types)
+	const omniSearchView = generateOmniSearchView(fullTextSearchTypes)
+
+	const channel = _.merge({}, props.channel, {
+		data: {
+			head: omniSearchView
+		}
+	})
+
+	const lens = getLens('full', omniSearchView, props.user)
+
+	return <lens.data.renderer {...props} channel={channel} />
+}
+
+export default {
+	slug: 'lens-omni-search',
+	type: 'lens',
+	version: '1.0.0',
+	name: 'Omni-search lens',
+	data: {
+		pathRegExp: '^search$',
+		format: 'search',
+		renderer: OmniSearchLens,
+		icon: 'address-card',
+		type: '*',
+		filter: {
+			type: 'object'
+		}
+	}
+}

--- a/apps/ui/lib/lens/misc/Table/CardTable.jsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.jsx
@@ -200,7 +200,10 @@ export default class CardTable extends React.Component {
 			'properties.updated_at'
 		])
 
-		const paths = helpers.getPathsInSchema(skhema.merge([ defaultSchema, ...typesSchemas ]), OMISSIONS)
+		// TODO: Improve safety of skhema.merge so that it doesn't throw if the
+		// skhemas can't be merged. That way we can merge all the typesSchemas
+		// instead of just the first one.
+		const paths = helpers.getPathsInSchema(skhema.merge([ defaultSchema, _.first(typesSchemas) ]), OMISSIONS)
 
 		return _.map(paths, ({
 			title, path

--- a/apps/ui/lib/lens/misc/index.js
+++ b/apps/ui/lib/lens/misc/index.js
@@ -10,6 +10,7 @@ import Table from './Table'
 import CRMTable from './CRMTable'
 import Chart from './Chart'
 import Inbox from './Inbox'
+import OmniSearch from './OmniSearch'
 
 export default [
 	Kanban,
@@ -17,5 +18,6 @@ export default [
 	Table,
 	CRMTable,
 	Chart,
-	Inbox
+	Inbox,
+	OmniSearch
 ]


### PR DESCRIPTION
Omni-search is a view that lets you search for cards across all searchable card types. It can be accessed via a new searchbox in the sidebar (or from the URL `/search`). A new omni-search lens wraps the normal view lens, constructing and passing in a filter based on the available searchable card types.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![Omni-search demo](https://user-images.githubusercontent.com/2925657/108470489-9f7b2d00-72bc-11eb-9b6f-59fae5dc153e.gif)

(This PR also adds a close button to the Inbox view in a [2nd commit](https://github.com/product-os/jellyfish/pull/5772/commits/d84ff43adcf71bdb2162777ff6ecf8a63864a9b0) - something that I've been meaning to do for a long time!)