### PR TITLE
Traefik networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,10 @@ services:
     ports:
       - 9229
     restart: always
+    labels:
+      - "traefik.http.routers.api.rule=HostRegexp(`api.ly.fish.local`,`api.{uuid:[a-z0-9]+}.balena-devices.com`)"
+      - "traefik.http.services.api-service.loadbalancer.server.port=80"
+      - "traefik.enable=true"
   livechat:
     build:
       args:
@@ -110,17 +114,29 @@ services:
     environment:
       - NGINX_PORT=80
       - LIVECHAT_PORT=80
+    labels:
+      - "traefik.http.routers.livechat.rule=HostRegexp(`livechat.ly.fish.local`)"
+      - "traefik.http.services.livechat-service.loadbalancer.server.port=80"
+      - "traefik.enable=true"
   postgres:
     image: balena/open-balena-db:4.1.0
     restart: always
     networks:
       - internal
+    labels:
+      - "traefik.tcp.routers.postgres.rule=HostSNI(`postgres.ly.fish.local`)"
+      - "traefik.tcp.services.postgres-service.loadbalancer.server.port=5432"
+      - "traefik.enable=true"
   redis:
     image: balena/balena-redis:0.0.3
     command: [sh, -c, "redis-server /usr/local/etc/redis/redis.conf --save ''"]
     restart: always
     networks:
       - internal
+    labels:
+      - "traefik.tcp.routers.redis.rule=HostSNI(`redis.ly.fish.local`)"
+      - "traefik.tcp.services.redis-service.loadbalancer.server.port=6379"
+      - "traefik.enable=true"
   tick:
     build:
       context: .
@@ -170,6 +186,10 @@ services:
       - NODE_ENV
     networks:
       - internal
+    labels:
+      - "traefik.http.routers.ui.rule=HostRegexp(`jel.ly.fish.local`,`jel.{uuid:[a-z0-9]+}.balena-devices.com`)"
+      - "traefik.http.services.ui-service.loadbalancer.server.port=80"
+      - "traefik.enable=true"
   worker_1:
     build:
       context: .
@@ -320,28 +340,45 @@ services:
         ["jel", "livechat", "api", "registry"]
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
-  haproxy:
-    image: 'balena/open-balena-haproxy:2.11.3'
-    cap_add:
-      - SYS_RESOURCE
-      - SYS_ADMIN
-    security_opt:
-      - 'apparmor=unconfined'
-    tmpfs:
-      - /run
-      - /sys/fs/cgroup
-    depends_on:
-      - worker_1
-      - worker_2
-      - ui
-      - tick
-      - livechat
-      - api
-      - balena-mdns-publisher
+  reverse-proxy:
+    image: traefik:v2.4
+    command: --api.insecure=true --providers.docker --providers.docker.endpoint="unix:///var/run/balena.sock" --providers.docker.exposedByDefault=false
     ports:
-      - '80:80'
-      - '5432:5432'
-      - '6379:6379'
+      - "80:80/tcp"
+      - '5432:5432/tcp'
+      - '6379:6379/tcp'
+    labels:
+      io.balena.features.balena-socket: true
+    depends_on:
+          - worker_1
+          - worker_2
+          - ui
+          - tick
+          - livechat
+          - api
+          - balena-mdns-publisher
+  # haproxy:
+  #   image: 'balena/open-balena-haproxy:2.11.3'
+  #   cap_add:
+  #     - SYS_RESOURCE
+  #     - SYS_ADMIN
+  #   security_opt:
+  #     - 'apparmor=unconfined'
+  #   tmpfs:
+  #     - /run
+  #     - /sys/fs/cgroup
+  #   depends_on:
+  #     - worker_1
+  #     - worker_2
+  #     - ui
+  #     - tick
+  #     - livechat
+  #     - api
+  #     - balena-mdns-publisher
+  #   ports:
+  #     - '80:80'
+  #     - '5432:5432'
+  #     - '6379:6379'
     networks:
       internal:
         aliases:
@@ -360,4 +397,3 @@ services:
 
 networks:
   internal: {}
-


### PR DESCRIPTION
Convert HA Proxy to Traefik networking

HA Proxy in its current form (and how it is integrated into JF) presents obstacles for getting a local development environment comparable to production (e.g. getting Github webhooks tested). Traefik allows for multi-domain exposure of the API, in addition to vastly simplifying the networking configuration.

Furthermore we are using Traefik in many other products, and would make logical sense to consolidate them all into the same networking.

Some potential work to do:

- [ ] Have others test (maybe in staging too?) to make sure I'm not missing anything
- [ ] Remove old HA Proxy Comments
- [ ] Remove old code in packages for injecting HA Proxy config files