### PR TITLE
Sort linked contracts when fetching via SDK

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -529,6 +529,11 @@ export const actionCreators = {
 				},
 				{
 					limit: 1,
+					links: {
+						[verb]: {
+							sortBy: 'created_at',
+						},
+					},
 				},
 			);
 


### PR DESCRIPTION
This will ensure a reasonable and consistent ordering of contracts in the `Segment` component (e.g. when viewing a list of linked contracts).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

