### PR TITLE
fix: failing actions just died without error

### DIFF
--- a/apps/server/lib/http/routes.js
+++ b/apps/server/lib/http/routes.js
@@ -621,6 +621,9 @@ module.exports = (application, jellyfish, worker, producer, options) => {
 						data
 					})
 				})
+				.catch((error) => {
+					return sendHTTPError(request, response, error)
+				})
 		})
 			.catch((error) => {
 				return sendHTTPError(request, response, error)


### PR DESCRIPTION
this lead e.g. CloudFlare to report a 502 bad gateway instead of an "element already exists"
