### PR TITLE
Remove unnecessary wait helper from discourse tests

### DIFF
--- a/test/e2e/sync/discourse-mirror.spec.js
+++ b/test/e2e/sync/discourse-mirror.spec.js
@@ -206,11 +206,7 @@ ava.before(async (test) => {
 			}
 		})
 
-		await test.context.waitForThreadSyncWhisper(result.id)
-
-		return test.context.sdk.getById(result.id, {
-			type: 'support-thread'
-		})
+		return test.context.sdk.getById(result.id)
 	}
 })
 

--- a/test/e2e/sync/helpers.js
+++ b/test/e2e/sync/helpers.js
@@ -12,46 +12,6 @@ const helpers = require('../sdk/helpers')
 exports.mirror = {
 	before: async (test) => {
 		await helpers.before(test)
-
-		test.context.waitForThreadSyncWhisper = async (threadId) => {
-			return test.context.waitForMatch({
-				type: 'object',
-				required: [ 'type', 'data' ],
-				properties: {
-					data: {
-						type: 'object',
-						required: [ 'target', 'payload' ],
-						additionalProperties: false,
-						properties: {
-							target: {
-								const: threadId
-							},
-							mirrors: {
-								type: 'array',
-								items: {
-									type: 'string',
-									pattern: '^https:\\/\\/forums\\.balena\\.io'
-								}
-							},
-							payload: {
-								type: 'object',
-								required: [ 'message' ],
-								additionalProperties: false,
-								properties: {
-									message: {
-										type: 'string',
-										pattern: 'This thread is synced to Jellyfish'
-									}
-								}
-							}
-						}
-					},
-					type: {
-						const: 'whisper@1.0.0'
-					}
-				}
-			})
-		}
 	},
 	after: async (test) => {
 		await helpers.after(test)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
