### PR TITLE
Minor AutoCompleteCardSelect improvements

### DIFF
--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.jsx
@@ -202,7 +202,7 @@ export default class AutoCompleteCardSelect extends React.Component {
 				formatOptionLabel={(option) => {
 					return (
 						<Flex alignItems="center" justifyContent="center">
-							{option.type && (
+							{_.isArray(cardType) && option.type && (
 								<Badge shade={option.shade} mr={2}>{option.type}</Badge>
 							)}
 							<Txt style={{

--- a/apps/ui/lib/components/AutoCompleteCardSelect/index.js
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/index.js
@@ -4,9 +4,27 @@
  * Proprietary and confidential.
  */
 
+import {
+	connect
+} from 'react-redux'
+import {
+	compose
+} from 'redux'
+import {
+	selectors
+} from '../../core'
 import AutoCompleteCardSelect from './AutoCompleteCardSelect'
 import {
 	withSetup
 } from '@balena/jellyfish-ui-components'
 
-export default withSetup(AutoCompleteCardSelect)
+const mapStateToProps = (state) => {
+	return {
+		types: selectors.getTypes(state)
+	}
+}
+
+export default compose(
+	withSetup,
+	connect(mapStateToProps)
+)(AutoCompleteCardSelect)

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/Steps/NewOwnerStep.jsx
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/Steps/NewOwnerStep.jsx
@@ -96,7 +96,6 @@ export default function NewOwnerStep ({
 					data-test="ghf__sel-new-owner"
 					classNamePrefix="ghf-async-select"
 					cardType="user"
-					types={types}
 					value={newOwnerValue}
 					isDisabled={unassigned}
 					onChange={setNewOwner}

--- a/apps/ui/lib/components/LinkModal/LinkModal.jsx
+++ b/apps/ui/lib/components/LinkModal/LinkModal.jsx
@@ -237,7 +237,6 @@ export class LinkModal extends React.Component {
 							cardType={_.map(allLinkTypeTargets, (linkTypeTarget) => {
 								return _.get(linkTypeTarget, [ 'data', 'to' ])
 							})}
-							types={types}
 							isDisabled={Boolean(target)}
 							onChange={this.handleTargetSelect}
 						/>

--- a/apps/ui/lib/components/LinkModal/UnlinkModal.jsx
+++ b/apps/ui/lib/components/LinkModal/UnlinkModal.jsx
@@ -171,7 +171,6 @@ export const UnlinkModal = ({
 					getQueryFilter={getLinkedCardsQuery}
 					value={selectedTargetValue}
 					cardType={linkTypeSlugs}
-					types={types}
 					isDisabled={Boolean(target)}
 					onChange={setSelectedTarget}
 				/>


### PR DESCRIPTION
Two small improvements to the `AutoCompleteCardSelect` component. These will be useful for the chart-configuration work.

***
[Hide prefix on AutoCompleteCardSelect if single type](https://github.com/product-os/jellyfish/commit/a7802432261f122e614f601f27c8876a4753b7e5)

If only one type is provided, it is redundant to show the type of the card in the value.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
[AutoCompleteCardSelect provides it's own types prop now](https://github.com/product-os/jellyfish/commit/fbffb4e5db202285f8dd445db6edc2bd7413f814)

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>


