### PR TITLE
Fix plugin-default nodemon watch path

### DIFF
--- a/apps/action-server/nodemon.json
+++ b/apps/action-server/nodemon.json
@@ -12,7 +12,7 @@
     "node_modules/@balena/jellyfish-mail/build/**/*.js",
     "node_modules/@balena/jellyfish-metrics/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-base/build/**/*.js",
-    "node_modules/@balena/jellyfish-plugin-default/build/**/*.js",
+    "node_modules/@balena/jellyfish-plugin-default/lib/**/*.js",
     "node_modules/@balena/jellyfish-plugin-product-os/build/**/*.js",
     "node_modules/@balena/jellyfish-queue/build/**/*.js",
     "node_modules/@balena/jellyfish-sync/build/**/*.js",

--- a/apps/server/nodemon.json
+++ b/apps/server/nodemon.json
@@ -12,7 +12,7 @@
     "node_modules/@balena/jellyfish-mail/build/**/*.js",
     "node_modules/@balena/jellyfish-metrics/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-base/build/**/*.js",
-    "node_modules/@balena/jellyfish-plugin-default/build/**/*.js",
+    "node_modules/@balena/jellyfish-plugin-default/lib/**/*.js",
     "node_modules/@balena/jellyfish-plugin-product-os/build/**/*.js",
     "node_modules/@balena/jellyfish-queue/build/**/*.js",
     "node_modules/@balena/jellyfish-sync/build/**/*.js",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Fix `nodemon` watch paths for `jellyfish-plugin-default`. We haven't converted this library to TypeScript yet, so we still need to watch it's `lib` directory, not `build`.
