### PR TITLE
Use docker image names in compose file

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: local_image_api
     build:
       context: .
       dockerfile: ./apps/server/Dockerfile
@@ -121,6 +122,7 @@ services:
     networks:
       - internal
   tick:
+    image: local_image_tick
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.tick
@@ -169,6 +171,7 @@ services:
       - internal
   {{#workers}}
   worker_{{idx}}:
+    image: local_image_worker_{{idx}}
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: local_image_api
     build:
       context: .
       dockerfile: ./apps/server/Dockerfile
@@ -120,6 +121,7 @@ services:
     networks:
       - internal
   tick:
+    image: local_image_tick
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.tick
@@ -167,6 +169,7 @@ services:
     networks:
       - internal
   worker_1:
+    image: local_image_worker_1
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.worker
@@ -230,6 +233,7 @@ services:
     networks:
       - internal
   worker_2:
+    image: local_image_worker_2
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile.worker


### PR DESCRIPTION
This should make CI builds faster as local images can be indentified and
used for cache.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
