### PR TITLE
Don't escalate privileges when mirroring or in action-broadcast

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -129,9 +129,9 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-11.1.5.tgz",
-      "integrity": "sha512-MM+PJNZP0/0LtdF+BtzOiym9CknquhgxPXCNulEvHBPxy7EifI5DBaY0HtTt46HmBCTBee+1UBSjsZTsVTBctQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-12.0.1.tgz",
+      "integrity": "sha512-uJ97qDiO0LRlNE34MAjov8i+sOZzSgphSW6L6kBDXK6zO5W8rN65nDflxG2h3L2qbI1C6cyzBL24N7Bj5VnPqg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.45",
         "@balena/jellyfish-environment": "^4.2.2",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -10,7 +10,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-action-library": "^11.1.5",
+    "@balena/jellyfish-action-library": "^12.0.1",
     "@balena/jellyfish-core": "^3.1.5",
     "@balena/jellyfish-environment": "^4.2.2",
     "@balena/jellyfish-logger": "^3.0.11",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -296,9 +296,9 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-11.1.5.tgz",
-      "integrity": "sha512-MM+PJNZP0/0LtdF+BtzOiym9CknquhgxPXCNulEvHBPxy7EifI5DBaY0HtTt46HmBCTBee+1UBSjsZTsVTBctQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-12.0.1.tgz",
+      "integrity": "sha512-uJ97qDiO0LRlNE34MAjov8i+sOZzSgphSW6L6kBDXK6zO5W8rN65nDflxG2h3L2qbI1C6cyzBL24N7Bj5VnPqg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.45",
         "@balena/jellyfish-environment": "^4.2.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,7 +19,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-action-library": "^11.1.5",
+    "@balena/jellyfish-action-library": "^12.0.1",
     "@balena/jellyfish-assert": "^1.1.45",
     "@balena/jellyfish-core": "^3.1.5",
     "@balena/jellyfish-environment": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,9 +222,9 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-11.1.5.tgz",
-      "integrity": "sha512-MM+PJNZP0/0LtdF+BtzOiym9CknquhgxPXCNulEvHBPxy7EifI5DBaY0HtTt46HmBCTBee+1UBSjsZTsVTBctQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-12.0.1.tgz",
+      "integrity": "sha512-uJ97qDiO0LRlNE34MAjov8i+sOZzSgphSW6L6kBDXK6zO5W8rN65nDflxG2h3L2qbI1C6cyzBL24N7Bj5VnPqg==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.45",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@balena/ci-task-runner": "^0.2.160",
-    "@balena/jellyfish-action-library": "^11.1.5",
+    "@balena/jellyfish-action-library": "^12.0.1",
     "@balena/jellyfish-chat-widget": "^8.0.104",
     "@balena/jellyfish-client-sdk": "^4.6.0",
     "@balena/jellyfish-config": "^1.3.0",


### PR DESCRIPTION
This is a precursor to https://github.com/product-os/jellyfish/pull/6563 where we will no longer escalate privileges when executing triggered action requests. It should (in theory) not make any difference to the current system.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
