### PR TITLE
Search for users with regexp in CreateView lens

### DIFF
--- a/apps/ui/lib/lens/actions/CreateView/index.jsx
+++ b/apps/ui/lib/lens/actions/CreateView/index.jsx
@@ -10,6 +10,7 @@ import {
 } from 'react-redux'
 import * as redux from 'redux'
 import {
+	sdk,
 	actionCreators,
 	selectors
 } from '../../../core'
@@ -18,6 +19,7 @@ import CreateView from './CreateView'
 
 const mapStateToProps = (state) => {
 	return {
+		sdk,
 		allTypes: selectors.getTypes(state),
 		user: selectors.getCurrentUser(state)
 	}

--- a/apps/ui/lib/lens/actions/CreateView/tests/CreateView.spec.jsx
+++ b/apps/ui/lib/lens/actions/CreateView/tests/CreateView.spec.jsx
@@ -4,24 +4,138 @@
  * Proprietary and confidential.
  */
 
+import {
+	getWrapper
+} from '../../../../../test/ui-setup'
+import userType from '../../../../../test/fixtures/types/user.json'
+import _ from 'lodash'
 import ava from 'ava'
 import {
-	shallow,
-	configure
+	mount
 } from 'enzyme'
+import sinon from 'sinon'
 import React from 'react'
 import CreateView from '../CreateView'
+import Bluebird from 'bluebird'
+
+const sandbox = sinon.createSandbox()
+
+const wrappingComponent = getWrapper({
+	core: {}
+}).wrapper
 
 // HACK: Don't use the standard test/ui-setup as it causes problems
 // with CreateView if the XMLHttpRequest global is declared
-import Adapter from 'enzyme-adapter-react-16'
+// import Adapter from 'enzyme-adapter-react-16'
 
-configure({
-	adapter: new Adapter()
+// configure({
+// 	adapter: new Adapter()
+// })
+
+ava.beforeEach((test) => {
+	test.context.commonProps = {
+		user: {
+			slug: 'user-1'
+		},
+		allTypes: [
+			userType
+		],
+		channel: {
+			id: 'c-1',
+			slug: 'channel-1',
+			type: 'channel',
+			active: true,
+			data: {
+				head: {
+					onDone: {
+						action: 'open'
+					}
+				},
+				format: 'createView',
+				canonical: false
+			}
+		},
+		card: {
+			onDone: {
+				action: 'open'
+			}
+		},
+		sdk: {},
+		actions: {
+			createLink: sandbox.stub(),
+			removeChannel: sandbox.stub()
+		}
+	}
 })
 
-ava('It should render', (test) => {
-	test.notThrows(() => {
-		shallow(<CreateView />)
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('The search query searches user slug by regex', async (test) => {
+	const {
+		commonProps
+	} = test.context
+	commonProps.sdk.query = sandbox.stub().resolves([])
+
+	const component = await mount(<CreateView {...commonProps} />, {
+		wrappingComponent
 	})
+
+	// Wait for debounced query
+	await Bluebird.delay(1000)
+
+	// The sdk is queried when the component is mounted
+	test.is(commonProps.sdk.query.callCount, 1)
+
+	let query = commonProps.sdk.query.getCall(0).firstArg
+
+	// And the query just searches all users
+	test.deepEqual(query, {
+		type: 'object',
+		additionalProperties: true,
+		required: [ 'type' ],
+		$$links: {
+			'is member of': {
+				type: 'object',
+				properties: {
+					slug: {
+						const: 'org-balena'
+					}
+				}
+			}
+		},
+		properties: {
+			type: {
+				const: 'user@1.0.0'
+			}
+		}
+	})
+
+	// Now enter a search term
+	const searchTerm = 'foo'
+	const searchInput = component.find('input[data-test="private-conversation-search-input"]').first()
+	searchInput.simulate('change', {
+		target: {
+			value: searchTerm
+		}
+	})
+
+	// Wait for debounced query
+	await Bluebird.delay(1000)
+
+	// The sdk is queried again
+	test.is(commonProps.sdk.query.callCount, 2)
+
+	// And the query contains a regexp search in the slug field
+	query = commonProps.sdk.query.getCall(1).firstArg
+	test.truthy(_.find(query.anyOf, {
+		properties: {
+			slug: {
+				regexp: {
+					pattern: searchTerm
+				}
+			}
+		}
+	}))
 })

--- a/apps/ui/test/fixtures/types/user.json
+++ b/apps/ui/test/fixtures/types/user.json
@@ -245,11 +245,13 @@
                   "properties": {
                     "last": {
                       "type": "string",
-                      "title": "Last name"
+                      "title": "Last name",
+                      "fullTextSearch": true
                     },
                     "first": {
                       "type": "string",
-                      "title": "First name"
+                      "title": "First name",
+                      "fullTextSearch": true
                     },
                     "pronouns": {
                       "type": "string",


### PR DESCRIPTION
When searching for users, include a regexp search for the user slug - this way a person doesn't have to know the full user slug before some potentially useful results are returned.

This commit also ensures the results are sorted alphabetically by slug.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #5826 

Added a unit test to test the querying in the CreateView lens.
