### PR TITLE
Upgrade to v8 worker

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -1082,9 +1082,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "7.0.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-7.0.51.tgz",
-      "integrity": "sha512-vGblQ7CcMwMGncnUDB0CsD5ql6mYCWgHy5L74qgn4cdKcE/5HUnkynQhfpAwG6WVXJEAlXBXjifK4nOz/LEg+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-8.0.0.tgz",
+      "integrity": "sha512-QyQuS/QwkkpYwk9PtmcHxHNABYcWiHdWqTjrhWHOt660GZTvnI9b0Lkly2+HFNzAedMhTMiMG3JDkGe1p1Cv8g==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.66",
         "@balena/jellyfish-jellyscript": "^4.7.1",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -38,7 +38,7 @@
     "@balena/jellyfish-plugin-typeform": "^3.0.182",
     "@balena/jellyfish-queue": "^1.0.228",
     "@balena/jellyfish-sync": "^6.1.1",
-    "@balena/jellyfish-worker": "^7.0.51",
+    "@balena/jellyfish-worker": "^8.0.0",
     "bluebird": "^3.7.2",
     "express": "^4.17.1",
     "lodash": "^4.17.21",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -823,9 +823,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "7.0.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-7.0.51.tgz",
-      "integrity": "sha512-vGblQ7CcMwMGncnUDB0CsD5ql6mYCWgHy5L74qgn4cdKcE/5HUnkynQhfpAwG6WVXJEAlXBXjifK4nOz/LEg+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-8.0.0.tgz",
+      "integrity": "sha512-QyQuS/QwkkpYwk9PtmcHxHNABYcWiHdWqTjrhWHOt660GZTvnI9b0Lkly2+HFNzAedMhTMiMG3JDkGe1p1Cv8g==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.66",
         "@balena/jellyfish-jellyscript": "^4.7.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -38,7 +38,7 @@
     "@balena/jellyfish-plugin-typeform": "^3.0.182",
     "@balena/jellyfish-queue": "^1.0.228",
     "@balena/jellyfish-sync": "^6.1.1",
-    "@balena/jellyfish-worker": "^7.0.51",
+    "@balena/jellyfish-worker": "^8.0.0",
     "aws-sdk": "^2.948.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,9 +1153,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "7.0.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-7.0.51.tgz",
-      "integrity": "sha512-vGblQ7CcMwMGncnUDB0CsD5ql6mYCWgHy5L74qgn4cdKcE/5HUnkynQhfpAwG6WVXJEAlXBXjifK4nOz/LEg+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-8.0.0.tgz",
+      "integrity": "sha512-QyQuS/QwkkpYwk9PtmcHxHNABYcWiHdWqTjrhWHOt660GZTvnI9b0Lkly2+HFNzAedMhTMiMG3JDkGe1p1Cv8g==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.66",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@balena/jellyfish-queue": "^1.0.228",
     "@balena/jellyfish-sync": "^6.1.1",
     "@balena/jellyfish-ui-components": "^10.0.14",
-    "@balena/jellyfish-worker": "^7.0.51",
+    "@balena/jellyfish-worker": "^8.0.0",
     "@balena/lint": "^6.1.1",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.5.1",


### PR DESCRIPTION
This update change the "trigger" input for the worker to be a plain
triggered-action contract, instead of a parsed intermediary object.
The only change we need to make to support this new worker version is to
no longer transform triggered action contracts before passing them to
the worker.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
