### PR TITLE
Correctly highlight summary when channel target uses a versioned slug

### DIFF
--- a/apps/ui/lib/lens/list/SupportThreads.tsx
+++ b/apps/ui/lib/lens/list/SupportThreads.tsx
@@ -303,15 +303,21 @@ export class SupportThreads extends React.Component<any, any> {
 											'data.timestamp',
 										);
 
+										// Mark the summary as active if there are any channels open that target this contract, either by slug, slug@version, or id
+										const summaryActive = !!_.find(threadTargets, (target) => {
+											return (
+												target === card.slug ||
+												target === `${card.slug}@${card.version}` ||
+												target === card.id
+											);
+										});
+
 										return (
 											<CardChatSummary
 												displayOwner
 												getActor={this.props.actions.getActor}
 												key={card.id}
-												active={
-													_.includes(threadTargets, card.slug) ||
-													_.includes(threadTargets, card.id)
-												}
+												active={summaryActive}
 												card={card}
 												timeline={timeline}
 												highlightedFields={['data.status', 'data.inbox']}


### PR DESCRIPTION
Fixes #6495

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
