### PR TITLE
JellyfishUser widget should cope with null user

### DIFF
--- a/apps/ui/lib/components/Widgets/JellyfishUserWidget.jsx
+++ b/apps/ui/lib/components/Widgets/JellyfishUserWidget.jsx
@@ -38,8 +38,11 @@ export const JellyfishUserWidget = ({
 						hideUsername: true
 					})
 				return (
-					<Link {...props} append={user.slug} tooltip={helpers.getUserTooltipText(user, tooltipOptions)}>
-						{helpers.username(user.slug)}{suffix}
+					<Link
+						{...props}
+						append={_.get(user, [ 'slug' ], value)}
+						tooltip={user && helpers.getUserTooltipText(user, tooltipOptions)}>
+						{user ? helpers.username(user.slug) : value}{suffix}
 					</Link>
 				)
 			}}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

While the user card is being fetched, we need to display a sensible link while `user` is null/undefined.
