### PR TITLE
getLinks should require target type

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -413,18 +413,28 @@ export const actionCreators = {
 	// TODO: This is NOT an action creator, it should be part of sdk or other helper
 	getLinks ({
 		sdk
-	}, card, verb) {
+	}, card, verb, targetType) {
+		const baseTargetType = targetType && helpers.getTypeBase(targetType)
 		if (!_.some(sdk.LINKS, {
-			name: verb
+			name: verb,
+			data: {
+				to: baseTargetType
+			}
 		})) {
-			throw new Error(`No link definition found for ${card.type} using ${verb}`)
+			throw new Error(`No link definition found from ${card.type} to ${baseTargetType} using ${verb}`)
 		}
 
 		return async () => {
 			const results = await sdk.query({
 				$$links: {
 					[verb]: {
-						type: 'object'
+						type: 'object',
+						required: [ 'type' ],
+						properties: {
+							type: {
+								const: targetType
+							}
+						}
 					}
 				},
 				description: `Get card with links ${card.id}`,

--- a/apps/ui/lib/lens/common/Segment.jsx
+++ b/apps/ui/lib/lens/common/Segment.jsx
@@ -101,7 +101,7 @@ class Segment extends React.Component {
 		if (segment.link) {
 			const results = await	actions.getLinks({
 				sdk
-			}, card, segment.link)
+			}, card, segment.link, `${segment.type}@1.0.0`)
 			this.updateResults(results)
 		} else if (segment.query) {
 			let context = [ card ]
@@ -109,7 +109,7 @@ class Segment extends React.Component {
 				if (relation.link) {
 					context = actions.getLinks({
 						sdk
-					}, card, relation.link)
+					}, card, relation.link, `${relation.type}@1.0.0`)
 				} else {
 					const mapped = await Bluebird.map(context, (item) => {
 						return actions.queryAPI(helpers.evalSchema(clone(relation), {


### PR DESCRIPTION
The getLinks action creator should require the target type as well as the verb - otherwise we can fetch cards of the wrong type that also has a link with the same verb.

Note - getLinks is currently just called from Segment and nowhere else so this is quite a constrained bug.

ASAP we should fix the client-sdk's `getWithLinks` method so that it requires the target type(s) to be provided as well. This will of course be a major bump as the API will change.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #5863 
