### PR TITLE
Katapult: Make REDIS_PASSWORD optional for Jellyfish deployment.

### DIFF
--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -29,7 +29,7 @@ properties:
   REDIS_HOST:
     type: string
   REDIS_PASSWORD:
-    type: string
+    type: string?
   NODE_ENV:
     type: string
   SENTRY_DSN_SERVER:


### PR DESCRIPTION
This should allow an empty password for connecting to the Redis server.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

