### PR TITLE
Livepush: Ignore lib TypeScript source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,6 @@ postgres_data
 **/package*.json.*
 .libs/*/package*.json
 .libs/*/*.tgz*
+.libs/*/lib
+# TS-TODO: remove this once plugin-default is TypeScript
+!.libs/jellyfish-plugin-default/lib


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

These changes should stop TypeScript source located under libs from being watched by Livepush. `build/` is still watched and copied into containers. The only exception to this is `jellyfish-plugin-default` as it has not yet been converted to TypeScript. The last line referring to `jellyfish-plugin-default` should be removed once it has been converted to TypeScript.