### PR TITLE
Fix OmniSearch lens search types logic

### DIFF
--- a/apps/ui/lib/lens/misc/OmniSearch.tsx
+++ b/apps/ui/lib/lens/misc/OmniSearch.tsx
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+import findPathDeep from 'deepdash/findPathDeep';
 import React from 'react';
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
@@ -18,10 +19,14 @@ const getFullTextSearchTypes = memoize((types) => {
 		if (typesToExclude.includes(type.slug)) {
 			return fullTextSearchTypes;
 		}
-		const flatSchema: any = SchemaSieve.flattenSchema(type.data.schema);
-		const fullTextSearchFieldFound = _.find(flatSchema.properties, {
-			fullTextSearch: true,
-		});
+		const flatSchema = SchemaSieve.flattenSchema(type.data.schema);
+		const fullTextSearchFieldFound = findPathDeep(
+			flatSchema.properties,
+			(value, key) => {
+				return Boolean(key === 'fullTextSearch' && value);
+			},
+		);
+
 		if (fullTextSearchFieldFound) {
 			fullTextSearchTypes.push(`${type.slug}@${type.version}`);
 		}

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -9409,6 +9409,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepdash": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/deepdash/-/deepdash-5.3.7.tgz",
+      "integrity": "sha512-jWRnA4nyfn63R9VUz8yoDExYjmOdQZ1C0icB7qxhDdM3REZVNBPWkv4COggS/HBxibWU+svwWKSr/BmacI/dKA==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -37,6 +37,7 @@
     "date-fns": "^2.25.0",
     "debounce-promise": "^3.1.2",
     "deep-copy": "^1.4.2",
+    "deepdash": "^5.3.7",
     "deepmerge": "^4.2.2",
     "fast-equals": "^2.0.3",
     "fast-json-patch": "^3.1.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

The current implementation of the logic that finds contract types that contain full-text searchable fields doesn't account for slightly complex field definitions such as `oneOf`. I don't believe this currently affects any contracts, but could in the future if we add a contract that has a single full-text searchable field that is defined with `oneOf`, etc. These changes modify that logic to search deeper within field children instead of assuming `fullTextSearch: true` will exist at the top level.

Found this while looking for where the omnisearch query is generated on the front-end as it doesn't include fields such as the `user` contract's `data.email`. I'm *assuming* this is because `data.email` is defined with `oneOf`.

## Issues
- Would like to do this without adding a new dependency (currently adding `deepdash`)

## Example
```
const _ = require('lodash')
const findPathDeep = require('deepdash/findPathDeep')

const schema = {
	email: {
		oneOf: [
			{
				type: "array",
				fullTextSearch: true
			},
			{
				type: "string",
				fullTextSearch: true
			}
		]
	}
}

console.log('_.find:', Boolean(_.find(schema, {
	fullTextSearch: true
})))

console.log('findPathDeep:', Boolean(findPathDeep(schema, (v, k) => {
	return Boolean(k === 'fullTextSearch' && v)
})))
```

Output:
```
$ node find.js
_.find: false
findPathDeep: true
```