### PR TITLE
Use NODE_ENV=production in CI

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,7 +26,7 @@ services:
       - LOGLEVEL=crit
       - LIVECHAT_HOST=http://livechat
       - LIVECHAT_PORT=80
-      - NODE_ENV=test
+      - NODE_ENV
       - POSTGRES_DATABASE=jellyfish
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker

--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -4,6 +4,8 @@ attemptsDefault: 3
 environment:
   - name: 'AVA_OPTS'
     value: '--fail-fast'
+  - name: 'NODE_ENV'
+    value: 'production'
 tasks:
   - name: 'wait-for-api'
     description: 'Wait for API to be available'

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -156,7 +156,7 @@ ava.serial('should parse application/vnd.api+json bodies', async (test) => {
 	test.truthy(result.headers['x-api-id'])
 })
 
-if (environment.isProduction()) {
+if (environment.isProduction() && !environment.isCI()) {
 	ava.serial('should not login as the default test user', async (test) => {
 		const result = await test.context.http(
 			'POST', '/api/v2/action', {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Try setting `NODE_ENV=production` for CI testing.
