### PR TITLE
Exclude index.html and build folder output from service worker precache manifest

### DIFF
--- a/apps/ui/.gitignore
+++ b/apps/ui/.gitignore
@@ -4,3 +4,6 @@ env-config.js
 # the command 'npm run doc' and committed to the root of the 
 # 'docs' branch.
 docs/
+
+# Ignore local build output (typescript definition files)
+build/

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -183,7 +183,8 @@ if (process.env.NODE_ENV === 'production' ||
 
 			// The vendors.js file is BIG - set this to a safe value of 40MB
 			maximumFileSizeToCacheInBytes: 40000000,
-			swSrc: './lib/service-worker.js'
+			swSrc: './lib/service-worker.js',
+			exclude: [ /build\/.*/, /index\.html/ ]
 		})
 	)
 }

--- a/scripts/lint/check-filenames.sh
+++ b/scripts/lint/check-filenames.sh
@@ -18,6 +18,7 @@ for file in $(find "${DIRECTORIES[@]}" -type f | grep -v -E node_modules); do
 		[ "$BASENAME" = "LICENSE" ] || \
 		[ "$BASENAME" = "README.md" ] || \
 		[ "$BASENAME" = "Makefile" ] || \
+		[[ $file =~ ^apps\/.*\/build ]] || \
 		[[ $BASENAME =~ ^Dockerfile ]]; then
 		continue
 	fi


### PR DESCRIPTION
The build folder output (as opposed to the dist folder) contains only TypeScript definition files.

Excluding index.html will hopefully fix the problem where some people are seeing blank screens on start-up.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes #3887

Note - I think since we migrated the UI app to TypeScript the service worker caching has been more broken than we realised. It was trying to cache all the `apps/ui/build/*.d.ts` TypeScript definition files generated as part of the build process. This resulted in run-time workbox errors (which don't show up in production as we turned off workbox logging). So I've also excluded these files from the precache manifest. 

I've tested this locally and it correctly caches expected files (e.g. main.js, css files, etc) but not the index.html file. When I make a code change, rebuild and then refresh the browser, the updated index.html is loaded, the updated main.js file is fetched from the network and cached. The 'New version of Jellyfish available. Update now?` popup shows. When I click 'OK', the browser tab refreshes and this time the main.js file is fetched from cache.

