### PR TITLE
Bump nginx docker image to v1.21.1

### DIFF
--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -45,7 +45,7 @@ RUN make build-livechat \
 # Runtime
 ###########################################################
 
-FROM nginx:1.21
+FROM nginx:1.21.1
 WORKDIR /usr/src/jellyfish
 COPY --from=base /usr/src/jellyfish/apps/livechat/dist/livechat /usr/share/nginx/html
 COPY apps/livechat/conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -31,7 +31,7 @@ RUN make build-ui \
 # Runtime
 ###########################################################
 
-FROM nginx:1.21
+FROM nginx:1.21.1
 WORKDIR /usr/share/nginx/html
 COPY --from=base /usr/src/jellyfish/apps/ui/dist/ui /usr/share/nginx/html
 COPY apps/ui/conf/env.sh /usr/share/nginx/html


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `nginx` docker image used by front-end apps to v1.21.1. Renovate should now include bump updates instead of only majors/minors for this image.
