### PR TITLE
Fix error in test helper that would rerun commands unnecessarily

### DIFF
--- a/test/e2e/sdk/helpers.js
+++ b/test/e2e/sdk/helpers.js
@@ -26,26 +26,26 @@ exports.before = async (test) => {
 
 	test.context.token = session.id
 
-	test.context.executeThenWait = async (asyncFn, waitQuery, times = 20) => {
-		if (times === 0) {
-			throw new Error('The wait query did not resolve')
-		}
-
+	test.context.executeThenWait = async (asyncFn, waitQuery) => {
 		if (asyncFn) {
 			await asyncFn()
 		}
 
-		const results = await test.context.sdk.query(waitQuery)
+		return test.context.waitForMatch(waitQuery)
+	}
+
+	test.context.waitForMatch = async (query, times = 20) => {
+		if (times === 0) {
+			throw new Error('The wait query did not resolve')
+		}
+
+		const results = await test.context.sdk.query(query)
+
 		if (results.length > 0) {
 			return results[0]
 		}
-
 		await Bluebird.delay(1000)
-		return test.context.executeThenWait(null, waitQuery, times - 1)
-	}
-
-	test.context.waitForMatch = async (query, options = {}) => {
-		return test.context.executeThenWait(null, query, options.times)
+		return test.context.waitForMatch(query, times - 1)
 	}
 }
 

--- a/test/e2e/server/subscriptions.spec.js
+++ b/test/e2e/server/subscriptions.spec.js
@@ -21,6 +21,8 @@ ava('Should generate a notification if subscribed view filter matches inserted c
 		sdk
 	} = test.context
 
+	const identifier = uuidv4()
+
 	const view = await sdk.card.create({
 		name: 'Foos',
 		type: 'view@1.0.0',
@@ -39,7 +41,7 @@ ava('Should generate a notification if subscribed view filter matches inserted c
 							data: {
 								properties: {
 									baz: {
-										const: 'qux'
+										const: identifier
 									}
 								},
 								required: [
@@ -71,7 +73,7 @@ ava('Should generate a notification if subscribed view filter matches inserted c
 		type: 'card@1.0.0',
 		slug: `card-${uuidv4()}`,
 		data: {
-			baz: 'qux'
+			baz: identifier
 		}
 	})
 
@@ -108,6 +110,8 @@ ava('Should not generate a notification if subscribed view filter does not match
 		sdk
 	} = test.context
 
+	const identifier = uuidv4()
+
 	const view = await sdk.card.create({
 		name: 'Foos',
 		type: 'view@1.0.0',
@@ -126,7 +130,7 @@ ava('Should not generate a notification if subscribed view filter does not match
 							data: {
 								properties: {
 									baz: {
-										const: 'qux'
+										const: identifier
 									}
 								},
 								required: [
@@ -158,7 +162,7 @@ ava('Should not generate a notification if subscribed view filter does not match
 		type: 'card@1.0.0',
 		slug: `card-${uuidv4()}`,
 		data: {
-			baz: 'bar'
+			baz: 'foobarbaz'
 		}
 	})
 
@@ -185,15 +189,15 @@ ava('Should not generate a notification if subscribed view filter does not match
 				]
 			}
 		}
-	}, {
-		times: 1
-	}))
+	}, 3))
 })
 
 ava('Should not generate a notification if view is not subscribed, but filter matches inserted card', async (test) => {
 	const {
 		sdk
 	} = test.context
+
+	const identifier = uuidv4()
 
 	await sdk.card.create({
 		name: 'Foos',
@@ -213,7 +217,7 @@ ava('Should not generate a notification if view is not subscribed, but filter ma
 							data: {
 								properties: {
 									baz: {
-										const: 'qux'
+										const: identifier
 									}
 								},
 								required: [
@@ -236,7 +240,7 @@ ava('Should not generate a notification if view is not subscribed, but filter ma
 		type: 'card@1.0.0',
 		slug: `card-${uuidv4()}`,
 		data: {
-			baz: 'qux'
+			baz: identifier
 		}
 	})
 
@@ -263,7 +267,5 @@ ava('Should not generate a notification if view is not subscribed, but filter ma
 				]
 			}
 		}
-	}, {
-		times: 1
-	}))
+	}, 3))
 })


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

Everytime `executeThenWait` is run recursively, the async function it executes gets rerun, which is not intended.
