### PR TITLE
Fix the layout for CardFields

### DIFF
--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.tsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.tsx
@@ -87,6 +87,7 @@ export default class SingleCardFull extends React.Component<any, any> {
 					<Tab title="Info">
 						<Box
 							p={3}
+							flex={1}
 							style={{
 								maxWidth: Theme.breakpoints[2],
 							}}


### PR DESCRIPTION
Allow card fields to take up the full available horizontal width.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

