### PR TITLE
Update jellyfish-core from 2.1.1 to 2.1.2

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -208,9 +208,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.1.1.tgz",
-      "integrity": "sha512-E8qZfQbkSJDC6XQyDga6QKCBFQuA1txk6OdVP1YA+Hlp17TEwggVl/6ziLszURi0tPjsTnulHDok/oMdeSaaqw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.1.2.tgz",
+      "integrity": "sha512-Ak501t71JnNM/WrC1MkuOJ62kp1vxkDmrNI42QVa7jqC5bBom8jKO10AJN9G7Q8HPzJUR9iVhFOnS5uLjjkVKA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.59",
         "@balena/jellyfish-environment": "^2.4.19",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -11,7 +11,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-action-library": "^8.0.67",
-    "@balena/jellyfish-core": "^2.1.1",
+    "@balena/jellyfish-core": "^2.1.2",
     "@balena/jellyfish-environment": "^2.4.19",
     "@balena/jellyfish-logger": "^1.0.33",
     "@balena/jellyfish-metrics": "^0.1.99",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -343,9 +343,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.1.1.tgz",
-      "integrity": "sha512-E8qZfQbkSJDC6XQyDga6QKCBFQuA1txk6OdVP1YA+Hlp17TEwggVl/6ziLszURi0tPjsTnulHDok/oMdeSaaqw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.1.2.tgz",
+      "integrity": "sha512-Ak501t71JnNM/WrC1MkuOJ62kp1vxkDmrNI42QVa7jqC5bBom8jKO10AJN9G7Q8HPzJUR9iVhFOnS5uLjjkVKA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.59",
         "@balena/jellyfish-environment": "^2.4.19",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@balena/jellyfish-action-library": "^8.0.67",
     "@balena/jellyfish-assert": "^1.0.59",
-    "@balena/jellyfish-core": "^2.1.1",
+    "@balena/jellyfish-core": "^2.1.2",
     "@balena/jellyfish-environment": "^2.4.19",
     "@balena/jellyfish-logger": "^1.0.33",
     "@balena/jellyfish-metrics": "^0.1.99",

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,9 +277,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.1.1.tgz",
-      "integrity": "sha512-E8qZfQbkSJDC6XQyDga6QKCBFQuA1txk6OdVP1YA+Hlp17TEwggVl/6ziLszURi0tPjsTnulHDok/oMdeSaaqw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.1.2.tgz",
+      "integrity": "sha512-Ak501t71JnNM/WrC1MkuOJ62kp1vxkDmrNI42QVa7jqC5bBom8jKO10AJN9G7Q8HPzJUR9iVhFOnS5uLjjkVKA==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.0.59",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@balena/jellyfish-action-library": "^8.0.67",
     "@balena/jellyfish-chat-widget": "^6.0.60",
     "@balena/jellyfish-client-sdk": "^2.14.6",
-    "@balena/jellyfish-core": "^2.1.1",
+    "@balena/jellyfish-core": "^2.1.2",
     "@balena/jellyfish-environment": "^2.4.19",
     "@balena/jellyfish-plugin-base": "^1.2.21",
     "@balena/jellyfish-plugin-channels": "^1.0.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
