### PR TITLE
Add tests for pattern snapbacks

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -724,9 +724,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-18.0.0.tgz",
-      "integrity": "sha512-65+juTeXDAwGqqKceksnVJYjTw6oygcQIgSZHQR6SyEdESCVNofbsztuDuq7KmbWUBzIF6cfhbBM2jPC3EFm3Q==",
+      "version": "18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d.tgz",
+      "integrity": "sha512-o5GFW9rZ9u8hSSoZFjY0meMeeZ9HY5IY5rv68YW6XdAlPlQWN+jAVBDcAUctlrrImTH5/vQm6dAuON3F8C9WCw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.60",
         "@balena/jellyfish-logger": "3.0.43",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-plugin-balena-api": "^1.0.0",
     "@balena/jellyfish-plugin-base": "^2.1.186",
     "@balena/jellyfish-plugin-channels": "^1.1.228",
-    "@balena/jellyfish-plugin-default": "^18.0.0",
+    "@balena/jellyfish-plugin-default": "18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d",
     "@balena/jellyfish-plugin-discourse": "^1.0.41",
     "@balena/jellyfish-plugin-flowdock": "^1.0.66",
     "@balena/jellyfish-plugin-front": "^1.0.7",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -564,9 +564,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-18.0.0.tgz",
-      "integrity": "sha512-65+juTeXDAwGqqKceksnVJYjTw6oygcQIgSZHQR6SyEdESCVNofbsztuDuq7KmbWUBzIF6cfhbBM2jPC3EFm3Q==",
+      "version": "18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d.tgz",
+      "integrity": "sha512-o5GFW9rZ9u8hSSoZFjY0meMeeZ9HY5IY5rv68YW6XdAlPlQWN+jAVBDcAUctlrrImTH5/vQm6dAuON3F8C9WCw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.60",
         "@balena/jellyfish-logger": "3.0.43",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-plugin-balena-api": "^1.0.0",
     "@balena/jellyfish-plugin-base": "^2.1.186",
     "@balena/jellyfish-plugin-channels": "^1.1.228",
-    "@balena/jellyfish-plugin-default": "^18.0.0",
+    "@balena/jellyfish-plugin-default": "18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d",
     "@balena/jellyfish-plugin-discourse": "^1.0.41",
     "@balena/jellyfish-plugin-flowdock": "^1.0.66",
     "@balena/jellyfish-plugin-front": "^1.0.7",

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -22617,7 +22617,8 @@
       "version": "3.13.7",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
       "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -492,9 +492,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-18.0.0.tgz",
-      "integrity": "sha512-65+juTeXDAwGqqKceksnVJYjTw6oygcQIgSZHQR6SyEdESCVNofbsztuDuq7KmbWUBzIF6cfhbBM2jPC3EFm3Q==",
+      "version": "18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d.tgz",
+      "integrity": "sha512-o5GFW9rZ9u8hSSoZFjY0meMeeZ9HY5IY5rv68YW6XdAlPlQWN+jAVBDcAUctlrrImTH5/vQm6dAuON3F8C9WCw==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.60",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@balena/jellyfish-plugin-balena-api": "^1.0.0",
     "@balena/jellyfish-plugin-base": "^2.1.186",
     "@balena/jellyfish-plugin-channels": "^1.1.228",
-    "@balena/jellyfish-plugin-default": "^18.0.0",
+    "@balena/jellyfish-plugin-default": "18.1.0-update-pattern-statuses-80aa5be12f7cd8ecdff47245a87625f17658153d",
     "@balena/jellyfish-plugin-discourse": "^1.0.41",
     "@balena/jellyfish-plugin-flowdock": "^1.0.66",
     "@balena/jellyfish-plugin-front": "^1.0.7",

--- a/test/e2e/server/patterns.spec.js
+++ b/test/e2e/server/patterns.spec.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const helpers = require('../sdk/helpers')
+
+ava.serial.before(helpers.before)
+ava.serial.after.always(helpers.after)
+
+ava.serial.beforeEach(helpers.beforeEach)
+ava.serial.afterEach.always(helpers.afterEach)
+
+ava('should set pattern status to partially-resolved if an attached improvement is released', async (test) => {
+	const {
+		sdk
+	} = test.context
+	const pattern = await sdk.card.create({
+		name: 'My pattern',
+		type: 'pattern',
+		version: '1.0.0',
+		data: {
+			status: 'improvement-in-progress'
+		}
+	})
+
+	const improvement = await sdk.card.create({
+		name: 'My improvement',
+		type: 'improvement',
+		version: '1.0.0',
+		data: {
+			status: 'merged'
+		}
+	})
+
+	await sdk.card.link(pattern, improvement, 'has attached')
+
+	// Release the improvement, and then wait for the pattern status to be updated
+	await sdk.card.update(improvement.id, improvement.type, [
+		{
+			op: 'replace',
+			path: '/data/status',
+			value: 'released'
+		}
+	])
+
+	const newPattern = await test.context.waitForMatch({
+		type: 'object',
+		required: [ 'id', 'data' ],
+		properties: {
+			id: {
+				const: pattern.id
+			},
+			data: {
+				type: 'object',
+				required: [ 'status' ],
+				properties: {
+					status: {
+						const: 'partially-resolved'
+					}
+				}
+			}
+		}
+	})
+
+	test.is(newPattern.data.status, 'partially-resolved')
+})

--- a/test/e2e/server/support.spec.js
+++ b/test/e2e/server/support.spec.js
@@ -192,12 +192,12 @@ ava('should re-open a closed support thread if an attached pattern is closed', a
 
 	await sdk.card.link(supportThread, pattern, 'has attached')
 
-	// Close the PR, and then wait for the support thread to be re-opened
+	// Close the pattern, and then wait for the support thread to be re-opened
 	await sdk.card.update(pattern.id, pattern.type, [
 		{
 			op: 'replace',
 			path: '/data/status',
-			value: 'closed'
+			value: 'closed-resolved'
 		}
 	])
 


### PR DESCRIPTION
Test: add e2e server tests for pattern snapback

Also updated test for snapback from pattern to support thread (using the new 'closed-resolved' status).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

TODO: Update dependencies to released versions once https://github.com/product-os/jellyfish-plugin-default/pull/568 has been merged/released.
