### PR TITLE
Bump fast-equals to v2.0.2

### DIFF
--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.jsx
@@ -5,7 +5,7 @@
  */
 
 import {
-	circularDeepEqual
+	deepEqual
 } from 'fast-equals'
 import _ from 'lodash'
 import React from 'react'
@@ -57,7 +57,7 @@ export default class SingleCardFull extends React.Component {
 	}
 
 	shouldComponentUpdate (nextProps, nextState) {
-		return	!circularDeepEqual(nextState, this.state) || !circularDeepEqual(nextProps, this.props)
+		return !deepEqual(nextState, this.state) || !deepEqual(nextProps, this.props)
 	}
 
 	setActiveIndex (activeIndex) {

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -9126,9 +9126,9 @@
       "dev": true
     },
     "fast-equals": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.1.tgz",
-      "integrity": "sha512-jIHAbyu5Txdi299DitHXr4wuvw7ajz8S4xVgShJmQOUD6TovsKzvMoHoq9G8+dO6xeKWrwH3DURT+ZDKnwjSsA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.2.tgz",
+      "integrity": "sha512-ehHsR38w6sqy5E0QrWQxclb+zl3ulNsgCVWt1cMoZ6QBFgtkr4lKZWpQP1kfEFn6bWnm78pmiDGak+zUvQ2/DQ=="
     },
     "fast-glob": {
       "version": "3.2.5",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -58,7 +58,7 @@
     "debounce-promise": "^3.1.2",
     "deep-copy": "^1.4.2",
     "deepmerge": "^4.2.2",
-    "fast-equals": "^2.0.1",
+    "fast-equals": "^2.0.2",
     "fast-json-patch": "^2.2.1",
     "file-loader": "^6.2.0",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Bump `fast-equals` to v2.0.2
- Use `deepEqual` as `circularDeepEqual` is slower and can cause UI unit tests to fail
