### PR TITLE
Check contract override of loop field schema

### DIFF
--- a/apps/ui/lib/lens/actions/CreateLens.tsx
+++ b/apps/ui/lib/lens/actions/CreateLens.tsx
@@ -329,7 +329,11 @@ export class CreateLens extends React.Component<any, any> {
 		_.set(
 			schema,
 			['properties', 'loop'],
-			baseCardType.data.schema.properties.loop,
+			_.merge(
+				{},
+				baseCardType.data.schema.properties.loop,
+				selectedTypeTarget.data.schema.properties.loop,
+			),
 		);
 
 		// Always show tags input

--- a/apps/ui/lib/lens/actions/EditLens.tsx
+++ b/apps/ui/lib/lens/actions/EditLens.tsx
@@ -55,7 +55,11 @@ export class EditLens extends React.Component<any, any> {
 		_.set(
 			schema,
 			['properties', 'loop'],
-			baseCardType.data.schema.properties.loop,
+			_.merge(
+				{},
+				baseCardType.data.schema.properties.loop,
+				cardType.data.schema.properties.loop,
+			),
 		);
 
 		this.state = {


### PR DESCRIPTION
This ensures that if a contract schema overrides what the schema for a loop field is, that this is used by the CreateLens and EditLens components.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

