### PR TITLE
Add 'Offboard user' action link for operators

### DIFF
--- a/apps/ui/lib/lens/full/User/index.jsx
+++ b/apps/ui/lib/lens/full/User/index.jsx
@@ -12,9 +12,21 @@ import {
 	bindActionCreators
 } from 'redux'
 import {
+	sdk,
+	selectors,
 	actionCreators
 } from '../../../core'
 import User from './User'
+
+const mapStateToProps = (state) => {
+	const balenaOrg = _.find(selectors.getOrgs(state), {
+		slug: 'org-balena'
+	})
+	return {
+		sdk,
+		balenaOrg
+	}
+}
 
 const mapDispatchToProps = (dispatch) => {
 	return {
@@ -34,7 +46,7 @@ const lens = {
 	data: {
 		format: 'full',
 		icon: 'address-card',
-		renderer: connect(null, mapDispatchToProps)(User),
+		renderer: connect(mapStateToProps, mapDispatchToProps)(User),
 		filter: {
 			type: 'object',
 			properties: {

--- a/scripts/lint/check-licenses.sh
+++ b/scripts/lint/check-licenses.sh
@@ -33,6 +33,7 @@ LICENSE_SHEBANG_SH="#!/bin/bash
 JAVASCRIPT_FILES="$(find . \( -name '*.js' -or -name '*.jsx' \) \
 	-and -not -path '**/node_modules/*' \
 	-and -not -path '**/dist/*' \
+	-and -not -path '**/env-config.js' \
 	-and -not -path '**/.libs/*' \
 	-and -not -path '**/.tmp/*')"
 


### PR DESCRIPTION
Clicking the 'Offboard user' link will:
1. Set the user's roles to `[ 'user-externl-support' ]`
2. Remove the user from the balena org

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![image](https://user-images.githubusercontent.com/2925657/118793442-cef10400-b8c2-11eb-9269-83e5ee49fd4d.png)
