### PR TITLE
Bump jellyfish-action-library to v9

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -588,72 +588,81 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "8.1.46",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-8.1.46.tgz",
-      "integrity": "sha512-ntQl25Bx2Q6hGa7Yb4iKa6zIyXVColmGF+EbBloQZ4GiSKd26vDeqbDCRNF6rD7x97hThPgwDN7aCorLdkQrig==",
+      "version": "9.0.83",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-9.0.83.tgz",
+      "integrity": "sha512-a3u3kvXxu+kzmhJT5BlbyYD42Au818Xro/dbB4RI5n6ct9YHqI7ew5W5jOpf5nrSY9k/omJVZNqitB0k//TRUA==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.1.6",
-        "@balena/jellyfish-environment": "^3.0.1",
-        "@balena/jellyfish-logger": "^1.0.57",
-        "@balena/jellyfish-mail": "^0.0.206",
-        "@balena/jellyfish-metrics": "^0.1.125",
-        "@balena/jellyfish-plugin-base": "^1.2.41",
-        "@balena/jellyfish-uuid": "^1.0.84",
+        "@balena/jellyfish-assert": "^1.1.9",
+        "@balena/jellyfish-environment": "^4.1.6",
+        "@balena/jellyfish-logger": "^2.1.34",
+        "@balena/jellyfish-mail": "^1.0.16",
+        "@balena/jellyfish-metrics": "^1.0.142",
+        "@balena/jellyfish-plugin-base": "^2.1.21",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "blueimp-md5": "^2.18.0",
-        "date-fns": "^2.20.3",
+        "date-fns": "^2.21.1",
         "googleapis": "^67.1.1",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
         "request-promise": "^4.2.6",
         "skhema": "^5.3.3",
-        "typed-errors": "^1.1.0"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "@balena/jellyfish-assert": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.6.tgz",
-          "integrity": "sha512-RpcM6yOyy/e28OC69m73iP6c49DCbUdkX0YuRfmLU6O7JGro77+Jojpyims/Y8Yt7k2Xi1HYOWxsdubpYXGjRQ==",
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.9.tgz",
+          "integrity": "sha512-3BsrYihE1A9kfaQHF2mKmTLtOsMeWrYznGfqFRWvIAFmoCMKrnFUfQcWmdD1IAwlvpnUihm2t3NXCWQHfRk+yg==",
           "requires": {
             "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
-          "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-logger": {
-          "version": "1.0.57",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-1.0.57.tgz",
-          "integrity": "sha512-ZTxmR7AxbUPVbuSSjbEnGTEouwdvDXtQDwj6nlyrsAXl3QcJKqUxh1VAlmp+gO8TKXsFflbMeZYHRiLd+1du4A==",
-          "requires": {
-            "@balena/jellyfish-assert": "^1.0.67",
-            "@balena/jellyfish-environment": "^3.0.1",
-            "@sentry/node": "^6.2.3",
-            "errio": "^1.2.2",
-            "lodash": "^4.17.21",
-            "r7insight_node": "^2.1.0",
-            "typed-errors": "^1.1.0",
-            "winston": "^3.3.3",
-            "winston-transport": "^4.4.0"
           }
         },
         "@balena/jellyfish-metrics": {
-          "version": "0.1.125",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-0.1.125.tgz",
-          "integrity": "sha512-mWCgCxo1fDPUbkx/zf6tyj3/dR5onWljhWdnTtEqMwg+lxwKY2UbaP8VSaj4BEdKYYrPIAgILc7ODAJp7ml/oA==",
+          "version": "1.0.143",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.143.tgz",
+          "integrity": "sha512-f8VGZtdvX0i8CB9yeam0d4O4lGZ3kzdl4i6iUXYZakWp4l9gO0YIQNCycgb4wBzmXVLSEsgt9L1LHYBNjmwW2w==",
           "requires": {
-            "@balena/jellyfish-environment": "^3.0.1",
-            "@balena/jellyfish-logger": "^1.0.57",
+            "@balena/jellyfish-environment": "^4.1.6",
+            "@balena/jellyfish-logger": "^2.1.34",
+            "@balena/jellyfish-types": "^0.5.55",
             "@balena/node-metrics-gatherer": "^5.7.3",
             "express": "^4.17.1",
             "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.22.tgz",
+          "integrity": "sha512-sGsdo0V170u66T5YjNXqAG3dvdFxw4Go16DWsk7MzU7XMoSUvarKLBGMICF4XjYJLrmMocCEQVqz62Kze/KgCw==",
+          "requires": {
+            "@balena/jellyfish-logger": "^2.1.34",
+            "@balena/jellyfish-types": "^0.5.55",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.3"
+          }
+        },
+        "@balena/jellyfish-types": {
+          "version": "0.5.55",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.5.55.tgz",
+          "integrity": "sha512-CWfgGluVYyu0Cojt8HTl3ilfxnH+/qOgMrZVRMUpuTtIQo5aJsmHJfoCc/E86lEtzwZVGmubSZlc7rL3U9T/RA==",
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        },
+        "json-schema": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -883,24 +892,13 @@
       }
     },
     "@balena/jellyfish-mail": {
-      "version": "0.0.206",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-0.0.206.tgz",
-      "integrity": "sha512-9sjR8GnUUFPoHctXs7TkJC7UrA8RHPbZOtzqQ3DOaAx/RHhsD+GzNNP+jk2t1u/XZzYduXDi48zO+c4JdMmFAg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-1.0.16.tgz",
+      "integrity": "sha512-Zn06Px641IyXiLlp0n+HZyjcOpTcapYWI+9vfr7n90FPVt+ziqrznRHTg1/HfPD+0j2ted2auZpn3P4sQfO/WQ==",
       "requires": {
-        "@balena/jellyfish-environment": "^3.0.1",
+        "@balena/jellyfish-environment": "^4.1.6",
         "request": "^2.88.2",
         "request-promise": "^4.2.6"
-      },
-      "dependencies": {
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
-          "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
-          }
-        }
       }
     },
     "@balena/jellyfish-metrics": {
@@ -1396,22 +1394,6 @@
       "integrity": "sha512-/aHx9UYK4faL1vI6R9JNYsRpiLtINzkkiYhZzk5IxyXQpImttbNRSUJa4DkQEdNwYDgBak5B5PKCF7psuq3gSQ==",
       "requires": {
         "json-schema-to-typescript": "^10.1.4"
-      }
-    },
-    "@balena/jellyfish-uuid": {
-      "version": "1.0.84",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-uuid/-/jellyfish-uuid-1.0.84.tgz",
-      "integrity": "sha512-DIxlh0T3I7BDIj0+wd/HRj/2T3/f6qQHB072uiNo+hLmUHU4zDrl/5b05CnzYSwPcdt4NHP4Ynhj+EPi+7ShZw==",
-      "requires": {
-        "@types/uuid": "^8.3.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
       }
     },
     "@balena/jellyfish-worker": {
@@ -2017,9 +1999,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@mapbox/node-pre-gyp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.3.tgz",
-      "integrity": "sha512-9dTIfQW8HVCxLku5QrJ/ysS/b2MdYngs9+/oPrOTLvp3TrggdANYVW2h8FGJGDf0J7MYfp44W+c90cVJx+ASuA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.4.tgz",
+      "integrity": "sha512-M669Qo4nRT7iDmQEjQYC7RU8Z6dpz9UmSbkJ1OFEja3uevCdLKh7IZZki7L1TZj02kRyl82snXFY8QqkyfowrQ==",
       "requires": {
         "detect-libc": "^1.0.3",
         "https-proxy-agent": "^5.0.0",
@@ -2563,11 +2545,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
-    },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -4046,9 +4023,9 @@
       }
     },
     "date-fns": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.20.3.tgz",
-      "integrity": "sha512-BbiJSlfmr1Fnfi1OHY8arklKdwtZ9n3NkjCeK8G9gtEe0ZSUwJuwHc6gYBl0uoC0Oa5RdpJV1gBBdXcZi8Efdw=="
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
+      "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA=="
     },
     "debounce-promise": {
       "version": "3.1.2",
@@ -5653,11 +5630,6 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -8665,9 +8637,9 @@
       "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -10,7 +10,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-action-library": "^8.1.46",
+    "@balena/jellyfish-action-library": "^9.0.83",
     "@balena/jellyfish-core": "^2.13.19",
     "@balena/jellyfish-environment": "^4.1.6",
     "@balena/jellyfish-logger": "^2.1.34",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -946,64 +946,73 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "8.1.46",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-8.1.46.tgz",
-      "integrity": "sha512-ntQl25Bx2Q6hGa7Yb4iKa6zIyXVColmGF+EbBloQZ4GiSKd26vDeqbDCRNF6rD7x97hThPgwDN7aCorLdkQrig==",
+      "version": "9.0.83",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-9.0.83.tgz",
+      "integrity": "sha512-a3u3kvXxu+kzmhJT5BlbyYD42Au818Xro/dbB4RI5n6ct9YHqI7ew5W5jOpf5nrSY9k/omJVZNqitB0k//TRUA==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.1.6",
-        "@balena/jellyfish-environment": "^3.0.1",
-        "@balena/jellyfish-logger": "^1.0.57",
-        "@balena/jellyfish-mail": "^0.0.206",
-        "@balena/jellyfish-metrics": "^0.1.125",
-        "@balena/jellyfish-plugin-base": "^1.2.41",
-        "@balena/jellyfish-uuid": "^1.0.84",
+        "@balena/jellyfish-assert": "^1.1.9",
+        "@balena/jellyfish-environment": "^4.1.6",
+        "@balena/jellyfish-logger": "^2.1.34",
+        "@balena/jellyfish-mail": "^1.0.16",
+        "@balena/jellyfish-metrics": "^1.0.142",
+        "@balena/jellyfish-plugin-base": "^2.1.21",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "blueimp-md5": "^2.18.0",
-        "date-fns": "^2.20.3",
+        "date-fns": "^2.21.1",
         "googleapis": "^67.1.1",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
         "request-promise": "^4.2.6",
         "skhema": "^5.3.3",
-        "typed-errors": "^1.1.0"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
-          "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-logger": {
-          "version": "1.0.57",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-1.0.57.tgz",
-          "integrity": "sha512-ZTxmR7AxbUPVbuSSjbEnGTEouwdvDXtQDwj6nlyrsAXl3QcJKqUxh1VAlmp+gO8TKXsFflbMeZYHRiLd+1du4A==",
-          "requires": {
-            "@balena/jellyfish-assert": "^1.0.67",
-            "@balena/jellyfish-environment": "^3.0.1",
-            "@sentry/node": "^6.2.3",
-            "errio": "^1.2.2",
-            "lodash": "^4.17.21",
-            "r7insight_node": "^2.1.0",
-            "typed-errors": "^1.1.0",
-            "winston": "^3.3.3",
-            "winston-transport": "^4.4.0"
-          }
-        },
         "@balena/jellyfish-metrics": {
-          "version": "0.1.125",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-0.1.125.tgz",
-          "integrity": "sha512-mWCgCxo1fDPUbkx/zf6tyj3/dR5onWljhWdnTtEqMwg+lxwKY2UbaP8VSaj4BEdKYYrPIAgILc7ODAJp7ml/oA==",
+          "version": "1.0.143",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.143.tgz",
+          "integrity": "sha512-f8VGZtdvX0i8CB9yeam0d4O4lGZ3kzdl4i6iUXYZakWp4l9gO0YIQNCycgb4wBzmXVLSEsgt9L1LHYBNjmwW2w==",
           "requires": {
-            "@balena/jellyfish-environment": "^3.0.1",
-            "@balena/jellyfish-logger": "^1.0.57",
+            "@balena/jellyfish-environment": "^4.1.6",
+            "@balena/jellyfish-logger": "^2.1.34",
+            "@balena/jellyfish-types": "^0.5.55",
             "@balena/node-metrics-gatherer": "^5.7.3",
             "express": "^4.17.1",
             "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.22.tgz",
+          "integrity": "sha512-sGsdo0V170u66T5YjNXqAG3dvdFxw4Go16DWsk7MzU7XMoSUvarKLBGMICF4XjYJLrmMocCEQVqz62Kze/KgCw==",
+          "requires": {
+            "@balena/jellyfish-logger": "^2.1.34",
+            "@balena/jellyfish-types": "^0.5.55",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.3"
+          }
+        },
+        "@balena/jellyfish-types": {
+          "version": "0.5.55",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.5.55.tgz",
+          "integrity": "sha512-CWfgGluVYyu0Cojt8HTl3ilfxnH+/qOgMrZVRMUpuTtIQo5aJsmHJfoCc/E86lEtzwZVGmubSZlc7rL3U9T/RA==",
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        },
+        "json-schema": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -1232,24 +1241,13 @@
       }
     },
     "@balena/jellyfish-mail": {
-      "version": "0.0.206",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-0.0.206.tgz",
-      "integrity": "sha512-9sjR8GnUUFPoHctXs7TkJC7UrA8RHPbZOtzqQ3DOaAx/RHhsD+GzNNP+jk2t1u/XZzYduXDi48zO+c4JdMmFAg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-1.0.16.tgz",
+      "integrity": "sha512-Zn06Px641IyXiLlp0n+HZyjcOpTcapYWI+9vfr7n90FPVt+ziqrznRHTg1/HfPD+0j2ted2auZpn3P4sQfO/WQ==",
       "requires": {
-        "@balena/jellyfish-environment": "^3.0.1",
+        "@balena/jellyfish-environment": "^4.1.6",
         "request": "^2.88.2",
         "request-promise": "^4.2.6"
-      },
-      "dependencies": {
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
-          "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
-          }
-        }
       }
     },
     "@balena/jellyfish-metrics": {
@@ -1729,15 +1727,6 @@
         "json-schema-to-typescript": "^10.1.4"
       }
     },
-    "@balena/jellyfish-uuid": {
-      "version": "1.0.84",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-uuid/-/jellyfish-uuid-1.0.84.tgz",
-      "integrity": "sha512-DIxlh0T3I7BDIj0+wd/HRj/2T3/f6qQHB072uiNo+hLmUHU4zDrl/5b05CnzYSwPcdt4NHP4Ynhj+EPi+7ShZw==",
-      "requires": {
-        "@types/uuid": "^8.3.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "@balena/jellyfish-worker": {
       "version": "4.1.27",
       "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-4.1.27.tgz",
@@ -2118,9 +2107,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@mapbox/node-pre-gyp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.3.tgz",
-      "integrity": "sha512-9dTIfQW8HVCxLku5QrJ/ysS/b2MdYngs9+/oPrOTLvp3TrggdANYVW2h8FGJGDf0J7MYfp44W+c90cVJx+ASuA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.4.tgz",
+      "integrity": "sha512-M669Qo4nRT7iDmQEjQYC7RU8Z6dpz9UmSbkJ1OFEja3uevCdLKh7IZZki7L1TZj02kRyl82snXFY8QqkyfowrQ==",
       "requires": {
         "detect-libc": "^1.0.3",
         "https-proxy-agent": "^5.0.0",
@@ -2690,11 +2679,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
-    },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -4595,9 +4579,9 @@
       }
     },
     "date-fns": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.20.3.tgz",
-      "integrity": "sha512-BbiJSlfmr1Fnfi1OHY8arklKdwtZ9n3NkjCeK8G9gtEe0ZSUwJuwHc6gYBl0uoC0Oa5RdpJV1gBBdXcZi8Efdw=="
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
+      "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA=="
     },
     "date-time": {
       "version": "3.1.0",
@@ -8879,9 +8863,9 @@
       "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,7 +19,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-action-library": "^8.1.46",
+    "@balena/jellyfish-action-library": "^9.0.83",
     "@balena/jellyfish-assert": "^1.1.9",
     "@balena/jellyfish-core": "^2.13.19",
     "@balena/jellyfish-environment": "^4.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,47 +740,74 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "8.1.46",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-8.1.46.tgz",
-      "integrity": "sha512-ntQl25Bx2Q6hGa7Yb4iKa6zIyXVColmGF+EbBloQZ4GiSKd26vDeqbDCRNF6rD7x97hThPgwDN7aCorLdkQrig==",
+      "version": "9.0.83",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-9.0.83.tgz",
+      "integrity": "sha512-a3u3kvXxu+kzmhJT5BlbyYD42Au818Xro/dbB4RI5n6ct9YHqI7ew5W5jOpf5nrSY9k/omJVZNqitB0k//TRUA==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-assert": "^1.1.6",
-        "@balena/jellyfish-environment": "^3.0.1",
-        "@balena/jellyfish-logger": "^1.0.57",
-        "@balena/jellyfish-mail": "^0.0.206",
-        "@balena/jellyfish-metrics": "^0.1.125",
-        "@balena/jellyfish-plugin-base": "^1.2.41",
-        "@balena/jellyfish-uuid": "^1.0.84",
+        "@balena/jellyfish-assert": "^1.1.9",
+        "@balena/jellyfish-environment": "^4.1.6",
+        "@balena/jellyfish-logger": "^2.1.34",
+        "@balena/jellyfish-mail": "^1.0.16",
+        "@balena/jellyfish-metrics": "^1.0.142",
+        "@balena/jellyfish-plugin-base": "^2.1.21",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "blueimp-md5": "^2.18.0",
-        "date-fns": "^2.20.3",
+        "date-fns": "^2.21.1",
         "googleapis": "^67.1.1",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
         "request-promise": "^4.2.6",
         "skhema": "^5.3.3",
-        "typed-errors": "^1.1.0"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "@balena/jellyfish-assert": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.6.tgz",
-          "integrity": "sha512-RpcM6yOyy/e28OC69m73iP6c49DCbUdkX0YuRfmLU6O7JGro77+Jojpyims/Y8Yt7k2Xi1HYOWxsdubpYXGjRQ==",
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.9.tgz",
+          "integrity": "sha512-3BsrYihE1A9kfaQHF2mKmTLtOsMeWrYznGfqFRWvIAFmoCMKrnFUfQcWmdD1IAwlvpnUihm2t3NXCWQHfRk+yg==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.21"
           }
         },
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.22.tgz",
+          "integrity": "sha512-sGsdo0V170u66T5YjNXqAG3dvdFxw4Go16DWsk7MzU7XMoSUvarKLBGMICF4XjYJLrmMocCEQVqz62Kze/KgCw==",
           "dev": true,
           "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
+            "@balena/jellyfish-logger": "^2.1.34",
+            "@balena/jellyfish-types": "^0.5.55",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.3"
+          }
+        },
+        "@balena/jellyfish-types": {
+          "version": "0.5.55",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.5.55.tgz",
+          "integrity": "sha512-CWfgGluVYyu0Cojt8HTl3ilfxnH+/qOgMrZVRMUpuTtIQo5aJsmHJfoCc/E86lEtzwZVGmubSZlc7rL3U9T/RA==",
+          "dev": true,
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        },
+        "json-schema": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -1060,78 +1087,158 @@
       }
     },
     "@balena/jellyfish-logger": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-1.0.57.tgz",
-      "integrity": "sha512-ZTxmR7AxbUPVbuSSjbEnGTEouwdvDXtQDwj6nlyrsAXl3QcJKqUxh1VAlmp+gO8TKXsFflbMeZYHRiLd+1du4A==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.34.tgz",
+      "integrity": "sha512-sjIVa//HvvoaUi48K7BsxLT9HgYSG8IGD6C2Ck4WPUhVFXFJiV9lq9utwQLT2j93ZbYzh6QRrhcCd8ZKwij7Jw==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-assert": "^1.0.67",
-        "@balena/jellyfish-environment": "^3.0.1",
-        "@sentry/node": "^6.2.3",
+        "@balena/jellyfish-assert": "^1.1.9",
+        "@balena/jellyfish-environment": "^4.1.6",
+        "@sentry/node": "^6.3.1",
         "errio": "^1.2.2",
         "lodash": "^4.17.21",
-        "r7insight_node": "^2.1.0",
+        "r7insight_node": "^2.1.1",
         "typed-errors": "^1.1.0",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0"
       },
       "dependencies": {
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
+        "@balena/jellyfish-assert": {
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.9.tgz",
+          "integrity": "sha512-3BsrYihE1A9kfaQHF2mKmTLtOsMeWrYznGfqFRWvIAFmoCMKrnFUfQcWmdD1IAwlvpnUihm2t3NXCWQHfRk+yg==",
           "dev": true,
           "requires": {
-            "@humanwhocodes/env": "^2.1.4",
             "lodash": "^4.17.21"
+          }
+        },
+        "@sentry/core": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.1.tgz",
+          "integrity": "sha512-aVuvVbaehGeN86jZlLDGGkhEtprdOtB6lvYLfGy40Dj1Tkh2mGWE550QsRXAXAqYvQzIYwQR23r6m3o8FujgVg==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "6.3.1",
+            "@sentry/minimal": "6.3.1",
+            "@sentry/types": "6.3.1",
+            "@sentry/utils": "6.3.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.1.tgz",
+          "integrity": "sha512-2er+OeVlsdVZkhl9kXQAANwgjwoCdM1etK2iFuhzX8xkMaJlAuZLyQInv2U1BbXBlIfWjvzRM8B95hCWvVrR3Q==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.3.1",
+            "@sentry/utils": "6.3.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.1.tgz",
+          "integrity": "sha512-0eN9S7HvXsCQEjX/qXHTMgvSb3mwrnZEWS9Qz/Bz5ig9pEGXKgJ1om5NTTHVHhXqd3wFCjdvIo6slufLHoCtSw==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "6.3.1",
+            "@sentry/types": "6.3.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/node": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.3.1.tgz",
+          "integrity": "sha512-D0r603fdNwUPkwvy0IcQaUSTafl+7lrOytiO5dfdLdlkhtTcwivwENc/n8ER8GOC2zpIvYOEIJvzP4PGL85khw==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "6.3.1",
+            "@sentry/hub": "6.3.1",
+            "@sentry/tracing": "6.3.1",
+            "@sentry/types": "6.3.1",
+            "@sentry/utils": "6.3.1",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.1.tgz",
+          "integrity": "sha512-qveDmoWsXy9qLEblZJwJ1OU/zZRlEd/q7Jhd0Hnwlob8Ci96huABEbYyGdJs18BKVHEFU3gSdVfvrikUE/W17g==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "6.3.1",
+            "@sentry/minimal": "6.3.1",
+            "@sentry/types": "6.3.1",
+            "@sentry/utils": "6.3.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.1.tgz",
+          "integrity": "sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.1.tgz",
+          "integrity": "sha512-cdtl/QWC9FtinAuW3w8QfvSfh/Q9ui5vwvjzVHiS1ga/U38edi2XX+cttY39ZYwz0SQG99cE10GOIhd1p7/mAA==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.3.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "r7insight_node": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/r7insight_node/-/r7insight_node-2.1.1.tgz",
+          "integrity": "sha512-xx0kgFxSHWY9aG1109uv4w2b+JLwHseSowOWo1bzCTDBpUk3er2rZdtQ90mAjUYbkh6Hus9DAwWvmHsX5pHaIQ==",
+          "dev": true,
+          "requires": {
+            "codependency": "^2.1.0",
+            "json-stringify-safe": "^5.0.1",
+            "lodash": "^4.17.15",
+            "reconnect-core": "^1.3.0"
           }
         }
       }
     },
     "@balena/jellyfish-mail": {
-      "version": "0.0.206",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-0.0.206.tgz",
-      "integrity": "sha512-9sjR8GnUUFPoHctXs7TkJC7UrA8RHPbZOtzqQ3DOaAx/RHhsD+GzNNP+jk2t1u/XZzYduXDi48zO+c4JdMmFAg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-mail/-/jellyfish-mail-1.0.16.tgz",
+      "integrity": "sha512-Zn06Px641IyXiLlp0n+HZyjcOpTcapYWI+9vfr7n90FPVt+ziqrznRHTg1/HfPD+0j2ted2auZpn3P4sQfO/WQ==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-environment": "^3.0.1",
+        "@balena/jellyfish-environment": "^4.1.6",
         "request": "^2.88.2",
         "request-promise": "^4.2.6"
-      },
-      "dependencies": {
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
-          "dev": true,
-          "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
-          }
-        }
       }
     },
     "@balena/jellyfish-metrics": {
-      "version": "0.1.125",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-0.1.125.tgz",
-      "integrity": "sha512-mWCgCxo1fDPUbkx/zf6tyj3/dR5onWljhWdnTtEqMwg+lxwKY2UbaP8VSaj4BEdKYYrPIAgILc7ODAJp7ml/oA==",
+      "version": "1.0.143",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.143.tgz",
+      "integrity": "sha512-f8VGZtdvX0i8CB9yeam0d4O4lGZ3kzdl4i6iUXYZakWp4l9gO0YIQNCycgb4wBzmXVLSEsgt9L1LHYBNjmwW2w==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-environment": "^3.0.1",
-        "@balena/jellyfish-logger": "^1.0.57",
+        "@balena/jellyfish-environment": "^4.1.6",
+        "@balena/jellyfish-logger": "^2.1.34",
+        "@balena/jellyfish-types": "^0.5.55",
         "@balena/node-metrics-gatherer": "^5.7.3",
         "express": "^4.17.1",
         "lodash": "^4.17.21"
       },
       "dependencies": {
-        "@balena/jellyfish-environment": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-3.0.1.tgz",
-          "integrity": "sha512-9zda7Ejx8Rz0ds6QLzL04yAcBqm1aHnCuZP9OO+eI/vZeVznONWtyU9tZal/UBsEjFcjmMUD/qxy8ROdZwTEHQ==",
+        "@balena/jellyfish-types": {
+          "version": "0.5.55",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.5.55.tgz",
+          "integrity": "sha512-CWfgGluVYyu0Cojt8HTl3ilfxnH+/qOgMrZVRMUpuTtIQo5aJsmHJfoCc/E86lEtzwZVGmubSZlc7rL3U9T/RA==",
           "dev": true,
           "requires": {
-            "@humanwhocodes/env": "^2.1.4",
-            "lodash": "^4.17.21"
+            "json-schema-to-typescript": "^10.1.4"
           }
         }
       }
@@ -2434,16 +2541,6 @@
         }
       }
     },
-    "@balena/jellyfish-uuid": {
-      "version": "1.0.84",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-uuid/-/jellyfish-uuid-1.0.84.tgz",
-      "integrity": "sha512-DIxlh0T3I7BDIj0+wd/HRj/2T3/f6qQHB072uiNo+hLmUHU4zDrl/5b05CnzYSwPcdt4NHP4Ynhj+EPi+7ShZw==",
-      "dev": true,
-      "requires": {
-        "@types/uuid": "^8.3.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "@balena/jellyfish-worker": {
       "version": "4.1.27",
       "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-4.1.27.tgz",
@@ -3489,9 +3586,9 @@
       }
     },
     "@mapbox/node-pre-gyp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.3.tgz",
-      "integrity": "sha512-9dTIfQW8HVCxLku5QrJ/ysS/b2MdYngs9+/oPrOTLvp3TrggdANYVW2h8FGJGDf0J7MYfp44W+c90cVJx+ASuA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.4.tgz",
+      "integrity": "sha512-M669Qo4nRT7iDmQEjQYC7RU8Z6dpz9UmSbkJ1OFEja3uevCdLKh7IZZki7L1TZj02kRyl82snXFY8QqkyfowrQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -4545,12 +4642,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@balena/ci-task-runner": "^0.2.124",
-    "@balena/jellyfish-action-library": "^8.1.46",
+    "@balena/jellyfish-action-library": "^9.0.83",
     "@balena/jellyfish-chat-widget": "^7.0.3",
     "@balena/jellyfish-client-sdk": "^3.2.109",
     "@balena/jellyfish-core": "^2.13.19",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `jellyfish-action-library` to v9, TypeScript version.
