### PR TITLE
Katapult: Reduce action-server replica count by half.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jellyfish-action-server
 spec:
-  replicas: 24
+  replicas: 12
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
This avoids choking the database and allows jobs to be queued.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>

