### PR TITLE
Discussion tab title should match hashtag

### DIFF
--- a/apps/ui/lib/lens/list/SupportThreads.jsx
+++ b/apps/ui/lib/lens/list/SupportThreads.jsx
@@ -229,7 +229,7 @@ export class SupportThreads extends React.Component {
 				cards: timestampSort(pendingEngineerResponse)
 			},
 			{
-				name: 'discussions',
+				name: 'discussion',
 				cards: timestampSort(discussions)
 			}
 		]


### PR DESCRIPTION
This will create less confusion with people wanting to use the hashtag ("Should I use `(#)discussions` or `(#)discussion`?")

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

