### PR TITLE
Add e2e sync test for GitHub thread linking message

### DIFF
--- a/test/e2e/server/helpers.js
+++ b/test/e2e/server/helpers.js
@@ -30,6 +30,18 @@ const waitForServer = async (test, retries = 50) => {
 
 module.exports = {
 	before: async (test) => {
+		test.context.retry = async (fn, checkResult, times = 5, delay = 500) => {
+			const result = await fn()
+			if (!checkResult(result)) {
+				if (times > 0) {
+					await Bluebird.delay(delay)
+					return test.context.retry(fn, checkResult, times - 1)
+				}
+				test.fail(`Function failed after ${times} attempts`)
+			}
+			return result
+		}
+
 		test.context.generateRandomSlug = (options) => {
 			const suffix = uuid()
 			if (options.prefix) {


### PR DESCRIPTION
Tests that when you link a support thread to a GitHub issue a message is added to the issue's timeline with the URL of the support thread. Also verifies that when you unlink the support thread, no further messages are automatically added to the issue's timeline.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes https://github.com/product-os/jellyfish/issues/6004

This new test [failed](https://ci.balena-dev.com/builds/835589) before I updated the `jellyfish-plugin-default` dependency to use the changes in [this PR](https://github.com/product-os/jellyfish-plugin-default/pull/300).

Depends on https://github.com/product-os/jellyfish-plugin-default/pull/300