### PR TITLE
Timeout on pendinguserresponse

### DIFF
--- a/apps/ui/lib/lens/list/SupportThreads.jsx
+++ b/apps/ui/lib/lens/list/SupportThreads.jsx
@@ -16,6 +16,7 @@ import {
 } from 'react-redux'
 import * as redux from 'redux'
 import styled from 'styled-components'
+import addBusinessDays from 'date-fns/addBusinessDays'
 import {
 	Box,
 	Tab,
@@ -48,6 +49,9 @@ const THREAD_REOPEN_NAME_RE = /Support Thread re-opened because linked (Issue|Pu
 
 // One day in milliseconds
 const ENGINEER_RESPONSE_TIMEOUT = 1000 * 60 * 60 * 24
+
+// Three (business) days
+const USER_RESPONSE_TIMEOUT_DAYS = 3
 
 const timestampSort = (cards) => {
 	return _.sortBy(cards, (element) => {
@@ -150,9 +154,14 @@ export class SupportThreads extends React.Component {
 						break
 					}
 
-					// If the message contains the 'pendinguserresponse' tag, then we are
+					// If the message contains the 'pendinguserresponse' tag and its
+					// been less than 3 working days since the message was created, then we are
 					// waiting on a response from the user and can break out of the loop
-					if (event.data.payload.message && event.data.payload.message.match(/#(<span>)?pendinguserresponse/gi)) {
+					if (
+						event.data.payload.message &&
+						event.data.payload.message.match(/#(<span>)?pendinguserresponse/gi) &&
+						addBusinessDays(new Date(event.data.timestamp), USER_RESPONSE_TIMEOUT_DAYS) > Date.now()
+					) {
 						isPendingUserResponse = true
 						break
 					}

--- a/apps/ui/lib/lens/list/tests/SupportThreads.spec.jsx
+++ b/apps/ui/lib/lens/list/tests/SupportThreads.spec.jsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getWrapper,
+	flushPromises
+} from '../../../../test/ui-setup'
+import _ from 'lodash'
+import subDays from 'date-fns/subDays'
+import subHours from 'date-fns/subHours'
+import subBusinessDays from 'date-fns/subBusinessDays'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import {
+	SupportThreads
+} from '../SupportThreads'
+import {
+	pendingEngineer,
+	pendingUser
+} from './fixtures'
+
+const sandbox = sinon.createSandbox()
+
+const now = new Date()
+
+const wrappingComponent = getWrapper().wrapper
+
+const getSegments = async (commonProps, thread, timestamp) => {
+	const adjustedThread = _.merge({}, thread, {
+		links: {
+			'has attached element': {
+				0: {
+					data: {
+						timestamp
+					}
+				}
+			}
+		}
+	})
+	const component = await mount((
+		<SupportThreads {...commonProps} tail={[ adjustedThread ]} />
+	), {
+		wrappingComponent
+	})
+
+	await flushPromises()
+	await flushPromises()
+
+	return component.state().segments
+}
+
+ava.beforeEach((test) => {
+	test.context.commonProps = {
+		actions: {
+			getActor: sandbox.stub().resolves({}),
+			setLensState: sandbox.stub()
+		},
+		page: 0,
+		pageOptions: {
+			page: 0, totalPages: 1, limit: 100, sortBy: [ 'created_at' ]
+		},
+		channels: [],
+		tail: [],
+		lensState: {
+			activeIndex: 2
+		}
+	}
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('Pending user response threads are displayed in the pending user response tab', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	// Update timestamp to be within 3 working days
+	const segments = await getSegments(commonProps, pendingUser, subDays(now, 1).toISOString())
+
+	const pendingUserResponse = _.find(segments, {
+		name: 'pending user response'
+	})
+
+	test.is(pendingUserResponse.cards.length, 1)
+	test.is(pendingUserResponse.cards[0].slug, pendingUser.slug)
+})
+
+ava('Pending user response threads that are more than 3 working days old ' +
+'are displayed in the pending agent response tab', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	// Update timestamp to be more than 3 working days old
+	const segments = await getSegments(commonProps, pendingUser, subBusinessDays(now, 3).toISOString())
+
+	const pendingAgentResponse = _.find(segments, {
+		name: 'pending agent response'
+	})
+
+	test.is(pendingAgentResponse.cards.length, 1)
+	test.is(pendingAgentResponse.cards[0].slug, pendingUser.slug)
+})
+
+ava('Pending engineer response threads are displayed in the pending engineer response tab', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	// Update timestamp to be within 24hrs
+	const segments = await getSegments(commonProps, pendingEngineer, subHours(now, 3).toISOString())
+
+	const pendingEngineerResponse = _.find(segments, {
+		name: 'pending engineer response'
+	})
+	test.is(pendingEngineerResponse.cards.length, 1)
+	test.is(pendingEngineerResponse.cards[0].slug, pendingEngineer.slug)
+})
+
+ava('Pending engineer response threads that are more than 24 hrs old ' +
+'are displayed in the pending agent response tab', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	// Update timestamp to be older than 24hrs
+	const segments = await getSegments(commonProps, pendingEngineer, subHours(now, 25).toISOString())
+
+	const pendingAgentResponse = _.find(segments, {
+		name: 'pending agent response'
+	})
+	test.is(pendingAgentResponse.cards.length, 1)
+	test.is(pendingAgentResponse.cards[0].slug, pendingEngineer.slug)
+})

--- a/apps/ui/lib/lens/list/tests/fixtures/index.js
+++ b/apps/ui/lib/lens/list/tests/fixtures/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	default as pendingUser
+} from './pending-user.json'
+export {
+	default as pendingEngineer
+} from './pending-engineer.json'

--- a/apps/ui/lib/lens/list/tests/fixtures/pending-engineer.json
+++ b/apps/ui/lib/lens/list/tests/fixtures/pending-engineer.json
@@ -1,0 +1,55 @@
+{
+  "id": "st-2",
+  "data": {
+    "inbox": "paid",
+    "status": "open",
+    "product": "balenaCloud",
+    "participants": []
+  },
+  "name": "Test thread that should be pendingengineerresponse",
+  "slug": "support-thread-2",
+  "tags": [
+    "pendingengineerresponse"
+  ],
+  "type": "support-thread@1.0.0",
+  "links": {
+    "has attached element": [
+      {
+        "id": "w-2",
+        "data": {
+          "actor": "a-1",
+          "target": "st-2",
+          "payload": {
+            "message": "#pendingengineerresponse",
+            "alertsUser": [],
+            "alertsGroup": [],
+            "mentionsUser": [],
+            "mentionsGroup": []
+          },
+          "timestamp": "2021-02-18T10:00:31.538Z"
+        },
+        "name": null,
+        "slug": "whisper-2",
+        "tags": [
+          "pendingengineerresponse"
+        ],
+        "type": "whisper@1.0.0",
+        "links": {},
+        "active": true,
+        "markers": [
+          "user-1"
+        ],
+        "version": "1.0.0",
+        "created_at": "2021-02-18T10:00:31.761Z",
+        "updated_at": null
+      }
+    ]
+  },
+  "active": true,
+  "markers": [
+    "user-1+org-balena"
+  ],
+  "version": "1.0.0",
+  "created_at": "2021-02-17T19:02:25.712Z",
+  "updated_at": "2021-02-19T08:14:44.464Z"
+}

--- a/apps/ui/lib/lens/list/tests/fixtures/pending-user.json
+++ b/apps/ui/lib/lens/list/tests/fixtures/pending-user.json
@@ -1,0 +1,55 @@
+{
+  "id": "st-1",
+  "data": {
+    "inbox": "paid",
+    "status": "open",
+    "product": "balenaCloud",
+    "participants": []
+  },
+  "name": "Test thread that should be pendinguserresponse",
+  "slug": "support-thread-1",
+  "tags": [
+    "pendinguserresponse"
+  ],
+  "type": "support-thread@1.0.0",
+  "links": {
+    "has attached element": [
+      {
+        "id": "w-1",
+        "data": {
+          "actor": "a-1",
+          "target": "st-1",
+          "payload": {
+            "message": "#pendinguserresponse",
+            "alertsUser": [],
+            "alertsGroup": [],
+            "mentionsUser": [],
+            "mentionsGroup": []
+          },
+          "timestamp": "2021-02-18T10:00:31.538Z"
+        },
+        "name": null,
+        "slug": "whisper-1",
+        "tags": [
+          "pendinguserresponse"
+        ],
+        "type": "whisper@1.0.0",
+        "links": {},
+        "active": true,
+        "markers": [
+          "user-1"
+        ],
+        "version": "1.0.0",
+        "created_at": "2021-02-18T10:00:31.761Z",
+        "updated_at": null
+      }
+    ]
+  },
+  "active": true,
+  "markers": [
+    "user-1+org-balena"
+  ],
+  "version": "1.0.0",
+  "created_at": "2021-02-17T19:02:25.712Z",
+  "updated_at": "2021-02-19T08:14:44.464Z"
+}


### PR DESCRIPTION
Threads only stay on the pendinguserresponse tab for 3 working days, before returning to the pendingagentresponse tab.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #3222 

Added unit tests to test relevant `SupportThreads` component behaviour.
