### PR TITLE
Ignore slice filtering if lens supports slices

### DIFF
--- a/apps/ui/lib/lens/full/View/Header/index.tsx
+++ b/apps/ui/lib/lens/full/View/Header/index.tsx
@@ -71,11 +71,13 @@ export default class Header extends React.Component<any, any> {
 								justifyContent="flex-end"
 								minWidth={['100%', '100%', 'auto']}
 							>
-								<SliceOptions
-									sliceOptions={sliceOptions}
-									activeSlice={activeSlice}
-									setSlice={setSlice}
-								/>
+								{!lens.data.supportsSlices && (
+									<SliceOptions
+										sliceOptions={sliceOptions}
+										activeSlice={activeSlice}
+										setSlice={setSlice}
+									/>
+								)}
 								<LensSelection
 									ml={3}
 									lenses={lenses}

--- a/apps/ui/lib/lens/full/View/tests/index.spec.tsx
+++ b/apps/ui/lib/lens/full/View/tests/index.spec.tsx
@@ -39,13 +39,20 @@ const lenses = [
 			renderer: _.constant(null),
 		},
 	},
+	{
+		slug: 'lens-kanban',
+		data: {
+			supportsSlices: true,
+			renderer: _.constant(null),
+		},
+	},
 ];
 
 const types = [supportThreadType];
 
 let context: any = {};
 
-describe('SupportThreads lens', () => {
+describe('View lens', () => {
 	beforeEach(() => {
 		context = {
 			commonProps: {
@@ -104,7 +111,6 @@ describe('SupportThreads lens', () => {
 		expect(wrapper.state().filters).toEqual([
 			{
 				$id: 'properties.data.properties.status',
-				type: 'object',
 				anyOf: [
 					{
 						$id: 'properties.data.properties.status',
@@ -116,7 +122,6 @@ describe('SupportThreads lens', () => {
 								properties: {
 									status: {
 										const: 'archived',
-										title: 'status',
 									},
 								},
 							},
@@ -178,5 +183,49 @@ describe('SupportThreads lens', () => {
 		);
 
 		expect(wrapper.state().activeLens).toBe('lens-chart');
+	});
+
+	test('Slice filter is ignored if lens supports slices', () => {
+		const { commonProps } = context;
+
+		// First load with a lens that does *not* support slices
+		let wrapper = shallow(
+			<ViewRenderer
+				{...commonProps}
+				lenses={lenses}
+				userActiveLens="lens-chart"
+			/>,
+		);
+
+		expect(wrapper.state().activeLens).toBe('lens-chart');
+		let filters = wrapper.state().filters;
+		let sliceFilter = filters.find((filter) => {
+			return (
+				_.get(filter, ['anyOf', 0, '$id']) ===
+				'properties.data.properties.status'
+			);
+		});
+		// An active slice filter is set
+		expect(sliceFilter).not.toBeUndefined();
+
+		// Now load with a lens that *does* support slices
+		wrapper = shallow(
+			<ViewRenderer
+				{...commonProps}
+				lenses={lenses}
+				userActiveLens="lens-kanban"
+			/>,
+		);
+
+		expect(wrapper.state().activeLens).toBe('lens-kanban');
+		filters = wrapper.state().filters;
+		sliceFilter = filters.find((filter) => {
+			return (
+				_.get(filter, ['anyOf', 0, '$id']) ===
+				'properties.data.properties.status'
+			);
+		});
+		// A slice filter is *not* set
+		expect(sliceFilter).toBeUndefined();
 	});
 });


### PR DESCRIPTION
If the lens defines `data.supportsSlices: true` then we:
a) hide the slice filter drop-down
b) remove the slice filter from the list of active filters

We need to (re)calculate filters based on the active slice and lens when the view component is loaded and whenever the lens is changed.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes #6669 

![Kanban ignores slice filter](https://user-images.githubusercontent.com/2925657/122355651-45455c80-cf7c-11eb-949e-94bdf60740ed.gif)
