### PR TITLE
Refactor front mirror tests

### DIFF
--- a/test/e2e/sdk/helpers.js
+++ b/test/e2e/sdk/helpers.js
@@ -34,7 +34,7 @@ exports.before = async (test) => {
 		return test.context.waitForMatch(waitQuery)
 	}
 
-	test.context.waitForMatch = async (query, times = 20) => {
+	test.context.waitForMatch = async (query, times = 100) => {
 		if (times === 0) {
 			throw new Error('The wait query did not resolve')
 		}

--- a/test/e2e/server/support.spec.js
+++ b/test/e2e/server/support.spec.js
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const randomWords = require('random-words')
+const helpers = require('../sdk/helpers')
+
+ava.serial.before(helpers.before)
+ava.serial.after.always(helpers.after)
+
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach.always(helpers.afterEach)
+
+const generateRandomWords = (number) => {
+	return randomWords(number).join(' ')
+}
+
+// TODO: These cases test the behaviour of a number triggered actions that are part of the
+// default plugin, and should be tested alongside the plugin instead of here
+ava('should close a thread with a #summary whisper', async (test) => {
+	const {
+		sdk
+	} = test.context
+	const thread = await sdk.card.create({
+		type: 'support-thread',
+		data: {
+			status: 'open'
+		}
+	})
+
+	await sdk.event.create({
+		target: thread,
+		type: 'whisper',
+		payload: {
+			message: `#summary ${generateRandomWords(5)}`
+		}
+	})
+
+	await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				const: thread.id
+			},
+			data: {
+				type: 'object',
+				required: [ 'status' ],
+				properties: {
+					status: {
+						const: 'closed'
+					}
+				}
+			}
+		}
+	})
+
+	// If a match was found the thread was closed successfully
+	test.pass()
+})
+
+ava('should re-open a closed support thread if an attached issue is closed', async (test) => {
+	const {
+		sdk
+	} = test.context
+	const issue = await sdk.card.create({
+		name: 'My issue',
+		type: 'issue',
+		data: {
+			repository: 'product-os/jellyfish-test-github',
+			description: 'Foo bar',
+			status: 'open'
+		}
+	})
+
+	const supportThread = await sdk.card.create({
+		type: 'support-thread',
+		data: {
+			status: 'closed'
+		}
+	})
+
+	await sdk.card.link(supportThread, issue, 'support thread is attached to issue')
+
+	// Close the issue, and then wait for the support thread to be re-opened
+	await sdk.card.update(issue.id, issue.type, [
+		{
+			op: 'replace',
+			path: '/data/status',
+			value: 'closed'
+		}
+	])
+
+	const newSupportThread = await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				const: supportThread.id
+			},
+			data: {
+				type: 'object',
+				required: [ 'status' ],
+				properties: {
+					status: {
+						const: 'open'
+					}
+				}
+			}
+		}
+	})
+
+	test.is(newSupportThread.data.status, 'open')
+})
+
+ava('should re-open a closed support thread if an attached pull request is closed', async (test) => {
+	const {
+		sdk
+	} = test.context
+	const pullRequest = await sdk.card.create({
+		name: 'My PR',
+		type: 'pull-request',
+		version: '1.0.0',
+		data: {
+			status: 'open'
+		}
+	})
+
+	const supportThread = await sdk.card.create({
+		type: 'support-thread',
+		data: {
+			status: 'closed'
+		}
+	})
+
+	await sdk.card.link(supportThread, pullRequest, 'support thread is attached to pull request')
+
+	// Close the PR, and then wait for the support thread to be re-opened
+	await sdk.card.update(pullRequest.id, pullRequest.type, [
+		{
+			op: 'replace',
+			path: '/data/status',
+			value: 'closed'
+		}
+	])
+
+	const newSupportThread = await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				const: supportThread.id
+			},
+			data: {
+				type: 'object',
+				required: [ 'status' ],
+				properties: {
+					status: {
+						const: 'open'
+					}
+				}
+			}
+		}
+	})
+
+	test.is(newSupportThread.data.status, 'open')
+})
+
+ava('should re-open a closed support thread if an attached pattern is closed', async (test) => {
+	const {
+		sdk
+	} = test.context
+	const pattern = await sdk.card.create({
+		name: 'My pattern',
+		type: 'pattern',
+		version: '1.0.0',
+		data: {
+			status: 'open'
+		}
+	})
+
+	const supportThread = await sdk.card.create({
+		type: 'support-thread',
+		data: {
+			status: 'closed'
+		}
+	})
+
+	await sdk.card.link(supportThread, pattern, 'has attached')
+
+	// Close the PR, and then wait for the support thread to be re-opened
+	await sdk.card.update(pattern.id, pattern.type, [
+		{
+			op: 'replace',
+			path: '/data/status',
+			value: 'closed'
+		}
+	])
+
+	const newSupportThread = await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				const: supportThread.id
+			},
+			data: {
+				type: 'object',
+				required: [ 'status' ],
+				properties: {
+					status: {
+						const: 'open'
+					}
+				}
+			}
+		}
+	})
+
+	test.is(newSupportThread.data.status, 'open')
+})
+
+ava('should re-open a closed support thread if a new message is added', async (test) => {
+	const {
+		sdk
+	} = test.context
+
+	const supportThread = await sdk.card.create({
+		type: 'support-thread',
+		data: {
+			status: 'closed'
+		}
+	})
+
+	// Add a new message to the thread, and then wait for the support thread to be re-opened
+	await sdk.event.create({
+		target: supportThread,
+		type: 'message',
+		payload: {
+			message: generateRandomWords(5)
+		}
+	})
+
+	const newSupportThread = await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				const: supportThread.id
+			},
+			data: {
+				type: 'object',
+				required: [ 'status' ],
+				properties: {
+					status: {
+						const: 'open'
+					}
+				}
+			}
+		}
+	})
+
+	test.is(newSupportThread.data.status, 'open')
+})


### PR DESCRIPTION
This change now tests triggered action behaviour seperately to front
interactions and adds additional checks for mirroring and editing
messages in front.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
