### PR TITLE
Add JellyfishLinkWidget

### DIFF
--- a/apps/ui/lib/components/Widgets/JellyfishLinkWidget.jsx
+++ b/apps/ui/lib/components/Widgets/JellyfishLinkWidget.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	UiOption
+} from 'rendition/dist/components/Renderer/widgets/ui-options'
+import {
+	JsonTypes
+} from 'rendition/dist/components/Renderer/types'
+import {
+	JellyfishLink as Link
+} from '@balena/jellyfish-ui-components'
+
+// This widget wraps the JellyfishLink component.
+//
+// The JellyfishLink component ensures that relative URLs and URLs on the Jellyfish domain
+// are appended to the current URL rather than opening in a new tab.
+export const JellyfishLinkWidget = ({
+	value,
+	schema,
+	uiSchema,
+	extraContext,
+	extraFormats,
+	...props
+}) => {
+	let href = _.get(props, [ 'href' ], value.toString())
+	if (_.get(schema, [ 'format' ]) === 'email') {
+		href = `mailto:${href.replace(/^mailto:/, '')}`
+	}
+	return (
+		<Link {...props} href={href}>
+			{value.toString()}
+		</Link>
+	)
+}
+
+JellyfishLinkWidget.displayName = 'JellyfishLink'
+
+JellyfishLinkWidget.uiOptions = {
+	blank: UiOption.boolean,
+	download: UiOption.string,
+	href: UiOption.string,
+	rel: UiOption.string,
+	type: UiOption.string
+}
+
+JellyfishLinkWidget.supportedTypes = [ JsonTypes.string ]

--- a/apps/ui/lib/components/Widgets/index.js
+++ b/apps/ui/lib/components/Widgets/index.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	MarkdownWidget
+} from 'rendition/dist/extra/Renderer/MarkdownWidget'
+import {
+	MermaidWidget
+} from 'rendition/dist/extra/Renderer/MermaidWidget'
+import {
+	withOptionProps
+} from 'rendition/dist/components/Renderer/widgets/widget-util'
+
+export const JellyfishWidgets = [
+	{
+		name: 'markdown',
+		format: '.*',
+		widget: MarkdownWidget
+	},
+	{
+		name: 'mermaid',
+		format: '.*',
+		widget: MermaidWidget
+	},
+	...[].map((widget) => ({
+		name: widget.displayName,
+		format: '.*',
+		widget: widget.uiOptions
+			? withOptionProps(widget.uiOptions)(widget)
+			: widget
+	}))
+]

--- a/apps/ui/lib/components/Widgets/index.js
+++ b/apps/ui/lib/components/Widgets/index.js
@@ -13,6 +13,9 @@ import {
 import {
 	withOptionProps
 } from 'rendition/dist/components/Renderer/widgets/widget-util'
+import {
+	JellyfishLinkWidget
+} from './JellyfishLinkWidget'
 
 export const JellyfishWidgets = [
 	{
@@ -25,7 +28,9 @@ export const JellyfishWidgets = [
 		format: '.*',
 		widget: MermaidWidget
 	},
-	...[].map((widget) => ({
+	...[
+		JellyfishLinkWidget
+	].map((widget) => ({
 		name: widget.displayName,
 		format: '.*',
 		widget: widget.uiOptions

--- a/apps/ui/lib/index.jsx
+++ b/apps/ui/lib/index.jsx
@@ -14,12 +14,6 @@ import {
 	MarkdownWidget as MarkdownEditor
 } from 'rendition/dist/extra/Form/markdown'
 import {
-	MarkdownWidget
-} from 'rendition/dist/extra/Renderer/MarkdownWidget'
-import {
-	MermaidWidget
-} from 'rendition/dist/extra/Renderer/MermaidWidget'
-import {
 	Provider
 } from 'react-redux'
 import {
@@ -58,6 +52,9 @@ import {
 } from 'connected-react-router'
 import * as environment from './environment'
 import PWA from './pwa'
+import {
+	JellyfishWidgets
+} from './components/Widgets'
 import MermaidEditor from './components/MermaidEditor'
 import CountFavicon from './components/CountFavicon'
 import CardLoaderContextProvider from './components/CardLoaderContextProvider'
@@ -126,18 +123,7 @@ const widgets = {
 		]
 	},
 	renderer: {
-		formats: [
-			{
-				name: 'markdown',
-				format: '.*',
-				widget: MarkdownWidget
-			},
-			{
-				name: 'mermaid',
-				format: '.*',
-				widget: MermaidWidget
-			}
-		]
+		formats: JellyfishWidgets
 	}
 }
 


### PR DESCRIPTION
[Refactor Renderer formats definition in preparation for custom widgets](https://github.com/product-os/jellyfish/commit/9b313fe1e65c2972279fad9784b2164bbfa028d4)

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

[Add JellyfishLinkWidget](https://github.com/product-os/jellyfish/commit/f828c03104c655fd5e39cd9d4f6b93e89683a86b)

This widget wraps the JellyfishLink component.

The JellyfishLink component ensures that relative URLs and URLs on the Jellyfish domain
are appended to the current URL rather than opening in a new tab.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This widget will be used to ensure that participant, mentionsUser links etc open in a new channel rather than refreshing the whole of Jellyfish. See [this issue](https://github.com/product-os/jellyfish/issues/5901).
