### PR TITLE
Delete library tarballs on push, support nocache flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,14 @@ DETACH ?=
 export CI
 VISUAL ?=
 export VISUAL
+NOCACHE ?=
+
+# Set balena push --nocache flag if necessary
+ifeq ($(NOCACHE),1)
+NOCACHE_FLAG = --nocache
+else
+NOCACHE_FLAG =
+endif
 
 # Set dotenv variables for local development/testing
 ifndef CI
@@ -431,7 +439,8 @@ dev-%:
 	cd apps/$(subst dev-,,$@) && SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) make dev-$(subst dev-,,$@)
 
 push:
-	balena push jel.ly.fish.local \
+	CMD="rm -f ./packages/*" make exec-apps
+	balena push jel.ly.fish.local $(NOCACHE_FLAG) \
 		--env INTEGRATION_DEFAULT_USER=$(INTEGRATION_DEFAULT_USER) \
 		--env INTEGRATION_GOOGLE_MEET_CREDENTIALS=$(INTEGRATION_GOOGLE_MEET_CREDENTIALS) \
 		--env INTEGRATION_BALENA_API_PRIVATE_KEY=$(INTEGRATION_BALENA_API_PRIVATE_KEY) \

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ $ psql -hpostgres.ly.fish.local -Udocker jellyfish -W (password = docker)
 $ redis-cli -h redis.ly.fish.local
 ```
 
+### Resetting
+Deleting cloned libraries from `.libs/` or deleting library tarballs from `apps/*/packages/` doesn't currently
+reset that library to it's original state in the app(s) on your Livepush device. This can lead to a confusing
+state in which your local source doesn't correctly mirror what's being executed on your device. To reset your
+device back to a clean state:
+- `rm -fr .libs/*` (Assuming you no longer need these libraries)
+- `make push NOCACHE=1`
+
+The `NOCACHE` option sets the `--nocache` flag for `balena push`: [balena CLI Documentation](https://www.balena.io/docs/reference/balena-cli/#-c---nocache)
+
 ### Troubleshooting
 - Tail individual service logs with `balena logs jel.ly.fish.local --service <name>`
 - Log into device with `make ssh`, which allows you to then:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***
- Automatically delete library tarballs generated by `make deploy-<lib>` stored under `apps/*/packages/` on `make push`.
- Add ability to set `balena push`s `--no-cache` flag through `NOCACHE=1`. Used to rebuild all images without using any Docker image layer cache, useful to reset Jellyfish back to a clean state.