### PR TITLE
Rollback plugin default due to race condition on sync

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -331,9 +331,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-6.0.3.tgz",
-      "integrity": "sha512-fFq3suAUMStUSLVCYcyzKaLpEQK3EpJrs6OfVG98aLqckI8QxreEbLZPrYGUAftbeQ7eSLci1PhU8A+yL773ZQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-5.3.6.tgz",
+      "integrity": "sha512-fPV8CM+PHwf9XUeTQysKAyQvSnBMlL1WjfUG9k2oHzSOKAKVkhxMTdUmRNbPZzqQuL5tFjxPuoMwyM/wY4DUgA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.62",
         "@balena/jellyfish-client-sdk": "^2.17.1",
@@ -344,7 +344,7 @@
         "@octokit/auth-app": "^2.11.0",
         "@octokit/plugin-retry": "^3.0.7",
         "@octokit/plugin-throttling": "^3.4.1",
-        "@octokit/rest": "^18.3.5",
+        "@octokit/rest": "^18.3.4",
         "bluebird": "^3.7.2",
         "front-sdk": "^0.8.1",
         "geoip-lite": "^1.4.2",
@@ -363,39 +363,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.2.tgz",
-          "integrity": "sha512-NxF1yfYOUO92rCx3dwvA2onF30Vdlg7YUkMVXkeptqpzA3tRLplThhFleV/UKWFgh7rpKu1yYRbvNDUtzSopKA=="
-        },
-        "@octokit/plugin-rest-endpoint-methods": {
-          "version": "4.13.5",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.5.tgz",
-          "integrity": "sha512-kYKcWkFm4Ldk8bZai2RVEP1z97k1C/Ay2FN9FNTBg7JIyKoiiJjks4OtT6cuKeZX39tqa+C3J9xeYc6G+6g8uQ==",
-          "requires": {
-            "@octokit/types": "^6.12.2",
-            "deprecation": "^2.3.1"
-          }
-        },
-        "@octokit/rest": {
-          "version": "18.3.5",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.3.5.tgz",
-          "integrity": "sha512-ZPeRms3WhWxQBEvoIh0zzf8xdU2FX0Capa7+lTca8YHmRsO3QNJzf1H3PcuKKsfgp91/xVDRtX91sTe1kexlbw==",
-          "requires": {
-            "@octokit/core": "^3.2.3",
-            "@octokit/plugin-paginate-rest": "^2.6.2",
-            "@octokit/plugin-request-log": "^1.0.2",
-            "@octokit/plugin-rest-endpoint-methods": "4.13.5"
-          }
-        },
-        "@octokit/types": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.2.tgz",
-          "integrity": "sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA==",
-          "requires": {
-            "@octokit/openapi-types": "^5.3.2"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -17,7 +17,7 @@
     "@balena/jellyfish-metrics": "^0.1.108",
     "@balena/jellyfish-plugin-base": "^1.2.30",
     "@balena/jellyfish-plugin-channels": "^1.0.18",
-    "@balena/jellyfish-plugin-default": "^6.0.3",
+    "@balena/jellyfish-plugin-default": "5.3.6",
     "@balena/jellyfish-plugin-product-os": "^1.0.75",
     "@balena/jellyfish-plugin-typeform": "^1.0.32",
     "@balena/jellyfish-queue": "^0.0.459",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -466,9 +466,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-6.0.3.tgz",
-      "integrity": "sha512-fFq3suAUMStUSLVCYcyzKaLpEQK3EpJrs6OfVG98aLqckI8QxreEbLZPrYGUAftbeQ7eSLci1PhU8A+yL773ZQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-5.3.6.tgz",
+      "integrity": "sha512-fPV8CM+PHwf9XUeTQysKAyQvSnBMlL1WjfUG9k2oHzSOKAKVkhxMTdUmRNbPZzqQuL5tFjxPuoMwyM/wY4DUgA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.62",
         "@balena/jellyfish-client-sdk": "^2.17.1",
@@ -479,7 +479,7 @@
         "@octokit/auth-app": "^2.11.0",
         "@octokit/plugin-retry": "^3.0.7",
         "@octokit/plugin-throttling": "^3.4.1",
-        "@octokit/rest": "^18.3.5",
+        "@octokit/rest": "^18.3.4",
         "bluebird": "^3.7.2",
         "front-sdk": "^0.8.1",
         "geoip-lite": "^1.4.2",
@@ -496,41 +496,6 @@
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.2.tgz",
-          "integrity": "sha512-NxF1yfYOUO92rCx3dwvA2onF30Vdlg7YUkMVXkeptqpzA3tRLplThhFleV/UKWFgh7rpKu1yYRbvNDUtzSopKA=="
-        },
-        "@octokit/plugin-rest-endpoint-methods": {
-          "version": "4.13.5",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.5.tgz",
-          "integrity": "sha512-kYKcWkFm4Ldk8bZai2RVEP1z97k1C/Ay2FN9FNTBg7JIyKoiiJjks4OtT6cuKeZX39tqa+C3J9xeYc6G+6g8uQ==",
-          "requires": {
-            "@octokit/types": "^6.12.2",
-            "deprecation": "^2.3.1"
-          }
-        },
-        "@octokit/rest": {
-          "version": "18.3.5",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.3.5.tgz",
-          "integrity": "sha512-ZPeRms3WhWxQBEvoIh0zzf8xdU2FX0Capa7+lTca8YHmRsO3QNJzf1H3PcuKKsfgp91/xVDRtX91sTe1kexlbw==",
-          "requires": {
-            "@octokit/core": "^3.2.3",
-            "@octokit/plugin-paginate-rest": "^2.6.2",
-            "@octokit/plugin-request-log": "^1.0.2",
-            "@octokit/plugin-rest-endpoint-methods": "4.13.5"
-          }
-        },
-        "@octokit/types": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.2.tgz",
-          "integrity": "sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA==",
-          "requires": {
-            "@octokit/openapi-types": "^5.3.2"
-          }
-        }
       }
     },
     "@balena/jellyfish-plugin-product-os": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,7 +27,7 @@
     "@balena/jellyfish-metrics": "^0.1.108",
     "@balena/jellyfish-plugin-base": "^1.2.30",
     "@balena/jellyfish-plugin-channels": "^1.0.18",
-    "@balena/jellyfish-plugin-default": "^6.0.3",
+    "@balena/jellyfish-plugin-default": "5.3.6",
     "@balena/jellyfish-plugin-product-os": "^1.0.75",
     "@balena/jellyfish-plugin-typeform": "^1.0.32",
     "@balena/jellyfish-queue": "^0.0.459",

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,9 +421,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-6.0.3.tgz",
-      "integrity": "sha512-fFq3suAUMStUSLVCYcyzKaLpEQK3EpJrs6OfVG98aLqckI8QxreEbLZPrYGUAftbeQ7eSLci1PhU8A+yL773ZQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-5.3.6.tgz",
+      "integrity": "sha512-fPV8CM+PHwf9XUeTQysKAyQvSnBMlL1WjfUG9k2oHzSOKAKVkhxMTdUmRNbPZzqQuL5tFjxPuoMwyM/wY4DUgA==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.0.62",
@@ -435,7 +435,7 @@
         "@octokit/auth-app": "^2.11.0",
         "@octokit/plugin-retry": "^3.0.7",
         "@octokit/plugin-throttling": "^3.4.1",
-        "@octokit/rest": "^18.3.5",
+        "@octokit/rest": "^18.3.4",
         "bluebird": "^3.7.2",
         "front-sdk": "^0.8.1",
         "geoip-lite": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@balena/jellyfish-environment": "^2.4.23",
     "@balena/jellyfish-plugin-base": "^1.2.30",
     "@balena/jellyfish-plugin-channels": "^1.0.18",
-    "@balena/jellyfish-plugin-default": "^6.0.3",
+    "@balena/jellyfish-plugin-default": "5.3.6",
     "@balena/jellyfish-plugin-product-os": "^1.0.75",
     "@balena/jellyfish-plugin-typeform": "^1.0.32",
     "@balena/jellyfish-queue": "^0.0.459",


### PR DESCRIPTION
Rolling back to previous major version 5 of the default plugin due to an
issue where a race condition would cause re-opened front threads to be
instantly closed. See https://jel.ly.fish/2a0001bd-9427-4945-8ff4-708ea38dfc41

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
