### PR TITLE
Add e2e tests for patterns and pull requests triggering support threads to reopen

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -1061,15 +1061,15 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "9.2.37",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.2.37.tgz",
-      "integrity": "sha512-T9xpGGPKUSSzsH+3nzW7m+v7wdBZYM+IY9nXNXUC6uZU1LMuPsZGsLsvkllFJB5glpu/a/A9C6FytIvFbGKYBg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.4.0.tgz",
+      "integrity": "sha512-63jg80niiXhGzeCbaI95GcBOmTYqg6dc+0lSvV6ReX9bOHfeNHzOw2/TrB5BpUjX1ADMsfKr3vgvfRo3Vtg4Sg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.17",
         "@balena/jellyfish-client-sdk": "^2.19.1",
         "@balena/jellyfish-environment": "^4.1.13",
         "@balena/jellyfish-logger": "2.1.58",
-        "@balena/jellyfish-plugin-base": "^2.1.86",
+        "@balena/jellyfish-plugin-base": "^2.1.87",
         "@octokit/auth-app": "^2.11.0",
         "@octokit/plugin-retry": "^3.0.7",
         "@octokit/plugin-throttling": "^3.4.1",
@@ -1196,6 +1196,45 @@
             "skhema": "^5.3.4"
           }
         },
+        "@balena/jellyfish-plugin-default": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.3.1.tgz",
+          "integrity": "sha512-gTc/ALNAPy1OX7zybiOheyCZSTp++JhqGnUCxfqY2tabVXxECBmfIlCwP6s7qZRmUP7Codk4EqQe2+JI12YNSg==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.17",
+            "@balena/jellyfish-client-sdk": "^2.19.1",
+            "@balena/jellyfish-environment": "^4.1.13",
+            "@balena/jellyfish-logger": "2.1.58",
+            "@balena/jellyfish-plugin-base": "^2.1.87",
+            "@octokit/auth-app": "^2.11.0",
+            "@octokit/plugin-retry": "^3.0.7",
+            "@octokit/plugin-throttling": "^3.4.1",
+            "@octokit/rest": "^18.5.3",
+            "bluebird": "^3.7.2",
+            "fast-json-patch": "^3.0.0-1",
+            "front-sdk": "^0.8.1",
+            "geoip-lite": "^1.4.2",
+            "intercom-client": "^2.11.2",
+            "is-uuid": "^1.0.2",
+            "jsonwebtoken": "^8.5.1",
+            "lodash": "^4.17.21",
+            "lru-cache": "^6.0.0",
+            "marked": "^1.2.9",
+            "native-url": "^0.3.4",
+            "node-jose": "^2.0.0",
+            "pluralize": "^8.0.0",
+            "randomstring": "^1.2.1",
+            "request": "^2.88.2",
+            "request-promise": "^4.2.6",
+            "uuid": "^8.3.2",
+            "yaml": "^1.10.2"
+          }
+        },
+        "fast-json-patch": {
+          "version": "3.0.0-1",
+          "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+          "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+        },
         "json-schema": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
@@ -1249,6 +1288,14 @@
         "lodash": "^4.17.21"
       },
       "dependencies": {
+        "@balena/jellyfish-assert": {
+          "version": "1.1.17",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.17.tgz",
+          "integrity": "sha512-psUts9IYOL55vpthps8C3iwyhVROUJU+5KpZNOVbORfjhMYZQgsQoiJ6J0jnUJl+YzJfPaWk6jz6v1qUJYbaEQ==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
         "@balena/jellyfish-plugin-base": {
           "version": "2.1.87",
           "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.87.tgz",
@@ -1261,6 +1308,45 @@
             "semver": "^7.3.5",
             "skhema": "^5.3.4"
           }
+        },
+        "@balena/jellyfish-plugin-default": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.3.1.tgz",
+          "integrity": "sha512-gTc/ALNAPy1OX7zybiOheyCZSTp++JhqGnUCxfqY2tabVXxECBmfIlCwP6s7qZRmUP7Codk4EqQe2+JI12YNSg==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.17",
+            "@balena/jellyfish-client-sdk": "^2.19.1",
+            "@balena/jellyfish-environment": "^4.1.13",
+            "@balena/jellyfish-logger": "2.1.58",
+            "@balena/jellyfish-plugin-base": "^2.1.87",
+            "@octokit/auth-app": "^2.11.0",
+            "@octokit/plugin-retry": "^3.0.7",
+            "@octokit/plugin-throttling": "^3.4.1",
+            "@octokit/rest": "^18.5.3",
+            "bluebird": "^3.7.2",
+            "fast-json-patch": "^3.0.0-1",
+            "front-sdk": "^0.8.1",
+            "geoip-lite": "^1.4.2",
+            "intercom-client": "^2.11.2",
+            "is-uuid": "^1.0.2",
+            "jsonwebtoken": "^8.5.1",
+            "lodash": "^4.17.21",
+            "lru-cache": "^6.0.0",
+            "marked": "^1.2.9",
+            "native-url": "^0.3.4",
+            "node-jose": "^2.0.0",
+            "pluralize": "^8.0.0",
+            "randomstring": "^1.2.1",
+            "request": "^2.88.2",
+            "request-promise": "^4.2.6",
+            "uuid": "^8.3.2",
+            "yaml": "^1.10.2"
+          }
+        },
+        "fast-json-patch": {
+          "version": "3.0.0-1",
+          "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+          "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
         },
         "json-schema": {
           "version": "0.3.0",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -17,7 +17,7 @@
     "@balena/jellyfish-metrics": "^1.0.208",
     "@balena/jellyfish-plugin-base": "^1.2.41",
     "@balena/jellyfish-plugin-channels": "^1.1.102",
-    "@balena/jellyfish-plugin-default": "^9.2.37",
+    "@balena/jellyfish-plugin-default": "^9.4.0",
     "@balena/jellyfish-plugin-product-os": "^2.0.37",
     "@balena/jellyfish-plugin-typeform": "^2.0.89",
     "@balena/jellyfish-queue": "^1.0.76",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1217,6 +1217,45 @@
             "skhema": "^5.3.4"
           }
         },
+        "@balena/jellyfish-plugin-default": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.3.1.tgz",
+          "integrity": "sha512-gTc/ALNAPy1OX7zybiOheyCZSTp++JhqGnUCxfqY2tabVXxECBmfIlCwP6s7qZRmUP7Codk4EqQe2+JI12YNSg==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.17",
+            "@balena/jellyfish-client-sdk": "^2.19.1",
+            "@balena/jellyfish-environment": "^4.1.13",
+            "@balena/jellyfish-logger": "2.1.58",
+            "@balena/jellyfish-plugin-base": "^2.1.87",
+            "@octokit/auth-app": "^2.11.0",
+            "@octokit/plugin-retry": "^3.0.7",
+            "@octokit/plugin-throttling": "^3.4.1",
+            "@octokit/rest": "^18.5.3",
+            "bluebird": "^3.7.2",
+            "fast-json-patch": "^3.0.0-1",
+            "front-sdk": "^0.8.1",
+            "geoip-lite": "^1.4.2",
+            "intercom-client": "^2.11.2",
+            "is-uuid": "^1.0.2",
+            "jsonwebtoken": "^8.5.1",
+            "lodash": "^4.17.21",
+            "lru-cache": "^6.0.0",
+            "marked": "^1.2.9",
+            "native-url": "^0.3.4",
+            "node-jose": "^2.0.0",
+            "pluralize": "^8.0.0",
+            "randomstring": "^1.2.1",
+            "request": "^2.88.2",
+            "request-promise": "^4.2.6",
+            "uuid": "^8.3.2",
+            "yaml": "^1.10.2"
+          }
+        },
+        "fast-json-patch": {
+          "version": "3.0.0-1",
+          "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+          "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+        },
         "json-schema": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
@@ -1233,15 +1272,15 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "9.2.37",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.2.37.tgz",
-      "integrity": "sha512-T9xpGGPKUSSzsH+3nzW7m+v7wdBZYM+IY9nXNXUC6uZU1LMuPsZGsLsvkllFJB5glpu/a/A9C6FytIvFbGKYBg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.4.0.tgz",
+      "integrity": "sha512-63jg80niiXhGzeCbaI95GcBOmTYqg6dc+0lSvV6ReX9bOHfeNHzOw2/TrB5BpUjX1ADMsfKr3vgvfRo3Vtg4Sg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.17",
         "@balena/jellyfish-client-sdk": "^2.19.1",
         "@balena/jellyfish-environment": "^4.1.13",
         "@balena/jellyfish-logger": "2.1.58",
-        "@balena/jellyfish-plugin-base": "^2.1.86",
+        "@balena/jellyfish-plugin-base": "^2.1.87",
         "@octokit/auth-app": "^2.11.0",
         "@octokit/plugin-retry": "^3.0.7",
         "@octokit/plugin-throttling": "^3.4.1",
@@ -1367,6 +1406,22 @@
         "lodash": "^4.17.21"
       },
       "dependencies": {
+        "@balena/jellyfish-client-sdk": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-2.19.1.tgz",
+          "integrity": "sha512-Owpwnfj4LVJQgljXz9psx1FCjYE9CZsBael4fLqMdNfPLv10zOAbi2VeRvyb7ZDWHmheXlzxpkKW21anpQsmWg==",
+          "requires": {
+            "axios": "^0.21.1",
+            "bluebird": "^3.7.2",
+            "common-tags": "^1.8.0",
+            "deep-copy": "^1.4.2",
+            "fast-json-patch": "^3.0.0-1",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "socket.io-client": "^2.4.0",
+            "uuid": "^8.3.2"
+          }
+        },
         "@balena/jellyfish-plugin-base": {
           "version": "2.1.87",
           "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.87.tgz",
@@ -1379,6 +1434,45 @@
             "semver": "^7.3.5",
             "skhema": "^5.3.4"
           }
+        },
+        "@balena/jellyfish-plugin-default": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.3.1.tgz",
+          "integrity": "sha512-gTc/ALNAPy1OX7zybiOheyCZSTp++JhqGnUCxfqY2tabVXxECBmfIlCwP6s7qZRmUP7Codk4EqQe2+JI12YNSg==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.17",
+            "@balena/jellyfish-client-sdk": "^2.19.1",
+            "@balena/jellyfish-environment": "^4.1.13",
+            "@balena/jellyfish-logger": "2.1.58",
+            "@balena/jellyfish-plugin-base": "^2.1.87",
+            "@octokit/auth-app": "^2.11.0",
+            "@octokit/plugin-retry": "^3.0.7",
+            "@octokit/plugin-throttling": "^3.4.1",
+            "@octokit/rest": "^18.5.3",
+            "bluebird": "^3.7.2",
+            "fast-json-patch": "^3.0.0-1",
+            "front-sdk": "^0.8.1",
+            "geoip-lite": "^1.4.2",
+            "intercom-client": "^2.11.2",
+            "is-uuid": "^1.0.2",
+            "jsonwebtoken": "^8.5.1",
+            "lodash": "^4.17.21",
+            "lru-cache": "^6.0.0",
+            "marked": "^1.2.9",
+            "native-url": "^0.3.4",
+            "node-jose": "^2.0.0",
+            "pluralize": "^8.0.0",
+            "randomstring": "^1.2.1",
+            "request": "^2.88.2",
+            "request-promise": "^4.2.6",
+            "uuid": "^8.3.2",
+            "yaml": "^1.10.2"
+          }
+        },
+        "fast-json-patch": {
+          "version": "3.0.0-1",
+          "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+          "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
         },
         "json-schema": {
           "version": "0.3.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,7 +27,7 @@
     "@balena/jellyfish-metrics": "^1.0.208",
     "@balena/jellyfish-plugin-base": "^1.2.41",
     "@balena/jellyfish-plugin-channels": "^1.1.102",
-    "@balena/jellyfish-plugin-default": "^9.2.37",
+    "@balena/jellyfish-plugin-default": "^9.4.0",
     "@balena/jellyfish-plugin-product-os": "^2.0.37",
     "@balena/jellyfish-plugin-typeform": "^2.0.89",
     "@balena/jellyfish-queue": "^1.0.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1479,16 +1479,16 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "9.2.37",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.2.37.tgz",
-      "integrity": "sha512-T9xpGGPKUSSzsH+3nzW7m+v7wdBZYM+IY9nXNXUC6uZU1LMuPsZGsLsvkllFJB5glpu/a/A9C6FytIvFbGKYBg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.4.0.tgz",
+      "integrity": "sha512-63jg80niiXhGzeCbaI95GcBOmTYqg6dc+0lSvV6ReX9bOHfeNHzOw2/TrB5BpUjX1ADMsfKr3vgvfRo3Vtg4Sg==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.17",
         "@balena/jellyfish-client-sdk": "^2.19.1",
         "@balena/jellyfish-environment": "^4.1.13",
         "@balena/jellyfish-logger": "2.1.58",
-        "@balena/jellyfish-plugin-base": "^2.1.86",
+        "@balena/jellyfish-plugin-base": "^2.1.87",
         "@octokit/auth-app": "^2.11.0",
         "@octokit/plugin-retry": "^3.0.7",
         "@octokit/plugin-throttling": "^3.4.1",
@@ -1740,6 +1740,32 @@
         "lodash": "^4.17.21"
       },
       "dependencies": {
+        "@balena/jellyfish-assert": {
+          "version": "1.1.17",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.17.tgz",
+          "integrity": "sha512-psUts9IYOL55vpthps8C3iwyhVROUJU+5KpZNOVbORfjhMYZQgsQoiJ6J0jnUJl+YzJfPaWk6jz6v1qUJYbaEQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-client-sdk": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-2.19.1.tgz",
+          "integrity": "sha512-Owpwnfj4LVJQgljXz9psx1FCjYE9CZsBael4fLqMdNfPLv10zOAbi2VeRvyb7ZDWHmheXlzxpkKW21anpQsmWg==",
+          "dev": true,
+          "requires": {
+            "axios": "^0.21.1",
+            "bluebird": "^3.7.2",
+            "common-tags": "^1.8.0",
+            "deep-copy": "^1.4.2",
+            "fast-json-patch": "^3.0.0-1",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "socket.io-client": "^2.4.0",
+            "uuid": "^8.3.2"
+          }
+        },
         "@balena/jellyfish-plugin-base": {
           "version": "2.1.87",
           "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.87.tgz",
@@ -1754,10 +1780,51 @@
             "skhema": "^5.3.4"
           }
         },
+        "@balena/jellyfish-plugin-default": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-9.3.1.tgz",
+          "integrity": "sha512-gTc/ALNAPy1OX7zybiOheyCZSTp++JhqGnUCxfqY2tabVXxECBmfIlCwP6s7qZRmUP7Codk4EqQe2+JI12YNSg==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.17",
+            "@balena/jellyfish-client-sdk": "^2.19.1",
+            "@balena/jellyfish-environment": "^4.1.13",
+            "@balena/jellyfish-logger": "2.1.58",
+            "@balena/jellyfish-plugin-base": "^2.1.87",
+            "@octokit/auth-app": "^2.11.0",
+            "@octokit/plugin-retry": "^3.0.7",
+            "@octokit/plugin-throttling": "^3.4.1",
+            "@octokit/rest": "^18.5.3",
+            "bluebird": "^3.7.2",
+            "fast-json-patch": "^3.0.0-1",
+            "front-sdk": "^0.8.1",
+            "geoip-lite": "^1.4.2",
+            "intercom-client": "^2.11.2",
+            "is-uuid": "^1.0.2",
+            "jsonwebtoken": "^8.5.1",
+            "lodash": "^4.17.21",
+            "lru-cache": "^6.0.0",
+            "marked": "^1.2.9",
+            "native-url": "^0.3.4",
+            "node-jose": "^2.0.0",
+            "pluralize": "^8.0.0",
+            "randomstring": "^1.2.1",
+            "request": "^2.88.2",
+            "request-promise": "^4.2.6",
+            "uuid": "^8.3.2",
+            "yaml": "^1.10.2"
+          }
+        },
         "json-schema": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
           "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+          "dev": true
+        },
+        "marked": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
+          "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
           "dev": true
         },
         "semver": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@balena/jellyfish-environment": "^4.1.13",
     "@balena/jellyfish-plugin-base": "^1.2.41",
     "@balena/jellyfish-plugin-channels": "^1.1.102",
-    "@balena/jellyfish-plugin-default": "^9.2.37",
+    "@balena/jellyfish-plugin-default": "^9.4.0",
     "@balena/jellyfish-plugin-product-os": "^2.0.37",
     "@balena/jellyfish-plugin-typeform": "^2.0.89",
     "@balena/jellyfish-queue": "^1.0.76",

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -83,7 +83,7 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 			name,
 			data: {
 				phase: 'proposed',
-				status: 'open'
+				status: 'proposed'
 			}
 		})
 	}, productImprovement1Name)
@@ -107,7 +107,9 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 	await macros.waitForThenClickSelector(page, selectors.addProductImprovement)
 	await page.waitForSelector('input#root_name')
 	await page.type('input#root_name', productImprovement2Name)
-	await macros.waitForThenClickSelector(page, '[data-test="card-creator__submit"]')
+	await macros.waitForThenClickSelector(page, '#root_data_status__input')
+	await macros.waitForThenClickSelector(page, '#root_data_status__select-drop button')
+	await macros.waitForThenClickSelector(page, '[data-test="card-creator__submit"]:not(:disabled)')
 
 	await page.waitForSelector(selectors.linkedProductImprovements)
 	let linkedProductImprovements = await page.$$(selectors.linkedProductImprovements)


### PR DESCRIPTION
Add e2e tests to check reopen triggered actions

Abstracted the existing test that verified issues re-opened support threads when closed and called this abstract test from three tests for issues, pull requests and patterns.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

