### PR TITLE
Add support for saving and loading chart-configurations

### DIFF
--- a/apps/ui/lib/lens/misc/Chart/Chart.spec.jsx
+++ b/apps/ui/lib/lens/misc/Chart/Chart.spec.jsx
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getWrapper,
+	flushPromises
+} from '../../../../test/ui-setup'
+import _ from 'lodash'
+import React from 'react'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import sinon from 'sinon'
+import {
+	SetupProvider
+} from '@balena/jellyfish-ui-components'
+import {
+	Chart,
+	stringifySettings
+} from './Chart'
+
+const channel = {
+	data: {
+		target: 'view-all-cards',
+		head: {
+			id: '1'
+		}
+	}
+}
+
+const card = {
+	id: 2,
+	slug: 'c-2',
+	type: 'card@1.0.0'
+}
+
+const newSettings = {
+	data: 'data'
+}
+
+const newChartConfigCard = {
+	id: 'c-1',
+	slug: 'chart-configuration-1',
+	name: 'New test config',
+	data: {
+		settings: stringifySettings(newSettings)
+	}
+}
+
+const {
+	wrapper: Wrapper
+} = getWrapper({
+	core: {}
+})
+
+const wrapperWithSetup = ({
+	children,
+	sdk,
+	analytics
+}) => {
+	return (
+		<Wrapper>
+			<SetupProvider sdk={sdk} analytics={analytics}>
+				{ children }
+			</SetupProvider>
+		</Wrapper>
+	)
+}
+
+const sandbox = sinon.createSandbox()
+
+const addChannel = (options) => {
+	options.head.onDone.callback(_.omit(newChartConfigCard, 'data'))
+}
+
+const mountChart = async (commonProps) => {
+	const component = await mount(<Chart {...commonProps} />, {
+		wrappingComponent: wrapperWithSetup,
+		wrappingComponentProps: {
+			sdk: commonProps.sdk,
+			analytics: {
+				track: sandbox.stub()
+			}
+		}
+	})
+	await flushPromises()
+	return component
+}
+
+const selectText = (chart) => chart.find('div.chart-config-select__single-value').text()
+const saveButton = (chart) => chart.find('button[data-test="btn_chart-config--save"]')
+const saveAsButton = (chart) => chart.find('button[data-test="btn_chart-config--save-as"]')
+const viewButton = (chart) => chart.find('button[data-test="btn_chart-config--view"]')
+
+ava.beforeEach((test) => {
+	test.context.commonProps = {
+		ChartComponent: () => <div data-test="chart-component">Chart</div>,
+		channel,
+		chartConfigurationType: {
+			id: 't-1',
+			slug: 'chart-configuration',
+			type: 'type@1.0.0'
+		},
+		actions: {
+			addChannel: sandbox.spy(addChannel)
+		},
+		history: {
+			push: sandbox.fake()
+		},
+		sdk: {
+			card: {
+				update: sandbox.stub().resolves(newChartConfigCard),
+				get: sandbox.stub().resolves(newChartConfigCard)
+			}
+		},
+		tail: [ card ]
+	}
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('Default chart configuration is loaded initially', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const chart = await mountChart(commonProps)
+
+	test.is(selectText(chart), 'New chart')
+	test.true(saveButton(chart).prop('disabled'))
+	test.true(saveAsButton(chart).prop('disabled'))
+	test.true(viewButton(chart).prop('disabled'))
+})
+
+ava('Changes to the default chart configuration can be saved as a new chart configuration', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	commonProps.sdk.card.get = sandbox.stub().returns(newChartConfigCard)
+
+	const chart = await mountChart(commonProps)
+
+	// Simulate an update to the chart settings
+	const chartComponent = chart.find('ChartComponent')
+	chartComponent.prop('onUpdate')(newSettings)
+	chart.update()
+
+	// The Save button is still disabled as this is a new chart configuration
+	test.true(chart.find('button[data-test="btn_chart-config--save"]').prop('disabled'))
+
+	// ...but the Save As button is now enabled - so click it!
+	test.false(saveAsButton(chart).prop('disabled'))
+	saveAsButton(chart).simulate('click')
+
+	// A new channel should be added, with the settings in the seed data.
+	test.true(commonProps.actions.addChannel.calledOnce)
+	const options = commonProps.actions.addChannel.getCall(0).firstArg
+	test.is(options.head.seed.data.settings, stringifySettings(newSettings))
+
+	// (Our simulated addChannel method immediately calls the onDone callback with
+	// a 'newly created' chart-configuration card)
+
+	await flushPromises()
+	chart.update()
+
+	// The newly saved chart is now the selected one
+	test.is(selectText(chart), newChartConfigCard.name)
+
+	// ...and the Save As button is now disabled again
+	test.true(saveAsButton(chart).prop('disabled'))
+
+	// ...and the View button is now enabled as we have a valid chart-configuration card we can view
+	test.false(viewButton(chart).prop('disabled'))
+})
+
+ava('Clicking on the view button loads the current chart-configuration\'s card in a new channel', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const chart = await mountChart(commonProps)
+
+	chart.find('AutoCompleteCardSelect').prop('onChange')(newChartConfigCard)
+	chart.update()
+
+	test.false(viewButton(chart).prop('disabled'))
+	viewButton(chart).simulate('click')
+
+	test.true(commonProps.history.push.calledOnce)
+	const newLocation = commonProps.history.push.getCall(0).firstArg
+	test.true(newLocation.endsWith(`/${newChartConfigCard.slug}`))
+})
+
+ava('Clicking on the save button saves the current chart-configuration\'s card', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const chart = await mountChart(commonProps)
+
+	// Load a chart-configuration and Simulate an update to the chart settings
+	chart.find('AutoCompleteCardSelect').prop('onChange')(newChartConfigCard)
+	chart.find('ChartComponent').prop('onUpdate')(newSettings)
+	chart.update()
+
+	// The Save button is now enabled - so click it!
+	test.false(saveButton(chart).prop('disabled'))
+	saveButton(chart).simulate('click')
+
+	// The data.settings field of the chart-configuration card is updated via the SDK
+	test.true(commonProps.sdk.card.update.calledOnce)
+	const patch = commonProps.sdk.card.update.getCall(0).args[2][0]
+	test.deepEqual(patch, {
+		op: 'replace',
+		path: '/data/settings',
+		value: stringifySettings(newSettings)
+	})
+})

--- a/apps/ui/lib/lens/misc/Chart/PlotlyChart.jsx
+++ b/apps/ui/lib/lens/misc/Chart/PlotlyChart.jsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+
+// HACK: Work-around for the fact that plotly throws a fit if you run it outside
+// of a browser environment.
+const plotly = window.isUnitTest ? null : require('plotly.js/dist/plotly')
+const PlotlyEditor = window.isUnitTest ? _.constant(null) : require('react-chart-editor').default
+
+const config = {
+	editable: true
+}
+
+export default React.memo(({
+	settings,
+	dataSources,
+	dataSourceOptions,
+	onUpdate
+}) => {
+	const onPlotlyUpdate = React.useCallback((data, layout, frames) => {
+		onUpdate({
+			data, layout, frames
+		})
+	}, [ onUpdate ])
+	return (
+		<PlotlyEditor
+			{...settings}
+			config={config}
+			dataSources={dataSources}
+			dataSourceOptions={dataSourceOptions}
+			plotly={plotly}
+			onUpdate={onPlotlyUpdate}
+			useResizeHandler
+			debug
+			advancedTraceTypeSelector
+		/>
+	)
+})

--- a/apps/ui/lib/lens/misc/Chart/index.jsx
+++ b/apps/ui/lib/lens/misc/Chart/index.jsx
@@ -5,11 +5,55 @@
  */
 
 import {
+	connect
+} from 'react-redux'
+import {
+	withRouter
+} from 'react-router-dom'
+import _ from 'lodash'
+import {
+	compose,
+	bindActionCreators
+} from 'redux'
+import {
+	actionCreators,
+	sdk,
+	selectors
+} from '../../../core'
+import {
+	helpers
+} from '@balena/jellyfish-ui-components'
+import {
+	Chart
+} from './Chart'
+
+import {
 	createLazyComponent
 } from '../../../components/SafeLazy'
 
 // eslint-disable-next-line
-const ChartLazy = createLazyComponent(() => import(/* webpackChunkName: "chart" */ './Chart'))
+const ChartLazy = createLazyComponent(() => import(/* webpackChunkName: "chart" */ './PlotlyChart'))
+
+const mapStateToProps = (state, ownProps) => {
+	const types = selectors.getTypes(state)
+	const chartConfigurationType = helpers.getType('chart-configuration', types)
+	return {
+		sdk,
+		chartConfigurationType,
+		ChartComponent: ChartLazy
+	}
+}
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, [
+				'addChannel'
+			]),
+			dispatch
+		)
+	}
+}
 
 const lens = {
 	slug: 'lens-chart',
@@ -20,7 +64,10 @@ const lens = {
 		label: 'Chart',
 		icon: 'chart-bar',
 		format: 'list',
-		renderer: ChartLazy,
+		renderer: compose(
+			withRouter,
+			connect(mapStateToProps, mapDispatchToProps)
+		)(Chart),
 		filter: {
 			type: 'array',
 			items: {


### PR DESCRIPTION
The chart lens has been refactored to allow the (Plotly) settings to be saved and reloaded using `chart-configuration` cards.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![image](https://user-images.githubusercontent.com/2925657/109971866-433af300-7d29-11eb-8474-d74a48f105ee.png)

The 'Save' button just saves the loaded chart-configuration card with any settings you have modified.
The 'Save As' button opens the create lens in a new channel, seeded with the chart-configuration settings. When you save this new card, it will be linked to the view and set as the selected chart configuration.
The View button (👁️)  opens the selected chart configuration card in a new channel. From there you can edit the name, description etc, manage it's links or delete it.

Chart configurations are linked to views. So you only see the chart configurations that have previously been configured and saved from that view. But, because you can view the chart configuration card itself and link it to another existing view via the card's 'Views' tab, there is a mechanism in the UI to 're-use' a chart configuration across multiple views. If it would help we could create a 'view-all-chart-configurations' view that would let you search for and link chart configurations as you like (e.g. linking multiple chart configurations to a view at the same time).

Unit tests have been added to verify the functionality of saving a new chart configuration, saving an existing chart configuration and viewing the chart configuration card.