### PR TITLE
Do not generate docs as part of test

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -13,7 +13,7 @@
     "lint": "balena-lint lib test && depcheck --ignore-bin-package --ignores=@babel/*,canvas,history,depcheck,css-loader,file-loader,babel-loader,style-loader,webpack-cli,webpack-dev-server,@types/jest,assert",
     "lint-fix": "balena-lint --fix lib test",
     "unit": "jest",
-    "test": "npm run doc && catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run unit",
+    "test": "catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run unit",
     "doc": "typedoc lib/",
     "prepack": "npm run build"
   },


### PR DESCRIPTION
This is a temporary measure as Typedoc generation  will be broken when we upgrade to TypeScript v4.3 until Typedoc supports this version (should be very soon: https://github.com/TypeStrong/typedoc/issues/1589#issuecomment-850734031). At that point, we can re-instate this.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
