### PR TITLE
Reset card model when switching contract type

### DIFF
--- a/apps/ui/lib/lens/actions/CreateLens.tsx
+++ b/apps/ui/lib/lens/actions/CreateLens.tsx
@@ -239,6 +239,7 @@ export class CreateLens extends React.Component<any, any> {
 		});
 
 		this.setState({
+			newCardModel: Object.assign({}, this.props.channel.data.head.seed),
 			selectedTypeTarget,
 			linkOption: option,
 		});


### PR DESCRIPTION
This fixes a bug where the data associated with the previously selected contract type was being carried over to the newly selected contract type - so you'd end up with contracts containing data that didn't match the schema for that contract type!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

