### PR TITLE
Add 'Disable notification sound' checkbox to my user settings form

### DIFF
--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.jsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.jsx
@@ -8,6 +8,7 @@ import {
 	getWrapper,
 	flushPromises
 } from '../../../test/ui-setup'
+import '../../../test/react-select-mock'
 import ava from 'ava'
 import {
 	mount
@@ -16,17 +17,6 @@ import React from 'react'
 import sinon from 'sinon'
 import Bluebird from 'bluebird'
 import AutoCompleteCardSelect from './AutoCompleteCardSelect'
-
-// HACK to get react-select not to complain
-// eslint-disable-next-line no-multi-assign
-global.getComputedStyle = global.window.getComputedStyle = () => {
-	return {
-		height: '100px',
-		getPropertyValue: (name) => {
-			return name === 'box-sizing' ? '' : null
-		}
-	}
-}
 
 const wrappingComponent = getWrapper().wrapper
 

--- a/apps/ui/lib/lens/full/MyUser/index.jsx
+++ b/apps/ui/lib/lens/full/MyUser/index.jsx
@@ -7,6 +7,7 @@
 import {
 	connect
 } from 'react-redux'
+import _ from 'lodash'
 import * as redux from 'redux'
 import {
 	actionCreators,
@@ -24,7 +25,11 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
 	return {
-		actions: redux.bindActionCreators(actionCreators, dispatch)
+		actions: redux.bindActionCreators(_.pick(actionCreators, [
+			'getIntegrationAuthUrl',
+			'updateUser',
+			'setPassword'
+		]), dispatch)
 	}
 }
 

--- a/apps/ui/lib/lens/full/MyUser/tests/MyUser.spec.jsx
+++ b/apps/ui/lib/lens/full/MyUser/tests/MyUser.spec.jsx
@@ -4,10 +4,14 @@
  * Proprietary and confidential.
  */
 
-import '../../../../../test/ui-setup'
-import ava from 'ava'
 import {
-	shallow
+	getWrapper
+} from '../../../../../test/ui-setup'
+import '../../../../../test/react-select-mock'
+import ava from 'ava'
+import sinon from 'sinon'
+import {
+	mount
 } from 'enzyme'
 import React from 'react'
 import MyUser from '../MyUser'
@@ -16,13 +20,142 @@ import {
 	userType
 } from './fixtures'
 
-ava('It should render', (test) => {
-	test.notThrows(() => {
-		shallow(
-			<MyUser
-				card={user}
-				types={[ userType ]}
-			/>
-		)
+const sandbox = sinon.createSandbox()
+
+const wrappingComponent = getWrapper({
+	core: {}
+}).wrapper
+
+const selectTab = (component, tabName) => {
+	component.find(`button[data-test="tab_${tabName}"]`).simulate('click')
+	component.update()
+}
+
+ava.beforeEach((test) => {
+	test.context.commonProps = {
+		actions: {
+			getIntegrationAuthUrl: sandbox.stub().resolves('http://localhost:9000'),
+			updateUser: sandbox.stub(),
+			setPassword: sandbox.stub()
+		},
+		card: user,
+		types: [ userType ]
+	}
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('The user profile can updated', async (test) => {
+	const {
+		commonProps
+	} = test.context
+	const component = await mount(<MyUser {...commonProps} />, {
+		wrappingComponent
 	})
+	selectTab(component, 'profile')
+
+	component.find('input#root_first').simulate('change', {
+		target: {
+			value: 'foo'
+		}
+	})
+	component.find('input#root_last').simulate('change', {
+		target: {
+			value: 'bar'
+		}
+	})
+	component.find('[data-test="form_profile"] form').simulate('submit')
+
+	test.true(commonProps.actions.updateUser.calledOnce)
+	test.deepEqual(commonProps.actions.updateUser.getCall(0).firstArg, [
+		{
+			op: 'add',
+			path: '/data/profile',
+			value: {
+				name: {
+					first: 'foo',
+					last: 'bar'
+				},
+				about: {}
+			}
+		}
+	])
+})
+
+ava('The user password can reset', async (test) => {
+	const {
+		commonProps
+	} = test.context
+	const component = await mount(<MyUser {...commonProps} />, {
+		wrappingComponent
+	})
+	selectTab(component, 'account')
+
+	component.find('input#root_currentPassword').simulate('change', {
+		target: {
+			value: 'currentpassword'
+		}
+	})
+	component.find('input#root_newPassword').simulate('change', {
+		target: {
+			value: 'newpassword'
+		}
+	})
+
+	component.find('button[type="submit"]').simulate('click')
+
+	test.true(commonProps.actions.setPassword.calledOnce)
+	test.is(commonProps.actions.setPassword.getCall(0).args[0], 'currentpassword')
+	test.is(commonProps.actions.setPassword.getCall(0).args[1], 'newpassword')
+})
+
+ava('The interface settings can updated', async (test) => {
+	const {
+		commonProps
+	} = test.context
+	const component = await mount(<MyUser {...commonProps} />, {
+		wrappingComponent
+	})
+	selectTab(component, 'interface')
+
+	component.find('button#root_profile_sendCommand').simulate('click')
+	component.find('div#root_profile_sendCommand__select-drop button').at(2).simulate('click')
+
+	component.find('div.rendition-form__field--root_profile_disableNotificationSound input')
+		.simulate('change',
+			{
+				target: {
+					checked: true
+				}
+			})
+
+	component.find('[data-test="form_interface"] form').simulate('submit')
+
+	test.true(commonProps.actions.updateUser.calledOnce)
+	test.deepEqual(commonProps.actions.updateUser.getCall(0).firstArg, [
+		{
+			op: 'add',
+			path: '/data/profile',
+			value: {
+				sendCommand: 'enter',
+				disableNotificationSound: true
+			}
+		}
+	])
+})
+
+ava('Oauth connections can be made', async (test) => {
+	const {
+		commonProps
+	} = test.context
+	const component = await mount(<MyUser {...commonProps} />, {
+		wrappingComponent
+	})
+	selectTab(component, 'oauth')
+
+	component.find('button[data-test="integration-connection--outreach"]').simulate('click')
+	test.true(commonProps.actions.getIntegrationAuthUrl.calledOnce)
+	test.is(commonProps.actions.getIntegrationAuthUrl.getCall(0).args[1], 'outreach')
 })

--- a/apps/ui/lib/lens/full/MyUser/tests/fixtures.js
+++ b/apps/ui/lib/lens/full/MyUser/tests/fixtures.js
@@ -130,6 +130,12 @@ export const userType = {
 									type: 'string',
 									default: 'shift+enter'
 								},
+								disableNotificationSound: {
+									title: 'Disable notification sound',
+									description: 'Do not play a sound when displaying notifications',
+									type: 'boolean',
+									default: false
+								},
 								viewSettings: {
 									type: 'object',
 									description: 'A map of settings for view cards, keyed by the view id',

--- a/apps/ui/test/react-select-mock.js
+++ b/apps/ui/test/react-select-mock.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+// HACK to get react-select not to complain
+// eslint-disable-next-line no-multi-assign
+global.getComputedStyle = global.window.getComputedStyle = () => {
+	return {
+		height: '100px',
+		getPropertyValue: (name) => {
+			return name === 'box-sizing' ? '' : null
+		}
+	}
+}

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -418,13 +418,19 @@ ava.serial('user profile: The send command should default to "shift+enter"', asy
 
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
 
-	await macros.waitForThenClickSelector(page, '[data-test="lens-my-user__send-command-select"]')
+	await macros.waitForThenClickSelector(page, 'button#root_profile_sendCommand')
 	await macros.waitForThenClickSelector(page, '[role="menubar"] > button[role="menuitem"]:nth-of-type(1)')
 
-	await page.waitForSelector('[data-test="lens-my-user__send-command-select"][value="shift+enter"]')
+	await page.waitForSelector('input#root_profile_sendCommand__input[value="shift+enter"]')
 
-	const value = await macros.getElementValue(page, '[data-test="lens-my-user__send-command-select"]')
+	const value = await macros.getElementValue(page, 'input#root_profile_sendCommand__input')
 	test.is(value, 'shift+enter')
+
+	await macros.waitForThenClickSelector(page, 'button[type="submit"]')
+
+	// Wait for the success alert as a heuristic for the action completing
+	// successfully
+	await macros.waitForThenDismissAlert(page, 'Success!')
 
 	const rand = uuid()
 
@@ -459,17 +465,19 @@ ava.serial('user profile: You should be able to change the send command to "ente
 	await page.waitForSelector('[data-test="lens--lens-my-user"]')
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
 
-	await macros.waitForThenClickSelector(page, '[data-test="lens-my-user__send-command-select"]')
+	await macros.waitForThenClickSelector(page, 'button#root_profile_sendCommand')
 	await macros.waitForThenClickSelector(page, '[role="menubar"] > button[role="menuitem"]:nth-of-type(3)')
+
+	await page.waitForSelector('input#root_profile_sendCommand__input[value="enter"]')
+
+	const value = await macros.getElementValue(page, 'input#root_profile_sendCommand__input')
+	test.is(value, 'enter')
+
+	await macros.waitForThenClickSelector(page, 'button[type="submit"]')
 
 	// Wait for the success alert as a heuristic for the action completing
 	// successfully
 	await macros.waitForThenDismissAlert(page, 'Success!')
-
-	await page.waitForSelector('[data-test="lens-my-user__send-command-select"][value="enter"]')
-
-	const value = await macros.getElementValue(page, '[data-test="lens-my-user__send-command-select"]')
-	test.is(value, 'enter')
 
 	const rand = uuid()
 
@@ -478,53 +486,6 @@ ava.serial('user profile: You should be able to change the send command to "ente
 	await bluebird.delay(500)
 	await page.keyboard.press('Enter')
 	await page.waitForSelector('.column--thread [data-test="event-card__message"]')
-
-	test.pass()
-})
-
-ava.serial('user profile: You should be able to change the send command to "ctrl+enter"', async (test) => {
-	const {
-		page
-	} = context
-
-	const user = await ensureCommunityLogin(page)
-
-	// Create a new thread
-	const thread = await page.evaluate(() => {
-		return window.sdk.card.create({
-			type: 'thread@1.0.0'
-		})
-	})
-
-	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${user.id}/${thread.id}`)
-
-	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
-
-	await macros.waitForThenClickSelector(page, '[data-test="lens-my-user__send-command-select"]')
-	await macros.waitForThenClickSelector(page, '[role="menubar"] > button[role="menuitem"]:nth-of-type(2)')
-
-	await page.waitForSelector('[data-test="lens-my-user__send-command-select"][value="ctrl+enter"]')
-
-	const value = await macros.getElementValue(page, '[data-test="lens-my-user__send-command-select"]')
-	test.is(value, 'ctrl+enter')
-
-	// Wait for the success alert as a heuristic for the action completing
-	// successfully
-	await macros.waitForThenDismissAlert(page, 'Success!')
-
-	// Unfortunately puppeteer Control+Enter doesn't seem to work at all
-	// TODO: Fix this test so it works
-	/*
-	const rand = uuid()
-
-	await page.waitForSelector('.new-message-input')
-	await page.type('textarea', rand)
-	await page.keyboard.down('ControlLeft')
-	await page.keyboard.press('Enter')
-	await page.keyboard.up('ControlLeft')
-	await page.waitForSelector('.column--thread [data-test="event-card__message"]')
-	*/
 
 	test.pass()
 })


### PR DESCRIPTION
Add disableNotificationSound to user settings form

Tidied up the MyUser lens significantly and added unit tests for each tab. The interface tab now includes a checkbox to facilitate enabling/disabling notification sounds.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes #5874