### PR TITLE
Fix bugged date comparison in Front inbox cleanup script

### DIFF
--- a/scripts/ci/front-delete-conversations.js
+++ b/scripts/ci/front-delete-conversations.js
@@ -91,7 +91,9 @@ const deleteConversation = async (context, inbox, conversation) => {
 	if (_.includes(context.deleted, conversation.id)) {
 		return
 	}
-	if (conversation.created_at <= BEFORE && conversation.status !== 'deleted') {
+
+	// `created_at` is in seconds and we want to compare it in ms
+	if (conversation.created_at * 1000 <= BEFORE && conversation.status !== 'deleted') {
 		try {
 			await context.front.conversation.update({
 				inbox_id: inbox,

--- a/scripts/ci/wait-for-api.sh
+++ b/scripts/ci/wait-for-api.sh
@@ -11,7 +11,7 @@
 
 set -eu
 
-ENDPOINT="$SERVER_HOST:$SERVER_PORT/ping"
+ENDPOINT="$SERVER_HOST:$SERVER_PORT/readiness"
 while :
 do
 	echo "Waiting for API at $ENDPOINT..."


### PR DESCRIPTION
When check front conversations, we were previously comparing the wrong unit
level: seconds to milliseconds.

This change also switches to the slightly more correct /readiness
endpoint when waiting for the API to start up in e2e tests.