### PR TITLE
Jellyfish: Set components pod count to 3.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jellyfish-action-server
 spec:
-  replicas: 12
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish
-  replicas: 16
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-livechat
-  replicas: 4
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-ui
-  replicas: 4
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
This is to have at least 1 pod per node in every AZ while avoiding
over-consumption of resources.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>
