### PR TITLE
ui: sort sidebar items by namespace first

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -212,7 +212,7 @@ const cleanPath = (location) => {
 
 const groupViews = memoize<any>(
 	(tail, usersStarredViews, userSlug, repos: core.Contract[], orgs) => {
-		const sortedTail = _.sortBy(tail, 'name');
+		const sortedTail = _.sortBy(tail, ['data.namespace', 'name']);
 		const groups: any = {
 			defaults: [],
 			main: {


### PR DESCRIPTION
This ensures that namespaced items appear before non-namespaced items and the namespaces are ordered alphabetically.

***

| Before | After |
|----------|---------|
|   ![Screenshot from 2021-07-30 12-12-04](https://user-images.githubusercontent.com/2925657/127603788-f3bdbfa1-0704-48c9-8e3c-d99fb590ff30.png) |  ![Screenshot from 2021-07-30 12-12-28](https://user-images.githubusercontent.com/2925657/127603819-65fd5ecd-89df-47b7-8dc5-aa09614c29d7.png)  |
