### PR TITLE
Add doc generation to npm test script

### DIFF
--- a/apps/ui/lib/components/LinkModal/UnlinkModal.tsx
+++ b/apps/ui/lib/components/LinkModal/UnlinkModal.tsx
@@ -24,7 +24,7 @@ import * as linkUtils from './util';
 import { TypeFilter } from './TypeFilter';
 import { LinkConstraint } from '@balena/jellyfish-client-sdk/build/types';
 
-interface UnlinkModalProps {
+export interface UnlinkModalProps {
 	actions: {
 		removeLink: (
 			fromCard: ContractSummary,

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -13,7 +13,7 @@
     "lint": "balena-lint lib test && depcheck --ignore-bin-package --ignores=@babel/*,canvas,history,depcheck,css-loader,file-loader,babel-loader,style-loader,webpack-cli,webpack-dev-server,@types/jest,assert",
     "lint-fix": "balena-lint --fix lib test",
     "unit": "jest",
-    "test": "catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run unit",
+    "test": "npm run doc && catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run unit",
     "doc": "typedoc lib/",
     "prepack": "npm run build"
   },


### PR DESCRIPTION
This ensures that the document generation must pass in order for the tests to pass.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
