### PR TITLE
Update rendition dependency

### DIFF
--- a/apps/livechat/package-lock.json
+++ b/apps/livechat/package-lock.json
@@ -8705,9 +8705,9 @@
       }
     },
     "rendition": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.2.0.tgz",
-      "integrity": "sha512-jcnyt+JH1TfeYa5QPDISM5zoYR3gYcRwazfxByosAUG3zdk3FmDbu+X1/+pxbOFzU/opitIItMmqRa0vGpHCJA==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.4.0.tgz",
+      "integrity": "sha512-LL59DOKvmuJTa/jJeLi1QsHmLX3bercbWRsf+GcnVemm5X3KJAewjpmkrD+zAZjE7q5EvOvo1Eqzj7pgoSeBJQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -20,7 +20,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.2.0",
-    "rendition": "^21.2.0",
+    "rendition": "^21.4.0",
     "style-loader": "^2.0.0",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^4.4.2"

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -19709,9 +19709,9 @@
       }
     },
     "rendition": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.2.0.tgz",
-      "integrity": "sha512-jcnyt+JH1TfeYa5QPDISM5zoYR3gYcRwazfxByosAUG3zdk3FmDbu+X1/+pxbOFzU/opitIItMmqRa0vGpHCJA==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.4.0.tgz",
+      "integrity": "sha512-LL59DOKvmuJTa/jJeLi1QsHmLX3bercbWRsf+GcnVemm5X3KJAewjpmkrD+zAZjE7q5EvOvo1Eqzj7pgoSeBJQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -75,7 +75,7 @@
     "redux": "^4.1.0",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
-    "rendition": "^21.2.0",
+    "rendition": "^21.4.0",
     "skhema": "^5.3.4",
     "style-loader": "^2.0.0",
     "styled-components": "^5.3.0",


### PR DESCRIPTION
Adds support for the ProgressBar Renderer widget

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***
