### PR TITLE
Remove frontend Renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,5 @@
 {
   "extends": [
     "github>product-os/jellyfish-config//config/renovate"
-  ],
-  "packageRules": [
-    {
-      "groupName": "non-major-frontend",
-      "matchPackageNames": [
-        "@balena/jellyfish-ui-components",
-        "@balena/jellyfish-chat-widget",
-        "rendition",
-        "styled-components"
-      ],
-      "matchPackagePatterns": ["^react"],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true
-    }
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

@grahammcculloch I believe we can remove this group now that `jellyfish-ui-components` and `jellyfish-chat-widget` no longer have `package-lock.json` files? (aka Shouldn't run into the multiple versions of react problem any longer.)
