### PR TITLE
Add JellyfishUser Renderer widget

### DIFF
--- a/apps/ui/lib/components/Widgets/JellyfishUserWidget.jsx
+++ b/apps/ui/lib/components/Widgets/JellyfishUserWidget.jsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	UiOption
+} from 'rendition/dist/components/Renderer/widgets/ui-options'
+import {
+	JsonTypes
+} from 'rendition/dist/components/Renderer/types'
+import {
+	CardLoader,
+	helpers,
+	Link
+} from '@balena/jellyfish-ui-components'
+
+// This widget fetches the user corresponding to the id or slug specified in the value
+// and renders a link to the user, displaying the username.
+//
+export const JellyfishUserWidget = ({
+	value,
+	schema,
+	uiSchema,
+	extraContext,
+	extraFormats,
+	suffix,
+	...props
+}) => {
+	return (
+		<CardLoader id={value} type="user">
+			{(user) => {
+				const tooltipOptions = _.defaults(
+					_.pick(props, 'hideUsername', 'hideName', 'hideEmail'), {
+						hideUsername: true
+					})
+				return (
+					<Link {...props} append={user.slug} tooltip={helpers.getUserTooltipText(user, tooltipOptions)}>
+						{helpers.username(user.slug)}{suffix}
+					</Link>
+				)
+			}}
+		</CardLoader>
+	)
+}
+
+JellyfishUserWidget.displayName = 'JellyfishUser'
+
+JellyfishUserWidget.uiOptions = {
+	hideUsername: UiOption.string,
+	hideName: UiOption.string,
+	hideEmail: UiOption.string,
+	suffix: UiOption.string
+}
+
+JellyfishUserWidget.supportedTypes = [ JsonTypes.string ]

--- a/apps/ui/lib/components/Widgets/index.js
+++ b/apps/ui/lib/components/Widgets/index.js
@@ -16,6 +16,9 @@ import {
 import {
 	JellyfishLinkWidget
 } from './JellyfishLinkWidget'
+import {
+	JellyfishUserWidget
+} from './JellyfishUserWidget'
 
 export const JellyfishWidgets = [
 	{
@@ -29,7 +32,8 @@ export const JellyfishWidgets = [
 		widget: MermaidWidget
 	},
 	...[
-		JellyfishLinkWidget
+		JellyfishLinkWidget,
+		JellyfishUserWidget
 	].map((widget) => ({
 		name: widget.displayName,
 		format: '.*',


### PR DESCRIPTION
[Add support for getting card by slug](https://github.com/product-os/jellyfish/commit/a32c8bdcfd6cfa91772332f0b9d45d39f7707f67)

The SD card.get method already supports the argument being either an ID or a slug. So we just abstract this a bit further to the store interface.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***
[Add JellyfishUser widget for Renderer](https://github.com/product-os/jellyfish/commit/8650bac125b211d9c56aeefde894783303362445)

This widget takes an id or a slug and renders the username as a link (with a tooltip).

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This widget will be used by the UI schema for `participants` (and `mentionsUser` etc) to produce a change like this:

Before:
![Participants - before](https://user-images.githubusercontent.com/2925657/110900911-147ad900-8336-11eb-9384-0d936d3553f7.PNG)

After:
![Participants - after](https://user-images.githubusercontent.com/2925657/110900925-193f8d00-8336-11eb-8067-9df156f40424.PNG)

See these PRs (which depend on this PR being merged first):
* https://github.com/product-os/jellyfish-core/pull/535
* https://github.com/product-os/jellyfish-plugin-default/pull/282