### PR TITLE
Fix pgp import

### DIFF
--- a/scripts/postgres-delete-test-databases.js
+++ b/scripts/postgres-delete-test-databases.js
@@ -6,7 +6,7 @@
  * Proprietary and confidential.
  */
 
-const pgp = require('@balena/jellyfish-core/lib/backend/postgres/pg-promise')
+const pgp = require('@balena/jellyfish-core/build/backend/postgres/pg-promise').default
 const Bluebird = require('bluebird')
 const Spinner = require('cli-spinner').Spinner
 const environment = require('@balena/jellyfish-environment').defaultEnvironment


### PR DESCRIPTION
Change-type: patch

***

After rewriting jellyfish-core to ts, module path is `/build` instead of `/lib`.

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
