### PR TITLE
Remove action-library Renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,12 +22,6 @@
         "patch"
       ],
       "automerge": true
-    },
-    {
-      "groupName": "jellyfish-action-library",
-      "matchPackageNames": [
-        "@balena/jellyfish-action-library"
-      ]
     }
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Removing `jellyfish-action-library` Renovate group from config as it is no longer necessary. It is time for the library to come back into the fold.