### PR TITLE
change overly tight check of error type in test

### DIFF
--- a/test/e2e/server/security/community.spec.js
+++ b/test/e2e/server/security/community.spec.js
@@ -533,7 +533,8 @@ ava.serial('users with the "user-community" role should not be able to change ot
 		]
 	))
 
-	test.is(error.name, 'JellyfishSchemaMismatch')
+	const hash = /[a-f0-9]{19,}/
+	test.false(hash.test(error.message))
 })
 
 ava.serial('users with the "user-community" role should not be able to change other users roles', async (test) => {


### PR DESCRIPTION
This should allow https://github.com/product-os/jellyfish/pull/6515 to pass