### PR TITLE
Check for empty/missing channel on stream update

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -497,12 +497,16 @@ export const actionCreators = {
 					id: channel.id
 				})
 
+				if (!currentChannel) {
+					return
+				}
+
 				const clonedChannel = clone(currentChannel)
 
 				if (channels.length > 0) {
 					// Merge required in the event that this is a pagination query
 					clonedChannel.data.head = merge(
-						clonedChannel.data.head,
+						_.get(clonedChannel, [ 'data', 'head' ], {}),
 						channels[0],
 						{
 							arrayMerge: (destinationArray, sourceArray) => {


### PR DESCRIPTION
Defensively check if the channel is present and account for channels without data.head set.

Relates to https://sentry.io/share/issue/cc5f7febab8e4deaa2315f509e81cb4e/

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

