### PR TITLE
Fix broken sentry logging caused by incorrect module import

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -978,9 +978,9 @@
       }
     },
     "@balena/jellyfish-logger": {
-      "version": "2.1.45",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.45.tgz",
-      "integrity": "sha512-dE/bPCDxP3LuYkVxQeHikFR/5CNtx+7ArrLKU44cdJW0kBjofd114zCJ8qwxzGojspbHMwr97CYs+wwxTrYQWw==",
+      "version": "2.1.47",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.47.tgz",
+      "integrity": "sha512-gLQEMMZrcUomZIshnPyIKp0CbTNdXdVchm0ZAbAsYd1hIB+TFjPnzd7XScQULGhmbWL97uJ7r5cJl+aym4Ejrw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.13",
         "@balena/jellyfish-environment": "^4.1.10",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -13,7 +13,7 @@
     "@balena/jellyfish-action-library": "^9.1.27",
     "@balena/jellyfish-core": "^2.13.78",
     "@balena/jellyfish-environment": "^4.1.10",
-    "@balena/jellyfish-logger": "^2.1.45",
+    "@balena/jellyfish-logger": "^2.1.47",
     "@balena/jellyfish-metrics": "^1.0.196",
     "@balena/jellyfish-plugin-base": "^1.2.41",
     "@balena/jellyfish-plugin-channels": "^1.1.88",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1247,9 +1247,9 @@
       }
     },
     "@balena/jellyfish-logger": {
-      "version": "2.1.45",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.45.tgz",
-      "integrity": "sha512-dE/bPCDxP3LuYkVxQeHikFR/5CNtx+7ArrLKU44cdJW0kBjofd114zCJ8qwxzGojspbHMwr97CYs+wwxTrYQWw==",
+      "version": "2.1.47",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-2.1.47.tgz",
+      "integrity": "sha512-gLQEMMZrcUomZIshnPyIKp0CbTNdXdVchm0ZAbAsYd1hIB+TFjPnzd7XScQULGhmbWL97uJ7r5cJl+aym4Ejrw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.13",
         "@balena/jellyfish-environment": "^4.1.10",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,7 +23,7 @@
     "@balena/jellyfish-assert": "^1.1.13",
     "@balena/jellyfish-core": "^2.13.78",
     "@balena/jellyfish-environment": "^4.1.10",
-    "@balena/jellyfish-logger": "^2.1.45",
+    "@balena/jellyfish-logger": "^2.1.47",
     "@balena/jellyfish-metrics": "^1.0.196",
     "@balena/jellyfish-plugin-base": "^1.2.41",
     "@balena/jellyfish-plugin-channels": "^1.1.88",


### PR DESCRIPTION
Sentry was incorrectly imported in the `jellyfish-logger` module, resulting in the exception reporting causing an error to be thrown.
See https://github.com/product-os/jellyfish-logger/pull/407

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
