### PR TITLE
Disable notification sound based on user profile preference

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/stream/helpers.js
+++ b/apps/ui/lib/core/store/actioncreators/stream/helpers.js
@@ -83,11 +83,16 @@ export const handleNotification = ({
 	cardType
 }) => {
 	return (dispatch, getState) => {
+		const state = getState()
+
 		// Skip notifications if the user's status is set to 'Do Not Disturb'
-		const userStatus = selectors.getCurrentUserStatus(getState())
+		const userStatus = selectors.getCurrentUserStatus(state)
 		if (_.get(userStatus, [ 'value' ]) === 'DoNotDisturb') {
 			return
 		}
+
+		const user = selectors.getCurrentUser(state)
+		const disableSound = _.get(user, [ 'data', 'profile', 'disableNotificationSound' ], false)
 
 		const baseType = card.type.split('@')[0]
 		const title = `New ${_.get(cardType, [ 'name' ], baseType)}`
@@ -98,6 +103,7 @@ export const handleNotification = ({
 			title,
 			body,
 			target,
+			disableSound,
 			tag: card.id,
 			historyPush: (path, pathState) => dispatch(push(path, pathState))
 		})

--- a/apps/ui/lib/services/notifications.js
+++ b/apps/ui/lib/services/notifications.js
@@ -38,7 +38,8 @@ export const createNotification = ({
 	historyPush,
 	title,
 	body,
-	target
+	target,
+	disableSound
 }) => {
 	if (!canUseNotifications) {
 		return
@@ -50,7 +51,9 @@ export const createNotification = ({
 		icon: '/icons/jellyfish.png'
 	})
 
-	sound.play()
+	if (!disableSound) {
+		sound.play()
+	}
 
 	const timeout = setTimeout(() => {
 		return notice.close()


### PR DESCRIPTION
Only play the notification sound if the user profile setting `disableNotificationSound` is not set.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Although this PR can be merged as-is, it will only have an effect after [this jellyfish-core PR](https://github.com/product-os/jellyfish-core/pull/522) is merged and used.

Additionally, there is [a separate PR](https://github.com/product-os/jellyfish/pull/5924) to expose the 'Disable notification sound' setting on the user profile so it can be toggled on/off.