### PR TITLE
Bump typescript to v4.3.2

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -21074,9 +21074,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
     },
     "typo-js": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -114,7 +114,7 @@
     "ts-jest": "^26.5.6",
     "ts-loader": "^8.0.0",
     "typedoc": "^0.20.36",
-    "typescript": "^4.2.4",
+    "typescript": "^4.3.2",
     "webpack-cli": "^4.7.0",
     "webpack-dev-server": "^3.11.2",
     "workbox-core": "^6.1.5",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
