### PR TITLE
ui: Allow linking to  new contracts when creating a new contract

### DIFF
--- a/apps/ui/lib/lens/actions/CreateLens.tsx
+++ b/apps/ui/lib/lens/actions/CreateLens.tsx
@@ -255,23 +255,27 @@ export class CreateLens extends React.Component<any, any> {
 				redirectTo: `/${newCard.slug || newCard.id}`,
 			});
 		} else if (_.get(onDone, ['action']) === 'link') {
-			const cards = onDone.targets;
-			const { linkOption, selectedTypeTarget } = this.state;
-			const createLink = async (card) => {
-				return this.props.actions.createLink(card, newCard, linkOption.name, {
-					skipSuccessMessage: true,
-				});
-			};
-			if (newCard && selectedTypeTarget) {
-				const linkTasks = cards.map(createLink);
-				await Bluebird.all(linkTasks);
-				notifications.addNotification(
-					'success',
-					`Created new link${cards.length > 1 ? 's' : ''}`,
-				);
-				this.close();
-				closed = true;
+			if (onDone.onLink) {
+				onDone.onLink(newCard);
+			} else {
+				const cards = onDone.targets;
+				const { linkOption, selectedTypeTarget } = this.state;
+				const createLink = async (card) => {
+					return this.props.actions.createLink(card, newCard, linkOption.name, {
+						skipSuccessMessage: true,
+					});
+				};
+				if (newCard && selectedTypeTarget) {
+					const linkTasks = cards.map(createLink);
+					await Bluebird.all(linkTasks);
+					notifications.addNotification(
+						'success',
+						`Created new link${cards.length > 1 ? 's' : ''}`,
+					);
+				}
 			}
+			this.close();
+			closed = true;
 		}
 		if (!closed) {
 			this.setState({
@@ -461,6 +465,7 @@ const mapDispatchToProps = (dispatch) => {
 		actions: redux.bindActionCreators(
 			_.pick(actionCreators, [
 				'createLink',
+				'addChannel',
 				'removeChannel',
 				'getLinks',
 				'queryAPI',

--- a/apps/ui/lib/lens/common/Segment.tsx
+++ b/apps/ui/lib/lens/common/Segment.tsx
@@ -11,6 +11,7 @@ import _ from 'lodash';
 import React from 'react';
 import { Box, Button, Flex } from 'rendition';
 import { helpers, Icon, withSetup } from '@balena/jellyfish-ui-components';
+import { core } from '@balena/jellyfish-types';
 import { LinkModal } from '../../components/LinkModal';
 
 class Segment extends React.Component<any, any> {
@@ -120,6 +121,7 @@ class Segment extends React.Component<any, any> {
 			card,
 			segment,
 			types,
+			onSave,
 		} = this.props;
 
 		addChannel({
@@ -133,6 +135,11 @@ class Segment extends React.Component<any, any> {
 				onDone: {
 					action: 'link',
 					targets: [card],
+					onLink: onSave
+						? (newCard: core.Contract) => {
+								return onSave(null, newCard, segment.link);
+						  }
+						: null,
 					callback: this.getData,
 				},
 			},
@@ -202,17 +209,15 @@ class Segment extends React.Component<any, any> {
 
 				{segment.link && type && (
 					<Flex px={3} pb={3} flexWrap="wrap">
-						{!onSave && (
-							<Button
-								mr={2}
-								mt={2}
-								success
-								data-test={`add-${type.slug}`}
-								onClick={this.openCreateChannel}
-							>
-								Add new {type.name || type.slug}
-							</Button>
-						)}
+						<Button
+							mr={2}
+							mt={2}
+							success
+							data-test={`add-${type.slug}`}
+							onClick={this.openCreateChannel}
+						>
+							Add new {type.name || type.slug}
+						</Button>
 
 						{showLinkToExistingElementButton && (
 							<Button


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Basically this adds the 'Add new <type>' button to the `Segment` components displayed in the `CreateLens`:

![Screenshot from 2021-07-15 15-29-57](https://user-images.githubusercontent.com/2925657/125755918-a04261b4-3c1a-4f1b-a143-312f4eacba4a.png)

This lets you, for example, add `milestone` contracts as you are creating an `improvement`. The contracts are linked only once the original contract is saved (same behaviour as when linking _existing_ contracts).
