### PR TITLE
Bump jellyfish-core to v2.9.8

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.9.6.tgz",
-      "integrity": "sha512-Yl7XYW4NNkSsUH3p/RCYIXGQUG0OrDTZEbnFCxXCQOMfD8Po7TvOLjQ3J3j8fRAjK3x5BmFPsx/UUfMvq/5YKA==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.9.8.tgz",
+      "integrity": "sha512-fd+q/MPoq6C0+xRRIvj9iVPwwNefuU/TgAUwl52gWa4wB6gIuhcQdni6iZT6wYLM9yOUAwbtXZr9z1lcaH+3gA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.63",
         "@balena/jellyfish-environment": "^2.4.24",
@@ -231,7 +231,7 @@
         "debounce-promise": "^3.1.2",
         "fast-equals": "^2.0.0",
         "fast-json-patch": "^2.2.1",
-        "json-e": "^4.3.0",
+        "json-e": "^4.4.0",
         "json-schema-deref-sync": "^0.14.0",
         "lodash": "^4.17.21",
         "pg-format": "^1.0.4",
@@ -249,6 +249,14 @@
           "integrity": "sha512-fnGh8FoVzc34QmgqGd5CItgKgUJLjYvxnz1BAA90LJH/letpXrB4pcV5/sr5gZWTmawq++1A9subudNgx7nbzw==",
           "requires": {
             "lodash": "^4.17.21"
+          }
+        },
+        "json-e": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/json-e/-/json-e-4.4.1.tgz",
+          "integrity": "sha512-wJDQQ6K0/j7eeYonrZr+eXhRNjyWyBuxZ5cKzklbMnJ11fg3M2ZQyp+C3PZq5YCcVz+3TMioW14Nmr3lUO5pEA==",
+          "requires": {
+            "json-stable-stringify-without-jsonify": "^1.0.1"
           }
         }
       }

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -11,7 +11,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-action-library": "^8.0.103",
-    "@balena/jellyfish-core": "^2.9.6",
+    "@balena/jellyfish-core": "^2.9.8",
     "@balena/jellyfish-environment": "^2.4.24",
     "@balena/jellyfish-logger": "^1.0.46",
     "@balena/jellyfish-metrics": "^0.1.114",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -343,9 +343,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.9.6.tgz",
-      "integrity": "sha512-Yl7XYW4NNkSsUH3p/RCYIXGQUG0OrDTZEbnFCxXCQOMfD8Po7TvOLjQ3J3j8fRAjK3x5BmFPsx/UUfMvq/5YKA==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.9.8.tgz",
+      "integrity": "sha512-fd+q/MPoq6C0+xRRIvj9iVPwwNefuU/TgAUwl52gWa4wB6gIuhcQdni6iZT6wYLM9yOUAwbtXZr9z1lcaH+3gA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.63",
         "@balena/jellyfish-environment": "^2.4.24",
@@ -356,7 +356,7 @@
         "debounce-promise": "^3.1.2",
         "fast-equals": "^2.0.0",
         "fast-json-patch": "^2.2.1",
-        "json-e": "^4.3.0",
+        "json-e": "^4.4.0",
         "json-schema-deref-sync": "^0.14.0",
         "lodash": "^4.17.21",
         "pg-format": "^1.0.4",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@balena/jellyfish-action-library": "^8.0.103",
     "@balena/jellyfish-assert": "^1.0.63",
-    "@balena/jellyfish-core": "^2.9.6",
+    "@balena/jellyfish-core": "^2.9.8",
     "@balena/jellyfish-environment": "^2.4.24",
     "@balena/jellyfish-logger": "^1.0.46",
     "@balena/jellyfish-metrics": "^0.1.114",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,9 +399,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.9.6.tgz",
-      "integrity": "sha512-Yl7XYW4NNkSsUH3p/RCYIXGQUG0OrDTZEbnFCxXCQOMfD8Po7TvOLjQ3J3j8fRAjK3x5BmFPsx/UUfMvq/5YKA==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.9.8.tgz",
+      "integrity": "sha512-fd+q/MPoq6C0+xRRIvj9iVPwwNefuU/TgAUwl52gWa4wB6gIuhcQdni6iZT6wYLM9yOUAwbtXZr9z1lcaH+3gA==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.0.63",
@@ -413,7 +413,7 @@
         "debounce-promise": "^3.1.2",
         "fast-equals": "^2.0.0",
         "fast-json-patch": "^2.2.1",
-        "json-e": "^4.3.0",
+        "json-e": "^4.4.0",
         "json-schema-deref-sync": "^0.14.0",
         "lodash": "^4.17.21",
         "pg-format": "^1.0.4",
@@ -435,9 +435,9 @@
           }
         },
         "@balena/jellyfish-logger": {
-          "version": "1.0.46",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-1.0.46.tgz",
-          "integrity": "sha512-l+rHlOa7wYsyy1exJ3o2bfuMF8HkIkSDqBG5c/VOHI9Q1Rh7kS0DqJ88/6ubw8A6SCfDy9VgLcvj8YoRqWERyA==",
+          "version": "1.0.47",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-1.0.47.tgz",
+          "integrity": "sha512-sdjuVOmnYhfmiSY7GUsqdAUNuNgrTXcVK9vNCIAmSPZXduT2jfntKde2K4AUgglVGsygBcTQYO03YiFSpE3X2A==",
           "dev": true,
           "requires": {
             "@balena/jellyfish-assert": "^1.0.63",
@@ -539,6 +539,15 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1"
+          }
+        },
+        "json-e": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/json-e/-/json-e-4.4.1.tgz",
+          "integrity": "sha512-wJDQQ6K0/j7eeYonrZr+eXhRNjyWyBuxZ5cKzklbMnJ11fg3M2ZQyp+C3PZq5YCcVz+3TMioW14Nmr3lUO5pEA==",
+          "dev": true,
+          "requires": {
+            "json-stable-stringify-without-jsonify": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@balena/jellyfish-action-library": "^8.0.103",
     "@balena/jellyfish-chat-widget": "^6.0.66",
     "@balena/jellyfish-client-sdk": "^2.18.4",
-    "@balena/jellyfish-core": "^2.9.6",
+    "@balena/jellyfish-core": "^2.9.8",
     "@balena/jellyfish-environment": "^2.4.24",
     "@balena/jellyfish-plugin-base": "^1.2.30",
     "@balena/jellyfish-plugin-channels": "^1.1.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
