### PR TITLE
CSV export: fix double quote escaping

### DIFF
--- a/apps/ui/lib/lens/full/View/Header/index.tsx
+++ b/apps/ui/lib/lens/full/View/Header/index.tsx
@@ -79,7 +79,7 @@ export default class Header extends React.Component<any, any> {
 					return _.mapValues(flattened, (field) => {
 						// escape all non-escaped double-quotes (double double-quotes escape them in CSV)
 						return _.isString(field)
-							? field.replace(/([^"]|^)"([^"]|$)/g, '$1""$2')
+							? field.replace(/([^"]|^)"(?=[^"]|$)/g, '$1""')
 							: field;
 					});
 			  })


### PR DESCRIPTION
The previous regex didn't account for overlapping matches. For example, the text `blah ":" blah` would be converted to `blah "":" blah` - with the second double-quote not getting escaped. The new regex uses a positive lookahead instead of a capture group to ensure we don't miss these cases.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

