### PR TITLE
Add ability to filter by type when linking/unlinking

### DIFF
--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.tsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.spec.tsx
@@ -10,7 +10,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 import Bluebird from 'bluebird';
-import AutoCompleteCardSelect from './AutoCompleteCardSelect';
+import { AutoCompleteCardSelect } from './AutoCompleteCardSelect';
 
 const wrappingComponent = getWrapper().wrapper;
 

--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.tsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.tsx
@@ -19,7 +19,7 @@ const preventClickPropagation = (event: any) => {
 	event.preventDefault();
 };
 
-export default class AutoCompleteCardSelect extends React.Component<any, any> {
+export class AutoCompleteCardSelect extends React.Component<any, any> {
 	container: any;
 	_isMounted: boolean = false;
 

--- a/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.tsx
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/AutoCompleteCardSelect.tsx
@@ -222,6 +222,7 @@ export class AutoCompleteCardSelect extends React.Component<any, any> {
 								</Badge>
 							)}
 							<Txt
+								tooltip={option.label as string}
 								style={{
 									flex: 1,
 									whiteSpace: 'nowrap',

--- a/apps/ui/lib/components/AutoCompleteCardSelect/index.ts
+++ b/apps/ui/lib/components/AutoCompleteCardSelect/index.ts
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withSetup } from '@balena/jellyfish-ui-components';
 import { selectors } from '../../core';
-import AutoCompleteCardSelect from './AutoCompleteCardSelect';
+import { AutoCompleteCardSelect as AutoCompleteCardSelectInner } from './AutoCompleteCardSelect';
 
 const mapStateToProps = (state: any) => {
 	return {
@@ -16,7 +16,7 @@ const mapStateToProps = (state: any) => {
 	};
 };
 
-export default compose<any>(
+export const AutoCompleteCardSelect = compose<any>(
 	withSetup,
 	connect(mapStateToProps),
-)(AutoCompleteCardSelect);
+)(AutoCompleteCardSelectInner);

--- a/apps/ui/lib/components/CardLinker/CardLinker.tsx
+++ b/apps/ui/lib/components/CardLinker/CardLinker.tsx
@@ -168,7 +168,11 @@ class CardLinker extends React.Component<any, any> {
 				</span>
 
 				{showLinkModal === 'link' && (
-					<LinkModal cards={[card]} types={types} onHide={this.hideLinkModal} />
+					<LinkModal
+						cards={[card]}
+						targetTypes={types}
+						onHide={this.hideLinkModal}
+					/>
 				)}
 
 				{showLinkModal === 'unlink' && (

--- a/apps/ui/lib/components/ChannelRenderer.tsx
+++ b/apps/ui/lib/components/ChannelRenderer.tsx
@@ -111,7 +111,7 @@ class ChannelRenderer extends React.Component<any, any> {
 						<LinkModal
 							target={head}
 							cards={[linkFrom]}
-							types={types}
+							targetTypes={types}
 							onHide={this.closeLinkModal}
 						/>
 					)}

--- a/apps/ui/lib/components/Flows/HandoverFlowPanel/Steps/NewOwnerStep.tsx
+++ b/apps/ui/lib/components/Flows/HandoverFlowPanel/Steps/NewOwnerStep.tsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import { Flex, RadioButton, Txt } from 'rendition';
 import styled from 'styled-components';
 import { helpers } from '@balena/jellyfish-ui-components';
-import AutoCompleteCardSelect from '../../../AutoCompleteCardSelect';
+import { AutoCompleteCardSelect } from '../../../AutoCompleteCardSelect';
 
 const UserSelect = styled<any>(AutoCompleteCardSelect)`
 	min-width: 180px;

--- a/apps/ui/lib/components/Hideable.tsx
+++ b/apps/ui/lib/components/Hideable.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+export interface HideableProps {
+	isHidden?: boolean;
+}
+
+export const Hideable = (Component) => styled(Component)<HideableProps>`
+	opacity: ${(props) => (props.isHidden ? 0 : 1)};
+	transition: opacity ease-in-out 300ms;
+`;

--- a/apps/ui/lib/components/LinkModal/LinkModal.tsx
+++ b/apps/ui/lib/components/LinkModal/LinkModal.tsx
@@ -4,108 +4,105 @@
  * Proprietary and confidential.
  */
 
-import _ from 'lodash';
-import memoize from 'memoize-one';
-import pluralize from 'pluralize';
 import React from 'react';
-import { Box, Modal, Flex, Select, Txt } from 'rendition';
-import { linkConstraints as LINKS } from '@balena/jellyfish-client-sdk';
-import { notifications, Icon } from '@balena/jellyfish-ui-components';
-import AutoCompleteCardSelect from '../AutoCompleteCardSelect';
-import { getCommonTypeBase } from './util';
+import _ from 'lodash';
+import { strict as assert } from 'assert';
+import pluralize from 'pluralize';
+import { Modal, Select, Txt, Box } from 'rendition';
+import styled from 'styled-components';
+import { notifications, Icon, helpers } from '@balena/jellyfish-ui-components';
+import {
+	Contract,
+	ContractSummary,
+	TypeContract,
+} from '@balena/jellyfish-types/build/core';
+import { AutoCompleteCardSelect } from '../AutoCompleteCardSelect';
+import { Hideable } from '../Hideable';
+import * as linkUtils from './util';
+import { TypeFilter } from './TypeFilter';
 
-export class LinkModal extends React.Component<any, any> {
-	constructor(props) {
-		super(props);
+const HideableBox = Hideable(Box);
 
-		const { target } = props;
+export interface LinkModalProps {
+	actions: {
+		createLink: (
+			fromCard: ContractSummary,
+			toCard: ContractSummary,
+			linkVerb: string,
+			options: any,
+		) => void;
+	};
+	allTypes: TypeContract[];
+	targetTypes: TypeContract[];
+	cards: Contract[];
+	target?: Contract;
+	linkVerb?: string;
+	onHide: () => void;
+	onSave?: (
+		fromCard: ContractSummary,
+		toCard: ContractSummary,
+		linkVerb: string,
+	) => void;
+	onSaved?: (toCard: ContractSummary, linkVerb: string) => void;
+}
 
-		this.state = {
-			submitting: false,
-			selectedTarget: target || null,
-			linkType: this.getLinkType(target),
-		};
-	}
+export const LinkModal: React.FunctionComponent<LinkModalProps> = ({
+	actions,
+	cards,
+	onHide,
+	onSave,
+	onSaved,
+	target,
+	allTypes,
+	targetTypes,
+	linkVerb,
+}) => {
+	const [selectedTarget, setSelectedTarget] =
+		React.useState<Contract | undefined>(target);
+	const [cardType, setCardType] = React.useState<TypeContract>();
+	const [submitting, setSubmitting] = React.useState(false);
+	const [linkType, setLinkType] = React.useState<linkUtils.LinkType>();
 
-	getAvailableTypeSlugs = memoize((types) => {
-		return _.reduce(
-			types || [],
-			(acc, type) => {
-				acc[type.slug] = true;
-				return acc;
-			},
-			{},
+	// Get and cache the type of the cards to be linked _from_
+	const fromType = linkUtils.getCommonTypeBase(cards);
+	const fromTypeContract: TypeContract = React.useMemo(() => {
+		return _.find(allTypes, ['slug', fromType])!;
+	}, [allTypes, fromType]);
+
+	// Find all types that can be linked _to_, based on:
+	// 1. the available types
+	// 2. the type of the source card(s)
+	// 3. the link verb (if specified)
+	// 4. the target ('to') card (if specified)
+	const validTypes = React.useMemo(() => {
+		return linkUtils.getValidTypes(targetTypes, fromType, linkVerb, target);
+	}, [targetTypes, fromType, linkVerb, target]);
+
+	// Get the link constraints that apply based on:
+	// 1. the type of the source card(s)
+	// 2. the link verb (if specified)
+	// 3. the target ('to') card (if specified)
+	const linkTypeTargets = React.useMemo(() => {
+		const targets = linkUtils.getFilteredLinkConstraints(
+			fromType,
+			linkVerb,
+			selectedTarget,
 		);
-	});
-
-	filterLinks = (linkVerb, availableTypeSlugs, target, fromType) => {
-		return _.filter(LINKS, (link) => {
-			// Filter by the link verb
-			if (linkVerb && linkVerb !== link.name) {
-				return false;
-			}
-
-			// Filter by the 'from' card
-			if (fromType !== link.data.from) {
-				return false;
-			}
-
-			// Filter by the 'types' prop
-			if (!availableTypeSlugs[link.data.to]) {
-				return false;
-			}
-
-			// If the target is specified, the link 'to' property must match it
-			if (target && target.type.split('@')[0] !== link.data.to) {
-				return false;
-			}
-
-			return true;
-		}).map((link) => {
-			// Move the data.title property to the root of the object, as the rendition Select
-			// component can't use a non-root field for the `labelKey` prop
-			return Object.assign({}, link, {
-				title: link.data.title,
-			});
-		});
-	};
-
-	getLinkTypeTargets(target) {
-		const { cards, linkVerb, types } = this.props;
-
-		const fromType = getCommonTypeBase(cards);
-		const availableTypeSlugs = this.getAvailableTypeSlugs(types);
-		return this.filterLinks(linkVerb, availableTypeSlugs, target, fromType);
-	}
-
-	getLinkType(target) {
-		const linkTypeTargets = this.getLinkTypeTargets(target);
-		return linkTypeTargets.length === 1 ? linkTypeTargets[0] : null;
-	}
-
-	handleTargetSelect = (target) => {
-		this.setState({
-			selectedTarget: target,
-			linkType: this.getLinkType(target),
-		});
-	};
-
-	handleLinkTypeSelect = (payload) => {
-		this.setState({
-			linkType: payload.option,
-		});
-	};
-
-	linkToExisting = async () => {
-		const { actions, cards, onHide, onSave, onSaved } = this.props;
-
-		const { linkType, selectedTarget } = this.state;
-
-		if (!linkType || !selectedTarget) {
-			return;
+		if (targets.length === 1) {
+			setLinkType(targets[0]);
+		} else {
+			setLinkType(undefined);
 		}
+		return targets;
+	}, [fromType, linkVerb, selectedTarget]);
 
-		const linkCard = async (card) => {
+	const onDone = async () => {
+		setSubmitting(true);
+
+		assert.ok(linkType);
+		assert.ok(selectedTarget);
+
+		const linkCard = async (card: ContractSummary) => {
 			if (onSave) {
 				onSave(card, selectedTarget, linkType.name);
 			} else {
@@ -118,55 +115,21 @@ export class LinkModal extends React.Component<any, any> {
 			}
 		};
 
-		this.setState(
-			{
-				submitting: true,
-			},
-			async () => {
-				const linkTasks = cards.map(linkCard);
-				await Promise.all(linkTasks);
-				notifications.addNotification(
-					'success',
-					`Created new link${cards.length > 1 ? 's' : ''}`,
-				);
-				this.setState(
-					{
-						submitting: false,
-						selectedTarget: null,
-					},
-					() => {
-						// Trigger the onHide callback to close the modal
-						onHide();
-					},
-				);
-			},
+		const linkTasks = cards.map(linkCard);
+		await Promise.all(linkTasks);
+
+		notifications.addNotification(
+			'success',
+			`Created new link${cards.length > 1 ? 's' : ''}`,
 		);
+		setSubmitting(false);
+		setSelectedTarget(undefined);
+		onHide();
 	};
 
-	render() {
-		const { cards, linkVerb, types, target } = this.props;
-		const { linkType, selectedTarget, submitting } = this.state;
-
-		const fromType = getCommonTypeBase(cards);
-		const availableTypeSlugs = this.getAvailableTypeSlugs(types);
-		const linkTypeTargets = this.filterLinks(
-			linkVerb,
-			availableTypeSlugs,
-			selectedTarget,
-			fromType,
-		);
-
-		if (!linkTypeTargets.length) {
-			console.error(`No matching link types for ${fromType}`);
-			notifications.addNotification(
-				'danger',
-				`No matching link types for ${fromType}`,
-			);
-			return null;
-		}
-
-		const typeCard = _.find(types, ['slug', fromType]);
-		const typeName = typeCard ? typeCard.name : fromType;
+	// The title is constructed based on the props passed to the component
+	const title = React.useMemo(() => {
+		const typeName = fromTypeContract ? fromTypeContract.name : fromType;
 
 		const titleSource = `${pluralize('this', cards.length)} ${pluralize(
 			typeName,
@@ -174,89 +137,61 @@ export class LinkModal extends React.Component<any, any> {
 			cards.length > 1,
 		)}`;
 		const titleTarget =
-			linkTypeTargets.length === 1
-				? linkTypeTargets[0].title
-				: 'another element';
-		const title = `Link ${titleSource} to ${titleTarget}`;
+			validTypes.length === 1 ? validTypes[0].name : 'another element';
+		return `Link ${titleSource} to ${titleTarget}`;
+	}, [linkVerb, fromTypeContract, validTypes, cards, linkTypeTargets]);
 
-		// Selected target display
-		let selectedTargetValue: any = null;
+	const selectedTargetValue = React.useMemo(() => {
+		return linkUtils.getContractSelectOption(targetTypes, selectedTarget);
+	}, [targetTypes, selectedTarget]);
 
-		if (selectedTarget) {
-			const selectedTargetCardTypeIndex = _.findIndex(types, {
-				slug: selectedTarget.type.split('@')[0],
-			});
-
-			selectedTargetValue = {
-				value: selectedTarget.id,
-				label: selectedTarget.name || selectedTarget.slug,
-				type: types[selectedTargetCardTypeIndex].name,
-				shade: selectedTargetCardTypeIndex,
-			};
-		}
-
-		const allLinkTypeTargets = this.filterLinks(
-			linkVerb,
-			availableTypeSlugs,
-			null,
-			fromType,
-		);
-
-		return (
-			<Modal
-				title={title}
-				cancel={this.props.onHide}
-				primaryButtonProps={
-					{
-						disabled: !linkType || !selectedTargetValue || submitting,
-						'data-test': 'card-linker--existing__submit',
-					} as any
-				}
-				action={submitting ? <Icon spin name="cog" /> : 'OK'}
-				done={this.linkToExisting}
-			>
-				<Flex flexDirection="column">
-					<Txt>
-						Look for the card types:{' '}
-						{allLinkTypeTargets
-							.map((linkTypeTarget) => {
-								return linkTypeTarget.title;
-							})
-							.join(', ')}
+	return (
+		<Modal
+			title={title}
+			cancel={onHide}
+			primaryButtonProps={
+				{
+					disabled: !linkType || !selectedTargetValue || submitting,
+					'data-test': 'card-linker--existing__submit',
+				} as any
+			}
+			action={submitting ? <Icon spin name="cog" /> : 'OK'}
+			done={onDone}
+		>
+			{!target && validTypes.length > 1 && (
+				<TypeFilter
+					types={validTypes}
+					activeFilter={cardType}
+					onSetType={setCardType}
+					mb={4}
+				/>
+			)}
+			<AutoCompleteCardSelect
+				placeholder="Search..."
+				autoFocus
+				value={selectedTargetValue}
+				cardType={_.map(_.castArray(cardType || validTypes), 'slug')}
+				isDisabled={Boolean(target)}
+				onChange={setSelectedTarget}
+			/>
+			{!linkVerb && (
+				<HideableBox isHidden={!selectedTarget || linkTypeTargets.length === 1}>
+					<Txt mt={3} mb={1}>
+						Select link type:
 					</Txt>
-					<Box
-						my={2}
-						alignSelf={['stretch', 'stretch', 'auto']}
-						data-test="card-linker--existing__input"
-					>
-						<AutoCompleteCardSelect
-							autoFocus
-							value={selectedTargetValue}
-							cardType={_.map(allLinkTypeTargets, (linkTypeTarget) => {
-								return _.get(linkTypeTarget, ['data', 'to']);
-							})}
-							isDisabled={Boolean(target)}
-							onChange={this.handleTargetSelect}
-						/>
-					</Box>
-					{selectedTarget && linkTypeTargets.length > 1 && (
-						<React.Fragment>
-							<Txt>Select link type</Txt>
-							<Box my={2}>
-								<Select
-									id="card-linker--type-select"
-									value={linkType || ''}
-									onChange={this.handleLinkTypeSelect}
-									labelKey="title"
-									valueKey="slug"
-									options={linkTypeTargets}
-									data-test="card-linker--type__input"
-								/>
-							</Box>
-						</React.Fragment>
-					)}
-				</Flex>
-			</Modal>
-		);
-	}
-}
+					<Select
+						id="card-linker--type-select"
+						value={linkType || ''}
+						onChange={({ option }: { option: linkUtils.LinkType }) => {
+							setLinkType(option);
+						}}
+						labelKey="title"
+						valueKey="slug"
+						options={linkTypeTargets}
+						data-test="card-linker--type__input"
+					/>
+				</HideableBox>
+			)}
+		</Modal>
+	);
+};

--- a/apps/ui/lib/components/LinkModal/TypeFilter.tsx
+++ b/apps/ui/lib/components/LinkModal/TypeFilter.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { TypeContract } from '@balena/jellyfish-types/build/core';
+import React from 'react';
+import _ from 'lodash';
+import { Box, BoxProps, Button, Flex, Txt } from 'rendition';
+import styled from 'styled-components';
+import { Hideable } from '../Hideable';
+
+const HideableBox = Hideable(Box);
+
+const ToggleButton = styled(Button)`
+	line-height: 1;
+	height: auto;
+`;
+
+interface TypeFilterProps extends BoxProps {
+	types: TypeContract[];
+	onSetType: (type?: TypeContract) => void;
+	activeFilter?: TypeContract;
+}
+
+export const TypeFilter = ({
+	types,
+	onSetType,
+	activeFilter,
+	...props
+}: TypeFilterProps) => {
+	return (
+		<Box {...props} data-test="type-filter__container">
+			<Txt mb={1}>
+				Filter by type:
+				<HideableBox display="inline" isHidden={!activeFilter} ml={2}>
+					<Button underline secondary onClick={() => onSetType(undefined)}>
+						clear
+					</Button>
+				</HideableBox>
+			</Txt>
+			<Flex flexWrap="wrap" mb={2}>
+				{types.map((type) => (
+					<ToggleButton
+						data-test="type-filter__button"
+						onClick={() => onSetType(activeFilter === type ? undefined : type)}
+						active={activeFilter === type}
+						my={1}
+						mr={2}
+						px={2}
+						py={1}
+					>
+						{type.name}
+					</ToggleButton>
+				))}
+			</Flex>
+		</Box>
+	);
+};

--- a/apps/ui/lib/components/LinkModal/UnlinkModal.tsx
+++ b/apps/ui/lib/components/LinkModal/UnlinkModal.tsx
@@ -6,64 +6,105 @@
 
 import React from 'react';
 import _ from 'lodash';
-import { Flex, Modal, Txt } from 'rendition';
+import { strict as assert } from 'assert';
 import pluralize from 'pluralize';
+import { Modal } from 'rendition';
 import {
 	linkConstraints,
 	getReverseConstraint,
 } from '@balena/jellyfish-client-sdk';
 import { notifications, Icon, helpers } from '@balena/jellyfish-ui-components';
-import AutoCompleteCardSelect from '../AutoCompleteCardSelect';
-import { getCommonTypeBase } from './util';
+import {
+	Contract,
+	ContractSummary,
+	TypeContract,
+} from '@balena/jellyfish-types/build/core';
+import { AutoCompleteCardSelect } from '../AutoCompleteCardSelect';
+import * as linkUtils from './util';
+import { TypeFilter } from './TypeFilter';
+import { LinkConstraint } from '@balena/jellyfish-client-sdk/build/types';
 
-export const UnlinkModal: React.FunctionComponent<any> = ({
+interface UnlinkModalProps {
+	actions: {
+		removeLink: (
+			fromCard: ContractSummary,
+			toCard: ContractSummary,
+			linkVerb: string,
+			options: any,
+		) => void;
+	};
+	allTypes: TypeContract[];
+	cards: Contract[];
+	target?: Contract;
+	onHide: () => void;
+}
+
+export const UnlinkModal: React.FunctionComponent<UnlinkModalProps> = ({
 	actions,
 	cards,
 	target,
-	types,
+	allTypes,
 	onHide,
 }) => {
+	const [selectedTarget, setSelectedTarget] =
+		React.useState<Contract | undefined>(target);
+	const [cardType, setCardType] = React.useState<TypeContract>();
 	const [submitting, setSubmitting] = React.useState(false);
-	const [selectedTarget, setSelectedTarget] = React.useState(target || null);
 
-	const cardsTypeBase = getCommonTypeBase(cards);
-	const typeCard = helpers.getType(cardsTypeBase, types);
-	const typeName = typeCard ? typeCard.name : cardsTypeBase;
+	// Get and cache the type of the cards to be unlinked _from_
+	const fromType = linkUtils.getCommonTypeBase(cards);
+	const fromTypeContract: TypeContract = React.useMemo(() => {
+		return _.find(allTypes, ['slug', fromType])!;
+	}, [allTypes, fromType]);
 
+	// Find all types that can be unlinked, based on:
+	// 1. the available types
+	// 2. the type of the source card(s)
+	// 3. the target ('to') card (if specified)
+	const validTypes = React.useMemo(() => {
+		return linkUtils.getValidTypes(allTypes, fromType, undefined, target);
+	}, [allTypes, fromType, undefined, target]);
+
+	// Get the link constraints that apply based on:
+	// 1. the type of the source card
+	// 2. the filtered target types
 	const allLinkTypeTargets = React.useMemo(() => {
-		return linkConstraints.reduce((acc: any, constraint) => {
-			if (constraint.data.from === cardsTypeBase) {
-				// Move the data.title property to the root of the object, as the rendition Select
-				// component can't use a non-root field for the `labelKey` prop
-				acc.push(
-					Object.assign({}, constraint, {
-						title: constraint.data.title,
-					}),
-				);
-			}
-			return acc;
-		}, []);
-	}, [cardsTypeBase]);
+		const cardTypes = _.castArray(cardType || validTypes);
+		return linkConstraints.reduce<linkUtils.LinkType[]>(
+			(acc: any, constraint) => {
+				if (
+					constraint.data.from === fromType &&
+					_.find(cardTypes, {
+						slug: constraint.data.to,
+					})
+				) {
+					// Move the data.title property to the root of the object, as the rendition Select
+					// component can't use a non-root field for the `labelKey` prop
+					acc.push(
+						Object.assign({}, constraint, {
+							title: constraint.data.title,
+						}),
+					);
+				}
+				return acc;
+			},
+			[],
+		);
+	}, [fromType, cardType, validTypes]);
 
-	const linkTypeSlugs = React.useMemo(() => {
-		return _.map(allLinkTypeTargets, 'data.to');
-	}, [allLinkTypeTargets]);
-
-	const targetTypeList = React.useMemo(() => {
-		return _.uniq(_.map(allLinkTypeTargets, 'title')).join(', ');
-	}, [allLinkTypeTargets]);
-
-	const unlinkCards = React.useCallback(async () => {
+	const onDone = React.useCallback(async () => {
 		setSubmitting(true);
 
-		const unlinkCard = async (card) => {
-			const constraint: any = _.find(linkConstraints, {
+		assert.ok(selectedTarget);
+
+		const unlinkCard = async (card: ContractSummary) => {
+			const constraint = _.find(linkConstraints, {
 				data: {
 					from: helpers.getTypeBase(card.type),
 					to: helpers.getTypeBase(selectedTarget.type),
 				},
 			});
-			await actions.removeLink(card, selectedTarget, constraint.name, {
+			await actions.removeLink(card, selectedTarget, constraint!.name, {
 				skipSuccessMessage: true,
 			});
 		};
@@ -75,97 +116,86 @@ export const UnlinkModal: React.FunctionComponent<any> = ({
 			`Removed ${pluralize('link', cards.length)}`,
 		);
 		setSubmitting(false);
+		setSelectedTarget(undefined);
 		onHide();
-	}, [cards, selectedTarget]);
-
-	// Adapt the selectedTarget state variable into an object
-	// structured in a way that the AutoCompleteCardSelect component
-	// knows how to render.
-	const selectedTargetValue = React.useMemo(() => {
-		if (!selectedTarget) {
-			return null;
-		}
-		const selectedTargetCardTypeIndex = _.findIndex(types, {
-			slug: helpers.getTypeBase(selectedTarget.type),
-		});
-
-		return {
-			value: selectedTarget.id,
-			label: selectedTarget.name || selectedTarget.slug,
-			type: types[selectedTargetCardTypeIndex].name,
-			shade: selectedTargetCardTypeIndex,
-		};
-	}, [selectedTarget, types]);
+	}, [cards, actions, selectedTarget]);
 
 	// We use a custom query callback for the AutoCompleteCardSelect
 	// as we need to filter on cards that are linked to all of the specified
 	// cards.
-	const getLinkedCardsQuery = React.useCallback(
-		(value) => {
-			return {
-				type: 'object',
-				anyOf: allLinkTypeTargets.map((constraint) => {
-					const revConstraint: any = getReverseConstraint(
-						constraint.data.from,
-						constraint.data.to,
-						constraint.name,
-					);
-					const toType = helpers.getType(constraint.data.to, types);
-					const query = {
-						type: 'object',
-						required: ['type'],
-						$$links: {
-							[revConstraint.name]: {
-								allOf: cards.map((card) => {
-									return {
-										type: 'object',
-										required: ['id'],
-										properties: {
-											id: {
-												const: card.id,
-											},
+	const getLinkedCardsQuery = (value: string) => {
+		return {
+			type: 'object',
+			anyOf: allLinkTypeTargets.map((constraint) => {
+				const revConstraint: LinkConstraint | undefined = getReverseConstraint(
+					constraint.data.from,
+					constraint.data.to,
+					constraint.name,
+				);
+				const toType = helpers.getType(constraint.data.to, allTypes);
+				const query = {
+					type: 'object',
+					required: ['type'],
+					$$links: {
+						[revConstraint!.name]: {
+							allOf: cards.map((card) => {
+								return {
+									type: 'object',
+									required: ['id'],
+									properties: {
+										id: {
+											const: card.id,
 										},
-									};
-								}),
-							},
+									},
+								};
+							}),
 						},
-						properties: {
-							type: {
-								const: `${toType.slug}@${toType.version}`,
-							},
+					},
+					properties: {
+						type: {
+							const: `${toType.slug}@${toType.version}`,
 						},
-					};
+					},
+				};
 
-					// Add full-text-search for the typed text (if set)
-					if (value) {
-						const filter = helpers.createFullTextSearchFilter(
-							toType.data.schema,
-							value,
-							{
-								fullTextSearchFieldsOnly: true,
-								includeIdAndSlug: true,
-							},
-						);
-						if (filter) {
-							_.merge(query, filter);
-						}
+				// Add full-text-search for the typed text (if set)
+				if (value) {
+					const filter = helpers.createFullTextSearchFilter(
+						toType.data.schema,
+						value,
+						{
+							fullTextSearchFieldsOnly: true,
+							includeIdAndSlug: true,
+						},
+					);
+					if (filter) {
+						_.merge(query, filter);
 					}
-					return query;
-				}),
-			};
-		},
-		[cards],
-	);
+				}
+				return query;
+			}),
+		};
+	};
 
-	const titleSource = `${pluralize('this', cards.length)} ${pluralize(
-		typeName,
-		cards.length,
-		cards.length > 1,
-	)}`;
+	// The title is constructed based on the props passed to the component
+	const title = React.useMemo(() => {
+		const typeName = fromTypeContract ? fromTypeContract.name : fromType;
+
+		const titleSource = `${pluralize('this', cards.length)} ${pluralize(
+			typeName,
+			cards.length,
+			cards.length > 1,
+		)}`;
+		return `Unlink ${titleSource} from another element`;
+	}, [fromTypeContract, cards]);
+
+	const selectedTargetValue = React.useMemo(() => {
+		return linkUtils.getContractSelectOption(allTypes, selectedTarget);
+	}, [allTypes, selectedTarget]);
 
 	return (
 		<Modal
-			title={`Unlink ${titleSource} from another element`}
+			title={title}
 			cancel={onHide}
 			primaryButtonProps={
 				{
@@ -174,19 +204,25 @@ export const UnlinkModal: React.FunctionComponent<any> = ({
 				} as any
 			}
 			action={submitting ? <Icon spin name="cog" /> : 'OK'}
-			done={unlinkCards}
+			done={onDone}
 		>
-			<Flex flexDirection="column">
-				<Txt>Look for the card types: {targetTypeList}</Txt>
-				<AutoCompleteCardSelect
-					autoFocus
-					getQueryFilter={getLinkedCardsQuery}
-					value={selectedTargetValue}
-					cardType={linkTypeSlugs}
-					isDisabled={Boolean(target)}
-					onChange={setSelectedTarget}
+			{!target && validTypes.length > 1 && (
+				<TypeFilter
+					types={validTypes}
+					activeFilter={cardType}
+					onSetType={setCardType}
+					mb={4}
 				/>
-			</Flex>
+			)}
+			<AutoCompleteCardSelect
+				placeholder="Search..."
+				autoFocus
+				getQueryFilter={getLinkedCardsQuery}
+				value={selectedTargetValue}
+				cardType={_.map(_.castArray(cardType || validTypes), 'slug')}
+				isDisabled={Boolean(target)}
+				onChange={setSelectedTarget}
+			/>
 		</Modal>
 	);
 };

--- a/apps/ui/lib/components/LinkModal/index.ts
+++ b/apps/ui/lib/components/LinkModal/index.ts
@@ -11,19 +11,26 @@ import { actionCreators, selectors } from '../../core';
 import { LinkModal as LinkModalInner } from './LinkModal';
 import { UnlinkModal as UnlinkModalInner } from './UnlinkModal';
 
-export const LinkModal = connect<any, any, any>(null, (dispatch) => {
-	return {
-		actions: bindActionCreators(
-			_.pick(actionCreators, ['createLink']),
-			dispatch,
-		),
-	};
-})(LinkModalInner);
+export const LinkModal = connect<any, any, any>(
+	(state) => {
+		return {
+			allTypes: selectors.getTypes(state),
+		};
+	},
+	(dispatch) => {
+		return {
+			actions: bindActionCreators(
+				_.pick(actionCreators, ['createLink']),
+				dispatch,
+			),
+		};
+	},
+)(LinkModalInner);
 
 export const UnlinkModal = connect<any, any, any>(
 	(state) => {
 		return {
-			types: selectors.getTypes(state),
+			allTypes: selectors.getTypes(state),
 		};
 	},
 	(dispatch) => {

--- a/apps/ui/lib/components/LinkModal/tests/LinkModal.spec.tsx
+++ b/apps/ui/lib/components/LinkModal/tests/LinkModal.spec.tsx
@@ -63,7 +63,7 @@ const mockAutoCompleteCardSelect = () => {
 	};
 	const autoCompleteCardSelectComponentStub = sandbox.stub(
 		AutoCompleteCardSelect,
-		'default',
+		'AutoCompleteCardSelect',
 	);
 	autoCompleteCardSelectComponentStub.callsFake((props) =>
 		FakeAutoCompleteCardSelect(props),

--- a/apps/ui/lib/components/LinkModal/tests/LinkModal.spec.tsx
+++ b/apps/ui/lib/components/LinkModal/tests/LinkModal.spec.tsx
@@ -107,6 +107,7 @@ describe('LinkModal', () => {
 			commonProps: {
 				onHide,
 				onSaved: sandbox.stub(),
+				allTypes: types,
 				actions: {
 					createLink: sandbox.stub().resolves(null),
 				},
@@ -122,7 +123,7 @@ describe('LinkModal', () => {
 		const { commonProps, onHidePromise, autoCompleteCallbacks } = context;
 
 		const linkModalComponent = await mount(
-			<LinkModal {...commonProps} cards={[card]} types={types} />,
+			<LinkModal {...commonProps} cards={[card]} targetTypes={types} />,
 			{
 				wrappingComponent: Wrapper,
 			},
@@ -141,7 +142,7 @@ describe('LinkModal', () => {
 		const { commonProps, onHidePromise, autoCompleteCallbacks } = context;
 
 		const linkModalComponent = await mount(
-			<LinkModal {...commonProps} cards={[card, card2]} types={types} />,
+			<LinkModal {...commonProps} cards={[card, card2]} targetTypes={types} />,
 			{
 				wrappingComponent: Wrapper,
 			},
@@ -168,7 +169,7 @@ describe('LinkModal', () => {
 				<LinkModal
 					{...commonProps}
 					cards={[card, orgInstanceCard]}
-					types={types}
+					targetTypes={types}
 				/>,
 				{
 					wrappingComponent: Wrapper,
@@ -176,4 +177,43 @@ describe('LinkModal', () => {
 			);
 		}).toThrow('All cards must be of the same type');
 	});
+
+	test('disables the select element if target is specified', async () => {
+		const { commonProps, onHidePromise } = context;
+
+		const linkModalComponent = await mount(
+			<LinkModal
+				{...commonProps}
+				cards={[card]}
+				targetTypes={types}
+				target={selectedTarget}
+			/>,
+			{
+				wrappingComponent: Wrapper,
+			},
+		);
+
+		const autoComplete = linkModalComponent
+			.find('AutoCompleteCardSelect')
+			.first();
+		expect(autoComplete.prop('isDisabled')).toBe(true);
+
+		submit(linkModalComponent);
+
+		await onHidePromise.promise;
+
+		verifyCard(commonProps, 0, card);
+	});
 });
+
+/**
+ * Scenarios:
+ *
+ * 1. Source and target are specified (disabled select), only one link
+ *    verb option (type filter not displayed)
+ * 2. Multiple target types (verify type buttons), simulate select
+ *    verify link type select, simulate link type select
+ * 3. Multiple target types - select type filter, simulate select
+ *    only one link verb option
+ *
+ */

--- a/apps/ui/lib/components/LinkModal/tests/UnlinkModal.spec.tsx
+++ b/apps/ui/lib/components/LinkModal/tests/UnlinkModal.spec.tsx
@@ -101,6 +101,7 @@ describe('UnlinkModal', () => {
 			autoCompleteCallbacks: mockAutoCompleteCardSelect(),
 			commonProps: {
 				onHide,
+				allTypes: types,
 				actions: {
 					removeLink: sandbox.stub().resolves(null),
 				},
@@ -116,7 +117,7 @@ describe('UnlinkModal', () => {
 		const { commonProps, onHidePromise, autoCompleteCallbacks } = context;
 
 		const unlinkModalComponent = await mount(
-			<UnlinkModal {...commonProps} cards={[card]} types={types} />,
+			<UnlinkModal {...commonProps} cards={[card]} targetTypes={types} />,
 			{
 				wrappingComponent: Wrapper,
 			},
@@ -137,7 +138,11 @@ describe('UnlinkModal', () => {
 		const { commonProps, onHidePromise, autoCompleteCallbacks } = context;
 
 		const unlinkModalComponent = await mount(
-			<UnlinkModal {...commonProps} cards={[card, card2]} types={types} />,
+			<UnlinkModal
+				{...commonProps}
+				cards={[card, card2]}
+				targetTypes={types}
+			/>,
 			{
 				wrappingComponent: Wrapper,
 			},
@@ -163,7 +168,7 @@ describe('UnlinkModal', () => {
 				<UnlinkModal
 					{...commonProps}
 					cards={[card, orgInstanceCard]}
-					types={types}
+					targetTypes={types}
 				/>,
 				{
 					wrappingComponent: Wrapper,

--- a/apps/ui/lib/components/LinkModal/tests/UnlinkModal.spec.tsx
+++ b/apps/ui/lib/components/LinkModal/tests/UnlinkModal.spec.tsx
@@ -63,7 +63,7 @@ const mockAutoCompleteCardSelect = () => {
 	};
 	const autoCompleteCardSelectComponentStub = sandbox.stub(
 		AutoCompleteCardSelect,
-		'default',
+		'AutoCompleteCardSelect',
 	);
 	autoCompleteCardSelectComponentStub.callsFake((props) =>
 		FakeAutoCompleteCardSelect(props),

--- a/apps/ui/lib/lens/common/Segment.tsx
+++ b/apps/ui/lib/lens/common/Segment.tsx
@@ -231,7 +231,7 @@ class Segment extends React.Component<any, any> {
 					<LinkModal
 						linkVerb={segment.link}
 						cards={[card]}
-						types={[type]}
+						targetTypes={[type]}
 						onHide={this.hideLinkModal}
 						onSave={onSave}
 						onSaved={this.getData}

--- a/apps/ui/lib/lens/misc/Chart/Chart.tsx
+++ b/apps/ui/lib/lens/misc/Chart/Chart.tsx
@@ -11,7 +11,7 @@ import * as flatten from 'flat';
 import styled, { createGlobalStyle } from 'styled-components';
 import { Button, Flex, Heading } from 'rendition';
 import { Icon, helpers } from '@balena/jellyfish-ui-components';
-import AutoCompleteCardSelect from '../../../components/AutoCompleteCardSelect';
+import { AutoCompleteCardSelect } from '../../../components/AutoCompleteCardSelect';
 import SaveCardButton from '../../../components/SaveCardButton';
 
 const NEW_CHART_CONFIGURATION_ID = '00000000-0000-0000-0000-000000000000';

--- a/apps/ui/lib/lens/misc/Table/CardTable.tsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.tsx
@@ -237,7 +237,7 @@ export default class CardTable extends React.Component<any, any> {
 					{showLinkModal === 'link' && (
 						<LinkModal
 							cards={checkedCards}
-							types={allTypes}
+							targetTypes={allTypes}
 							onHide={this.hideLinkModal}
 						/>
 					)}

--- a/apps/ui/lib/lens/misc/Table/tests/CardTable.spec.tsx
+++ b/apps/ui/lib/lens/misc/Table/tests/CardTable.spec.tsx
@@ -13,9 +13,13 @@ import props from './fixtures/props.json';
 
 const sandbox = sinon.createSandbox();
 
-const wrappingComponent = getWrapper().wrapper;
-
 const { channel, tail, page, totalPages, type, user, allTypes } = props;
+
+const wrappingComponent = getWrapper({
+	core: {
+		types: allTypes,
+	},
+}).wrapper;
 
 const mountCardTable = async (actions, setPageStub) => {
 	return mount(

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -4400,25 +4400,27 @@
       }
     },
     "assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
       "requires": {
-        "object-assign": "^4.1.1",
-        "util": "0.10.3"
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
         "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
           "requires": {
-            "inherits": "2.0.1"
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
           }
         }
       }
@@ -4491,6 +4493,11 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
       "integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ=="
+    },
+    "available-typed-arrays": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+      "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -8561,6 +8568,11 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -11806,7 +11818,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
       "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -11973,6 +11984,11 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-generator-function": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -12001,6 +12017,15 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
+    },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -12118,6 +12143,18 @@
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -15480,6 +15517,30 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
+        "assert": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+          "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+          "requires": {
+            "object-assign": "^4.1.1",
+            "util": "0.10.3"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "util": {
+              "version": "0.10.3",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+              "requires": {
+                "inherits": "2.0.1"
+              }
+            }
+          }
+        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -15738,7 +15799,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -22967,6 +23027,20 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf build",
     "build": "npm run clean && tsc",
-    "lint": "balena-lint lib test && depcheck --ignore-bin-package --ignores=@babel/*,canvas,history,depcheck,css-loader,file-loader,babel-loader,style-loader,webpack-cli,webpack-dev-server,@types/jest",
+    "lint": "balena-lint lib test && depcheck --ignore-bin-package --ignores=@babel/*,canvas,history,depcheck,css-loader,file-loader,babel-loader,style-loader,webpack-cli,webpack-dev-server,@types/jest,assert",
     "lint-fix": "balena-lint --fix lib test",
     "unit": "jest",
     "test": "catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run unit",
@@ -31,6 +31,7 @@
     "@balena/jellyfish-ui-components": "^9.2.6",
     "@primer/styled-octicons": "^14.1.0",
     "analytics-client": "^1.6.0",
+    "assert": "^2.0.0",
     "babel-loader": "^8.2.2",
     "bluebird": "^3.7.2",
     "classnames": "^2.3.1",

--- a/test/e2e/ui/guided-teardown.spec.js
+++ b/test/e2e/ui/guided-teardown.spec.js
@@ -114,7 +114,7 @@ ava.serial('You can teardown a support thread following a specific flow', async 
 
 	// Link to an existing Pattern
 	await macros.waitForThenClickSelector(page, selectors.linkPattern)
-	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"]')
+	await page.waitForSelector('[data-test="card-linker--existing__submit"]')
 	await page.type('.jellyfish-async-select__input input', pattern1Name)
 	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
 	await page.keyboard.press('Enter')

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -190,7 +190,7 @@ ava.serial('should let users create new opportunities and directly link existing
 
 	// Create new Link to Account
 	await macros.waitForThenClickSelector(page, '[data-test="link-to-account"]')
-	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"]')
+	await page.waitForSelector('[data-test="card-linker--existing__submit"]')
 	await page.type('.jellyfish-async-select__input input', 'test')
 	await page.waitForSelector('.jellyfish-async-select__option--is-focused')
 	await page.keyboard.press('Enter')

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -229,7 +229,7 @@ ava.serial('You should be able to link support threads to existing support issue
 
 	await macros.waitForThenClickSelector(page, '[data-test="card-linker-action--existing"]')
 
-	await macros.waitForThenClickSelector(page, '[data-test="card-linker--existing__input"] input:not(:disabled)')
+	await page.waitForSelector('.jellyfish-async-select__input input:not(:disabled)')
 
 	await page.type('.jellyfish-async-select__input input', name, {
 		delay: 300


### PR DESCRIPTION
This involves a re-write of the LinkModal component. It is now a functional component and shares much of its logic with UnlinkModal.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![Filter by type](https://user-images.githubusercontent.com/2925657/119962482-47497a80-bfd1-11eb-8113-a012e2b3ed98.gif)


