### PR TITLE
Renovate: Temporarily add bump group for action-library

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,12 @@
         "patch"
       ],
       "automerge": true
+    },
+    {
+      "groupName": "jellyfish-action-library",
+      "matchPackageNames": [
+        "@balena/jellyfish-action-library"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Temporarily add new Renovate package group for `jellyfish-action-library` until it stops causing CI test failures.