### PR TITLE
allow JF URLs to contain a @version suffix

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.spec.js
+++ b/apps/ui/lib/core/store/actioncreators/index.spec.js
@@ -488,3 +488,20 @@ ava('setDefault() sets the homeView field in the user\'s profile', async (test) 
 		} ]
 	)
 })
+
+ava('createChannelQuery() handles IDs', (test) => {
+	const query = actionCreators.createChannelQuery(cardId)
+	test.is(query.properties.id.const, cardId)
+})
+
+ava('createChannelQuery() handles plain slugs', (test) => {
+	const query = actionCreators.createChannelQuery(cardSlug)
+	test.is(query.properties.slug.const, cardSlug)
+	test.is(query.properties.version.const, '1.0.0')
+})
+
+ava('createChannelQuery() handles versioned slugs', (test) => {
+	const query = actionCreators.createChannelQuery(`${cardSlug}@2.4.5`)
+	test.is(query.properties.slug.const, cardSlug)
+	test.is(query.properties.version.const, '2.4.5')
+})

--- a/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/snippet/SingleCard/SingleCard.jsx
@@ -56,7 +56,10 @@ export default class SingleCard extends React.Component {
 		})
 		const threadTargets = _.map(channels, 'data.target')
 
-		const active = _.includes(threadTargets, card.slug) || _.includes(threadTargets, card.id)
+		const active =
+			_.includes(threadTargets, `${card.slug}@${card.version}`) ||
+			_.includes(threadTargets, card.slug) ||
+			_.includes(threadTargets, card.id)
 
 		// Count the number of non-event links the card has
 		const numLinks = _.reduce(card.links, (carry, value, key) => {


### PR DESCRIPTION
This change allows URLs of the forms
* http://jel.ly.fish.local/thread-867410c1-ce7d-4906-a1e2-a5c17def0a94@0.9.0
* http://jel.ly.fish.local/thread-867410c1-ce7d-4906-a1e2-a5c17def0a94 (being interpreted as 1.0.0)

so we can show and link to versions other than 1.0.0

There will be a follow-up PR to make lists etc actually use these versioned links