### PR TITLE
ViewFooter drop-down button should 'drop' up

### DIFF
--- a/apps/ui/lib/lens/common/ViewFooter/ViewFooter.jsx
+++ b/apps/ui/lib/lens/common/ViewFooter/ViewFooter.jsx
@@ -20,6 +20,13 @@ const Footer = styled(Flex) `
 	border-top: 1px solid #eee;
 `
 
+const DropUpButton = styled(DropDownButton).attrs({
+	dropUp: true
+}) `
+	&>div:last-child {
+		max-height: 80vh;
+	}
+`
 const isSynchronous = (type) => {
 	return type.slug === 'thread'
 }
@@ -60,7 +67,8 @@ export const ViewFooter = ({
 			{...rest}
 		>
 			{ types.length > 1 ? (
-				<DropDownButton
+				<DropUpButton
+					alignRight
 					disabled={isBusy}
 					success
 					data-test="viewfooter__add-dropdown"
@@ -80,7 +88,7 @@ export const ViewFooter = ({
 							</ActionLink>
 						))
 					}
-				</DropDownButton>
+				</DropUpButton>
 			) : (
 				<Button
 					disabled={isBusy}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before:
![ViewFooter DropDown](https://user-images.githubusercontent.com/2925657/111093281-18437100-856b-11eb-8808-5f89d82f13ff.gif)

After:
![image](https://user-images.githubusercontent.com/2925657/111093162-d1ee1200-856a-11eb-9fd7-5f37110f1d8e.png)
