### PR TITLE
Keep MyUser as presentational component

### DIFF
--- a/apps/ui/lib/lens/full/MyUser/MyUser.jsx
+++ b/apps/ui/lib/lens/full/MyUser/MyUser.jsx
@@ -26,8 +26,7 @@ import {
 	helpers,
 	timezones,
 	Icon,
-	UserAvatar,
-	withSetup
+	UserAvatar
 } from '@balena/jellyfish-ui-components'
 import CardLayout from '../../../layouts/CardLayout'
 
@@ -64,7 +63,7 @@ const interfaceUiSchema = {
 	}
 }
 
-export default withSetup(class MyUser extends React.Component {
+export default class MyUser extends React.Component {
 	constructor (props) {
 		super(props)
 
@@ -362,4 +361,4 @@ export default withSetup(class MyUser extends React.Component {
 			</CardLayout>
 		)
 	}
-})
+}

--- a/apps/ui/lib/lens/full/MyUser/index.jsx
+++ b/apps/ui/lib/lens/full/MyUser/index.jsx
@@ -10,6 +10,9 @@ import {
 import _ from 'lodash'
 import * as redux from 'redux'
 import {
+	withSetup
+} from '@balena/jellyfish-ui-components'
+import {
 	actionCreators,
 	selectors
 } from '../../../core'
@@ -41,7 +44,10 @@ export default {
 	data: {
 		icon: 'address-card',
 		format: 'full',
-		renderer: connect(mapStateToProps, mapDispatchToProps)(MyUser),
+		renderer: redux.compose(
+			withSetup,
+			connect(mapStateToProps, mapDispatchToProps)
+		)(MyUser),
 		filter: {
 			type: 'object',
 			properties: {

--- a/apps/ui/lib/lens/full/MyUser/tests/MyUser.spec.jsx
+++ b/apps/ui/lib/lens/full/MyUser/tests/MyUser.spec.jsx
@@ -19,9 +19,6 @@ import {
 	user,
 	userType
 } from './fixtures'
-import {
-	SetupProvider
-} from '@balena/jellyfish-ui-components'
 
 const sdk = {
 	authToken: 'xxx-xxx-xxx-xxx'
@@ -40,6 +37,7 @@ const selectTab = (component, tabName) => {
 
 ava.beforeEach((test) => {
 	test.context.commonProps = {
+		sdk,
 		actions: {
 			getIntegrationAuthUrl: sandbox.stub().resolves('http://localhost:9000'),
 			updateUser: sandbox.stub(),
@@ -58,11 +56,7 @@ ava('The user profile can updated', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const component = await mount((
-		<SetupProvider sdk={sdk}>
-			<MyUser {...commonProps} />
-		</SetupProvider>
-	), {
+	const component = await mount(<MyUser {...commonProps} />, {
 		wrappingComponent
 	})
 	selectTab(component, 'profile')
@@ -99,11 +93,7 @@ ava('The user password can reset', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const component = await mount((
-		<SetupProvider sdk={sdk}>
-			<MyUser {...commonProps} />
-		</SetupProvider>
-	), {
+	const component = await mount(<MyUser {...commonProps} />, {
 		wrappingComponent
 	})
 	selectTab(component, 'account')
@@ -130,11 +120,7 @@ ava('The interface settings can updated', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const component = await mount((
-		<SetupProvider sdk={sdk}>
-			<MyUser {...commonProps} />
-		</SetupProvider>
-	), {
+	const component = await mount(<MyUser {...commonProps} />, {
 		wrappingComponent
 	})
 	selectTab(component, 'interface')
@@ -169,11 +155,7 @@ ava('Oauth connections can be made', async (test) => {
 	const {
 		commonProps
 	} = test.context
-	const component = await mount((
-		<SetupProvider sdk={sdk}>
-			<MyUser {...commonProps} />
-		</SetupProvider>
-	), {
+	const component = await mount(<MyUser {...commonProps} />, {
 		wrappingComponent
 	})
 	selectTab(component, 'oauth')


### PR DESCRIPTION
In general we should try and keep HOCs out of presentational component files. This makes testing the presentational component much easier.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
