### PR TITLE
Add functionality to download view results as a CSV

### DIFF
--- a/apps/ui/lib/lens/full/View/index.tsx
+++ b/apps/ui/lib/lens/full/View/index.tsx
@@ -895,6 +895,7 @@ export class ViewRenderer extends React.Component<any, any> {
 					pageOptions={options}
 					setSortByField={this.setSortByField}
 					timelineFilter={TIMELINE_FILTER_PROP}
+					tail={tail}
 				/>
 				<Flex height="100%" minHeight="0" mt={filters.length ? 0 : 3}>
 					<Content

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -18816,6 +18816,11 @@
         }
       }
     },
+    "react-csv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.0.3.tgz",
+      "integrity": "sha512-exyAdFLAxtuM4wNwLYrlKyPYLiJ7e0mv9tqPAd3kq+k1CiJFtznevR3yP0icv5q/y200w+lzNgi7TQn1Wrhu0w=="
+    },
     "react-day-picker": {
       "version": "7.4.8",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.8.tgz",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -60,6 +60,7 @@
     "query-string": "^7.0.1",
     "react": "^16.14.0",
     "react-chart-editor": "^0.45.0",
+    "react-csv": "^2.0.3",
     "react-dnd": "^11.1.3",
     "react-dnd-html5-backend": "^11.1.3",
     "react-dom": "^16.14.0",


### PR DESCRIPTION
Adds a link to the View renderer that downloads the current tail as a CSV

![image](https://user-images.githubusercontent.com/15064535/120168040-5a895f80-c1f6-11eb-8960-799b2e9cde68.png)


Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
