### PR TITLE
Inherit loops from view card or active loop

### DIFF
--- a/apps/ui/lib/components/CardLinker/CardLinker.tsx
+++ b/apps/ui/lib/components/CardLinker/CardLinker.tsx
@@ -64,6 +64,7 @@ class CardLinker extends React.Component<any, any> {
 		this.props.actions.addChannel({
 			head: {
 				seed: {
+					loop: this.props.card.loop || this.props.activeLoop,
 					markers: this.props.card.markers,
 				},
 				onDone: {
@@ -196,4 +197,12 @@ const cardSource = {
 	},
 };
 
-export default DragSource('channel', cardSource, collect)(CardLinker);
+const DragSourceCardLinker = DragSource(
+	'channel',
+	cardSource,
+	collect,
+)(CardLinker);
+
+// TypeScript doesn't know how to handle DragSource as an input to redux's connect() function
+// so we just wrap it in a simple functional component.
+export default (props) => <DragSourceCardLinker {...props} />;

--- a/apps/ui/lib/components/CardLinker/index.tsx
+++ b/apps/ui/lib/components/CardLinker/index.tsx
@@ -4,6 +4,14 @@
  * Proprietary and confidential.
  */
 
+import { connect } from 'react-redux';
+import { selectors } from '../../core';
 import CardLinker from './CardLinker';
 
-export default CardLinker;
+const mapStateToProps = (state: any) => {
+	return {
+		activeLoop: selectors.getActiveLoop(state),
+	};
+};
+
+export default connect(mapStateToProps)(CardLinker);

--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -370,7 +370,16 @@ const getCardInternal = (idOrSlug, type, linkVerbs: any[] = []) => {
 	};
 };
 
-export const getSeedData = (viewCard, user) => {
+export interface SeedData {
+	markers?: string[];
+	loop?: string;
+	[key: string]: any;
+}
+
+export const getSeedData = (
+	viewCard: core.ViewContract,
+	user: core.UserContract,
+): SeedData => {
 	if (
 		!viewCard ||
 		(viewCard.type !== 'view' && viewCard.type !== 'view@1.0.0')
@@ -382,9 +391,13 @@ export const getSeedData = (viewCard, user) => {
 		return {};
 	}
 
-	// Always inherit markers from the view card
+	const activeLoop = _.get(user, ['data', 'profile', 'activeLoop'], null);
+
 	return Object.assign(helpers.getUpdateObjectFromSchema(schema), {
+		// Always inherit markers from the view card
 		markers: viewCard.markers,
+		// Inherit the loop from the view card or the active loop
+		loop: viewCard.loop || activeLoop,
 	});
 };
 


### PR DESCRIPTION
[Inherit loop when linking a card](https://github.com/product-os/jellyfish/commit/eb34230bbbd7100d06bd6bbab8d25df5e7d87b33)

Inherit from view card's loop, if set; otherwise from the active loop (if set).

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

[Inherit loop when creating new contracts](https://github.com/product-os/jellyfish/commit/315f6bbcd71bb77d8bf457a4760e9db31baacfc4)

Inherit from view card's loop, if set; otherwise from the active loop (if set).

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
