### PR TITLE
Fetch repos in sidebar based on active loop

### DIFF
--- a/apps/ui/lib/components/HomeChannel/index.ts
+++ b/apps/ui/lib/components/HomeChannel/index.ts
@@ -30,6 +30,7 @@ const mapStateToProps = (state, ownProps) => {
 		mentions: selectors.getInboxViewData(state),
 		subscriptions: selectors.getSubscriptions(state),
 		starredViews: selectors.getStarredViews(state),
+		activeLoop: selectors.getActiveLoop(state),
 		isChatWidgetOpen: selectors.getChatWidgetOpen(state),
 		user,
 		homeView: selectors.getHomeView(state),

--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -247,6 +247,10 @@ export const selectors = {
 		const user = selectors.getCurrentUser(state);
 		return _.get(user, ['data', 'profile', 'homeView'], null);
 	},
+	getActiveLoop: (state): string | null => {
+		const user = selectors.getCurrentUser(state);
+		return _.get(user, ['data', 'profile', 'activeLoop'], null);
+	},
 	getInboxQuery: (state) => {
 		const user = selectors.getCurrentUser(state);
 		const groupNames = selectors.getMyGroupNames(state);


### PR DESCRIPTION
Defaults to 'product-os' if no active loop is set.

New section heading: 'Repositories'

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

See [this Jellyfish improvement](https://jel.ly.fish/repository-product-os-jellyfish/8ce4e29f-da25-4c5c-af40-6ec790061228/54f9383f-6627-4dc9-ba2a-a5bf51428672) for the overall plan. This is step 1 (milestone 1)!

This is a preparatory change in anticipation of being able to display a specific organization's repositories based on the active loop filter. Currently as `activeLoop` is never set, we will always fall back to fetching and displaying `product-os` repos. So the only visual change at the moment is that the `productOS` section heading has been replaced by `Repositories`. See screenshot below:

![Screenshot from 2021-06-30 18-07-00](https://user-images.githubusercontent.com/2925657/123950662-1f817400-d9ce-11eb-9409-80e7598204b5.png)
