### PR TITLE
Use generic/extensible approach to filtering by timeline message

### DIFF
--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/filter-utils.spec.tsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/filter-utils.spec.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { JSONSchema } from '@balena/jellyfish-types';
+import {
+	getLinkedContractDataFilterKey,
+	unpackLinksSchema,
+} from './filter-utils';
+
+describe('getLinkedContractDataFilterKey', () => {
+	it('handles a single type', () => {
+		const key = getLinkedContractDataFilterKey(
+			'is attached to',
+			'pattern@1.0.0',
+			'___name',
+		);
+		expect(key).toBe('___$$links___is attached to___pattern@1.0.0___name');
+	});
+
+	it('handles multiple types', () => {
+		const key = getLinkedContractDataFilterKey(
+			'is attached to',
+			['pattern@1.0.0', 'improvement@1.0.0'],
+			'___name',
+		);
+		expect(key).toBe(
+			'___$$links___is attached to___pattern@1.0.0,improvement@1.0.0___name',
+		);
+	});
+
+	it("throws if a type isn't versioned", () => {
+		expect(() => {
+			getLinkedContractDataFilterKey(
+				'is attached to',
+				['pattern@1.0.0', 'improvement'],
+				'___name',
+			);
+		}).toThrow('getLinkedContractDataFilterKey: types must be versioned');
+	});
+
+	it("throws if the keyPath doesn't start with the delimiter", () => {
+		expect(() => {
+			getLinkedContractDataFilterKey('is attached to', 'pattern@1.0.0', 'name');
+		}).toThrow("getLinkedContractDataFilterKey: keyPath must start with '___'");
+	});
+});
+
+describe('unpackLinksSchema', () => {
+	it('handles a single type', () => {
+		const pseudoLinksSchema: JSONSchema = {
+			type: 'object',
+			required: ['is attached to'],
+			properties: {
+				'is attached to': {
+					type: 'object',
+					required: ['pattern@1.0.0'],
+					properties: {
+						'pattern@1.0.0': {
+							required: ['name'],
+							properties: {
+								name: {
+									type: 'string',
+									const: 'testing',
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+		const linksSchema = unpackLinksSchema(pseudoLinksSchema);
+		expect(linksSchema).toEqual({
+			'is attached to': {
+				type: 'object',
+				additionalProperties: true,
+				required: ['name', 'type'],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'pattern@1.0.0',
+					},
+					name: {
+						type: 'string',
+						const: 'testing',
+					},
+				},
+			},
+		});
+	});
+
+	it('handles multiple types', () => {
+		const pseudoLinksSchema: JSONSchema = {
+			type: 'object',
+			required: ['is attached to'],
+			properties: {
+				'is attached to': {
+					type: 'object',
+					required: ['pattern@1.0.0,improvement@1.0.0'],
+					properties: {
+						'pattern@1.0.0,improvement@1.0.0': {
+							required: ['name'],
+							properties: {
+								name: {
+									type: 'string',
+									const: 'testing',
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+		const linksSchema = unpackLinksSchema(pseudoLinksSchema);
+		expect(linksSchema).toEqual({
+			'is attached to': {
+				type: 'object',
+				additionalProperties: true,
+				required: ['name', 'type'],
+				properties: {
+					type: {
+						type: 'string',
+						enum: ['pattern@1.0.0', 'improvement@1.0.0'],
+					},
+					name: {
+						type: 'string',
+						const: 'testing',
+					},
+				},
+			},
+		});
+	});
+});

--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/filter-utils.tsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/filter-utils.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { JSONSchema } from '@balena/jellyfish-types';
+import skhema from 'skhema';
+import _ from 'lodash';
+
+const DELIMITER = '___';
+const DELIMITER_PREFIX_REGEXP = new RegExp(`^${DELIMITER}`);
+
+// getLinkedContractDataFilterKey and unpackLinksSchema are a pair of functions used to encode/decode linked contract data.
+// The important thing here is that both the link verb and the contract type (or types) need to be encoded
+// in the filter key. The Filters component will 'unflatten' this key when calling back with updated filters.
+// We then need to dig through the unpacked pseudo schema to extract the link verb and type(s) and then construct
+// our query object!
+
+export const getLinkedContractDataFilterKey = (
+	linkVerb: string,
+	type: string | string[],
+	keyPath: string,
+): string => {
+	if (!keyPath.startsWith(DELIMITER)) {
+		throw new Error(
+			`getLinkedContractDataFilterKey: keyPath must start with '${DELIMITER}'`,
+		);
+	}
+	const types = _.castArray(type);
+	if (!_.every(types, (t) => t.includes('@'))) {
+		throw new Error(`getLinkedContractDataFilterKey: types must be versioned`);
+	}
+	return _.join(
+		[
+			'',
+			'$$links',
+			linkVerb,
+			types.join(','),
+			keyPath.replace(DELIMITER_PREFIX_REGEXP, ''),
+		],
+		DELIMITER,
+	);
+};
+
+export const unpackLinksSchema = (
+	pseudoLinksSchema: JSONSchema,
+): {
+	[key: string]: JSONSchema;
+} => {
+	// The link verb is presented as a property on the schema
+	const linkVerb = _.get(pseudoLinksSchema, ['required', 0]);
+
+	// The type(s) have been embedded as a property. Types are versioned and comma-separated.
+	const toTypes = _.get(pseudoLinksSchema, [
+		'properties',
+		linkVerb,
+		'required',
+		0,
+	]).split(',');
+	// If there were multiple types specified, use an enum query matcher; otherwise const.
+	const typeMatcher: JSONSchema =
+		toTypes.length > 1
+			? {
+					type: 'string',
+					enum: toTypes,
+			  }
+			: {
+					type: 'string',
+					const: toTypes[0],
+			  };
+	const typeSchema: JSONSchema = {
+		type: 'object',
+		required: ['type'],
+		properties: {
+			type: typeMatcher,
+		},
+	};
+
+	// Drill down through the pseudo unflattened schema to get to the actual schema!
+	const linkedContractSchema = _.get(pseudoLinksSchema, [
+		'properties',
+		linkVerb,
+		'properties',
+		toTypes,
+	]);
+
+	return {
+		[linkVerb]: skhema.merge([linkedContractSchema, typeSchema]) as JSONSchema,
+	};
+};

--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/index.tsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/index.tsx
@@ -9,10 +9,12 @@ import _ from 'lodash';
 import skhema from 'skhema';
 import clone from 'deep-copy';
 import type { JSONSchema7 } from 'json-schema';
-import { Box, Filters, Flex, Search, Theme } from 'rendition';
+import { Box, Filters, Flex, SchemaSieve, Search, Theme } from 'rendition';
 import SortByButton from './SortByButton';
+import { JSONSchema } from '@balena/jellyfish-types';
+import { getLinkedContractDataFilterKey } from './filter-utils';
 
-const getSchemaForFilters = (tailTypes, timelineFilter) => {
+const getSchemaForFilters = (tailTypes) => {
 	const tailSchemas = _.map(tailTypes, (tailType) => {
 		return clone(_.get(tailType, ['data', 'schema'], {}));
 	});
@@ -20,7 +22,21 @@ const getSchemaForFilters = (tailTypes, timelineFilter) => {
 	// TODO: Improve safety of skhema.merge so that it doesn't throw if the
 	// skhemas can't be merged. That way we can merge all the typesSchemas
 	// instead of just the first one.
-	const schemaForFilters = skhema.merge([_.first(tailSchemas)]);
+	const unflattenedSchemaForFilters = skhema.merge([
+		_.first(tailSchemas),
+	]) as JSONSchema;
+
+	// The filters component doesn't care if our schema is flat or not, but
+	// by flattening it, it's easier to set the title field for each item.
+	const schemaForFilters = SchemaSieve.flattenSchema(
+		unflattenedSchemaForFilters,
+	);
+
+	// Set the filter titles to be Start Case
+	_.forEach(schemaForFilters.properties, (prop, propName) => {
+		const filterSchema = prop as JSONSchema;
+		filterSchema.title = _.startCase(filterSchema.title || propName);
+	});
 
 	// Always expose the loop, created_at and updated_at field for filtering
 	_.set(schemaForFilters, ['properties', 'created_at'], {
@@ -38,102 +54,107 @@ const getSchemaForFilters = (tailTypes, timelineFilter) => {
 		type: 'string',
 	});
 
-	// Add the timeline link prop to spoof the filters component into generating
-	// subschemas for the $$links property - see the createSyntheticViewCard()
-	// method for how we unpack the filters
-	_.set(schemaForFilters, ['properties', timelineFilter], {
-		title: 'Timeline',
-		type: 'object',
-		properties: {
-			data: {
-				type: 'object',
-				properties: {
-					payload: {
-						type: 'object',
-						properties: {
-							message: {
-								title: 'Timeline message',
-								type: 'string',
-							},
-						},
-					},
-				},
-			},
+	// Manually add a 'Timeline message' filter
+	_.set(
+		schemaForFilters,
+		[
+			'properties',
+			getLinkedContractDataFilterKey(
+				'has attached element',
+				['whisper@1.0.0', 'message@1.0.0'],
+				'___data___payload___message',
+			),
+		],
+		{
+			type: 'string',
+			title: 'Timeline message',
 		},
-	});
+	);
 	return schemaForFilters;
 };
 
-const ViewFilters = ({
-	tailTypes,
-	filters,
-	searchFilter,
-	updateFilters,
-	saveView,
-	searchTerm,
-	updateSearch,
-	updateFiltersFromSummary,
-	pageOptions,
-	setSortByField,
-	timelineFilter,
-}) => {
-	const summaryFilters = _.compact([...filters, searchFilter]);
+const ViewFilters = React.memo<any>(
+	({
+		tailTypes,
+		filters,
+		searchFilter,
+		updateFilters,
+		saveView,
+		searchTerm,
+		updateSearch,
+		updateFiltersFromSummary,
+		pageOptions,
+		setSortByField,
+	}) => {
+		const summaryFilters = React.useMemo(() => {
+			return _.compact([...filters, searchFilter]);
+		}, [filters, searchFilter]);
 
-	const schemaForFilters = getSchemaForFilters(tailTypes, timelineFilter);
+		const schemaForFilters = React.useMemo(() => {
+			return getSchemaForFilters(tailTypes);
+		}, [tailTypes]);
 
-	// Only render filters in compact mode for the first breakpoint
-	const FiltersBreakpointSettings = _.sortBy(Theme.breakpoints).map(
-		(breakpoint, index) => Boolean(index <= 0),
-	);
-	return (
-		<React.Fragment>
-			<Box flex="1">
-				<Flex mt={0} flex="1 0 auto" justifyContent="space-between">
-					<Filters
-						schema={schemaForFilters as JSONSchema7}
-						filters={filters}
-						onFiltersUpdate={updateFilters}
-						onViewsUpdate={saveView}
-						compact={FiltersBreakpointSettings}
-						renderMode={['add']}
-					/>
-					<Flex
-						flexWrap="wrap"
-						alignItems="center"
-						justifyContent="flex-end"
-						flex={1}
-					>
-						<Box mb={3} flex="0 1 500px">
-							<Search
-								className="view__search"
-								value={searchTerm}
-								onChange={updateSearch}
-							/>
-						</Box>
-						<SortByButton
-							pageOptions={pageOptions}
-							setSortByField={setSortByField}
-							tailTypes={tailTypes}
-							ml={2}
-							mb={3}
-							minWidth="150px"
+		// Only render filters in compact mode for the first breakpoint
+		const filtersBreakpointSettings = React.useMemo(() => {
+			return _.sortBy(Theme.breakpoints).map((breakpoint, index) =>
+				Boolean(index <= 0),
+			);
+		}, [Theme.breakpoints]);
+
+		return (
+			<React.Fragment>
+				<Box flex="1">
+					<Flex mt={0} flex="1 0 auto" justifyContent="space-between">
+						<Filters
+							schema={schemaForFilters as JSONSchema7}
+							filters={filters}
+							onFiltersUpdate={updateFilters}
+							onViewsUpdate={saveView}
+							compact={filtersBreakpointSettings}
+							renderMode={['add']}
 						/>
+						<Flex
+							flexWrap="wrap"
+							alignItems="center"
+							justifyContent="flex-end"
+							flex={1}
+						>
+							<Box mb={3} flex="0 1 500px">
+								<Search
+									className="view__search"
+									value={searchTerm}
+									onChange={updateSearch}
+								/>
+							</Box>
+							<SortByButton
+								pageOptions={pageOptions}
+								setSortByField={setSortByField}
+								tailTypes={tailTypes}
+								ml={2}
+								mb={3}
+								minWidth="150px"
+							/>
+						</Flex>
 					</Flex>
-				</Flex>
-			</Box>
-			{summaryFilters.length > 0 && (
-				<Box flex="1 0 auto" mt={-3} data-test="view__filters-summary-wrapper">
-					<Filters
-						schema={schemaForFilters as JSONSchema7}
-						filters={summaryFilters}
-						onFiltersUpdate={updateFiltersFromSummary}
-						onViewsUpdate={saveView}
-						renderMode={['summary']}
-					/>
 				</Box>
-			)}
-		</React.Fragment>
-	);
-};
+				{summaryFilters.length > 0 && (
+					<Box
+						flex="1 0 auto"
+						mt={-3}
+						data-test="view__filters-summary-wrapper"
+					>
+						<Filters
+							schema={schemaForFilters as JSONSchema7}
+							filters={summaryFilters}
+							onFiltersUpdate={updateFiltersFromSummary}
+							onViewsUpdate={saveView}
+							renderMode={['summary']}
+						/>
+					</Box>
+				)}
+			</React.Fragment>
+		);
+	},
+);
 
 export default ViewFilters;

--- a/apps/ui/lib/lens/full/View/Header/index.tsx
+++ b/apps/ui/lib/lens/full/View/Header/index.tsx
@@ -50,7 +50,6 @@ export default class Header extends React.Component<any, any> {
 			updateFiltersFromSummary,
 			pageOptions,
 			setSortByField,
-			timelineFilter,
 			tail,
 		} = this.props;
 
@@ -145,7 +144,6 @@ export default class Header extends React.Component<any, any> {
 							updateFiltersFromSummary={updateFiltersFromSummary}
 							pageOptions={pageOptions}
 							setSortByField={setSortByField}
-							timelineFilter={timelineFilter}
 						/>
 					</Collapsible>
 					<CloseButton

--- a/apps/ui/lib/lens/full/View/constants.tsx
+++ b/apps/ui/lib/lens/full/View/constants.tsx
@@ -9,11 +9,8 @@ const EVENTS_FULL_TEXT_SEARCH_TITLE = 'events_full_text_search';
 
 const USER_FILTER_NAME = 'user-generated-filter';
 
-const TIMELINE_FILTER_PROP = '$$links';
-
 export {
 	FULL_TEXT_SEARCH_TITLE,
 	EVENTS_FULL_TEXT_SEARCH_TITLE,
 	USER_FILTER_NAME,
-	TIMELINE_FILTER_PROP,
 };

--- a/apps/ui/lib/lens/full/View/index.tsx
+++ b/apps/ui/lib/lens/full/View/index.tsx
@@ -128,15 +128,18 @@ const getSliceOptions = (card, types) => {
 	}
 	const sliceOptions: any = [];
 	for (const slice of slices) {
-		for (const sliceValue of slice.values) {
+		_.forEach(slice.values, (sliceValue: string, index: number) => {
+			// If the slice defines user-friendly names (from the JSON schema's enumNames property) use that;
+			// otherwise just use the sliceValue (from the JSON schema's enum property)
+			const sliceOptionTitle = _.get(slice, ['names', index], sliceValue);
 			sliceOptions.push({
-				title: `${slice.title}: ${sliceValue}`,
+				title: `${slice.title}: ${sliceOptionTitle}`,
 				value: {
 					path: slice.path,
 					value: sliceValue,
 				},
 			});
-		}
+		});
 
 		sliceOptions.push({
 			title: `${slice.title}: All`,

--- a/apps/ui/lib/lens/full/View/index.tsx
+++ b/apps/ui/lib/lens/full/View/index.tsx
@@ -22,6 +22,7 @@ import {
 	withResponsiveContext,
 } from '@balena/jellyfish-ui-components';
 import jsf from 'json-schema-faker';
+import { JSONSchema } from '@balena/jellyfish-types';
 import { actionCreators, analytics, selectors, sdk } from '../../../core';
 import { getLenses } from '../../';
 import Header from './Header';
@@ -31,8 +32,8 @@ import {
 	USER_FILTER_NAME,
 	FULL_TEXT_SEARCH_TITLE,
 	EVENTS_FULL_TEXT_SEARCH_TITLE,
-	TIMELINE_FILTER_PROP,
 } from './constants';
+import { unpackLinksSchema } from './Header/ViewFilters/filter-utils';
 
 const getActiveLens = (lenses, lensSlug) => {
 	return (
@@ -161,40 +162,33 @@ const createSyntheticViewCard = (view, filters) => {
 		: [];
 	syntheticViewCard.data.allOf = originalFilters;
 
-	// If the filter users the timeline filter prop, add a $$links expression to
-	// additionally filter by the timeline
-	// TODO: Make the filters component generate $$links statements natively
 	filters.forEach((filter) => {
-		const linkSchema = _.get(filter, [
-			'anyOf',
-			'0',
-			'properties',
-			TIMELINE_FILTER_PROP,
-		]);
-		const schema: any = linkSchema
-			? {
-					$$links: {
-						'has attached element': linkSchema,
-					},
-			  }
-			: _.assign(_.omit(filter, '$id'), {
-					type: 'object',
-			  });
-
-		// $$link queries don't work with full text search as they `anyOf` logic
-		// can't express the query on timeline elements, so the subschema has to be
-		// stripped from the full text search query schema
-		if (schema.title === FULL_TEXT_SEARCH_TITLE) {
-			_.forEach(_.filter(schema.anyOf, 'anyOf'), (subSchema) => {
-				subSchema.anyOf = subSchema.anyOf.filter((item) => {
-					return !item.properties.$$links;
-				});
+		if (
+			// Full text search filters do not need unpacking
+			filter.$id !== FULL_TEXT_SEARCH_TITLE &&
+			filter.$id !== EVENTS_FULL_TEXT_SEARCH_TITLE &&
+			filter.anyOf
+		) {
+			filter.anyOf = filter.anyOf.map((subSchema: JSONSchema) => {
+				const isLinkFilter = _.has(subSchema, 'properties.$$links');
+				// Only $$links filters need unflattening and re-structuring slightly
+				if (isLinkFilter) {
+					return {
+						$$links: unpackLinksSchema(
+							subSchema.properties!.$$links as JSONSchema,
+						),
+					};
+				}
+				return subSchema;
 			});
 		}
 
 		syntheticViewCard.data.allOf.push({
 			name: USER_FILTER_NAME,
-			schema,
+			schema: {
+				type: 'object',
+				..._.omit(filter, '$id'),
+			},
 		});
 	});
 
@@ -894,7 +888,6 @@ export class ViewRenderer extends React.Component<any, any> {
 					updateFiltersFromSummary={this.updateFiltersFromSummary}
 					pageOptions={options}
 					setSortByField={this.setSortByField}
-					timelineFilter={TIMELINE_FILTER_PROP}
 					tail={tail}
 				/>
 				<Flex height="100%" minHeight="0" mt={filters.length ? 0 : 3}>

--- a/test/e2e/ui/macros.js
+++ b/test/e2e/ui/macros.js
@@ -168,13 +168,11 @@ exports.waitForInnerText = async (page, selector, text, index = 0, options = {})
 }
 
 exports.clearInput = async (page, selector) => {
-	const inputValue = await page.$eval(selector, (el) => {
-		return el.value
+	const input = await page.$(selector)
+	await input.click({
+		clickCount: 3
 	})
-	await page.click(selector)
-	for (let index = 0; index < inputValue.length; index++) {
-		await page.keyboard.press('Backspace')
-	}
+	await page.keyboard.press('Backspace')
 }
 
 exports.waitForSelectorToDisappear = async (page, selector, retryCount = 30) => {


### PR DESCRIPTION
This is a preliminary step towards supporting filtering by any linked contract data.

Two e2e tests have been added that exercise the filters and the search functionality. This adds a good check that the functionality is still working!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

We also now use 'Start Case' for filter titles - so all filter field options are displayed consistently.