### PR TITLE
Switch lens query options

### DIFF
--- a/apps/ui/lib/lens/misc/SupportAuditChart/index.jsx
+++ b/apps/ui/lib/lens/misc/SupportAuditChart/index.jsx
@@ -81,11 +81,6 @@ const lens = {
 		queryOptions: {
 			mask: (query) => {
 				Reflect.deleteProperty(query, '$$links')
-				query.properties.data = {
-					type: 'object',
-					additionalProperties: true
-				}
-
 				return query
 			},
 			limit: 1000,


### PR DESCRIPTION
Two commits that fix issues relating to the view and lenses:
***
[Fix lens-support-threads-to-audit query mask](https://github.com/product-os/jellyfish/commit/d81051d63938d7b799c7d3929a816f3bd782d4e5)

This mask was inadvertently removing the requirement that data.status was 'closed'.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***
[Ensure each lens' query options are respected](https://github.com/product-os/jellyfish/commit/6860f152c113d992b110878b8d92208c3215aba8)

When selecting a lens, always make sure the query options are recalculated and the view is reloaded if required.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes #5936