### PR TITLE
Enable remote debugging for live push by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ The `NOCACHE` option sets the `--nocache` flag for `balena push`: [balena CLI Do
 	- Enter running container with `balena exec -ti <name> bash`
 	- Check container logs directly from within device using `balena logs <name>`
 
+### Debugging
+When using live push the API and action servers start with remote debugging enabled via the `--inspect` flag. Use Chrome dev tools, or your IDE to [start a debugging session](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
+
+- To debug API server connect to `<DEVICE-IP-ADDRESS>:9229`
+- To debug the tick server connect to `<DEVICE-IP-ADDRESS>:9230`
+- To debug the worker server connect to `<DEVICE-IP-ADDRESS>:923<WORKER-ID>`
+	- e.g. to connect to the first worker `<DEVICE-IP-ADDRESS>:9231`
+
 Testing
 -------
 

--- a/apps/action-server/Dockerfile.tick
+++ b/apps/action-server/Dockerfile.tick
@@ -16,7 +16,7 @@ COPY ./apps/action-server/Makefile /usr/src/jellyfish/apps/action-server/Makefil
 #dev-copy=./apps/action-server/packages/ /usr/src/jellyfish/packages/
 #dev-run=/usr/src/jellyfish/scripts/install-packages.js
 
-#dev-cmd-live=cd /usr/src/jellyfish/apps/action-server && npx nodemon ./lib/tick.js
+#dev-cmd-live=cd /usr/src/jellyfish/apps/action-server && npx nodemon --inspect=0.0.0.0 ./lib/tick.js
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/action-server/node_modules/@balena/
 RUN rm -f ~/.npmrc
 COPY ./apps/action-server/lib/ /usr/src/jellyfish/apps/action-server/lib/

--- a/apps/action-server/Dockerfile.worker
+++ b/apps/action-server/Dockerfile.worker
@@ -16,7 +16,7 @@ COPY ./apps/action-server/Makefile /usr/src/jellyfish/apps/action-server/Makefil
 #dev-copy=./apps/action-server/packages/ /usr/src/jellyfish/packages/
 #dev-run=/usr/src/jellyfish/scripts/install-packages.js
 
-#dev-cmd-live=cd /usr/src/jellyfish/apps/action-server && npx nodemon ./lib/worker.js
+#dev-cmd-live=cd /usr/src/jellyfish/apps/action-server && npx nodemon --inspect=0.0.0.0 ./lib/worker.js
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/action-server/node_modules/@balena/
 RUN rm -f ~/.npmrc
 COPY ./apps/action-server/lib/ /usr/src/jellyfish/apps/action-server/lib/

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -16,7 +16,7 @@ COPY ./apps/server/Makefile /usr/src/jellyfish/apps/server/Makefile
 #dev-copy=./apps/server/packages/ /usr/src/jellyfish/packages/
 #dev-run=/usr/src/jellyfish/scripts/install-packages.js
 
-#dev-cmd-live=cd /usr/src/jellyfish/apps/server && npx nodemon ./lib/index.js
+#dev-cmd-live=cd /usr/src/jellyfish/apps/server && npx nodemon --inspect=0.0.0.0 ./lib/index.js
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/server/node_modules/@balena/
 RUN rm -f ~/.npmrc
 COPY ./apps/server/lib/ /usr/src/jellyfish/apps/server/lib/

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -91,6 +91,8 @@ services:
       timeout: 10s
     expose:
       - 80
+    ports:
+      - 9229
     restart: always
   livechat:
     build:
@@ -149,6 +151,8 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - 9230:9229
   ui:
     build:
       args:
@@ -231,6 +235,8 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - 923{{idx}}:9229
   {{/workers}}
   balena-mdns-publisher:
     image: 'balena/balena-mdns-publisher:master'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,8 @@ services:
       timeout: 10s
     expose:
       - 80
+    ports:
+      - 9229
     restart: always
   livechat:
     build:
@@ -148,6 +150,8 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - 9230:9229
   ui:
     build:
       args:
@@ -229,6 +233,8 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - 9231:9229
   worker_2:
     build:
       context: .
@@ -292,6 +298,8 @@ services:
     restart: always
     networks:
       - internal
+    ports:
+      - 9232:9229
   balena-mdns-publisher:
     image: 'balena/balena-mdns-publisher:master'
     network_mode: host


### PR DESCRIPTION
- Add `--inspect=0.0.0.0` flag to live push `nodemon` command
- Open ports in compose so debugging client can connect
- Update README with remote debugging details
