### PR TITLE
Fix the layout of the Kanban board

### DIFF
--- a/apps/ui/lib/lens/misc/Kanban.jsx
+++ b/apps/ui/lib/lens/misc/Kanban.jsx
@@ -13,6 +13,7 @@ import {
 import {
 	withRouter
 } from 'react-router-dom'
+import styled from 'styled-components'
 import ReactTrello from 'react-trello'
 import {
 	bindActionCreators
@@ -31,6 +32,20 @@ import {
 	selectors,
 	sdk
 } from '../../core'
+
+const TrelloWrapper = styled(Flex) `
+	height: 100%;
+	width: 100%;
+	position: relative;
+	overflow-x: auto;
+	.react-trello-board > div {
+		display: flex;
+		height: 100%;
+	}
+	.smooth-dnd-draggable-wrapper > section {
+		max-height: 100%
+	} 
+`
 
 const UNSORTED_GROUP_ID = 'JELLYFISH_UNSORTED_GROUP'
 
@@ -188,12 +203,9 @@ class Kanban extends React.Component {
 		const components = {}
 
 		return (
-			<Flex
+			<TrelloWrapper
 				data-test={`lens--${SLUG}`}
 				flexDirection="column"
-				style={{
-					height: '100%', width: '100%', position: 'relative', overflowX: 'auto'
-				}}
 			>
 				<ReactTrello
 					style={{
@@ -206,7 +218,7 @@ class Kanban extends React.Component {
 					handleDragEnd={this.handleDragEnd}
 					onCardClick={this.onCardClick}
 				/>
-			</Flex>
+			</TrelloWrapper>
 		)
 	}
 }


### PR DESCRIPTION
Ensure Kanban board doesn't take up more room than is available, so you can scroll to the bottom of a lane's cards.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
| Before | After |
|---------|-------|
|  ![Kanban Before](https://user-images.githubusercontent.com/2925657/109101226-ebb0ec00-7758-11eb-9312-6576dc592a2b.gif) | ![Kanban After](https://user-images.githubusercontent.com/2925657/109101233-f075a000-7758-11eb-89c2-a91852e7556f.gif)  |


