### PR TITLE
Run a reduced set of tests against prior Postgres dumps

### DIFF
--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -113,10 +113,13 @@ tasks:
     dependencies:
       - 'postgres-export'
   - name: 'e2e-server-previous-dump'
-    description: 'E2E Server Tests (Previous Dump)'
-    command: 'make test-e2e-server'
+    description: 'E2E Server Smoke Tests (Previous Dump)'
+    command: 'make test'
     cwd: '/usr/src/jellyfish'
     required: true
+    environment:
+      - name: 'FILES'
+        value: './test/e2e/server/index.spec.js'
     dependencies:
       - 'postgres-import'
   - name: 'summary'


### PR DESCRIPTION
The intention of running the tests against a previous dump of the DB is
to rule out a category of errors where basic operations would fail when
bootstrapping the stack with a pre-existing database. As such we only
need to run a limited set of smoke tests to verify this.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
