### PR TITLE
Use enumNames for Kanban lane titles if available

### DIFF
--- a/apps/ui/lib/lens/misc/Kanban.tsx
+++ b/apps/ui/lib/lens/misc/Kanban.tsx
@@ -162,11 +162,11 @@ class Kanban extends React.Component<any, any> {
 				},
 			];
 		}
-		slice.values.forEach((value) => {
+		slice.values.forEach((value, index) => {
 			const lane: any = {
 				id: `${slice.path}__${value}`,
 				cards: [],
-				title: value,
+				title: slice.names ? slice.names[index] : value,
 			};
 			if (!cards.length) {
 				lanes.push(lane);


### PR DESCRIPTION
These are more user-friendly than the actual enum values.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before:
![Screenshot from 2021-07-19 13-07-33](https://user-images.githubusercontent.com/2925657/126110835-142c2adf-65b8-4ec6-86c6-fc7b6e8d10b1.png)

After:
![Screenshot from 2021-07-19 13-06-15](https://user-images.githubusercontent.com/2925657/126110802-b10a6379-0736-4908-ba3f-9e3ebcf56506.png)
