### PR TITLE
Accept navigation event from parent window

### DIFF
--- a/apps/livechat/lib/components/AuthenticationTask.jsx
+++ b/apps/livechat/lib/components/AuthenticationTask.jsx
@@ -34,7 +34,7 @@ const authenticate = async ({
 }
 
 export const AuthenticationTask = ({
-	userSlug, oauthUrl, children
+	userSlug, oauthUrl, children, ...rest
 }) => {
 	const {
 		sdk
@@ -48,6 +48,6 @@ export const AuthenticationTask = ({
 	}, [ sdk, userSlug, oauthUrl ])
 
 	return (
-		<Task task={authenticationTask}>{children}</Task>
+		<Task task={authenticationTask} {...rest}>{children}</Task>
 	)
 }

--- a/apps/livechat/package-lock.json
+++ b/apps/livechat/package-lock.json
@@ -953,9 +953,9 @@
       }
     },
     "@balena/jellyfish-chat-widget": {
-      "version": "11.0.11",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-chat-widget/-/jellyfish-chat-widget-11.0.11.tgz",
-      "integrity": "sha512-V+AbIaQX3aagFTguI63zIKTW6kEzQ+zq7hoDfTRlQl7RWCYLlYst67pDCk0jqrBtH64VekuE4y5A771xOjbUFw==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-chat-widget/-/jellyfish-chat-widget-12.0.6.tgz",
+      "integrity": "sha512-HFnfrkzLRN27N9XS3DsD5DrfllvDwv1TahCdR2IIVuoWY7r0b/qLxv9bbEJV54guYAtgv8GVpozuw4fldpRLig==",
       "requires": {
         "immutability-helper": "^3.1.1",
         "lodash": "^4.17.21",
@@ -1863,6 +1863,11 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "@use-it/event-listener": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.6.tgz",
+      "integrity": "sha512-e6V7vbU8xpuqy4GZkTLExHffOFgxmGHo3kNWnlhzM/zcX2v+idbD/HaJ9sKdQMgTh+L7MIhdRDXGX3SdAViZzA=="
     },
     "@vue/compiler-core": {
       "version": "3.1.2",

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -10,9 +10,10 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-chat-widget": "^11.0.11",
+    "@balena/jellyfish-chat-widget": "^12.0.6",
     "@balena/jellyfish-client-sdk": "^5.3.4",
     "@balena/jellyfish-ui-components": "^10.0.12",
+    "@use-it/event-listener": "^0.1.6",
     "css-loader": "^5.2.6",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^4.5.2",

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -2814,9 +2814,9 @@
       }
     },
     "@balena/jellyfish-chat-widget": {
-      "version": "11.0.11",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-chat-widget/-/jellyfish-chat-widget-11.0.11.tgz",
-      "integrity": "sha512-V+AbIaQX3aagFTguI63zIKTW6kEzQ+zq7hoDfTRlQl7RWCYLlYst67pDCk0jqrBtH64VekuE4y5A771xOjbUFw==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-chat-widget/-/jellyfish-chat-widget-12.0.6.tgz",
+      "integrity": "sha512-HFnfrkzLRN27N9XS3DsD5DrfllvDwv1TahCdR2IIVuoWY7r0b/qLxv9bbEJV54guYAtgv8GVpozuw4fldpRLig==",
       "requires": {
         "immutability-helper": "^3.1.1",
         "lodash": "^4.17.21",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -20,7 +20,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-chat-widget": "^11.0.11",
+    "@balena/jellyfish-chat-widget": "^12.0.6",
     "@balena/jellyfish-client-sdk": "^5.3.4",
     "@balena/jellyfish-environment": "^4.3.16",
     "@balena/jellyfish-ui-components": "^10.0.12",

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@balena/jellyfish-config/config/tsconfig.json",
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2016",
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "jsx": "react"

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,9 +262,9 @@
       }
     },
     "@balena/jellyfish-chat-widget": {
-      "version": "11.0.11",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-chat-widget/-/jellyfish-chat-widget-11.0.11.tgz",
-      "integrity": "sha512-V+AbIaQX3aagFTguI63zIKTW6kEzQ+zq7hoDfTRlQl7RWCYLlYst67pDCk0jqrBtH64VekuE4y5A771xOjbUFw==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-chat-widget/-/jellyfish-chat-widget-12.0.6.tgz",
+      "integrity": "sha512-HFnfrkzLRN27N9XS3DsD5DrfllvDwv1TahCdR2IIVuoWY7r0b/qLxv9bbEJV54guYAtgv8GVpozuw4fldpRLig==",
       "dev": true,
       "requires": {
         "immutability-helper": "^3.1.1",
@@ -647,16 +647,6 @@
           "integrity": "sha512-vdEYIdvQ6Xx4mQYd1M7yPgWYOhCTSjPsTJu+vtz64SDj3pn0CHcQzB26Az4biHDtFsty23F20z1itAGqh7zIdA==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-environment": {
-          "version": "4.3.16",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
-          "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
-          "dev": true,
-          "requires": {
-            "@humanwhocodes/env": "^2.2.0",
             "lodash": "^4.17.21"
           }
         },
@@ -9365,9 +9355,9 @@
       "dev": true
     },
     "monaco-editor": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.26.0.tgz",
-      "integrity": "sha512-Ce1Zs/dPCFv+FQ7x9BIKNRN8ytsj8IyompD3zaENnb8h8W8HMaW/RIw723WOs27ZTLsESiFAQfHrhZs+zDyO3w==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.26.1.tgz",
+      "integrity": "sha512-mm45nUrBDk0DgZKgbD7+bhDOtcAFNGPJJRAdS6Su1kTGl6XEgC7U3xOmDUW/0RrLf+jlvCGaqLvD4p2VjwuwwQ==",
       "dev": true
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
       "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "dev": true,
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -23,25 +22,6 @@
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.12.13"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
-      "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.13.16",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -67,28 +47,71 @@
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.5",
             "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "@balena/jellyfish-environment": {
+              "version": "4.3.16",
+              "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
+              "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
+              "requires": {
+                "@humanwhocodes/env": "^2.2.0",
+                "lodash": "^4.17.21"
+              }
+            }
+          }
+        },
+        "@balena/jellyfish-assert": {
+          "version": "1.1.64",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.64.tgz",
+          "integrity": "sha512-vdEYIdvQ6Xx4mQYd1M7yPgWYOhCTSjPsTJu+vtz64SDj3pn0CHcQzB26Az4biHDtFsty23F20z1itAGqh7zIdA==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "3.0.51",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.51.tgz",
+          "integrity": "sha512-jQ1VabY96O43EGFGyqylCMDk4bLHmmY8kDEIwiRErJXCx7erU6loIxLwqD8VTmOAS+FP3KetcN03r1BZGE28Gg==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.64",
+            "@balena/jellyfish-environment": "^4.3.16",
+            "@sentry/node": "^6.8.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-errors": "^1.1.0",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
           }
         }
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -98,56 +121,38 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
-      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+      "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
       "dev": true
     },
     "@babel/runtime": {
@@ -170,39 +175,79 @@
       }
     },
     "@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.13.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
-      "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.16",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.16",
-        "@babel/types": "^7.13.17",
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.14.5",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.14.7",
+        "@babel/types": "^7.14.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+          "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/types": {
-      "version": "7.13.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
-      "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -332,6 +377,53 @@
         "uuid-v4-regex": "^1.0.2"
       },
       "dependencies": {
+        "@balena/jellyfish-metrics": {
+          "version": "1.0.322",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.322.tgz",
+          "integrity": "sha512-p7ER/uQtl0VgzjFPMbYLS7tzcleq6BKuHjFrHaP2Ee6zBdVv2JMGJvP8cZWFwFsV16ypubdDpswxIv5U4R+NNQ==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-environment": "^4.3.16",
+            "@balena/jellyfish-logger": "^3.0.51",
+            "@balena/jellyfish-types": "^0.8.10",
+            "@balena/node-metrics-gatherer": "^5.7.5",
+            "express": "^4.17.1",
+            "lodash": "^4.17.21"
+          },
+          "dependencies": {
+            "@balena/jellyfish-environment": {
+              "version": "4.3.16",
+              "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
+              "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
+              "dev": true,
+              "requires": {
+                "@humanwhocodes/env": "^2.2.0",
+                "lodash": "^4.17.21"
+              }
+            }
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.196",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.196.tgz",
+          "integrity": "sha512-V7olFAZYmVNaTtgDsXCqTioq8369Atu5ITTy3k7hfLxnUsFKZIzj2i6apfcEEQvGVdgcp6dtMZF3MKVqH0R9lQ==",
+          "requires": {
+            "@balena/jellyfish-logger": "^3.0.51",
+            "@balena/jellyfish-types": "^0.8.10",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4"
+          }
+        },
+        "@balena/jellyfish-types": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
+          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        },
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -345,13 +437,41 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1"
+          },
+          "dependencies": {
+            "@balena/jellyfish-environment": {
+              "version": "4.3.16",
+              "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
+              "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
+              "requires": {
+                "@humanwhocodes/env": "^2.2.0",
+                "lodash": "^4.17.21"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
           }
         },
         "json-schema": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
-          "dev": true
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -359,7 +479,6 @@
       "version": "4.3.16",
       "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
       "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
-      "dev": true,
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "lodash": "^4.17.21"
@@ -397,7 +516,6 @@
       "version": "3.0.51",
       "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.51.tgz",
       "integrity": "sha512-jQ1VabY96O43EGFGyqylCMDk4bLHmmY8kDEIwiRErJXCx7erU6loIxLwqD8VTmOAS+FP3KetcN03r1BZGE28Gg==",
-      "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.64",
         "@balena/jellyfish-environment": "^4.3.16",
@@ -413,7 +531,6 @@
           "version": "1.1.64",
           "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.64.tgz",
           "integrity": "sha512-vdEYIdvQ6Xx4mQYd1M7yPgWYOhCTSjPsTJu+vtz64SDj3pn0CHcQzB26Az4biHDtFsty23F20z1itAGqh7zIdA==",
-          "dev": true,
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -456,6 +573,17 @@
         "@balena/node-metrics-gatherer": "^5.7.5",
         "express": "^4.17.1",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@balena/jellyfish-types": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
+          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
+          "dev": true,
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-balena-api": {
@@ -486,70 +614,6 @@
           "requires": {
             "lodash": "^4.17.21"
           }
-        },
-        "@balena/jellyfish-environment": {
-          "version": "4.3.16",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
-          "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
-          "dev": true,
-          "requires": {
-            "@humanwhocodes/env": "^2.2.0",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-logger": {
-          "version": "3.0.51",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.51.tgz",
-          "integrity": "sha512-jQ1VabY96O43EGFGyqylCMDk4bLHmmY8kDEIwiRErJXCx7erU6loIxLwqD8VTmOAS+FP3KetcN03r1BZGE28Gg==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-assert": "^1.1.64",
-            "@balena/jellyfish-environment": "^4.3.16",
-            "@sentry/node": "^6.8.0",
-            "errio": "^1.2.2",
-            "lodash": "^4.17.21",
-            "typed-errors": "^1.1.0",
-            "winston": "^3.3.3",
-            "winston-transport": "^4.4.0"
-          }
-        },
-        "@balena/jellyfish-plugin-base": {
-          "version": "2.1.196",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.196.tgz",
-          "integrity": "sha512-V7olFAZYmVNaTtgDsXCqTioq8369Atu5ITTy3k7hfLxnUsFKZIzj2i6apfcEEQvGVdgcp6dtMZF3MKVqH0R9lQ==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-logger": "^3.0.51",
-            "@balena/jellyfish-types": "^0.8.10",
-            "json-schema": "^0.3.0",
-            "lodash": "^4.17.21",
-            "semver": "^7.3.5",
-            "skhema": "^5.3.4"
-          }
-        },
-        "@balena/jellyfish-types": {
-          "version": "0.8.10",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
-          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
-          "dev": true,
-          "requires": {
-            "json-schema-to-typescript": "^10.1.4"
-          }
-        },
-        "json-schema": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -567,6 +631,15 @@
         "skhema": "^5.3.4"
       },
       "dependencies": {
+        "@balena/jellyfish-types": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
+          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
+          "dev": true,
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        },
         "json-schema": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
@@ -595,6 +668,17 @@
         "@balena/jellyfish-types": "^0.8.10",
         "lodash": "^4.17.21",
         "slugify": "^1.5.3"
+      },
+      "dependencies": {
+        "@balena/jellyfish-types": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
+          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
+          "dev": true,
+          "requires": {
+            "json-schema-to-typescript": "^10.1.4"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-default": {
@@ -649,60 +733,6 @@
           "requires": {
             "lodash": "^4.17.21"
           }
-        },
-        "@balena/jellyfish-logger": {
-          "version": "3.0.51",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.51.tgz",
-          "integrity": "sha512-jQ1VabY96O43EGFGyqylCMDk4bLHmmY8kDEIwiRErJXCx7erU6loIxLwqD8VTmOAS+FP3KetcN03r1BZGE28Gg==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-assert": "^1.1.64",
-            "@balena/jellyfish-environment": "^4.3.16",
-            "@sentry/node": "^6.8.0",
-            "errio": "^1.2.2",
-            "lodash": "^4.17.21",
-            "typed-errors": "^1.1.0",
-            "winston": "^3.3.3",
-            "winston-transport": "^4.4.0"
-          }
-        },
-        "@balena/jellyfish-plugin-base": {
-          "version": "2.1.196",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.196.tgz",
-          "integrity": "sha512-V7olFAZYmVNaTtgDsXCqTioq8369Atu5ITTy3k7hfLxnUsFKZIzj2i6apfcEEQvGVdgcp6dtMZF3MKVqH0R9lQ==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-logger": "^3.0.51",
-            "@balena/jellyfish-types": "^0.8.10",
-            "json-schema": "^0.3.0",
-            "lodash": "^4.17.21",
-            "semver": "^7.3.5",
-            "skhema": "^5.3.4"
-          }
-        },
-        "@balena/jellyfish-types": {
-          "version": "0.8.10",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
-          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
-          "dev": true,
-          "requires": {
-            "json-schema-to-typescript": "^10.1.4"
-          }
-        },
-        "json-schema": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -716,81 +746,6 @@
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
         "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "@balena/jellyfish-assert": {
-          "version": "1.1.64",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.1.64.tgz",
-          "integrity": "sha512-vdEYIdvQ6Xx4mQYd1M7yPgWYOhCTSjPsTJu+vtz64SDj3pn0CHcQzB26Az4biHDtFsty23F20z1itAGqh7zIdA==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-environment": {
-          "version": "4.3.16",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.16.tgz",
-          "integrity": "sha512-WDXW/iXqclsng0/uUtaSS6Q2jYZYIUHTrvar/luupItYIdzi89MqKIUURiqTrtAAXBkNpBDVP0t+d06c0/FSIg==",
-          "dev": true,
-          "requires": {
-            "@humanwhocodes/env": "^2.2.0",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@balena/jellyfish-logger": {
-          "version": "3.0.51",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.51.tgz",
-          "integrity": "sha512-jQ1VabY96O43EGFGyqylCMDk4bLHmmY8kDEIwiRErJXCx7erU6loIxLwqD8VTmOAS+FP3KetcN03r1BZGE28Gg==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-assert": "^1.1.64",
-            "@balena/jellyfish-environment": "^4.3.16",
-            "@sentry/node": "^6.8.0",
-            "errio": "^1.2.2",
-            "lodash": "^4.17.21",
-            "typed-errors": "^1.1.0",
-            "winston": "^3.3.3",
-            "winston-transport": "^4.4.0"
-          }
-        },
-        "@balena/jellyfish-plugin-base": {
-          "version": "2.1.196",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.196.tgz",
-          "integrity": "sha512-V7olFAZYmVNaTtgDsXCqTioq8369Atu5ITTy3k7hfLxnUsFKZIzj2i6apfcEEQvGVdgcp6dtMZF3MKVqH0R9lQ==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-logger": "^3.0.51",
-            "@balena/jellyfish-types": "^0.8.10",
-            "json-schema": "^0.3.0",
-            "lodash": "^4.17.21",
-            "semver": "^7.3.5",
-            "skhema": "^5.3.4"
-          }
-        },
-        "@balena/jellyfish-types": {
-          "version": "0.8.10",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-types/-/jellyfish-types-0.8.10.tgz",
-          "integrity": "sha512-dc0ggqIa0zcVIhJLBzhGQLYrYn4jmbRkA+auZGsxTq7nA2TlWOT/rG6R3Kc6N0vMPkLLD1vVsEnfvYbLrnuL4A==",
-          "dev": true,
-          "requires": {
-            "json-schema-to-typescript": "^10.1.4"
-          }
-        },
-        "json-schema": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@balena/jellyfish-plugin-front": {
@@ -1317,7 +1272,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
       "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-      "dev": true,
       "requires": {
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
@@ -1572,8 +1526,7 @@
     "@humanwhocodes/env": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/env/-/env-2.2.0.tgz",
-      "integrity": "sha512-L2+9dTj3w2IG59IN1tNfYGkOg9C0HKXgCRc9VpFfwNeYcwyDb2gIokxZlg3Ss8wycrfnllaFXkfinDJpEuzp7g==",
-      "dev": true
+      "integrity": "sha512-L2+9dTj3w2IG59IN1tNfYGkOg9C0HKXgCRc9VpFfwNeYcwyDb2gIokxZlg3Ss8wycrfnllaFXkfinDJpEuzp7g=="
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.0",
@@ -1584,8 +1537,7 @@
     "@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "dev": true
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@mapbox/hast-util-table-cell-style": {
       "version": "0.2.0",
@@ -2140,7 +2092,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.8.0.tgz",
       "integrity": "sha512-vJzWt/znEB+JqVwtwfjkRrAYRN+ep+l070Ti8GhJnvwU4IDtVlV3T/jVNrj6rl6UChcczaJQMxVxtG5x0crlAA==",
-      "dev": true,
       "requires": {
         "@sentry/hub": "6.8.0",
         "@sentry/minimal": "6.8.0",
@@ -2153,7 +2104,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.8.0.tgz",
       "integrity": "sha512-hFrI2Ss1fTov7CH64FJpigqRxH7YvSnGeqxT9Jc1BL7nzW/vgCK+Oh2mOZbosTcrzoDv+lE8ViOnSN3w/fo+rg==",
-      "dev": true,
       "requires": {
         "@sentry/types": "6.8.0",
         "@sentry/utils": "6.8.0",
@@ -2164,7 +2114,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.8.0.tgz",
       "integrity": "sha512-MRxUKXiiYwKjp8mOQMpTpEuIby1Jh3zRTU0cmGZtfsZ38BC1JOle8xlwC4FdtOH+VvjSYnPBMya5lgNHNPUJDQ==",
-      "dev": true,
       "requires": {
         "@sentry/hub": "6.8.0",
         "@sentry/types": "6.8.0",
@@ -2175,7 +2124,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.8.0.tgz",
       "integrity": "sha512-DPUtDd1rRbDJys+aZdQTScKy2Xxo4m8iSQPxzfwFROsLmzE7XhDoriDwM+l1BpiZYIhxUU2TLxDyVzmdc/TMAw==",
-      "dev": true,
       "requires": {
         "@sentry/core": "6.8.0",
         "@sentry/hub": "6.8.0",
@@ -2192,7 +2140,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.8.0.tgz",
       "integrity": "sha512-3gDkQnmOuOjHz5rY7BOatLEUksANU3efR8wuBa2ujsPQvoLSLFuyZpRjPPsxuUHQOqAYIbSNAoDloXECvQeHjw==",
-      "dev": true,
       "requires": {
         "@sentry/hub": "6.8.0",
         "@sentry/minimal": "6.8.0",
@@ -2204,14 +2151,12 @@
     "@sentry/types": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA==",
-      "dev": true
+      "integrity": "sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA=="
     },
     "@sentry/utils": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.8.0.tgz",
       "integrity": "sha512-OYlI2JNrcWKMdvYbWNdQwR4QBVv2V0y5wK0U6f53nArv6RsyO5TzwRu5rMVSIZofUUqjoE5hl27jqnR+vpUrsA==",
-      "dev": true,
       "requires": {
         "@sentry/types": "6.8.0",
         "tslib": "^1.9.3"
@@ -2359,7 +2304,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
-      "dev": true,
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -2393,8 +2337,7 @@
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-      "dev": true
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -2414,8 +2357,7 @@
     "@types/lodash": {
       "version": "4.14.168",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
-      "dev": true
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
     "@types/lru-cache": {
       "version": "5.1.1",
@@ -2447,14 +2389,12 @@
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
-      "dev": true
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
     },
     "@types/node": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
-      "dev": true
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2497,8 +2437,7 @@
     "@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
-      "dev": true
+      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog=="
     },
     "@types/prop-types": {
       "version": "15.7.4",
@@ -2813,7 +2752,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -2832,7 +2770,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2843,8 +2780,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -2936,8 +2872,7 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-      "dev": true
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -3000,8 +2935,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-differ": {
       "version": "3.0.0",
@@ -3129,8 +3063,7 @@
     "async": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-      "dev": true
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -3141,8 +3074,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "ava": {
       "version": "3.15.0",
@@ -3384,8 +3316,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-arraybuffer": {
       "version": "0.1.4",
@@ -3595,7 +3526,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3713,8 +3643,7 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "callsites": {
       "version": "3.1.0",
@@ -3881,7 +3810,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
       "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.1.1",
         "d": "^1.0.1",
@@ -3894,8 +3822,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
@@ -3996,7 +3923,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
       "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -4006,7 +3932,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -4014,8 +3939,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         }
       }
     },
@@ -4037,14 +3961,12 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
       "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -4059,14 +3981,12 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "colorspace": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
-      "dev": true,
       "requires": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
@@ -4076,7 +3996,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4133,7 +4052,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
       "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-      "dev": true,
       "requires": {
         "validate.io-array": "^1.0.3",
         "validate.io-function": "^1.0.2",
@@ -4144,7 +4062,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
       "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-      "dev": true,
       "requires": {
         "compute-gcd": "^1.2.1",
         "validate.io-array": "^1.0.3",
@@ -4155,8 +4072,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4307,8 +4223,7 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -4334,8 +4249,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -4421,7 +4335,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -4785,7 +4698,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4820,8 +4732,7 @@
     "deep-copy": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/deep-copy/-/deep-copy-1.4.2.tgz",
-      "integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ==",
-      "dev": true
+      "integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ=="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -4886,8 +4797,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -5086,8 +4996,7 @@
     "drange": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
-      "dev": true
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5165,8 +5074,7 @@
     "enabled": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-      "dev": true
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5279,8 +5187,7 @@
     "errio": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/errio/-/errio-1.2.2.tgz",
-      "integrity": "sha1-JDCvpm+m3DY9tYjD2DxEB6hdAlU=",
-      "dev": true
+      "integrity": "sha1-JDCvpm+m3DY9tYjD2DxEB6hdAlU="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -5338,7 +5245,6 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -5349,7 +5255,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -5375,7 +5280,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -5385,7 +5289,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -6013,8 +5916,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esprima-walk": {
       "version": "0.1.0",
@@ -6084,7 +5986,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -6196,7 +6097,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
       "requires": {
         "type": "^2.0.0"
       },
@@ -6204,8 +6104,7 @@
         "type": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
-          "dev": true
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
         }
       }
     },
@@ -6262,8 +6161,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -6300,8 +6198,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6312,14 +6209,12 @@
     "fast-memoize": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
-      "dev": true
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fast-text-encoding": {
       "version": "1.0.3",
@@ -6380,8 +6275,7 @@
     "fecha": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
-      "dev": true
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "figures": {
       "version": "3.2.0",
@@ -6492,8 +6386,7 @@
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "dev": true
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
       "version": "1.14.1",
@@ -6521,8 +6414,7 @@
     "format-util": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
-      "dev": true
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -6573,8 +6465,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -6741,8 +6632,7 @@
     "get-stdin": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-      "dev": true
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
     },
     "get-stream": {
       "version": "6.0.1",
@@ -6763,7 +6653,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6786,7 +6675,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
       "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
-      "dev": true,
       "requires": {
         "@types/glob": "*"
       }
@@ -7280,7 +7168,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -7385,7 +7272,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7394,8 +7280,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "2.0.0",
@@ -7497,8 +7382,7 @@
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-base64": {
       "version": "1.1.0",
@@ -7581,8 +7465,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -7594,7 +7477,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -7704,8 +7586,7 @@
     "is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
       "version": "1.1.2",
@@ -7726,8 +7607,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-string": {
       "version": "1.0.5",
@@ -7792,8 +7672,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -7863,7 +7742,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -7932,7 +7810,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
       "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.4"
       }
@@ -7957,7 +7834,6 @@
       "version": "0.5.0-rcv.34",
       "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.34.tgz",
       "integrity": "sha512-Q68XN31eg8rtDNZQpW7f3BrOJxdpBFdPRTmvbn3rex0fI7hrQJGyoqEKb2lb5UiUS+sblOwgKq4aPtdzwHph9Q==",
-      "dev": true,
       "requires": {
         "json-schema-ref-parser": "^6.1.0",
         "jsonpath-plus": "^3.0.0",
@@ -7968,7 +7844,6 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
           "requires": {
             "sprintf-js": "~1.0.2"
           }
@@ -7977,7 +7852,6 @@
           "version": "3.14.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
           "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -7987,7 +7861,6 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
           "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-          "dev": true,
           "requires": {
             "call-me-maybe": "^1.0.1",
             "js-yaml": "^3.12.1",
@@ -8000,7 +7873,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
       "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-      "dev": true,
       "requires": {
         "compute-lcm": "^1.1.0",
         "json-schema-compare": "^0.2.2",
@@ -8011,7 +7883,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
       "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
-      "dev": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "9.0.9"
       }
@@ -8020,7 +7891,6 @@
       "version": "10.1.4",
       "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.4.tgz",
       "integrity": "sha512-HWm23Z6Fnj3rnm4FKZh3sMz70hNoA+AfqVuV+ZcwFIhq6v76YVUMZSLlonrw7GI5yIoiuuJjB5rqakIYRCLlsg==",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.6",
         "@types/lodash": "^4.14.168",
@@ -8042,8 +7912,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8054,8 +7923,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -8069,8 +7937,7 @@
     "jsonpath-plus": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz",
-      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA==",
-      "dev": true
+      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA=="
     },
     "jsonpointer": {
       "version": "4.1.0",
@@ -8186,8 +8053,7 @@
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "dev": true
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "latest-version": {
       "version": "5.1.0",
@@ -8391,8 +8257,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -8549,7 +8414,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
       "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
-      "dev": true,
       "requires": {
         "colors": "^1.2.1",
         "fast-safe-stringify": "^2.0.4",
@@ -8583,7 +8447,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -8592,7 +8455,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "dev": true,
       "requires": {
         "es5-ext": "~0.10.2"
       }
@@ -8600,8 +8462,7 @@
     "lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=",
-      "dev": true
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "magic-string": {
       "version": "0.25.7",
@@ -8770,7 +8631,6 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
       "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.53",
@@ -8785,8 +8645,7 @@
         "next-tick": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-          "dev": true
+          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
         }
       }
     },
@@ -8948,14 +8807,12 @@
     "mime-db": {
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
-      "dev": true
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
     },
     "mime-types": {
       "version": "2.1.30",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
       "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
-      "dev": true,
       "requires": {
         "mime-db": "1.47.0"
       }
@@ -8986,7 +8843,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8994,8 +8850,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",
@@ -9025,8 +8880,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mocha": {
       "version": "7.2.0",
@@ -9363,8 +9217,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "5.0.0",
@@ -9389,7 +9242,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -9426,8 +9278,7 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nock": {
       "version": "13.1.1",
@@ -9572,8 +9423,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-deep-search": {
       "version": "0.0.7",
@@ -9765,7 +9615,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -9774,7 +9623,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dev": true,
       "requires": {
         "fn.name": "1.x.x"
       }
@@ -9792,7 +9640,6 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
       "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dev": true,
       "requires": {
         "format-util": "^1.0.3"
       }
@@ -10032,8 +9879,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -10429,8 +10275,7 @@
     "prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "dev": true
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
     },
     "pretty-ms": {
       "version": "7.0.1",
@@ -10462,8 +10307,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -10550,8 +10394,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -10675,7 +10518,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
       "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
-      "dev": true,
       "requires": {
         "drange": "^1.0.2",
         "ret": "^0.2.0"
@@ -11140,7 +10982,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11680,8 +11521,7 @@
     "ret": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
-      "dev": true
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -11725,8 +11565,7 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -11954,7 +11793,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       }
@@ -11963,7 +11801,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.4.tgz",
       "integrity": "sha512-2xYL0EwAjqFfbr414RP/wKfM1fRd30kJAS2RsOA+UDq/vvszZeLXZWK9yTPYrr31rQzrczLMvLuD4z74EC3VBw==",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^6.0.1",
         "ajv": "^6.5.1",
@@ -11980,14 +11817,12 @@
         "@types/json-schema": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
-          "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ==",
-          "dev": true
+          "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ=="
         },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -11995,8 +11830,7 @@
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -12183,8 +12017,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -12206,8 +12039,7 @@
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stack-utils": {
       "version": "2.0.3",
@@ -12370,7 +12202,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -12632,8 +12463,7 @@
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "dev": true
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -12651,7 +12481,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
       }
@@ -12660,7 +12489,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
@@ -12681,7 +12509,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "dev": true,
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
@@ -12775,8 +12602,7 @@
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-      "dev": true
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "trough": {
       "version": "1.0.5",
@@ -12816,8 +12642,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tslint": {
       "version": "6.1.3",
@@ -12935,8 +12760,7 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -12966,14 +12790,12 @@
     "typed-error": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
-      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ==",
-      "dev": true
+      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ=="
     },
     "typed-errors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/typed-errors/-/typed-errors-1.1.0.tgz",
       "integrity": "sha1-idWguD01UP7WCZyfE6V7rewQozA=",
-      "dev": true,
       "requires": {
         "underscore": "^1.8.3"
       }
@@ -13036,8 +12858,7 @@
     "underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
-      "dev": true
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -13225,7 +13046,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -13296,8 +13116,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -13342,20 +13161,17 @@
     "validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-      "dev": true
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
     },
     "validate.io-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-      "dev": true
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
     },
     "validate.io-integer": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
       "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "dev": true,
       "requires": {
         "validate.io-number": "^1.0.3"
       }
@@ -13364,7 +13180,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
       "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-      "dev": true,
       "requires": {
         "validate.io-array": "^1.0.3",
         "validate.io-integer": "^1.0.4"
@@ -13373,8 +13188,7 @@
     "validate.io-number": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-      "dev": true
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "value-equal": {
       "version": "1.0.1",
@@ -13537,7 +13351,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
       "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
-      "dev": true,
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.1.0",
@@ -13554,7 +13367,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
       "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.3.7",
         "triple-beam": "^1.2.0"
@@ -13564,7 +13376,6 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -13578,14 +13389,12 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -13612,8 +13421,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -13688,8 +13496,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@balena/jellyfish-action-library": "^15.0.35",
-    "@balena/jellyfish-chat-widget": "^11.0.11",
+    "@balena/jellyfish-chat-widget": "^12.0.6",
     "@balena/jellyfish-client-sdk": "^5.3.4",
     "@balena/jellyfish-config": "^1.4.5",
     "@balena/jellyfish-core": "^5.1.8",
@@ -116,7 +116,6 @@
     "simple-git-hooks": "^2.5.1",
     "uuid": "^8.3.2"
   },
-  "dependencies": {},
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },


### PR DESCRIPTION
Change-type: major

***

Livechat should be able to navigate to url passed by parent window emitting `navigate` event with `livechatIframe.postMessage`. With previous structure I could not change livechat component property when I received navigate event, so I had to move window's message event listener into the component, but this introduced new challenge, because livechat react component may not be initialized when it received `init` event, so I had to remove this event and initialize livechat on page load (I think it should have worked this way from beginning). Dashboard already has this scenario implemented, see: https://github.com/balena-io/balena-ui/pull/4628

Flowdock thread that led to this change: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/e83ksByzqoTAfnDFSuhDeftwmVX

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
