### PR TITLE
Add loop drop-down to sidebar

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -26,6 +26,7 @@ import TreeMenu from './TreeMenu';
 import UserStatusMenuItem from '../UserStatusMenuItem';
 import ViewLink from '../ViewLink';
 import OmniSearch from '../OmniSearch';
+import { LoopSelector } from '../LoopSelector';
 import { registerForNotifications } from '../../services/notifications';
 import { ChatButton } from './ChatButton';
 
@@ -517,7 +518,7 @@ export default class HomeChannel extends React.Component<any, any> {
 	}
 
 	componentDidUpdate(prevProps) {
-		if (!prevProps.channel.data.head && this.props.channel.data.head) {
+		if (prevProps.channel.data.head !== this.props.channel.data.head) {
 			this.loadData();
 		}
 		if (
@@ -693,6 +694,7 @@ export default class HomeChannel extends React.Component<any, any> {
 								)}
 							</Flex>
 							<OmniSearch ml={3} mr={2} />
+							<LoopSelector ml={2} mr={2} mb={2} />
 						</Flex>
 
 						{this.state.showMenu && (

--- a/apps/ui/lib/components/HomeChannel/tests/HomeChannel.spec.tsx
+++ b/apps/ui/lib/components/HomeChannel/tests/HomeChannel.spec.tsx
@@ -22,6 +22,7 @@ const initialState = {
 		session: {
 			user: {},
 		},
+		loops: [],
 	},
 };
 

--- a/apps/ui/lib/components/LoopSelector/LoopSelector.spec.tsx
+++ b/apps/ui/lib/components/LoopSelector/LoopSelector.spec.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { withDefaults } from '../../../test/ui-setup';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import React from 'react';
+import { LoopSelector } from './LoopSelector';
+import { core } from '@balena/jellyfish-types';
+
+const sandbox = sinon.createSandbox();
+
+const loop1 = withDefaults({
+	type: 'loop@1.0.0',
+	slug: 'loop-1',
+	name: 'Loop 1',
+	data: {},
+});
+
+const loop2 = withDefaults({
+	type: 'loop@1.0.0',
+	slug: 'loop-2',
+	name: 'Loop 2',
+	data: {},
+});
+
+describe('LoopSelector', () => {
+	const loops: core.LoopContract[] = [loop1, loop2];
+	const onSetLoop = sandbox.stub();
+
+	afterEach(() => {
+		sandbox.reset();
+	});
+
+	it('displays the loop options', () => {
+		const component = shallow(
+			<LoopSelector onSetLoop={onSetLoop} loops={loops} activeLoop="" />,
+		);
+		const select = component.find('#loopselector__select');
+		expect(select.prop('options')).toEqual([
+			{
+				name: 'All loops',
+				slug: null,
+			},
+			...loops,
+		]);
+	});
+
+	it('defaults to "All loops" if no activeLoop is specified', () => {
+		const component = shallow(
+			<LoopSelector onSetLoop={onSetLoop} loops={loops} activeLoop="" />,
+		);
+		const select = component.find('#loopselector__select');
+		expect(select.prop('value')).toEqual({
+			name: 'All loops',
+			slug: null,
+		});
+	});
+
+	it('defaults to the activeLoop if specified', () => {
+		const component = shallow(
+			<LoopSelector
+				onSetLoop={onSetLoop}
+				loops={loops}
+				activeLoop={`${loop1.slug}@${loop1.version}`}
+			/>,
+		);
+		const select = component.find('#loopselector__select');
+		expect(select.prop('value').slug).toBe(loop1.slug);
+	});
+
+	it('calls onSetLoop when a loop is selected', () => {
+		const component = shallow(
+			<LoopSelector onSetLoop={onSetLoop} loops={loops} activeLoop="" />,
+		);
+		const select = component.find('#loopselector__select');
+		select.prop('onChange')({ value: loop1 });
+		expect(onSetLoop.calledOnce).toBe(true);
+		expect(onSetLoop.getCall(0).firstArg).toBe(
+			`${loop1.slug}@${loop1.version}`,
+		);
+	});
+});

--- a/apps/ui/lib/components/LoopSelector/LoopSelector.tsx
+++ b/apps/ui/lib/components/LoopSelector/LoopSelector.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import { core } from '@balena/jellyfish-types';
+import { HighlightedName, Select, RenditionSystemProps } from 'rendition';
+import { helpers } from '@balena/jellyfish-ui-components';
+
+interface DefaultOption {
+	name: string;
+	slug: null;
+}
+
+interface LoopOption {
+	name?: string | null;
+	slug: string;
+	version: string;
+}
+
+interface LoopDisplayProps extends Omit<RenditionSystemProps, 'color' | 'bg'> {
+	option: DefaultOption | LoopOption;
+}
+
+const allLoops: DefaultOption = {
+	name: 'All loops',
+	slug: null,
+};
+
+// Display of a particular loop (option or selected value) within the loop selector
+const LoopDisplay: React.FunctionComponent<LoopDisplayProps> = React.memo(
+	({ option, ...rest }) => (
+		<HighlightedName
+			{...rest}
+			data-test={`loop-option--${option.slug}`}
+			bg={option.slug ? helpers.colorHash(option.slug) : '#fff'}
+		>
+			{option.name || option.slug!.replace(/^loop-/, '')}
+		</HighlightedName>
+	),
+);
+
+export interface LoopSelectorProps extends RenditionSystemProps {
+	onSetLoop: (loopVersionedSlug?: string) => void;
+	loops: core.LoopContract[];
+	activeLoop: string;
+}
+
+// A drop-down component for selecting a loop
+export const LoopSelector: React.FunctionComponent<LoopSelectorProps> =
+	React.memo(({ onSetLoop, loops, activeLoop, children, ...rest }) => {
+		const [activeLoopSlug, activeLoopVersion] = activeLoop.split('@');
+
+		const [selectedLoop, setSelectedLoop] = React.useState(
+			_.find(loops, {
+				slug: activeLoopSlug,
+				version: activeLoopVersion,
+			}) || allLoops,
+		);
+
+		const loopOptions = React.useMemo(() => {
+			return _.concat<DefaultOption | core.Contract>([allLoops], ...loops);
+		}, [loops]);
+
+		const onChange = ({ value }) => {
+			setSelectedLoop(value || null);
+			onSetLoop(_.get(value, 'slug') && `${value.slug}@${value.version}`);
+		};
+
+		return (
+			<Select
+				{...rest}
+				id="loopselector__select"
+				plain
+				placeholder="Select loop..."
+				options={loopOptions}
+				value={selectedLoop}
+				valueLabel={<LoopDisplay option={selectedLoop} mx={2} />}
+				labelKey={(option) => <LoopDisplay option={option} />}
+				valueKey="slug"
+				onChange={onChange}
+			/>
+		);
+	});

--- a/apps/ui/lib/components/LoopSelector/index.ts
+++ b/apps/ui/lib/components/LoopSelector/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import _ from 'lodash';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { actionCreators, selectors } from '../../core';
+import { LoopSelector as InnerLoopSelector } from './LoopSelector';
+
+const mapStateToProps = (state) => {
+	return {
+		activeLoop: selectors.getActiveLoop(state) || '',
+		loops: selectors.getLoops(state),
+	};
+};
+
+const mapDispatchToProps = (dispatch) => {
+	const { setActiveLoop } = bindActionCreators(
+		_.pick(actionCreators, ['setActiveLoop']),
+		dispatch,
+	);
+	return {
+		onSetLoop: (loopSlug?: string) => {
+			return setActiveLoop(loopSlug || null);
+		},
+	};
+};
+
+export const LoopSelector = connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(InnerLoopSelector);

--- a/apps/ui/test/ui-setup.tsx
+++ b/apps/ui/test/ui-setup.tsx
@@ -24,6 +24,8 @@ import { CardLoaderContext } from '@balena/jellyfish-ui-components/build/CardLoa
 
 import Adapter from 'enzyme-adapter-react-16';
 import { SetupProvider } from '@balena/jellyfish-ui-components';
+import { core } from '@balena/jellyfish-types';
+import { v4 as uuid } from 'uuid';
 
 const emotionCache = createCache({
 	key: 'test',
@@ -71,6 +73,29 @@ export const getPromiseResolver = () => {
 		promise,
 		resolver,
 	};
+};
+
+export const withDefaults = (
+	cardFields: core.ContractDefinition,
+): core.Contract => {
+	return Object.assign(
+		{
+			id: uuid(),
+			created_at: '2020-01-01T00:00:00.000Z',
+			updated_at: null,
+			linked_at: {},
+			active: true,
+			version: '1.0.0',
+			tags: [],
+			markers: [],
+			loop: null,
+			links: {},
+			requires: [],
+			capabilities: [],
+			data: {},
+		},
+		cardFields,
+	);
 };
 
 export const getWrapper = (

--- a/test/e2e/ui/loops.spec.js
+++ b/test/e2e/ui/loops.spec.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const {
+	v4: uuid
+} = require('uuid')
+const environment = require('@balena/jellyfish-environment').defaultEnvironment
+const helpers = require('./helpers')
+const macros = require('./macros')
+
+const context = {
+	context: {
+		id: `UI-INTEGRATION-TEST-${uuid()}`
+	}
+}
+
+const user = helpers.generateUserDetails()
+
+const selectors = {
+	loopSelect: '#loopselector__select',
+	loopDropdown: '#loopselector__select__select-drop>div',
+	loopSelectOption: (loop) => {
+		return `[data-test="loop-option--${loop.slug}"]`
+	},
+	loopSelectValue: (loop) => {
+		return `#loopselector__select [data-test="loop-option--${loop.slug}"]`
+	},
+	viewBlogPosts: '[data-test="home-channel__item--view-all-blog-posts"]',
+	viewFaqs: '[data-test="home-channel__item--view-all-faqs"]'
+}
+
+const setLoop = async (sdk, viewSlug, versionedLoopSlug) => {
+	const {
+		id, type
+	} = await sdk.card.get(viewSlug)
+	return sdk.card.update(id, type, [ {
+		op: 'replace',
+		path: '/loop',
+		value: versionedLoopSlug
+	} ])
+}
+
+ava.serial.before(async () => {
+	await helpers.browser.beforeEach({
+		context
+	})
+
+	// Create user and log in to the web browser client
+	context.communityUser = await context.createUser(user)
+	await context.addUserToBalenaOrg(context.communityUser.id)
+	await macros.loginUser(context.page, user)
+
+	context.loop1 = await context.sdk.card.get('loop-product-os')
+	context.loop2 = await context.sdk.card.get('loop-balena-io')
+
+	// Update some of the views to belong to specific loops
+	await setLoop(context.sdk, 'view-all-blog-posts', `${context.loop1.slug}@${context.loop1.version}`)
+	await setLoop(context.sdk, 'view-all-faqs', `${context.loop2.slug}@${context.loop2.version}`)
+
+	// Navigate to the home page again (to force the sidebar views to be refreshed)
+	await context.page.goto(`${environment.ui.host}:${environment.ui.port}`)
+
+	// Open up the balena sidebar menu section
+	await macros.navigateToHomeChannelItem(context.page, [
+		'[data-test="home-channel__group-toggle--org-balena"]'
+	])
+})
+
+ava.serial.afterEach.always(async (test) => {
+	await helpers.afterEach({
+		context, test
+	})
+})
+
+ava.serial.after.always(async () => {
+	// Reset the loops on the views
+	await setLoop(context.sdk, 'view-all-blog-posts', null)
+	await setLoop(context.sdk, 'view-all-faqs', null)
+
+	await helpers.after({
+		context
+	})
+	await helpers.browser.afterEach({
+		context
+	})
+})
+
+ava.serial('When "All loops" is selected, views in all loops are displayed in the sidebar', async (test) => {
+	const {
+		page
+	} = context
+
+	const loopDisplayText = await macros.getElementText(page, selectors.loopSelect)
+	test.is(loopDisplayText, 'All loops')
+
+	// Both the loop-specific views should be visible
+	await page.waitForSelector(selectors.viewBlogPosts)
+	await page.waitForSelector(selectors.viewFaqs)
+})
+
+ava.serial('When a loop is selected, only views in that loops are displayed in the sidebar', async (test) => {
+	const {
+		page,
+		loop1,
+		loop2
+	} = context
+
+	let loopDisplayText = await macros.getElementText(page, selectors.loopSelect)
+	test.is(loopDisplayText, 'All loops')
+
+	// Select loop1 from the Loop Selector
+	await macros.waitForThenClickSelector(page, selectors.loopSelect)
+	await macros.waitForThenClickSelector(page, selectors.loopSelectOption(loop1))
+
+	// Verify that loop1 is now selected in the loop selector
+	await page.waitForSelector(selectors.loopSelectValue(loop1), macros.WAIT_OPTS)
+	loopDisplayText = await macros.getElementText(page, selectors.loopSelect)
+	test.is(loopDisplayText, loop1.name)
+
+	// And wait for the view in loop2 to disappear
+	await macros.waitForSelectorToDisappear(page, selectors.viewFaqs)
+
+	// Check that the view in loop1 is still there
+	await page.waitForSelector(selectors.viewBlogPosts)
+
+	// Now select loop2 from the Loop Selector
+	await macros.waitForThenClickSelector(page, selectors.loopSelect)
+	await macros.waitForThenClickSelector(page, selectors.loopSelectOption(loop2))
+
+	// Verify that loop2 is now selected in the loop selector
+	await page.waitForSelector(selectors.loopSelectValue(loop2), macros.WAIT_OPTS)
+	loopDisplayText = await macros.getElementText(page, selectors.loopSelect)
+	test.is(loopDisplayText, loop2.name)
+
+	// And wait for the view in loop1 to disappear
+	await macros.waitForSelectorToDisappear(page, selectors.viewBlogPosts)
+
+	// Check that the view in loop2 is still there
+	await page.waitForSelector(selectors.viewFaqs)
+})
+
+ava.serial('The selected loop is persisted and selected next time Jellyfish is loaded', async (test) => {
+	const {
+		page,
+		loop1
+	} = context
+
+	// Select loop1 from the Loop Selector
+	await macros.waitForThenClickSelector(page, selectors.loopSelect)
+	await macros.waitForThenClickSelector(page, selectors.loopSelectOption(loop1))
+
+	// Verify that loop1 is now selected in the loop selector
+	await page.waitForSelector(selectors.loopSelectValue(loop1), macros.WAIT_OPTS)
+
+	// Refresh the page
+	await page.goto(`${environment.ui.host}:${environment.ui.port}`)
+
+	// Verify that loop1 is still selected in the loop selector
+	await page.waitForSelector(selectors.loopSelectValue(loop1), macros.WAIT_OPTS)
+	const loopDisplayText = await macros.getElementText(page, selectors.loopSelect)
+	test.is(loopDisplayText, loop1.name)
+})


### PR DESCRIPTION
When a loop is selected, the loop is used to create a global query mask for the SDK that will affect all subsequent SDK calls. The app is then re-bootstrapped (using this global query mask).

The active loop is also saved to the user's profile so that it persists across sessions.

Note - for now, contracts with no loop specified will always be returned regardless of what the global loop filter is. This allows us to slowly migrate contracts in the appropriate loops. Once all contracts have been migrated to a specific loop, we can modify the global query mask to filter out contracts with no loop specified when filtering by a particular loop.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

![Selecting loop from sidebar](https://user-images.githubusercontent.com/2925657/127617785-f6762c28-b5a4-45da-b2f1-8af366483037.gif)

Added e2e tests (`loops.spec.js`) to verify the behaviour.

Depends on:
* https://github.com/product-os/jellyfish/pull/6796/
    * https://github.com/product-os/jellyfish-core/pull/906
    * https://github.com/product-os/jellyfish/pull/6806
