### PR TITLE
Katapult Generators: Set readiness probe delay for action servers.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -246,6 +246,14 @@ spec:
         ports:
           - containerPort: {{{METRICS_PORT}}}
             name: prometheus-a
-
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - netstat -nltp | grep 8888
+          failureThreshold: 3
+          initialDelaySeconds: 60
+          periodSeconds: 5
       imagePullSecrets:
         - name: com.docker.hub.travisciresin


### PR DESCRIPTION
This gives a sufficient delay for the new action server pods to
become ready after performing migrations.  This is to avoid the
cluster from immediately replacing all action servers while the
new ones are not yet ready to receive requests.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

