### PR TITLE
fix display of linked contracts for links without a type constraint

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.js
+++ b/apps/ui/lib/core/store/actioncreators/index.js
@@ -431,7 +431,15 @@ export const actionCreators = {
 	getLinks ({
 		sdk
 	}, card, verb, targetType) {
-		const baseTargetType = targetType && helpers.getTypeBase(targetType)
+		let baseTargetType = targetType && helpers.getTypeBase(targetType)
+		let linkedType = targetType
+
+		// Link constraints allow '*' to indicate any type
+		if (targetType === 'undefined@1.0.0') {
+			// eslint-disable-next-line no-undefined
+			linkedType = undefined
+			baseTargetType = '*'
+		}
 		if (!_.some(sdk.LINKS, {
 			name: verb,
 			data: {
@@ -449,7 +457,7 @@ export const actionCreators = {
 						required: [ 'type' ],
 						properties: {
 							type: {
-								const: targetType
+								const: linkedType
 							}
 						}
 					}

--- a/apps/ui/lib/lens/common/Segment.jsx
+++ b/apps/ui/lib/lens/common/Segment.jsx
@@ -207,7 +207,7 @@ class Segment extends React.Component {
 					)}
 				</Box>
 
-				{segment.link && (
+				{segment.link && type && (
 					<Flex px={3} pb={3} flexWrap="wrap">
 
 						{!onSave &&


### PR DESCRIPTION
after allowing '*' in link constraint to indicate links that may point to any type, the view of those linked contracts broke.