### PR TITLE
Remove redundant meta relationships

### DIFF
--- a/apps/ui/lib/components/LinkModal/tests/fixtures/org.json
+++ b/apps/ui/lib/components/LinkModal/tests/fixtures/org.json
@@ -1,15 +1,6 @@
 {
   "id": "11d22be7-1be3-493b-986f-54522b004c22",
   "data": {
-    "meta": {
-      "relationships": [
-        {
-          "link": "has member",
-          "type": "user",
-          "title": "Members"
-        }
-      ]
-    },
     "schema": {
       "type": "object",
       "required": [

--- a/apps/ui/lib/components/LinkModal/tests/fixtures/user.json
+++ b/apps/ui/lib/components/LinkModal/tests/fixtures/user.json
@@ -4,11 +4,6 @@
     "meta": {
       "relationships": [
         {
-          "link": "has attached contact",
-          "type": "contact",
-          "title": "Contact"
-        },
-        {
           "query": [
             {
               "type": "object",
@@ -87,41 +82,6 @@
             }
           ],
           "title": "Support"
-        },
-        {
-          "query": [
-            {
-              "type": "object",
-              "$$links": {
-                "is owned by": {
-                  "type": "object",
-                  "required": [
-                    "id"
-                  ],
-                  "properties": {
-                    "id": {
-                      "const": {
-                        "$eval": "result.id"
-                      }
-                    },
-                    "type": {
-                      "const": "user@1.0.0"
-                    }
-                  }
-                }
-              },
-              "properties": {
-                "type": {
-                  "enum": [
-                    "support-thread@1.0.0",
-                    "sales-thread@1.0.0"
-                  ]
-                }
-              },
-              "additionalProperties": true
-            }
-          ],
-          "title": "Owned conversations"
         }
       ]
     },

--- a/apps/ui/lib/lens/actions/CreateView/tests/fixtures/user.json
+++ b/apps/ui/lib/lens/actions/CreateView/tests/fixtures/user.json
@@ -4,11 +4,6 @@
       "meta": {
         "relationships": [
           {
-            "link": "has attached contact",
-            "type": "contact",
-            "title": "Contact"
-          },
-          {
             "query": [
               {
                 "type": "object",
@@ -87,41 +82,6 @@
               }
             ],
             "title": "Support"
-          },
-          {
-            "query": [
-              {
-                "type": "object",
-                "$$links": {
-                  "is owned by": {
-                    "type": "object",
-                    "required": [
-                      "id"
-                    ],
-                    "properties": {
-                      "id": {
-                        "const": {
-                          "$eval": "result.id"
-                        }
-                      },
-                      "type": {
-                        "const": "user@1.0.0"
-                      }
-                    }
-                  }
-                },
-                "properties": {
-                  "type": {
-                    "enum": [
-                      "support-thread@1.0.0",
-                      "sales-thread@1.0.0"
-                    ]
-                  }
-                },
-                "additionalProperties": true
-              }
-            ],
-            "title": "Owned conversations"
           }
         ]
       },

--- a/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.tsx
@@ -122,7 +122,10 @@ export const RelationshipsTab: React.FunctionComponent<RelationshipsTabProps> =
 					const links = _.get(cardWithLinks, ['links', relationship.link]);
 					if (links && links.length) {
 						const linkTypeBase = helpers.getTypeBase(links[0].type);
-						if (relationship.type === linkTypeBase) {
+						if (
+							relationship.type === linkTypeBase ||
+							relationship.type === '*'
+						) {
 							relationship.count = links.length;
 						}
 					}
@@ -157,11 +160,14 @@ export const RelationshipsTab: React.FunctionComponent<RelationshipsTabProps> =
 									type: 'object',
 									required: ['type'],
 									additionalProperties: false,
-									properties: {
-										type: {
-											const: `${relationship.type}@1.0.0`,
-										},
-									},
+									properties:
+										relationship.type === '*'
+											? {}
+											: {
+													type: {
+														const: `${relationship.type}@1.0.0`,
+													},
+											  },
 								},
 							},
 						} as JSONSchema;

--- a/apps/ui/lib/lens/common/Segment.tsx
+++ b/apps/ui/lib/lens/common/Segment.tsx
@@ -83,7 +83,7 @@ class Segment extends React.Component<any, any> {
 				},
 				card,
 				segment.link,
-				`${segment.type}@1.0.0`,
+				segment.type === '*' ? 'undefined@1.0.0' : `${segment.type}@1.0.0`,
 			);
 			this.updateResults(results);
 		} else if (segment.query) {

--- a/apps/ui/lib/lens/misc/CRMTable/tests/fixtures/props.json
+++ b/apps/ui/lib/lens/misc/CRMTable/tests/fixtures/props.json
@@ -353,15 +353,6 @@
         "requires": [],
         "capabilities": [],
         "data": {
-            "meta": {
-                "relationships": [
-                    {
-                        "link": "is attached to",
-                        "type": "account",
-                        "title": "Account"
-                    }
-                ]
-            },
             "schema": {
                 "type": "object",
                 "properties": {

--- a/apps/ui/lib/lens/misc/Table/tests/fixtures/props.json
+++ b/apps/ui/lib/lens/misc/Table/tests/fixtures/props.json
@@ -1163,22 +1163,6 @@
     "requires": [],
     "capabilities": [],
     "data": {
-      "meta": {
-        "relationships": [
-          {
-            "link": "has attached",
-            "type": "opportunity",
-            "title": "Opportunities"
-          },
-          { "link": "has", "type": "contact", "title": "Contacts" },
-          { "link": "is owned by", "type": "user", "title": "Owner" },
-          {
-            "link": "has backup owner",
-            "type": "user",
-            "title": "Backup owners"
-          }
-        ]
-      },
       "schema": {
         "type": "object",
         "required": ["name", "data"],
@@ -1361,22 +1345,6 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "meta": {
-          "relationships": [
-            {
-              "link": "has attached",
-              "type": "opportunity",
-              "title": "Opportunities"
-            },
-            { "link": "has", "type": "contact", "title": "Contacts" },
-            { "link": "is owned by", "type": "user", "title": "Owner" },
-            {
-              "link": "has backup owner",
-              "type": "user",
-              "title": "Backup owners"
-            }
-          ]
-        },
         "schema": {
           "type": "object",
           "required": ["name", "data"],

--- a/apps/ui/test/fixtures/types/account.json
+++ b/apps/ui/test/fixtures/types/account.json
@@ -1,30 +1,6 @@
 {
   "id": "9397c2d7-f27c-463c-9982-608896a897b2",
   "data": {
-    "meta": {
-      "relationships": [
-        {
-          "link": "has attached",
-          "type": "opportunity",
-          "title": "Opportunities"
-        },
-        {
-          "link": "has",
-          "type": "contact",
-          "title": "Contacts"
-        },
-        {
-          "link": "is owned by",
-          "type": "user",
-          "title": "Owner"
-        },
-        {
-          "link": "has backup owner",
-          "type": "user",
-          "title": "Backup owners"
-        }
-      ]
-    },
     "schema": {
       "type": "object",
       "required": [

--- a/apps/ui/test/fixtures/types/contact.json
+++ b/apps/ui/test/fixtures/types/contact.json
@@ -4,21 +4,6 @@
     "meta": {
       "relationships": [
         {
-          "link": "is member of",
-          "type": "account",
-          "title": "Account"
-        },
-        {
-          "link": "is owned by",
-          "type": "user",
-          "title": "Owner"
-        },
-        {
-          "link": "has backup owner",
-          "type": "user",
-          "title": "Backup owners"
-        },
-        {
           "query": [
             {
               "link": "is attached to user",

--- a/apps/ui/test/fixtures/types/org.json
+++ b/apps/ui/test/fixtures/types/org.json
@@ -1,15 +1,6 @@
 {
   "id": "11d22be7-1be3-493b-986f-54522b004c22",
   "data": {
-    "meta": {
-      "relationships": [
-        {
-          "link": "has member",
-          "type": "user",
-          "title": "Members"
-        }
-      ]
-    },
     "schema": {
       "type": "object",
       "required": [

--- a/apps/ui/test/fixtures/types/user.json
+++ b/apps/ui/test/fixtures/types/user.json
@@ -4,11 +4,6 @@
     "meta": {
       "relationships": [
         {
-          "link": "has attached contact",
-          "type": "contact",
-          "title": "Contact"
-        },
-        {
           "query": [
             {
               "type": "object",
@@ -87,41 +82,6 @@
             }
           ],
           "title": "Support"
-        },
-        {
-          "query": [
-            {
-              "type": "object",
-              "$$links": {
-                "is owned by": {
-                  "type": "object",
-                  "required": [
-                    "id"
-                  ],
-                  "properties": {
-                    "id": {
-                      "const": {
-                        "$eval": "result.id"
-                      }
-                    },
-                    "type": {
-                      "const": "user@1.0.0"
-                    }
-                  }
-                }
-              },
-              "properties": {
-                "type": {
-                  "enum": [
-                    "support-thread@1.0.0",
-                    "sales-thread@1.0.0"
-                  ]
-                }
-              },
-              "additionalProperties": true
-            }
-          ],
-          "title": "Owned conversations"
         }
       ]
     },


### PR DESCRIPTION
These are now materialized automatically on the front-end using link constraints.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***