### PR TITLE
ui: Avoid fetching (and displaying) too many repositories in the sidebar

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -466,6 +466,9 @@ export default class HomeChannel extends React.Component<any, any> {
 					},
 				},
 				{
+					// TODO: Find a better way to display repositories when there are
+					// a _lot_ of them. For now just limit the number to a manageable amount.
+					limit: 50,
 					sortBy: 'name',
 				},
 			)


### PR DESCRIPTION
This is a temporary measure until we come up with an improved UX for displaying repositories that works when there are a _lot_ of repositories in the same organization/loop.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

