### PR TITLE
Bump ci-task-runner to v0.2.168

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,9 @@
       }
     },
     "@balena/ci-task-runner": {
-      "version": "0.2.163",
-      "resolved": "https://registry.npmjs.org/@balena/ci-task-runner/-/ci-task-runner-0.2.163.tgz",
-      "integrity": "sha512-SUnbMFunjTckp2xo6QoYs1/vH7/xkKr86iPkI76DD532Rm5mGvMJlW+eYZXmHeRdLaE+YtmywlRLu5OzLOC6Kg==",
+      "version": "0.2.168",
+      "resolved": "https://registry.npmjs.org/@balena/ci-task-runner/-/ci-task-runner-0.2.168.tgz",
+      "integrity": "sha512-/gbaviAez9nmCKex/26oUzfQIruezDtl89uO1yompNdOqQN4jzHmqNY+zzvBHdQhU2DrevbhqdfpRRsy3gWuaA==",
       "dev": true,
       "requires": {
         "fkill": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "devDependencies": {
-    "@balena/ci-task-runner": "^0.2.163",
+    "@balena/ci-task-runner": "^0.2.168",
     "@balena/jellyfish-action-library": "^13.0.30",
     "@balena/jellyfish-chat-widget": "^8.0.107",
     "@balena/jellyfish-client-sdk": "^5.0.1",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
