### PR TITLE
Add docker-compose.dev.yml for testing with Livepush

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -5,50 +5,16 @@
 FROM resinci/jellyfish-test:v1.3.40
 
 WORKDIR /usr/src/jellyfish
-ENV SIDECAR=1
 ARG NPM_TOKEN
 
-COPY ./scripts ./scripts
-
-# Install npm packages
 COPY package.json package-lock.json /usr/src/jellyfish/
+ARG NPM_TOKEN
 RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
-    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
-RUN mkdir -p /usr/src/jellyfish/apps/{action-server,livechat,server,ui,oauth-provider-example}
-COPY apps/action-server/package*.json /usr/src/jellyfish/apps/action-server/
-COPY apps/livechat/package*.json /usr/src/jellyfish/apps/livechat/
-COPY apps/oauth-provider-example/package*.json /usr/src/jellyfish/apps/oauth-provider-example/
-COPY apps/server/package*.json /usr/src/jellyfish/apps/server/
-COPY apps/ui/package*.json /usr/src/jellyfish/apps/ui/
-RUN cd /usr/src/jellyfish/apps/action-server && npm ci && \
-    cd /usr/src/jellyfish/apps/livechat && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci && \
-    cd /usr/src/jellyfish/apps/oauth-provider-example && npm ci && \
-    cd /usr/src/jellyfish/apps/server && npm ci && \
-    cd /usr/src/jellyfish/apps/ui && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install && rm ~/.npmrc
 
-# Copy source and tests
-COPY apps/action-server/Makefile /usr/rsc/jellyfish/apps/action-server/
-COPY apps/livechat/Makefile /usr/rsc/jellyfish/apps/livechat/
-COPY apps/oauth-provider-example/Makefile /usr/rsc/jellyfish/apps/oauth-provider-example/
-COPY apps/server/Makefile /usr/rsc/jellyfish/apps/server/
-COPY apps/ui/Makefile /usr/rsc/jellyfish/apps/ui/
-
-COPY apps/action-server/packages /usr/src/jellyfish/apps/action-server/
-COPY apps/livechat/packages /usr/src/jellyfish/apps/livechat/
-COPY apps/server/packages /usr/src/jellyfish/apps/server/
-COPY apps/ui/packages /usr/src/jellyfish/apps/ui/
-
-# TODO: Install packages for all apps if SIDECAR=1 (?)
-RUN /usr/src/jellyfish/scripts/install-packages.js
-
-COPY apps/action-server/lib /usr/src/jellyfish/apps/action-server/
-COPY apps/livechat/lib /usr/src/jellyfish/apps/livechat/
-COPY apps/oauth-provider-example/lib /usr/src/jellyfish/apps/oauth-provider-example/
-COPY apps/server/lib /usr/src/jellyfish/apps/server/
-COPY apps/ui/lib /usr/src/jellyfish/apps/ui/
-COPY apps/ui/test /usr/src/jellyfish/apps/ui/
-
-COPY ./test ./test
 COPY ./Makefile ./Makefile
+COPY ./scripts ./scripts
+COPY ./apps ./apps
+COPY ./test ./test
 
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,0 +1,54 @@
+###########################################################
+# Runtime
+###########################################################
+
+FROM resinci/jellyfish-test:v1.3.40
+
+WORKDIR /usr/src/jellyfish
+ENV SIDECAR=1
+ARG NPM_TOKEN
+
+COPY ./scripts ./scripts
+
+# Install npm packages
+COPY package.json package-lock.json /usr/src/jellyfish/
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
+RUN mkdir -p /usr/src/jellyfish/apps/{action-server,livechat,server,ui,oauth-provider-example}
+COPY apps/action-server/package*.json /usr/src/jellyfish/apps/action-server/
+COPY apps/livechat/package*.json /usr/src/jellyfish/apps/livechat/
+COPY apps/oauth-provider-example/package*.json /usr/src/jellyfish/apps/oauth-provider-example/
+COPY apps/server/package*.json /usr/src/jellyfish/apps/server/
+COPY apps/ui/package*.json /usr/src/jellyfish/apps/ui/
+RUN cd /usr/src/jellyfish/apps/action-server && npm ci && \
+    cd /usr/src/jellyfish/apps/livechat && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci && \
+    cd /usr/src/jellyfish/apps/oauth-provider-example && npm ci && \
+    cd /usr/src/jellyfish/apps/server && npm ci && \
+    cd /usr/src/jellyfish/apps/ui && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
+
+# Copy source and tests
+COPY apps/action-server/Makefile /usr/rsc/jellyfish/apps/action-server/
+COPY apps/livechat/Makefile /usr/rsc/jellyfish/apps/livechat/
+COPY apps/oauth-provider-example/Makefile /usr/rsc/jellyfish/apps/oauth-provider-example/
+COPY apps/server/Makefile /usr/rsc/jellyfish/apps/server/
+COPY apps/ui/Makefile /usr/rsc/jellyfish/apps/ui/
+
+COPY apps/action-server/packages /usr/src/jellyfish/apps/action-server/
+COPY apps/livechat/packages /usr/src/jellyfish/apps/livechat/
+COPY apps/server/packages /usr/src/jellyfish/apps/server/
+COPY apps/ui/packages /usr/src/jellyfish/apps/ui/
+
+# TODO: Install packages for all apps if SIDECAR=1 (?)
+RUN /usr/src/jellyfish/scripts/install-packages.js
+
+COPY apps/action-server/lib /usr/src/jellyfish/apps/action-server/
+COPY apps/livechat/lib /usr/src/jellyfish/apps/livechat/
+COPY apps/oauth-provider-example/lib /usr/src/jellyfish/apps/oauth-provider-example/
+COPY apps/server/lib /usr/src/jellyfish/apps/server/
+COPY apps/ui/lib /usr/src/jellyfish/apps/ui/
+COPY apps/ui/test /usr/src/jellyfish/apps/ui/
+
+COPY ./test ./test
+COPY ./Makefile ./Makefile
+
+CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@
 	push \
 	ssh \
 	npm-ci \
-	exec-apps
+	exec-apps \
+	livetest
 
 # See https://stackoverflow.com/a/18137056
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -490,3 +491,6 @@ deploy-%:
 # Execute a command under each app directory
 exec-apps:
 	for app in $(shell find $(MAKEFILE_DIR)/apps -maxdepth 1 -mindepth 1 -type d | sort -g); do cd $$app && echo - $$app: && $(CMD); done
+
+livetest:
+	echo "balena exec sidecar_12_1 pwd" | balena ssh jel.ly.fish.local

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -19,6 +19,7 @@ COPY ./apps/server/Makefile /usr/src/jellyfish/apps/server/Makefile
 #dev-cmd-live=cd /usr/src/jellyfish/apps/server && npx nodemon ./lib/index.js
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/server/node_modules/@balena/
 RUN rm -f ~/.npmrc
+#dev-copy=./apps/server/test/ /usr/src/jellyfish/apps/server/test/
 COPY ./apps/server/lib/ /usr/src/jellyfish/apps/server/lib/
 
 # Production debugging scripts

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -28,6 +28,7 @@ COPY ./apps/ui/Makefile /usr/src/jellyfish/apps/ui/Makefile
 #dev-cmd-live=cd /usr/src/jellyfish/apps/ui && make dev-ui
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/ui/node_modules/@balena/
 RUN rm -f ~/.npmrc
+#dev-copy=./apps/ui/test/ /usr/src/jellyfish/apps/ui/test/
 COPY ./apps/ui/lib/ /usr/src/jellyfish/apps/ui/lib/
 
 ARG SENTRY_DSN_UI=https://ff836b1e4abc4d0699bcaaf07ce4ea08@sentry.io/1366139

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,83 @@
+version: '2.1'
+
+services:
+  oauth-provider-example:
+    build:
+      context: ./apps/oauth-provider-example
+    networks:
+      - internal
+    expose:
+      - 80
+  sut:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+      args:
+        NPM_TOKEN: $NPM_TOKEN
+    command: [bash, -c, "trap : TERM INT; sleep infinity & wait"]
+    depends_on:
+      - api
+      - livechat
+      - postgres
+      - ui
+      - balena-mdns-publisher
+      - oauth-provider-example
+    environment:
+      - DATABASE=postgres
+      - LOGLEVEL=crit
+      - LIVECHAT_HOST=http://livechat
+      - LIVECHAT_PORT=80
+      - NODE_ENV=test
+      - POSTGRES_DATABASE=jellyfish
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_USER=docker
+      - SERVER_HOST=http://api
+      - SERVER_PORT=80
+      - UI_HOST=http://ui
+      - UI_PORT=80
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=
+      - REDIS_PORT=6379
+      - SCRUB=0
+      - COVERAGE=0
+      - CI=1
+      - FS_DRIVER
+      - AWS_ACCESS_KEY_ID
+      - AWS_S3_BUCKET_NAME
+      - AWS_SECRET_ACCESS_KEY
+      - OAUTH_REDIRECT_BASE_URL=https://jel.ly.fish
+      - INTEGRATION_BALENA_API_OAUTH_BASE_URL=https://api.balena-cloud.com
+      - INTEGRATION_BALENA_API_PRIVATE_KEY
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
+      - INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING=foobar
+      - INTEGRATION_DEFAULT_USER
+      - INTEGRATION_DISCOURSE_SIGNATURE_KEY
+      - INTEGRATION_DISCOURSE_TOKEN
+      - INTEGRATION_DISCOURSE_USERNAME
+      - INTEGRATION_FLOWDOCK_SIGNATURE_KEY
+      - INTEGRATION_FLOWDOCK_TOKEN
+      - INTEGRATION_FRONT_TOKEN
+      - INTEGRATION_GITHUB_APP_ID
+      - INTEGRATION_GITHUB_PRIVATE_KEY
+      - INTEGRATION_GITHUB_SIGNATURE_KEY
+      - INTEGRATION_GITHUB_TOKEN
+      - INTEGRATION_GOOGLE_MEET_CREDENTIALS
+      - INTEGRATION_INTERCOM_TOKEN
+      - INTEGRATION_OUTREACH_APP_ID
+      - INTEGRATION_OUTREACH_APP_SECRET
+      - INTEGRATION_OUTREACH_SIGNATURE_KEY
+      - INTEGRATION_TYPEFORM_SIGNATURE_KEY
+      - MAILGUN_BASE_URL
+      - MAILGUN_DOMAIN
+      - MAILGUN_TOKEN
+      - MONITOR_SECRET_TOKEN
+      - NPM_TOKEN
+      - RESET_PASSWORD_SECRET_TOKEN
+      - REGISTRY_TOKEN_AUTH_CERT_ISSUER=api.ly.fish.local
+      - REGISTRY_TOKEN_AUTH_CERT_KEY="LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU4xWUw1WVRjb3NVVnhHdXlXMGt4cGE0ekxzbEpGQ2JvZUxIUWlpaW1vTkhvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFR0RRQ2FpK1FnNG9GZE9HMXZNdWdtMFA5bTViSUR3R29MNjg1aGVYR0hwZWJVblgxOGQvYwpQUTZGbDBQaklQam9iUzlCNW5oSTF1Y0p3MW8vclE2UXdnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
+      - REGISTRY_TOKEN_AUTH_CERT_KID="UkNVNTo2Q1RaOkJITjc6RlBCUjpKWUJIOjVHRVI6QVdQSDpIRk9aOjZaT0c6VVUzTzo3Q0gzOjZFU0sK"
+      - REGISTRY_TOKEN_AUTH_JWT_ALGO=ES256
+      - REGISTRY_HOST=registry.ly.fish.local
+    networks:
+      - internal

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,13 +8,12 @@ services:
       - internal
     expose:
       - 80
-  sut:
+  sidecar:
     build:
       context: .
-      dockerfile: Dockerfile.ci
+      dockerfile: Dockerfile.sidecar
       args:
         NPM_TOKEN: $NPM_TOKEN
-    command: [bash, -c, "trap : TERM INT; sleep infinity & wait"]
     depends_on:
       - api
       - livechat


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add `docker-compose.dev.yml` to allow developers to run tests on Livepush devices using the same Docker container used in CI.

## ToDo
- [ ] Add `make` command(s) for executing tests in this new container (wrapper for `balena ssh`)