### PR TITLE
Fix Mark as Read button behaviour

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
@@ -71,7 +71,6 @@ const InboxTab = ({
 
 	const user = useSelector(selectors.getCurrentUser)
 	const groupNames = useSelector(selectors.getMyGroupNames)
-	const inboxData = useSelector(selectors.getInboxViewData)
 	const unreadMentions = canMarkAsRead ? useSelector(selectors.getInboxViewData) : []
 
 	const [ loading, setLoading ] = useState(true)
@@ -185,13 +184,14 @@ const InboxTab = ({
 				<DebouncedSearch
 					onChange={setSearchTerm}
 				/>
-				<MarkAsReadButton
-					inboxData={inboxData}
-					canMarkAsRead={canMarkAsRead}
-					user={user}
-					groupNames={groupNames}
-					sdk={sdk}
-				/>
+				{ canMarkAsRead && (
+					<MarkAsReadButton
+						messages={messages}
+						user={user}
+						groupNames={groupNames}
+						sdk={sdk}
+					/>
+				)}
 
 			</Flex>
 

--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.jsx
@@ -51,6 +51,7 @@ const DebouncedSearch = (props) => {
 
 	return (
 		<Search
+			className="inbox__search"
 			onChange={onChange}
 			value={term}
 		/>

--- a/apps/ui/lib/lens/misc/Inbox/MarkAsReadButton.jsx
+++ b/apps/ui/lib/lens/misc/Inbox/MarkAsReadButton.jsx
@@ -25,24 +25,20 @@ const markMessagesAsRead = (sdk, inboxData, user, groupNames) => {
 }
 
 const MarkAsReadButton = ({
-	canMarkAsRead,
-	inboxData,
+	messages,
 	user,
 	groupNames,
 	sdk
 }) => {
-	if (!canMarkAsRead) {
-		return null
-	}
 	const [ isMarkingAllAsRead, setIsMarkingAllAsRead ] = useState(false)
 
 	const markAllAsRead = useCallback(async () => {
 		setIsMarkingAllAsRead(true)
-		if (inboxData) {
-			await markMessagesAsRead(sdk, inboxData, user, groupNames)
+		if (messages) {
+			await markMessagesAsRead(sdk, messages, user, groupNames)
 		}
 		setIsMarkingAllAsRead(false)
-	}, [ inboxData, sdk, user, groupNames ])
+	}, [ messages, sdk, user, groupNames ])
 
 	return (
 		<Button
@@ -52,7 +48,7 @@ const MarkAsReadButton = ({
 			data-test="inbox__mark-all-as-read"
 			icon={isMarkingAllAsRead ? <Icon name="cog" spin /> : <Icon name="check-circle" />}
 		>
-			{`Mark ${inboxData ? inboxData.length : 'all'} as read`}
+			{`Mark ${messages ? messages.length : 'all'} as read`}
 		</Button>
 	)
 }


### PR DESCRIPTION
Mark as read button should act on the messages that are listed in the (potentially filtered) unread inbox.

Fixes https://github.com/product-os/jellyfish/issues/5982

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
