### PR TITLE
Worker: Wait for plugin type cards to be inserted

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -12,10 +12,6 @@ services:
     depends_on:
       - postgres
       - redis
-      - tick
-      {{#workers}}
-      - worker_{{idx}}
-      {{/workers}}
       - balena-mdns-publisher
     environment:
       - DATABASE={{DATABASE}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
     depends_on:
       - postgres
       - redis
-      - tick
-      - worker_1
-      - worker_2
       - balena-mdns-publisher
     environment:
       - DATABASE=postgres


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Currently, with the "right" timing, a worker instance can be created when only a handful of card types have been inserted into the database. If we wait for the api bootstrap to insert all card types before the worker instance is created, its `options.typeContracts` will include all cards.

I believe this will resolve our flaky e2e server subscription test issue. Found that this test can fail when the worker subscription notification logic returns [here](https://github.com/product-os/jellyfish-worker/blob/master/lib/subscriptions.ts#L149), because the `notification@1.0.0` type isn't found in the provided list `options.typeContracts`.