### PR TITLE
Add debug log to front mirror retry function

### DIFF
--- a/test/e2e/sync/front-mirror.spec.js
+++ b/test/e2e/sync/front-mirror.spec.js
@@ -35,6 +35,8 @@ const retryWhile429 = async (fn, times = 100) => {
 	try {
 		return await fn()
 	} catch (error) {
+		console.log('retryWhile429 error:', JSON.stringify(error))
+		console.log('retryWhile429 times:', times)
 		if (error.name === 'FrontError' && error.status === 429 && times > 0) {
 			const delay = _.parseInt(_.first(error.message.match(/(\d+)/))) || 2000
 			await Bluebird.delay(delay)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Not for merge, just wanting to run this through CI a few times to see if we can debug the cause of some flaky Front mirror tests.
