### PR TITLE
Fix timestamp used in support thread lens test

### DIFF
--- a/apps/ui/lib/lens/list/tests/SupportThreads.spec.jsx
+++ b/apps/ui/lib/lens/list/tests/SupportThreads.spec.jsx
@@ -101,7 +101,7 @@ ava('Pending user response threads that are more than 3 working days old ' +
 	} = test.context
 
 	// Update timestamp to be more than 3 working days old
-	const segments = await getSegments(commonProps, pendingUser, subBusinessDays(now, 3).toISOString())
+	const segments = await getSegments(commonProps, pendingUser, subBusinessDays(now, 4).toISOString())
 
 	const pendingAgentResponse = _.find(segments, {
 		name: 'pending agent response'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Test: `lens › list › tests › SupportThreads.jsx › Pending user response threads that are more than 3 working days old are displayed in the pending agent response tab`

Test implies threads should be **more** than 3 working days old, but timestamp used in test is only 3 business days old. This test fails consistently locally as well, not only in balenaCI. Not sure how this ever passed in the first place...
