### PR TITLE
Katapult: Increase component replica count.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jellyfish-action-server
 spec:
-  replicas: 3
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish
-  replicas: 3
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: jellyfish-ui
-  replicas: 3
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
This increases the replica count of action-server, jellyfish-api,
and jellyfish-ui to maximize the current EKS node count for
product-os.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>

