### PR TITLE
Add filter options for all linked contract fields

### DIFF
--- a/apps/livechat/package-lock.json
+++ b/apps/livechat/package-lock.json
@@ -968,6 +968,87 @@
         "rendition": "^20.20.3",
         "styled-components": "^5.3.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "rendition": {
+          "version": "20.20.3",
+          "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.20.3.tgz",
+          "integrity": "sha512-/yf+AFR5f6NjX3UcTOPFQGYtUHKv4TLsee3sCPLy+Gf6gz5y2zVSgNWQJnIiUNGD/764z5nlJBsk9caWZ9GWWg==",
+          "requires": {
+            "@fortawesome/fontawesome-svg-core": "^1.2.35",
+            "@fortawesome/free-regular-svg-icons": "^5.15.3",
+            "@fortawesome/free-solid-svg-icons": "^5.15.3",
+            "@fortawesome/react-fontawesome": "^0.1.14",
+            "@mapbox/rehype-prism": "^0.5.0",
+            "@react-google-maps/api": "^1.13.0",
+            "@rjsf/core": "^2.2.1",
+            "@types/ajv-keywords": "^3.4.0",
+            "@types/color": "^3.0.0",
+            "@types/history": "^4.7.8",
+            "@types/json-schema": "^7.0.5",
+            "@types/lodash": "4.14.165",
+            "@types/node": "^14.14.35",
+            "@types/prop-types": "^15.7.0",
+            "@types/react-helmet": "^6.1.0",
+            "@types/recompose": "^0.26.2",
+            "@types/styled-components": "^5.1.9",
+            "@types/styled-system": "^4.0.0",
+            "@types/uuid": "^3.4.3",
+            "ajv": "^6.12.3",
+            "ajv-keywords": "^3.5.2",
+            "color": "^3.1.3",
+            "color-hash": "^1.0.3",
+            "copy-to-clipboard": "^3.0.8",
+            "date-fns": "^2.16.1",
+            "grommet": "^2.16.3",
+            "hast-util-sanitize": "^3.0.0",
+            "json-e": "^4.1.0",
+            "lodash": "^4.17.21",
+            "mermaid": "^8.8.3",
+            "prismjs": "^1.21.0",
+            "prop-types": "^15.7.2",
+            "qs": "^6.10.1",
+            "react-google-recaptcha": "^2.1.0",
+            "react-helmet": "^6.0.0",
+            "react-monaco-editor": "^0.40.0",
+            "react-notifications-component": "^2.4.1",
+            "react-simplemde-editor": "^4.1.3",
+            "recompose": "0.26.0",
+            "regex-parser": "^2.2.11",
+            "regexp-match-indices": "^1.0.2",
+            "rehype-raw": "^5.0.0",
+            "rehype-react": "^6.1.0",
+            "rehype-sanitize": "^3.0.1",
+            "remark-breaks": "^2.0.1",
+            "remark-parse": "^8.0.3",
+            "remark-rehype": "^7.0.0",
+            "resize-observer": "^1.0.0",
+            "skhema": "^5.3.4",
+            "styled-components": "^5.2.1",
+            "styled-system": "^4.1.0",
+            "tslib": "^2.1.0",
+            "unified": "^9.1.0",
+            "unist-util-visit-parents": "^3.1.0",
+            "uuid": "^3.2.1",
+            "xterm": "^4.8.1",
+            "xterm-addon-fit": "^0.4.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
+          }
+        }
       }
     },
     "@balena/jellyfish-client-sdk": {
@@ -1031,6 +1112,90 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-hash/-/color-hash-2.0.1.tgz",
           "integrity": "sha512-/wIYAQ3xL9ruURLmDbxAsXEsivaOfwWDUVy+zbWJZL3bnNQIDNSmmqbkNzeTOQvDdiz11Kb010UlJN7hUXLg/w=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "rendition": {
+          "version": "20.20.3",
+          "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.20.3.tgz",
+          "integrity": "sha512-/yf+AFR5f6NjX3UcTOPFQGYtUHKv4TLsee3sCPLy+Gf6gz5y2zVSgNWQJnIiUNGD/764z5nlJBsk9caWZ9GWWg==",
+          "requires": {
+            "@fortawesome/fontawesome-svg-core": "^1.2.35",
+            "@fortawesome/free-regular-svg-icons": "^5.15.3",
+            "@fortawesome/free-solid-svg-icons": "^5.15.3",
+            "@fortawesome/react-fontawesome": "^0.1.14",
+            "@mapbox/rehype-prism": "^0.5.0",
+            "@react-google-maps/api": "^1.13.0",
+            "@rjsf/core": "^2.2.1",
+            "@types/ajv-keywords": "^3.4.0",
+            "@types/color": "^3.0.0",
+            "@types/history": "^4.7.8",
+            "@types/json-schema": "^7.0.5",
+            "@types/lodash": "4.14.165",
+            "@types/node": "^14.14.35",
+            "@types/prop-types": "^15.7.0",
+            "@types/react-helmet": "^6.1.0",
+            "@types/recompose": "^0.26.2",
+            "@types/styled-components": "^5.1.9",
+            "@types/styled-system": "^4.0.0",
+            "@types/uuid": "^3.4.3",
+            "ajv": "^6.12.3",
+            "ajv-keywords": "^3.5.2",
+            "color": "^3.1.3",
+            "color-hash": "^1.0.3",
+            "copy-to-clipboard": "^3.0.8",
+            "date-fns": "^2.16.1",
+            "grommet": "^2.16.3",
+            "hast-util-sanitize": "^3.0.0",
+            "json-e": "^4.1.0",
+            "lodash": "^4.17.21",
+            "mermaid": "^8.8.3",
+            "prismjs": "^1.21.0",
+            "prop-types": "^15.7.2",
+            "qs": "^6.10.1",
+            "react-google-recaptcha": "^2.1.0",
+            "react-helmet": "^6.0.0",
+            "react-monaco-editor": "^0.40.0",
+            "react-notifications-component": "^2.4.1",
+            "react-simplemde-editor": "^4.1.3",
+            "recompose": "0.26.0",
+            "regex-parser": "^2.2.11",
+            "regexp-match-indices": "^1.0.2",
+            "rehype-raw": "^5.0.0",
+            "rehype-react": "^6.1.0",
+            "rehype-sanitize": "^3.0.1",
+            "remark-breaks": "^2.0.1",
+            "remark-parse": "^8.0.3",
+            "remark-rehype": "^7.0.0",
+            "resize-observer": "^1.0.0",
+            "skhema": "^5.3.4",
+            "styled-components": "^5.2.1",
+            "styled-system": "^4.1.0",
+            "tslib": "^2.1.0",
+            "unified": "^9.1.0",
+            "unist-util-visit-parents": "^3.1.0",
+            "uuid": "^3.2.1",
+            "xterm": "^4.8.1",
+            "xterm-addon-fit": "^0.4.0"
+          },
+          "dependencies": {
+            "color-hash": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/color-hash/-/color-hash-1.1.1.tgz",
+              "integrity": "sha512-OOZ2pKPuon1H7/77G0+xzSRDgITsik/kYzfJxmCBEI4ozM6UFhZ1aaZ6OhASbDwolHUq5PTRnhDle9FR72tqbw=="
+            },
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
+          }
         }
       }
     },
@@ -1476,17 +1641,17 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
-      "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.2.tgz",
+      "integrity": "sha512-Op5W7jYgZI7AWKY5wQ0/QNMzQM7dGQPyW1rXKNiymVCy5iTfdPuGu4HhYNOM2sIv8gUfIuIdcYlXmAepwaowow==",
       "requires": {
         "@types/unist": "*"
       }
     },
     "@types/history": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
-      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
+      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -1518,9 +1683,9 @@
       "integrity": "sha512-fdg0NO4qpuHWtZk6dASgsrBggY+8N4dWthl1bAQG9ceKUNKFjqpHaDKCAhRUI6y8vavG7hLSJ4YBwJtZyZEXqw=="
     },
     "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.4.tgz",
+      "integrity": "sha512-gIdhbLDFlspL53xzol2hVzrXAbzt71erJHoOwQZWssjaiouOotf03lNtMmFm9VfFkvnLWccSVjUAZGQ5Kqw+jA==",
       "requires": {
         "@types/unist": "*"
       }
@@ -1563,9 +1728,9 @@
       }
     },
     "@types/react-helmet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.1.tgz",
-      "integrity": "sha512-VmSCMz6jp/06DABoY60vQa++h1YFt0PfAI23llxBJHbowqFgLUL0dhS1AQeVPNqYfRp9LAfokrfWACTNeobOrg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.2.tgz",
+      "integrity": "sha512-dcfAZNlWb5JYFbO9CGfrPWLJAyFcT6UeR3u35eBbv8liY2Rg4K7fM1G5+HnwVgot+C+kVwXAZ8pLEn2jsMfTDg==",
       "requires": {
         "@types/react": "*"
       }
@@ -4188,9 +4353,9 @@
           }
         },
         "@types/marked": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.3.tgz",
-          "integrity": "sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.4.tgz",
+          "integrity": "sha512-L9VRSe0Id8xbPL99mUo/4aKgD7ZoRwFZqUQScNKHi2pFjF9ZYSMNShUHD6VlMT6J/prQq0T1mxuU25m3R7dFzg=="
         }
       }
     },
@@ -8535,9 +8700,9 @@
       }
     },
     "rendition": {
-      "version": "20.20.3",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.20.3.tgz",
-      "integrity": "sha512-/yf+AFR5f6NjX3UcTOPFQGYtUHKv4TLsee3sCPLy+Gf6gz5y2zVSgNWQJnIiUNGD/764z5nlJBsk9caWZ9GWWg==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.2.0.tgz",
+      "integrity": "sha512-jcnyt+JH1TfeYa5QPDISM5zoYR3gYcRwazfxByosAUG3zdk3FmDbu+X1/+pxbOFzU/opitIItMmqRa0vGpHCJA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -19,7 +19,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.2.0",
-    "rendition": "^20.20.3",
+    "rendition": "^21.2.0",
     "style-loader": "^2.0.0",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^4.4.2"

--- a/apps/ui/lib/lens/full/View/Header/ViewFilters/filter-utils.tsx
+++ b/apps/ui/lib/lens/full/View/Header/ViewFilters/filter-utils.tsx
@@ -7,9 +7,27 @@
 import type { JSONSchema } from '@balena/jellyfish-types';
 import skhema from 'skhema';
 import _ from 'lodash';
+import { FilterFieldOption } from 'rendition/dist/components/Filters/FilterModal';
 
+export const LINKED_CONTRACT_PREFIX = '🔗';
 const DELIMITER = '___';
 const DELIMITER_PREFIX_REGEXP = new RegExp(`^${DELIMITER}`);
+
+// A comparer function for filter field options that ensures linked contract field options
+// appear _after_ those fields relating to the target contract type itself.
+export const compareFilterFields = (
+	a: FilterFieldOption,
+	b: FilterFieldOption,
+): number => {
+	const aIsLink = a.title.startsWith(LINKED_CONTRACT_PREFIX);
+	const bIsLink = b.title.startsWith(LINKED_CONTRACT_PREFIX);
+	if (aIsLink === bIsLink) {
+		return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+	} else if (aIsLink) {
+		return 1;
+	}
+	return -1;
+};
 
 // getLinkedContractDataFilterKey and unpackLinksSchema are a pair of functions used to encode/decode linked contract data.
 // The important thing here is that both the link verb and the contract type (or types) need to be encoded

--- a/apps/ui/lib/lens/full/View/Header/index.tsx
+++ b/apps/ui/lib/lens/full/View/Header/index.tsx
@@ -41,6 +41,7 @@ export default class Header extends React.Component<any, any> {
 			lens,
 			filters,
 			tailTypes,
+			allTypes,
 			updateFilters,
 			saveView,
 			channel,
@@ -135,6 +136,7 @@ export default class Header extends React.Component<any, any> {
 						</Flex>
 						<ViewFilters
 							tailTypes={tailTypes}
+							allTypes={allTypes}
 							filters={filters}
 							searchFilter={searchFilter}
 							updateFilters={updateFilters}

--- a/apps/ui/lib/lens/full/View/index.tsx
+++ b/apps/ui/lib/lens/full/View/index.tsx
@@ -830,7 +830,7 @@ export class ViewRenderer extends React.Component<any, any> {
 	}
 
 	render() {
-		const { lenses, channel, isMobile, tail } = this.props;
+		const { lenses, channel, isMobile, tail, types } = this.props;
 
 		const { head } = channel.data;
 
@@ -886,6 +886,7 @@ export class ViewRenderer extends React.Component<any, any> {
 					lens={lens}
 					filters={filters}
 					tailTypes={tailTypes}
+					allTypes={types}
 					updateFilters={this.updateFilters}
 					saveView={this.saveView}
 					channel={channel}

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -2829,6 +2829,92 @@
         "rendition": "^20.20.3",
         "styled-components": "^5.3.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "rendition": {
+          "version": "20.20.3",
+          "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.20.3.tgz",
+          "integrity": "sha512-/yf+AFR5f6NjX3UcTOPFQGYtUHKv4TLsee3sCPLy+Gf6gz5y2zVSgNWQJnIiUNGD/764z5nlJBsk9caWZ9GWWg==",
+          "requires": {
+            "@fortawesome/fontawesome-svg-core": "^1.2.35",
+            "@fortawesome/free-regular-svg-icons": "^5.15.3",
+            "@fortawesome/free-solid-svg-icons": "^5.15.3",
+            "@fortawesome/react-fontawesome": "^0.1.14",
+            "@mapbox/rehype-prism": "^0.5.0",
+            "@react-google-maps/api": "^1.13.0",
+            "@rjsf/core": "^2.2.1",
+            "@types/ajv-keywords": "^3.4.0",
+            "@types/color": "^3.0.0",
+            "@types/history": "^4.7.8",
+            "@types/json-schema": "^7.0.5",
+            "@types/lodash": "4.14.165",
+            "@types/node": "^14.14.35",
+            "@types/prop-types": "^15.7.0",
+            "@types/react-helmet": "^6.1.0",
+            "@types/recompose": "^0.26.2",
+            "@types/styled-components": "^5.1.9",
+            "@types/styled-system": "^4.0.0",
+            "@types/uuid": "^3.4.3",
+            "ajv": "^6.12.3",
+            "ajv-keywords": "^3.5.2",
+            "color": "^3.1.3",
+            "color-hash": "^1.0.3",
+            "copy-to-clipboard": "^3.0.8",
+            "date-fns": "^2.16.1",
+            "grommet": "^2.16.3",
+            "hast-util-sanitize": "^3.0.0",
+            "json-e": "^4.1.0",
+            "lodash": "^4.17.21",
+            "mermaid": "^8.8.3",
+            "prismjs": "^1.21.0",
+            "prop-types": "^15.7.2",
+            "qs": "^6.10.1",
+            "react-google-recaptcha": "^2.1.0",
+            "react-helmet": "^6.0.0",
+            "react-monaco-editor": "^0.40.0",
+            "react-notifications-component": "^2.4.1",
+            "react-simplemde-editor": "^4.1.3",
+            "recompose": "0.26.0",
+            "regex-parser": "^2.2.11",
+            "regexp-match-indices": "^1.0.2",
+            "rehype-raw": "^5.0.0",
+            "rehype-react": "^6.1.0",
+            "rehype-sanitize": "^3.0.1",
+            "remark-breaks": "^2.0.1",
+            "remark-parse": "^8.0.3",
+            "remark-rehype": "^7.0.0",
+            "resize-observer": "^1.0.0",
+            "skhema": "^5.3.4",
+            "styled-components": "^5.2.1",
+            "styled-system": "^4.1.0",
+            "tslib": "^2.1.0",
+            "unified": "^9.1.0",
+            "unist-util-visit-parents": "^3.1.0",
+            "uuid": "^3.2.1",
+            "xterm": "^4.8.1",
+            "xterm-addon-fit": "^0.4.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
+          }
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@balena/jellyfish-client-sdk": {
@@ -2916,6 +3002,95 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-hash/-/color-hash-2.0.1.tgz",
           "integrity": "sha512-/wIYAQ3xL9ruURLmDbxAsXEsivaOfwWDUVy+zbWJZL3bnNQIDNSmmqbkNzeTOQvDdiz11Kb010UlJN7hUXLg/w=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "rendition": {
+          "version": "20.20.3",
+          "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.20.3.tgz",
+          "integrity": "sha512-/yf+AFR5f6NjX3UcTOPFQGYtUHKv4TLsee3sCPLy+Gf6gz5y2zVSgNWQJnIiUNGD/764z5nlJBsk9caWZ9GWWg==",
+          "requires": {
+            "@fortawesome/fontawesome-svg-core": "^1.2.35",
+            "@fortawesome/free-regular-svg-icons": "^5.15.3",
+            "@fortawesome/free-solid-svg-icons": "^5.15.3",
+            "@fortawesome/react-fontawesome": "^0.1.14",
+            "@mapbox/rehype-prism": "^0.5.0",
+            "@react-google-maps/api": "^1.13.0",
+            "@rjsf/core": "^2.2.1",
+            "@types/ajv-keywords": "^3.4.0",
+            "@types/color": "^3.0.0",
+            "@types/history": "^4.7.8",
+            "@types/json-schema": "^7.0.5",
+            "@types/lodash": "4.14.165",
+            "@types/node": "^14.14.35",
+            "@types/prop-types": "^15.7.0",
+            "@types/react-helmet": "^6.1.0",
+            "@types/recompose": "^0.26.2",
+            "@types/styled-components": "^5.1.9",
+            "@types/styled-system": "^4.0.0",
+            "@types/uuid": "^3.4.3",
+            "ajv": "^6.12.3",
+            "ajv-keywords": "^3.5.2",
+            "color": "^3.1.3",
+            "color-hash": "^1.0.3",
+            "copy-to-clipboard": "^3.0.8",
+            "date-fns": "^2.16.1",
+            "grommet": "^2.16.3",
+            "hast-util-sanitize": "^3.0.0",
+            "json-e": "^4.1.0",
+            "lodash": "^4.17.21",
+            "mermaid": "^8.8.3",
+            "prismjs": "^1.21.0",
+            "prop-types": "^15.7.2",
+            "qs": "^6.10.1",
+            "react-google-recaptcha": "^2.1.0",
+            "react-helmet": "^6.0.0",
+            "react-monaco-editor": "^0.40.0",
+            "react-notifications-component": "^2.4.1",
+            "react-simplemde-editor": "^4.1.3",
+            "recompose": "0.26.0",
+            "regex-parser": "^2.2.11",
+            "regexp-match-indices": "^1.0.2",
+            "rehype-raw": "^5.0.0",
+            "rehype-react": "^6.1.0",
+            "rehype-sanitize": "^3.0.1",
+            "remark-breaks": "^2.0.1",
+            "remark-parse": "^8.0.3",
+            "remark-rehype": "^7.0.0",
+            "resize-observer": "^1.0.0",
+            "skhema": "^5.3.4",
+            "styled-components": "^5.2.1",
+            "styled-system": "^4.1.0",
+            "tslib": "^2.1.0",
+            "unified": "^9.1.0",
+            "unist-util-visit-parents": "^3.1.0",
+            "uuid": "^3.2.1",
+            "xterm": "^4.8.1",
+            "xterm-addon-fit": "^0.4.0"
+          },
+          "dependencies": {
+            "color-hash": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/color-hash/-/color-hash-1.1.1.tgz",
+              "integrity": "sha512-OOZ2pKPuon1H7/77G0+xzSRDgITsik/kYzfJxmCBEI4ozM6UFhZ1aaZ6OhASbDwolHUq5PTRnhDle9FR72tqbw=="
+            },
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
+          }
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
       }
     },
@@ -4846,17 +5021,17 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
-      "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.2.tgz",
+      "integrity": "sha512-Op5W7jYgZI7AWKY5wQ0/QNMzQM7dGQPyW1rXKNiymVCy5iTfdPuGu4HhYNOM2sIv8gUfIuIdcYlXmAepwaowow==",
       "requires": {
         "@types/unist": "*"
       }
     },
     "@types/history": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
-      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
+      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -4922,9 +5097,9 @@
       "integrity": "sha512-fdg0NO4qpuHWtZk6dASgsrBggY+8N4dWthl1bAQG9ceKUNKFjqpHaDKCAhRUI6y8vavG7hLSJ4YBwJtZyZEXqw=="
     },
     "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.4.tgz",
+      "integrity": "sha512-gIdhbLDFlspL53xzol2hVzrXAbzt71erJHoOwQZWssjaiouOotf03lNtMmFm9VfFkvnLWccSVjUAZGQ5Kqw+jA==",
       "requires": {
         "@types/unist": "*"
       }
@@ -4978,9 +5153,9 @@
       }
     },
     "@types/react-helmet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.1.tgz",
-      "integrity": "sha512-VmSCMz6jp/06DABoY60vQa++h1YFt0PfAI23llxBJHbowqFgLUL0dhS1AQeVPNqYfRp9LAfokrfWACTNeobOrg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.2.tgz",
+      "integrity": "sha512-dcfAZNlWb5JYFbO9CGfrPWLJAyFcT6UeR3u35eBbv8liY2Rg4K7fM1G5+HnwVgot+C+kVwXAZ8pLEn2jsMfTDg==",
       "requires": {
         "@types/react": "*"
       }
@@ -9659,9 +9834,9 @@
           }
         },
         "@types/marked": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.3.tgz",
-          "integrity": "sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.4.tgz",
+          "integrity": "sha512-L9VRSe0Id8xbPL99mUo/4aKgD7ZoRwFZqUQScNKHi2pFjF9ZYSMNShUHD6VlMT6J/prQq0T1mxuU25m3R7dFzg=="
         }
       }
     },
@@ -19534,9 +19709,9 @@
       }
     },
     "rendition": {
-      "version": "20.20.3",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.20.3.tgz",
-      "integrity": "sha512-/yf+AFR5f6NjX3UcTOPFQGYtUHKv4TLsee3sCPLy+Gf6gz5y2zVSgNWQJnIiUNGD/764z5nlJBsk9caWZ9GWWg==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.2.0.tgz",
+      "integrity": "sha512-jcnyt+JH1TfeYa5QPDISM5zoYR3gYcRwazfxByosAUG3zdk3FmDbu+X1/+pxbOFzU/opitIItMmqRa0vGpHCJA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -75,7 +75,7 @@
     "redux": "^4.1.0",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
-    "rendition": "^20.20.3",
+    "rendition": "^21.2.0",
     "skhema": "^5.3.4",
     "style-loader": "^2.0.0",
     "styled-components": "^5.3.0",


### PR DESCRIPTION
Linked contract filter options are displayed in the format:
🔗 \<Link constraint name\>: \<field title\>

Linked contract filter options appear in the drop-down list _after_ the target contract's filter options.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![Filtering by linked contract data](https://user-images.githubusercontent.com/2925657/125603037-a9864d03-8e5f-4a99-97d6-dfdf1f5c6800.gif)

A new e2e test verifies a simple use case
