### PR TITLE
GitHub mirror test refactor

### DIFF
--- a/test/e2e/server/issues.spec.js
+++ b/test/e2e/server/issues.spec.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const randomWords = require('random-words')
+const helpers = require('../sdk/helpers')
+const environment = require('@balena/jellyfish-environment').defaultEnvironment
+
+ava.serial.before(helpers.before)
+ava.serial.after.always(helpers.after)
+
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach.always(helpers.afterEach)
+
+const generateRandomWords = (number) => {
+	return randomWords(number).join(' ')
+}
+
+// TODO: These cases test the behaviour of a number triggered actions that are part of the
+// default plugin, and should be tested alongside the plugin instead of here
+ava('linking a support thread to an issue results in a message on that issue\'s timeline', async (test) => {
+	const issue = await test.context.sdk.card.create({
+		name: `Test Issue: ${randomWords(3)}`,
+		type: 'issue',
+		data: {
+			repository: environment.test.integration.github.repo,
+			description: generateRandomWords(5),
+			status: 'open',
+			archived: false
+		}
+	})
+
+	const supportThread = await test.context.sdk.card.create({
+		type: 'support-thread',
+		name: 'test subject',
+		data: {
+			product: 'test-product',
+			inbox: 'S/Paid_Support',
+			status: 'open'
+		}
+	})
+
+	await test.context.sdk.card.link(supportThread, issue, 'support thread is attached to issue')
+
+	await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'type', 'data' ],
+		properties: {
+			type: {
+				const: 'message@1.0.0'
+			},
+			data: {
+				type: 'object',
+				required: [ 'payload' ],
+				properties: {
+					payload: {
+						type: 'object',
+						required: [ 'message' ],
+						properties: {
+							message: {
+								regexp: {
+									pattern: 'This issue has attached support thread'
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				required: [ 'id' ],
+				properties: {
+					id: {
+						const: issue.id
+					}
+				}
+			}
+		}
+	})
+
+	// If the wait query resolved, the message was generated successfully
+	test.pass()
+})

--- a/test/e2e/sync/github-mirror.spec.js
+++ b/test/e2e/sync/github-mirror.spec.js
@@ -10,6 +10,7 @@ const Bluebird = require('bluebird')
 const {
 	v4: uuid
 } = require('uuid')
+const randomWords = require('random-words')
 const {
 	retry
 } = require('@octokit/plugin-retry')
@@ -49,47 +50,7 @@ const getMirrorWaitSchema = (slug) => {
 	}
 }
 
-const getSyncMessage = (targetId, message) => {
-	return {
-		type: 'object',
-		required: [ 'type', 'data' ],
-		properties: {
-			type: {
-				const: 'message@1.0.0'
-			},
-			data: {
-				type: 'object',
-				required: [ 'payload' ],
-				properties: {
-					payload: {
-						type: 'object',
-						required: [ 'message' ],
-						properties: {
-							message: {
-								regexp: {
-									pattern: message
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		$$links: {
-			'is attached to': {
-				type: 'object',
-				required: [ 'id' ],
-				properties: {
-					id: {
-						const: targetId
-					}
-				}
-			}
-		}
-	}
-}
-
-ava.serial.before(async (test) => {
+ava.before(async (test) => {
 	await helpers.mirror.before(test)
 
 	const [ owner, repo ] = environment.test.integration.github.repo.split('/')
@@ -98,50 +59,32 @@ ava.serial.before(async (test) => {
 		repo: repo.trim()
 	}
 
-	test.context.getIssueSlug = () => {
-		return test.context.generateRandomSlug({
-			prefix: 'issue'
+	test.context.createIssue = async (repository, title, options) => {
+		const issue = await test.context.sdk.card.create({
+			name: title,
+			slug: test.context.generateRandomSlug({
+				prefix: 'issue'
+			}),
+			type: 'issue',
+			data: {
+				repository: `${repository.owner}/${repository.repo}`,
+				description: options.body,
+				status: options.status,
+				archived: options.archived
+			}
 		})
+		return test.context.waitForMatch(getMirrorWaitSchema(issue.slug))
 	}
 
-	test.context.getMessageSlug = () => {
-		return test.context.generateRandomSlug({
-			prefix: 'message'
+	test.context.createMessage = async (target, body) => {
+		const message = await test.context.sdk.event.create({
+			target,
+			type: 'message',
+			payload: {
+				message: body
+			}
 		})
-	}
-
-	test.context.createIssue = async (repository, slug, title, options) => {
-		return test.context.executeThenWait(async () => {
-			return test.context.sdk.card.create({
-				name: title,
-				slug,
-				type: 'issue',
-				version: '1.0.0',
-				data: {
-					repository: `${repository.owner}/${repository.repo}`,
-					mentionsUser: [],
-					alertsUser: [],
-					description: options.body,
-					status: options.status,
-					archived: options.archived
-				}
-			})
-		}, getMirrorWaitSchema(slug))
-	}
-
-	test.context.createMessage = async (target, slug, body) => {
-		return test.context.executeThenWait(async () => {
-			return test.context.sdk.event.create({
-				target,
-				type: 'message',
-				slug,
-				payload: {
-					mentionsUser: [],
-					alertsUser: [],
-					message: body
-				}
-			})
-		}, getMirrorWaitSchema(slug))
+		return test.context.waitForMatch(getMirrorWaitSchema(message.slug))
 	}
 
 	test.context.github = new Octokit({
@@ -153,29 +96,27 @@ ava.serial.before(async (test) => {
 	})
 })
 
-ava.serial.after.always(helpers.mirror.after)
-ava.serial.beforeEach(async (test) => {
+ava.after.always(helpers.mirror.after)
+ava.beforeEach(async (test) => {
 	test.timeout(1000 * 60 * 5)
 	await helpers.mirror.beforeEach(test, uuid())
 })
 
-ava.serial.afterEach.always(helpers.mirror.afterEach)
+ava.afterEach.always(helpers.mirror.afterEach)
 
 // Skip all tests if there is no GitHub token
-const avaTest = _.some(_.values(TOKEN), _.isEmpty) || environment.test.integration.skip ? ava.serial.skip : ava.serial
+const avaTest = _.some(_.values(TOKEN), _.isEmpty) || environment.test.integration.skip ? ava.skip : ava
 
 avaTest('should be able to create an issue with a comment and update the comment after remote deletion', async (test) => {
-	const issueSlug = test.context.getIssueSlug()
 	const title = `Test Issue ${uuid()}`
 	const issue = await test.context.createIssue(
-		test.context.repository, issueSlug, title, {
+		test.context.repository, title, {
 			body: 'Issue body',
 			status: 'open',
 			archived: false
 		})
 
-	const messageSlug = test.context.getMessageSlug()
-	const message = await test.context.createMessage(issue, messageSlug, 'First comment')
+	const message = await test.context.createMessage(issue, 'First comment')
 	const mirror = message.data.mirrors[0]
 
 	await test.context.github.issues.deleteComment({
@@ -207,10 +148,9 @@ avaTest('should be able to create an issue with a comment and update the comment
 })
 
 avaTest('should be able to create an issue without comments', async (test) => {
-	const slug = test.context.getIssueSlug()
-	const title = `Test Issue ${uuid()}`
+	const title = `Test Issue: ${randomWords(3).join(' ')}`
 	const issue = await test.context.createIssue(
-		test.context.repository, slug, title, {
+		test.context.repository, title, {
 			body: 'Issue body',
 			status: 'open',
 			archived: false
@@ -236,10 +176,9 @@ avaTest('should be able to create an issue without comments', async (test) => {
 })
 
 avaTest('should sync issues given the mirror url if the repository changes', async (test) => {
-	const slug = test.context.getIssueSlug()
 	const title = `Test Issue ${uuid()}`
 	const issue = await test.context.createIssue(
-		test.context.repository, slug, title, {
+		test.context.repository, title, {
 			body: 'Issue body',
 			status: 'open',
 			archived: false
@@ -253,8 +192,7 @@ avaTest('should sync issues given the mirror url if the repository changes', asy
 		}
 	])
 
-	const messageSlug = test.context.getMessageSlug()
-	await test.context.createMessage(issue, messageSlug, 'First comment')
+	await test.context.createMessage(issue, 'First comment')
 
 	const mirror = issue.data.mirrors[0]
 	const external = await test.context.github.issues.get({
@@ -273,17 +211,15 @@ avaTest('should sync issues given the mirror url if the repository changes', asy
 })
 
 avaTest('should be able to create an issue with a comment', async (test) => {
-	const issueSlug = test.context.getIssueSlug()
 	const title = `Test Issue ${uuid()}`
 	const issue = await test.context.createIssue(
-		test.context.repository, issueSlug, title, {
+		test.context.repository, title, {
 			body: 'Issue body',
 			status: 'open',
 			archived: false
 		})
 
-	const messageSlug = test.context.getMessageSlug()
-	await test.context.createMessage(issue, messageSlug, 'First comment')
+	await test.context.createMessage(issue, 'First comment')
 
 	const mirror = issue.data.mirrors[0]
 	const externalIssue = await test.context.github.issues.get({
@@ -305,81 +241,4 @@ avaTest('should be able to create an issue with a comment', async (test) => {
 	test.is(externalMessages.data.length, 1)
 	test.is(externalMessages.data[0].body, `[${test.context.username}] First comment`)
 	test.is(externalMessages.data[0].user.login, currentUser.data.login)
-})
-
-avaTest('linking a support/sales thread to an issue results in a message on that issue\'s timeline', async (test) => {
-	const issueSlug = test.context.getIssueSlug()
-	const title = `Test Issue ${uuid()}`
-	const issue = await test.context.createIssue(
-		test.context.repository, issueSlug, title, {
-			body: 'Issue body',
-			status: 'open',
-			archived: false
-		})
-
-	const supportThread = await test.context.sdk.card.create({
-		type: 'support-thread',
-		name: 'test subject',
-		data: {
-			product: 'test-product',
-			inbox: 'S/Paid_Support',
-			status: 'open'
-		}
-	})
-
-	test.context.executeThenWait(async () => {
-		return test.context.sdk.card.link(supportThread, issue, 'support thread is attached to issue')
-	}, getSyncMessage(issue.id, 'This issue has attached support thread'))
-
-	const mirror = issue.data.mirrors[0]
-
-	const externalIssue = await test.context.github.issues.get({
-		owner: test.context.repository.owner,
-		repo: test.context.repository.repo,
-		issue_number: _.last(mirror.split('/'))
-	})
-
-	await Bluebird.delay(5000)
-
-	const externalMessages = await test.context.retry(() => {
-		return test.context.github.issues.listComments({
-			owner: test.context.repository.owner,
-			repo: test.context.repository.repo,
-			issue_number: externalIssue.data.number
-		})
-	}, (extMsgs) => {
-		return _.get(extMsgs, [ 'data', 'length' ]) === 1
-	})
-
-	test.is(externalMessages.data[0].body, `[${test.context.username}] This issue has attached support thread https://jel.ly.fish/${supportThread.id}`)
-
-	// TOOD: Remove all the code below once we are confident we don't re-trigger a message on unlinking
-
-	// Now unlink the thread. We should not generate a second message
-	await test.context.sdk.card.unlink(supportThread, issue, 'support thread is attached to issue')
-
-	// Wait for a while to allow triggered actions to run.
-	await Bluebird.delay(5000)
-
-	const messages = await test.context.sdk.query({
-		type: 'object',
-		properties: {
-			type: {
-				const: 'message@1.0.0'
-			}
-		},
-		$$links: {
-			'is attached to': {
-				type: 'object',
-				properties: {
-					id: {
-						const: issue.id
-					}
-				}
-			}
-		}
-	})
-
-	// There should still only be one message on this issue.
-	test.is(messages.length, 1)
 })


### PR DESCRIPTION
Refactors GitHub mirror tests:
- Cleans up a lot of redundant code in test utilities
- Moves code that tests triggered action behaviour to a separate test file, and isolates the tested interaction
- Refactors GitHub code to work with asynchronous triggered actions (future-proofing for updates to the worker)