### PR TITLE
Display version of cards in UI

### DIFF
--- a/apps/ui/lib/layouts/CardLayout/index.tsx
+++ b/apps/ui/lib/layouts/CardLayout/index.tsx
@@ -36,19 +36,21 @@ const CardLayout = (props) => {
 
 	const typeBase = card.type && card.type.split('@')[0];
 
-	const typeName = _.get(
+	const typeContract =
 		_.find(types, {
 			slug: typeBase,
-		}),
-		['name'],
-		null,
-	);
+		}) || {};
+	const typeName =
+		!typeContract.version || typeContract.version === '1.0.0'
+			? typeContract.name
+			: `${typeContract.name} v${typeContract.version}`;
+	const versionSuffix = card.version === '1.0.0' ? '' : ` v${card.version}`;
 
 	return (
 		<LinksProvider sdk={sdk} cards={typeBase ? [card] : []} link="is owned by">
 			<Column
 				className={`column--${typeBase || 'unknown'} column--slug-${
-					card.slug || 'unkown'
+					card.slug || 'unknown'
 				}`}
 				overflowY={overflowY}
 				data-test={props['data-test']}
@@ -69,7 +71,10 @@ const CardLayout = (props) => {
 
 						{!title && (
 							<div>
-								<Heading.h4>{card.name || card.slug || card.type}</Heading.h4>
+								<Heading.h4>
+									{card.name || card.slug || card.type}
+									{versionSuffix}
+								</Heading.h4>
 
 								{Boolean(typeName) && (
 									<Txt color="text.light" fontSize="0">

--- a/apps/ui/lib/lens/snippet/SingleCard/SingleCard.tsx
+++ b/apps/ui/lib/lens/snippet/SingleCard/SingleCard.tsx
@@ -55,6 +55,9 @@ export default class SingleCard extends React.Component<any, any> {
 			0,
 		);
 
+		const versionSuffix =
+			card.version && card.version !== '1.0.0' ? ` v${card.version}` : '';
+
 		return (
 			<CardBox
 				active={active}
@@ -65,7 +68,7 @@ export default class SingleCard extends React.Component<any, any> {
 				<Flex justifyContent="space-between">
 					<Txt>
 						<Link to={helpers.appendToChannelPath(channel, card)}>
-							<strong>{card.name || card.slug}</strong>
+							<strong>{card.name || card.slug}</strong> {versionSuffix}
 						</Link>
 					</Txt>
 


### PR DESCRIPTION
show slug+version in the small type header and display the version in lists IF it's not a 1.0.0 version

Edit: note, the versions you see in the screenshot below are now only displayed for non 1.0.0 versions
![image](https://user-images.githubusercontent.com/167847/129016355-b286b23e-26fe-4153-ab37-ee51767b1e71.png)

Resolves https://github.com/product-os/jellyfish/issues/6399