### PR TITLE
Remove reset-state makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,14 +476,6 @@ push:
 ssh:
 	balena ssh jel.ly.fish.local
 
-# During livepush development the NUC could stop watching files and streaming logs.
-# The current advised fix is to reset the target state and push to the device again.
-# More information: https://www.flowdock.com/app/rulemotion/resin-starters/threads/yuS9WCzSeUGm4e_FwBp2bbc7ALU
-reset-state:
-	@echo "Resetting target state..."
-	@curl -X POST --header "Content-Type:application/json" "http://jel.ly.fish.local:48484/v2/local/target-state" -d '{"local": {"name": "restless-frost","config": {},"apps": {}},"dependent": {"config": {}}}'
-	@echo "You might need to manually reboot the device before pushing again"
-
 deploy-%:
 	./scripts/deploy-package.js jellyfish-$(subst deploy-,,$@)
 


### PR DESCRIPTION
This command is unused by the team, and has some issues such as renaming
your device.
It also obscures the underlying issue which is that livepush has bugs
that still need to be resolved.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
