### PR TITLE
Expose all relationships in tabs

### DIFF
--- a/apps/ui/lib/index.tsx
+++ b/apps/ui/lib/index.tsx
@@ -80,6 +80,10 @@ const customTheme: any = {
 		background: '#fff',
 		border: '#eee',
 	},
+	tab: {
+		// Keep tab height consistent with height of Select component
+		extend: `${Theme.tab.extend}; height: 32px;`,
+	},
 };
 
 const widgets: any = {

--- a/apps/ui/lib/lens/actions/EditLens.tsx
+++ b/apps/ui/lib/lens/actions/EditLens.tsx
@@ -11,6 +11,7 @@ import * as _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import * as redux from 'redux';
+import styled from 'styled-components';
 import { Box, Button, Flex, Heading, Form } from 'rendition';
 import {
 	notifications,
@@ -21,6 +22,10 @@ import CardLayout from '../../layouts/CardLayout';
 import * as skhema from 'skhema';
 import { actionCreators, analytics, sdk } from '../../core';
 import { getUiSchema, UI_SCHEMA_MODE } from '../schema-util';
+
+const FormBox = styled(Box)`
+	overflow-y: auto;
+`;
 
 export class EditLens extends React.Component<any, any> {
 	constructor(props) {
@@ -172,7 +177,6 @@ export class EditLens extends React.Component<any, any> {
 
 		return (
 			<CardLayout
-				overflowY
 				noActions
 				onClose={this.close}
 				card={card}
@@ -183,23 +187,24 @@ export class EditLens extends React.Component<any, any> {
 					</Heading.h4>
 				}
 			>
-				<Box p={3}>
-					<Form
-						uiSchema={uiSchema}
-						schema={schema}
-						value={editModel}
-						onFormChange={this.handleFormChange}
-						hideSubmitButton={true}
-					/>
+				<Flex flexDirection="column" minHeight={0}>
+					<FormBox p={3}>
+						<Form
+							uiSchema={uiSchema}
+							schema={schema}
+							value={editModel}
+							onFormChange={this.handleFormChange}
+							hideSubmitButton={true}
+						/>
 
-					<FreeFieldForm
-						schema={localSchema}
-						data={freeFieldData}
-						onDataChange={this.setFreeFieldData}
-						onSchemaChange={this.setLocalSchema}
-					/>
-
-					<Flex justifyContent="flex-end" mt={4}>
+						<FreeFieldForm
+							schema={localSchema}
+							data={freeFieldData}
+							onDataChange={this.setFreeFieldData}
+							onSchemaChange={this.setLocalSchema}
+						/>
+					</FormBox>
+					<Flex justifyContent="flex-end" my={3}>
 						<Button onClick={this.close} mr={2}>
 							Cancel
 						</Button>
@@ -213,7 +218,7 @@ export class EditLens extends React.Component<any, any> {
 							Submit
 						</Button>
 					</Flex>
-				</Box>
+				</Flex>
 			</CardLayout>
 		);
 	}

--- a/apps/ui/lib/lens/common/CustomQueryTab/CustomQueryTab.tsx
+++ b/apps/ui/lib/lens/common/CustomQueryTab/CustomQueryTab.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import { Tab } from 'rendition';
+import { helpers } from '@balena/jellyfish-ui-components';
+import Segment from '../Segment';
+
+export const CustomQueryTab: React.FunctionComponent<any> = ({
+	segment,
+	card,
+	types,
+	actions,
+}) => (
+	<Tab
+		title={segment.title}
+		key={segment.title}
+		data-test={`card-relationship-tab-${helpers.slugify(segment.title)}`}
+	>
+		<Segment card={card} segment={segment} types={types} actions={actions} />
+	</Tab>
+);

--- a/apps/ui/lib/lens/common/CustomQueryTab/index.tsx
+++ b/apps/ui/lib/lens/common/CustomQueryTab/index.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import memoize from 'memoize-one';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { selectors, actionCreators } from '../../../core';
+import { CustomQueryTab as InnerCustomQueryTab } from './CustomQueryTab';
+
+const mapStateToProps = (state, props) => {
+	return {
+		types: selectors.getTypes(state),
+	};
+};
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, ['getLinks', 'queryAPI', 'addChannel']),
+			dispatch,
+		),
+	};
+};
+
+export const CustomQueryTab = connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(InnerCustomQueryTab);
+
+const getCustomQueries = memoize((typeCard) => {
+	return _.filter(
+		_.get(typeCard, ['data', 'meta', 'relationships'], []),
+		'query',
+	);
+});
+
+export const customQueryTabs = (card, typeCard) => {
+	const customQueries = getCustomQueries(typeCard);
+	return customQueries.map((segment) => (
+		<CustomQueryTab key={segment.title} card={card} segment={segment} />
+	));
+};

--- a/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.spec.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.spec.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { getWrapper } from '../../../../test/ui-setup';
+import sinon from 'sinon';
+import React from 'react';
+import _ from 'lodash';
+import { mount } from 'enzyme';
+import { RelationshipsTab, getRelationships } from './RelationshipsTab';
+
+const wrappingComponent = getWrapper().wrapper;
+
+const sandbox = sinon.createSandbox();
+
+const type1 = {
+	slug: 'user',
+	name: 'User',
+};
+
+const type2 = {
+	slug: 'org',
+	name: 'Organization',
+};
+
+const card = {
+	slug: 'user-1',
+	type: 'user@1.0.0',
+};
+
+const types = [type1, type2];
+
+let context: any = {};
+
+describe('getRelationships', () => {
+	it('should return all relevant relationships', () => {
+		const relationships = getRelationships('issue');
+		const attachedMilestones = _.find(relationships, {
+			link: 'has attached',
+			type: 'milestone',
+		});
+		expect(attachedMilestones).not.toBeUndefined();
+	});
+
+	it('should default all counts to 0', () => {
+		const relationships = getRelationships('issue');
+		expect(_.every(relationships, { count: 0 })).toBe(true);
+	});
+
+	it('should return an empty array for unknown contract types', () => {
+		const relationships = getRelationships('this-is-not-a-type');
+		expect(relationships).toEqual([]);
+	});
+});
+
+// NOTE: Unit testing RelationshipsTab is limited because:
+//       1. The Grommet Select component doesn't seem to play nicely
+//          with enzyme - throwing an unhandled error 'onActivate is not a function'
+//          when the tab component is clicked.
+//       2. Enzyme can't access the state hook values of a functional
+//          component so you can't even test that the state is correct.
+describe('RelationshipsTab', () => {
+	beforeEach(() => {
+		context = {
+			defaultProps: {
+				viewData: undefined,
+				types,
+				card,
+				actions: {
+					loadViewData: sandbox.stub(),
+				},
+			},
+		};
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('loads view data when mounted', async () => {
+		const { defaultProps } = context;
+		await mount(<RelationshipsTab {...defaultProps} />, {
+			wrappingComponent,
+		});
+		expect(defaultProps.actions.loadViewData.callCount).toBe(1);
+	});
+});

--- a/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import pluralize from 'pluralize';
+import { Tab, Txt, Select, TxtProps } from 'rendition';
+import styled from 'styled-components';
+import { helpers, useDebounce } from '@balena/jellyfish-ui-components';
+import { linkConstraints } from '@balena/jellyfish-client-sdk';
+import Segment from '../Segment';
+import { Contract, TypeContract } from '@balena/jellyfish-types/build/core';
+import { JSONSchema } from 'rendition/dist/components/Renderer/types';
+
+const TabTitleSelect = styled(Select)`
+	input {
+		height: 24px;
+		padding: 0;
+		padding-left: 0;
+		padding-bottom: ${(props) => {
+			return helpers.px(props.theme.space[1]);
+		}};
+	}
+`;
+
+interface LinkRelationship {
+	count?: number;
+	title: string;
+	link: string;
+	type: string;
+}
+
+export const getViewId = (id: string): string => {
+	return `${id}-relationships`;
+};
+
+export const getRelationships = (typeSlug: string) => {
+	const relationships: LinkRelationship[] = [];
+	const typeSlugBase = helpers.getTypeBase(typeSlug);
+	return _.sortBy(
+		linkConstraints.reduce((acc, constraint) => {
+			if (constraint.data.from === typeSlugBase) {
+				acc.push({
+					title: pluralize(constraint.data.title),
+					link: constraint.name,
+					type: constraint.data.to,
+					count: 0,
+				});
+			}
+			return acc;
+		}, relationships),
+		['type', 'title'],
+	);
+};
+
+interface LinkDisplayProps extends TxtProps {
+	option?: LinkRelationship;
+}
+
+const LinkDisplay: React.FunctionComponent<LinkDisplayProps> = React.memo(
+	({ option, ...rest }) => {
+		return option ? (
+			<Txt
+				data-test="reltab_option"
+				data-test-count={option.count}
+				data-test-id={helpers.slugify(`${option.link}-${option.type}`)}
+				{...rest}
+			>
+				{`${option.title}${option.count ? ` (${option.count})` : ''}`}
+			</Txt>
+		) : (
+			<Txt data-test="reltab_placeholder" {...rest} color="text.light">
+				Links...
+			</Txt>
+		);
+	},
+);
+
+export interface RelationshipsTabProps {
+	viewData: any;
+	card: Contract;
+	types: TypeContract[];
+	actions: {
+		loadViewData: (query: JSONSchema, options: any) => void;
+	};
+}
+
+export const RelationshipsTab: React.FunctionComponent<RelationshipsTabProps> =
+	({ viewData, card, types, actions }) => {
+		const [activeRelationship, setActiveRelationship] =
+			React.useState<LinkRelationship>();
+		const [relationships, setRelationships] = React.useState<
+			LinkRelationship[]
+		>(getRelationships(card.type));
+		const [searchTerm, setSearchTerm] = React.useState<string>();
+		const debouncedSearchTerm = useDebounce(searchTerm, 300);
+
+		const filteredRelationships = React.useMemo(() => {
+			if (!debouncedSearchTerm) {
+				return relationships;
+			}
+			const searchRE = new RegExp(debouncedSearchTerm, 'i');
+			return relationships.filter((relationship) => {
+				return _.some(_.values(relationship) as string[], (field) => {
+					return searchRE.test(field);
+				});
+			});
+		}, [relationships, debouncedSearchTerm]);
+
+		// When the view data comes in, use it to populate the counts in the relationships
+		React.useEffect(() => {
+			if (!viewData || !viewData.length) {
+				return;
+			}
+			const newRelationships = _.cloneDeep(relationships);
+			const [cardWithLinks] = viewData;
+			if (cardWithLinks) {
+				newRelationships.forEach((relationship) => {
+					const links = _.get(cardWithLinks, ['links', relationship.link]);
+					if (links && links.length) {
+						const linkTypeBase = helpers.getTypeBase(links[0].type);
+						if (relationship.type === linkTypeBase) {
+							relationship.count = links.length;
+						}
+					}
+				});
+			}
+			setRelationships(
+				_.orderBy(
+					newRelationships,
+					['count', 'type', 'title'],
+					['desc', 'asc', 'asc'],
+				),
+			);
+		}, [viewData]);
+
+		// Fetch relationships as view data when the component loads
+		React.useEffect(() => {
+			const query: JSONSchema = {
+				description: `Fetch all contracts linked to ${card.slug}`,
+				type: 'object',
+				// HACK: Include type here to force linked contracts to return type (see issue #6602)
+				required: ['id', 'type'],
+				properties: {
+					id: {
+						const: card.id,
+					},
+				},
+				anyOf: relationships
+					.map((relationship) => {
+						return {
+							$$links: {
+								[relationship.link]: {
+									type: 'object',
+									required: ['type'],
+									additionalProperties: false,
+									properties: {
+										type: {
+											const: `${relationship.type}@1.0.0`,
+										},
+									},
+								},
+							},
+						} as JSONSchema;
+					})
+					.concat(true as JSONSchema),
+			};
+			actions.loadViewData(query, { limit: 1, viewId: getViewId(card.id) });
+		}, []);
+
+		return (
+			<Tab
+				title={
+					<TabTitleSelect
+						mr={-3}
+						data-test="reltab_select"
+						plain
+						placeholder="Links..."
+						searchPlaceholder="Search for links..."
+						emptySearchMessage="No matching links"
+						onSearch={setSearchTerm}
+						onClose={() => setSearchTerm('')}
+						onChange={({ option }) => {
+							setActiveRelationship(option as LinkRelationship);
+						}}
+						value={activeRelationship}
+						options={filteredRelationships || []}
+						valueLabel={
+							<LinkDisplay
+								option={activeRelationship}
+								pb={1}
+								data-test="reltab_value"
+							/>
+						}
+						labelKey={(option) => <LinkDisplay option={option} />}
+					/>
+				}
+				key="relationships"
+				data-test="card-relationships-tab"
+			>
+				{activeRelationship && (
+					<Segment
+						card={card}
+						segment={activeRelationship}
+						types={types}
+						actions={actions}
+					/>
+				)}
+			</Tab>
+		);
+	};

--- a/apps/ui/lib/lens/common/RelationshipsTab/__mocks__/index.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/__mocks__/index.tsx
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+export { getRelationships } from '../RelationshipsTab';
+
+export const RelationshipsTab = () => (
+	<div data-test="mock-relationships-tab"></div>
+);

--- a/apps/ui/lib/lens/common/RelationshipsTab/index.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/index.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import memoize from 'memoize-one';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { selectors, actionCreators } from '../../../core';
+import {
+	getViewId,
+	RelationshipsTab as InnerRelationshipsTab,
+} from './RelationshipsTab';
+
+export { getRelationships } from './RelationshipsTab';
+
+const mapStateToProps = (state, props) => {
+	const viewData = selectors.getViewData(state, getViewId(props.card.id));
+	return {
+		viewData,
+		types: selectors.getTypes(state),
+	};
+};
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, [
+				'loadViewData',
+				'getLinks',
+				'queryAPI',
+				'addChannel',
+			]),
+			dispatch,
+		),
+	};
+};
+
+export const RelationshipsTab = connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(InnerRelationshipsTab);

--- a/apps/ui/lib/lens/common/index.ts
+++ b/apps/ui/lib/lens/common/index.ts
@@ -6,3 +6,5 @@
 
 export { default as Segment } from './Segment';
 export { ViewFooter } from './ViewFooter';
+export * from './RelationshipsTab';
+export * from './CustomQueryTab';

--- a/apps/ui/lib/lens/full/MyUser/MyUser.tsx
+++ b/apps/ui/lib/lens/full/MyUser/MyUser.tsx
@@ -28,6 +28,7 @@ import {
 	Icon,
 	UserAvatar,
 } from '@balena/jellyfish-ui-components';
+import { RelationshipsTab, customQueryTabs } from '../../common';
 import CardLayout from '../../../layouts/CardLayout';
 
 const SLUG = 'lens-my-user';
@@ -195,7 +196,7 @@ export default class MyUser extends React.Component<any, any> {
 	}
 
 	render() {
-		const { channel, card: user } = this.props;
+		const { types, channel, card: user } = this.props;
 
 		const {
 			changePassword,
@@ -240,6 +241,8 @@ export default class MyUser extends React.Component<any, any> {
 		const emails = Array.isArray(user.data.email)
 			? user.data.email.join(', ')
 			: user.data.email;
+
+		const userTypeCard = helpers.getType('user', types);
 
 		return (
 			<CardLayout
@@ -374,6 +377,9 @@ export default class MyUser extends React.Component<any, any> {
 							</TextWithCopy>
 						</Box>
 					</Tab>
+
+					{customQueryTabs(user, userTypeCard)}
+					<RelationshipsTab card={user} />
 				</Tabs>
 			</CardLayout>
 		);

--- a/apps/ui/lib/lens/full/MyUser/tests/MyUser.spec.tsx
+++ b/apps/ui/lib/lens/full/MyUser/tests/MyUser.spec.tsx
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+jest.mock('../../../common/RelationshipsTab');
+
 import { getWrapper } from '../../../../../test/ui-setup';
 import '../../../../../test/react-select-mock';
 import sinon from 'sinon';

--- a/apps/ui/lib/lens/full/Repository/Repository.tsx
+++ b/apps/ui/lib/lens/full/Repository/Repository.tsx
@@ -20,7 +20,7 @@ import {
 } from 'rendition';
 import styled from 'styled-components';
 import { helpers, Icon } from '@balena/jellyfish-ui-components';
-import Segment from '../../common/Segment';
+import { RelationshipsTab, customQueryTabs } from '../../common';
 import CardFields from '../../../components/CardFields';
 import CardLayout from '../../../layouts/CardLayout';
 import { getContextualThreadsQuery, getLensBySlug } from '../../';
@@ -168,14 +168,11 @@ export default class RepositoryFull extends React.Component<any, any> {
 	}
 
 	render() {
-		const { actions, card, channel, types } = this.props;
+		const { card, channel, types } = this.props;
 		const { searchTerm, expanded } = this.state;
-		const type = _.find(types, {
-			slug: card.type.split('@')[0],
-		});
+		const type = helpers.getType(card.type, types);
 
 		const threadType = helpers.getType('thread', types);
-		const relationships = _.get(type, ['data', 'meta', 'relationships']);
 		const messages = _.sortBy(this.props.messages, 'created_at');
 
 		const Interleaved = getLensBySlug('lens-interleaved').data.renderer;
@@ -229,18 +226,8 @@ export default class RepositoryFull extends React.Component<any, any> {
 							</Box>
 						</Tab>
 
-						{_.map(relationships, (segment) => {
-							return (
-								<Tab title={segment.title} key={segment.title}>
-									<Segment
-										card={card}
-										segment={segment}
-										types={types}
-										actions={actions}
-									/>
-								</Tab>
-							);
-						})}
+						{customQueryTabs(card, type)}
+						<RelationshipsTab card={card} />
 					</SingleCardTabs>
 				)}
 

--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.tsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.tsx
@@ -15,6 +15,7 @@ import CardFields from '../../../components/CardFields';
 import CardLayout from '../../../layouts/CardLayout';
 import Timeline from '../../list/Timeline';
 import { UI_SCHEMA_MODE } from '../../schema-util';
+import { RelationshipsTab, customQueryTabs } from '../../common';
 
 export const SingleCardTabs = styled(Tabs)`
 	flex: 1;
@@ -60,11 +61,8 @@ export default class SingleCardFull extends React.Component<any, any> {
 	render() {
 		const { actions, card, channel, types, actionItems } = this.props;
 
-		const type = _.find(types, {
-			slug: card.type.split('@')[0],
-		});
+		const type = helpers.getType(card.type, types);
 
-		const relationships = _.get(type, ['data', 'meta', 'relationships']);
 		const tail = _.get(card.links, ['has attached element'], []);
 
 		// Never display a timeline segment for a user card. The `contact` card type
@@ -107,24 +105,8 @@ export default class SingleCardFull extends React.Component<any, any> {
 						</Tab>
 					)}
 
-					{_.map(relationships, (segment, index) => {
-						return (
-							<Tab
-								title={segment.title}
-								key={segment.title}
-								data-test={`card-relationship-tab-${helpers.slugify(
-									segment.title,
-								)}`}
-							>
-								<Segment
-									card={card}
-									segment={segment}
-									types={types}
-									actions={actions}
-								/>
-							</Tab>
-						);
-					})}
+					{customQueryTabs(card, type)}
+					<RelationshipsTab card={card} />
 				</SingleCardTabs>
 			</CardLayout>
 		);

--- a/apps/ui/lib/lens/full/TransformerWorker/TransformerWorker.tsx
+++ b/apps/ui/lib/lens/full/TransformerWorker/TransformerWorker.tsx
@@ -10,10 +10,10 @@ import React from 'react';
 import _ from 'lodash';
 import { Box, Heading, Flex, Tab, Table, Txt, Divider } from 'rendition';
 import { helpers } from '@balena/jellyfish-ui-components';
-import Segment from '../../common/Segment';
 import CardLayout from '../../../layouts/CardLayout';
 import { DeviceMetrics } from '../../../components/Metrics/DeviceMetrics';
 import { SingleCardTabs } from '../SingleCard';
+import { RelationshipsTab, customQueryTabs } from '../../common';
 
 export const SLUG = 'lens-full-transformer-worker';
 
@@ -56,13 +56,10 @@ export const TransformerWorker = ({
 }) => {
 	const [activeIndex, setActiveIndex] = React.useState(0);
 
-	const type = _.find(types, {
-		slug: card.type.split('@')[0],
-	});
+	const type = helpers.getType(card.type, types);
 
 	const os = _.get(card, ['data', 'os']);
 	const architecture = _.get(card, ['data', 'architecture']);
-	const relationships = _.get(type, ['data', 'meta', 'relationships']);
 
 	const metrics = React.useMemo(() => {
 		const cpuUsage = _.get(card, ['data', 'cpu_load']);
@@ -114,18 +111,9 @@ export const TransformerWorker = ({
 						/>
 					</Flex>
 				</Tab>
-				{_.map(relationships, (segment, index) => {
-					return (
-						<Tab title={segment.title} key={segment.title}>
-							<Segment
-								card={card}
-								segment={segment}
-								types={types}
-								actions={actions}
-							/>
-						</Tab>
-					);
-				})}
+
+				{customQueryTabs(card, type)}
+				<RelationshipsTab card={card} />
 			</SingleCardTabs>
 		</CardLayout>
 	);

--- a/apps/ui/lib/lens/full/User/User.spec.tsx
+++ b/apps/ui/lib/lens/full/User/User.spec.tsx
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+jest.mock('../../common/RelationshipsTab');
+
 import { getWrapper, flushPromises } from '../../../../test/ui-setup';
 import { mount } from 'enzyme';
 import sinon from 'sinon';

--- a/test/e2e/ui/sales.spec.js
+++ b/test/e2e/ui/sales.spec.js
@@ -79,8 +79,12 @@ ava.serial('should let users create new contacts attached to accounts', async (t
 	const {
 		page
 	} = context
+	await macros.waitForThenClickSelector(page, '[data-test="reltab_value"]')
+	await macros.waitForThenClickSelector(
+		page,
+		'[data-test="reltab_option"][data-test-id="has-contact"]'
+	)
 
-	await macros.waitForThenClickSelector(page, '[role="tablist"] [data-test="card-relationship-tab-contacts"]')
 	await macros.waitForThenClickSelector(page, '[data-test="add-contact"]')
 
 	const name = `test contact ${uuid()}`

--- a/test/e2e/ui/user-contract.spec.js
+++ b/test/e2e/ui/user-contract.spec.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const {
+	v4: uuid
+} = require('uuid')
+const environment = require('@balena/jellyfish-environment').defaultEnvironment
+const helpers = require('./helpers')
+const macros = require('./macros')
+
+const context = {
+	context: {
+		id: `UI-INTEGRATION-TEST-${uuid()}`
+	}
+}
+
+const user = helpers.generateUserDetails()
+
+ava.serial.before(async () => {
+	await helpers.browser.beforeEach({
+		context
+	})
+
+	// Create user and log in to the web browser client
+	context.communityUser = await context.createUser(user)
+	await context.addUserToBalenaOrg(context.communityUser.id)
+	await macros.loginUser(context.page, user)
+	context.balenaOrg = await context.sdk.card.get('org-balena')
+	await context.page.goto(`${environment.ui.host}:${environment.ui.port}/user-${user.username}`)
+})
+
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
+ava.serial.after.always(async () => {
+	await helpers.after({
+		context
+	})
+	await helpers.browser.afterEach({
+		context
+	})
+})
+
+ava.serial('A user\'s linked organization can be viewed on the links tab', async (test) => {
+	const {
+		page,
+		balenaOrg
+	} = context
+
+	// Open the Links tab drop-down
+	await macros.waitForThenClickSelector(page, '[data-test="reltab_value"]')
+	await page.waitForSelector('[data-test="reltab_option"]')
+	let linkOptions = await page.$$('[data-test="reltab_option"]')
+	test.true(linkOptions.length > 1)
+
+	// Search for 'Orgs'
+	await macros.setInputValue(page, 'input[placeholder="Search for links..."]', 'Orgs')
+
+	// Now there should only be one item in the list
+	await macros.waitForSelectorToDisappear(page, '[data-test="reltab_option"][data-test-id="owns-account"]')
+	linkOptions = await page.$$('[data-test="reltab_option"]')
+	test.is(linkOptions.length, 1)
+
+	// Select that option
+	await macros.waitForThenClickSelector(
+		page,
+		'[data-test="reltab_option"][data-test-id="is-member-of-org"][data-test-count="1"]'
+	)
+
+	// The selected link option is displayed in the tab title
+	const linkLabel = await macros.getElementText(page, '[data-test="reltab_value"]')
+	test.is(linkLabel, 'Orgs (1)')
+
+	// ...and the linked organization is rendered in the tab content
+	await page.waitForSelector(`[data-test-id="snippet-card-${balenaOrg.id}"]`)
+})


### PR DESCRIPTION
Abstract this functionality into a reusable RelationshipsTab component.

Also refactored the CreateLens and EditLens components to always display the submit and cancel buttons at the bottom and make the form itself scrollable. This should improve the UX as the user can always quickly press cancel or submit and it's clear (from the submit disabled state) whether the form data is valid.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Note: 'Custom' meta relationships defined in contract cards (e.g. ['Sales' in the user contract](https://github.com/product-os/jellyfish-core/blob/2b9982138fd5085fc108958df4cc57deae538102/lib/cards/user.ts#L350-L385)) are still rendered as their own tabs.

A follow-up task will be to remove the `withRelationships` mixin and all 'link' relationships that are explicitly defined in contract cards. The `Owned Conversations` custom query relationship can also be removed as you can access owned support threads and sales threads through the new 'Links' tab now.
 
![Relationships Tab](https://user-images.githubusercontent.com/2925657/121638819-cf418100-cab5-11eb-88bb-c0523d436bc3.gif)

Basic unit test added and a more comprehensive e2e test (as the `Select` component proved hard to unit test!)