### PR TITLE
Bump jellyfish-assert to v1.1.49

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -336,9 +336,9 @@
       }
     },
     "@balena/jellyfish-assert": {
-      "version": "1.1.46",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.46.tgz",
-      "integrity": "sha512-TFVikpMxp7geDwk33RnWlqa5Hhb3kBFo4DrhkI+fyxmeJqGeOt1E9By6udp5osnYsK5eTb09IsuQwz1VqPkjWw==",
+      "version": "1.1.49",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.49.tgz",
+      "integrity": "sha512-Sq0PVVODfMuaMR9VUI+CcSG1IUEXY8FgNCEq3/+mOd7E4OE7LjyCiYOiu/ymIbmRUQCSKkeulznbKsPBDZbucA==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,7 +20,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-action-library": "^13.0.30",
-    "@balena/jellyfish-assert": "^1.1.46",
+    "@balena/jellyfish-assert": "^1.1.49",
     "@balena/jellyfish-core": "^3.1.12",
     "@balena/jellyfish-environment": "^4.2.3",
     "@balena/jellyfish-logger": "^3.0.14",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
