### PR TITLE
Allow users to edit email address

### DIFF
--- a/apps/ui/lib/lens/full/MyUser/MyUser.jsx
+++ b/apps/ui/lib/lens/full/MyUser/MyUser.jsx
@@ -81,6 +81,7 @@ export default class MyUser extends React.Component {
 		const userProfileSchema = _.pick(userTypeCard.data.schema, [
 			'properties.data.type',
 			'properties.data.properties.avatar',
+			'properties.data.properties.email',
 			'properties.data.properties.profile.properties.name',
 			'properties.data.properties.profile.properties.startDate',
 			'properties.data.properties.profile.properties.birthday',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Resolves #6309 

Allow users to edit their own email address from user settings:
![email-input](https://user-images.githubusercontent.com/45343541/116512145-87e6a300-a902-11eb-920f-83b1cd4341e6.png)

The issues I've found with this is that email inputs are not saved as expected, which might be a bit jarring for users. This is an issue with the input components themselves though and not with changes made in this PR.

Also added `title: 'Email'` to the `email` property of `user` cards in https://github.com/product-os/jellyfish-core/pull/686 so the input title will display as `Email` instead of `email` once that bump is merged.