### PR TITLE
Bump aws-sdk to v2.927.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -2149,9 +2149,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.912.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.912.0.tgz",
-      "integrity": "sha512-ImeMEC014AB9DMlS3X25G+y1Q/jGDwh7kOY+5AE0PBOMjDrQOYjfiqVYbFU2nZx57Uk7UVFclOb3Lty3hEz2gg==",
+      "version": "2.927.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.927.0.tgz",
+      "integrity": "sha512-S1dbpq26bQNYBQPHAsZBt0/L/e0FAWFdjjQoU3zdaVIXa08eA9d/oRI3kEs568ErJgBjwWU1CUUlr1byBxKjUQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,7 +36,7 @@
     "@balena/jellyfish-queue": "^1.0.150",
     "@balena/jellyfish-sync": "^6.0.232",
     "@balena/jellyfish-worker": "^5.0.27",
-    "aws-sdk": "^2.912.0",
+    "aws-sdk": "^2.927.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",
     "errio": "^1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2869,9 +2869,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.912.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.912.0.tgz",
-      "integrity": "sha512-ImeMEC014AB9DMlS3X25G+y1Q/jGDwh7kOY+5AE0PBOMjDrQOYjfiqVYbFU2nZx57Uk7UVFclOb3Lty3hEz2gg==",
+      "version": "2.927.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.927.0.tgz",
+      "integrity": "sha512-S1dbpq26bQNYBQPHAsZBt0/L/e0FAWFdjjQoU3zdaVIXa08eA9d/oRI3kEs568ErJgBjwWU1CUUlr1byBxKjUQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@octokit/plugin-throttling": "^3.4.3",
     "@octokit/rest": "^18.5.6",
     "ava": "^3.15.0",
-    "aws-sdk": "^2.912.0",
+    "aws-sdk": "^2.927.0",
     "bluebird": "^3.7.2",
     "blueimp-md5": "^2.18.0",
     "cli-spinner": "^0.2.10",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
