### PR TITLE
Inherit loop when creating new contracts

### DIFF
--- a/apps/ui/lib/lens/common/Segment.tsx
+++ b/apps/ui/lib/lens/common/Segment.tsx
@@ -5,6 +5,7 @@
  */
 
 import Bluebird from 'bluebird';
+import { connect } from 'react-redux';
 import clone from 'deep-copy';
 import { circularDeepEqual } from 'fast-equals';
 import _ from 'lodash';
@@ -13,6 +14,7 @@ import { Box, Button, Flex } from 'rendition';
 import { helpers, Icon, withSetup } from '@balena/jellyfish-ui-components';
 import { core } from '@balena/jellyfish-types';
 import { LinkModal } from '../../components/LinkModal';
+import { selectors } from '../../core';
 
 class Segment extends React.Component<any, any> {
 	constructor(props) {
@@ -122,6 +124,7 @@ class Segment extends React.Component<any, any> {
 			segment,
 			types,
 			onSave,
+			activeLoop,
 		} = this.props;
 
 		addChannel({
@@ -131,6 +134,7 @@ class Segment extends React.Component<any, any> {
 				}),
 				seed: {
 					markers: card.markers,
+					loop: card.loop || activeLoop,
 				},
 				onDone: {
 					action: 'link',
@@ -247,4 +251,10 @@ class Segment extends React.Component<any, any> {
 	}
 }
 
-export default withSetup(Segment);
+const mapStateToProps = (state: any) => {
+	return {
+		activeLoop: selectors.getActiveLoop(state),
+	};
+};
+
+export default withSetup(connect<any, any, any>(mapStateToProps)(Segment));

--- a/apps/ui/lib/lens/misc/CRMTable/CRMTable.tsx
+++ b/apps/ui/lib/lens/misc/CRMTable/CRMTable.tsx
@@ -31,15 +31,29 @@ class CRMTable extends React.Component<any, any> {
 		this.generateTableData = this.generateTableData.bind(this);
 	}
 
-	openCreateChannel() {
-		const {
-			type,
-			actions,
-			channel: {
-				data: { head },
+	openCreateChannel(item) {
+		const { allTypes, activeLoop, actions, tail } = this.props;
+		const accountType = helpers.getType('account', allTypes);
+		const opportunity = _.find(tail, { id: item.id });
+		if (!opportunity) {
+			console.warn(`Could not find opportunity ${item.id}`);
+			return;
+		}
+		actions.addChannel({
+			head: {
+				types: accountType,
+				seed: {
+					markers: opportunity.markers,
+					loop: opportunity.loop || activeLoop,
+				},
+				onDone: {
+					action: 'link',
+					targets: [opportunity],
+				},
 			},
-		} = this.props;
-		actions.openCreateChannel(head, type);
+			format: 'create',
+			canonical: false,
+		});
 	}
 
 	initColumns() {
@@ -65,7 +79,7 @@ class CRMTable extends React.Component<any, any> {
 								mr={2}
 								success
 								// TODO: This should open a linked account create modal
-								onClick={this.openCreateChannel}
+								onClick={() => this.openCreateChannel(item)}
 							>
 								Add new linked Account
 							</Button>

--- a/apps/ui/lib/lens/misc/CRMTable/index.tsx
+++ b/apps/ui/lib/lens/misc/CRMTable/index.tsx
@@ -17,7 +17,7 @@ const mapStateToProps = (state, ownProps) => {
 	const target = _.get(ownProps, ['channel', 'data', 'head', 'id']);
 	return {
 		user: selectors.getCurrentUser(state),
-
+		activeLoop: selectors.getActiveLoop(state),
 		allTypes,
 		types: _.get(_.find(allTypes, ['slug', 'opportunity']), [
 			'data',

--- a/apps/ui/lib/lens/misc/Chart/Chart.tsx
+++ b/apps/ui/lib/lens/misc/Chart/Chart.tsx
@@ -44,6 +44,7 @@ const ViewIcon = <Icon name="eye" />;
 export const Chart = React.memo<any>(
 	({
 		actions,
+		activeLoop,
 		channel,
 		chartConfigurationType,
 		history,
@@ -157,6 +158,7 @@ export const Chart = React.memo<any>(
 					types: chartConfigurationType,
 					seed: {
 						markers: channel.data.head.markers,
+						loop: channel.data.head.loop || activeLoop,
 						data: {
 							settings: stringifySettings(settings),
 						},

--- a/apps/ui/lib/lens/misc/Chart/index.tsx
+++ b/apps/ui/lib/lens/misc/Chart/index.tsx
@@ -23,6 +23,7 @@ const mapStateToProps = (state, ownProps) => {
 	const chartConfigurationType = helpers.getType('chart-configuration', types);
 	return {
 		sdk,
+		activeLoop: selectors.getActiveLoop(state),
 		chartConfigurationType,
 		ChartComponent: ChartLazy,
 	};

--- a/apps/ui/lib/lens/misc/Table/CardTable.tsx
+++ b/apps/ui/lib/lens/misc/Table/CardTable.tsx
@@ -102,6 +102,7 @@ export default class CardTable extends React.Component<any, any> {
 			head: {
 				seed: {
 					markers: this.props.channel.data.head.markers,
+					loop: this.props.channel.data.head.loop || this.props.activeLoop,
 				},
 				onDone: {
 					action: 'link',

--- a/apps/ui/lib/lens/misc/Table/index.ts
+++ b/apps/ui/lib/lens/misc/Table/index.ts
@@ -16,6 +16,7 @@ const mapStateToProps = (state, ownProps) => {
 	const target = _.get(ownProps, ['channel', 'data', 'head', 'id']);
 	return {
 		allTypes: selectors.getTypes(state),
+		activeLoop: selectors.getActiveLoop(state),
 		user: selectors.getCurrentUser(state),
 		lensState: selectors.getLensState(state, SLUG, target),
 		SLUG,

--- a/apps/ui/lib/lens/misc/Table/tests/CardTable.spec.tsx
+++ b/apps/ui/lib/lens/misc/Table/tests/CardTable.spec.tsx
@@ -145,6 +145,7 @@ describe('CardTable lens', () => {
 			head: {
 				seed: {
 					markers: channel.data.head.markers,
+					loop: channel.data.head.loop,
 				},
 				onDone: {
 					action: 'link',

--- a/apps/ui/lib/lens/misc/Table/tests/fixtures/props.json
+++ b/apps/ui/lib/lens/misc/Table/tests/fixtures/props.json
@@ -12,6 +12,7 @@
       "head": {
         "id": "7ff03977-e8ae-4ef4-8ac7-4519ecbb3de2",
         "slug": "view-all-customers",
+        "loop": "loop-balena-io@1.0.0",
         "type": "view@1.0.0",
         "active": true,
         "version": "1.0.0",


### PR DESCRIPTION
Inherit loop when creating new contracts

Turns out there's quite a few places in the code where we create new contracts! (We should refactor/abstract this in a future PR).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fix linking to new accounts in CRM table

This was sooooo broken before!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***