### PR TITLE
Only run sut tests if CI is set

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,4 +3,8 @@ FROM resinci/jellyfish-test:v1.4.7
 WORKDIR /usr/src/jellyfish
 COPY . ./
 
-CMD /bin/bash -c "task test"
+ARG NPM_TOKEN
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
+	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true make npm-install
+
+CMD /bin/bash -c "if [ "$CI" ]; then task test; else trap : TERM INT; sleep infinity; fi"

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,9 @@ DOCKER_COMPOSE_FILES = --file docker-compose.yml
 ifdef MONITOR
 DOCKER_COMPOSE_FILES += --file docker-compose.monitor.yml
 endif
+ifdef SUT
+DOCKER_COMPOSE_FILES += --file docker-compose.test.yml
+endif
 
 DOCKER_COMPOSE_OPTIONS = \
 	$(DOCKER_COMPOSE_FILES) \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Many parts of Jellyfish are still under development, and this document aims to c
 	- [**Working with the backend**](https://github.com/product-os/jellyfish/blob/master/docs/developing/backend.markdown)
 	- [**Adding a new type**](https://github.com/product-os/jellyfish/blob/master/docs/developing/add-new-type.markdown)
 	- [**Developing locally**](https://github.com/product-os/jellyfish/blob/master/docs/developing/local-development.markdown)
-	- [**Running in Compose**](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-in-compose.markdown)
+	- [**Running in compose**](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-in-compose.markdown)
+	- [**Running tests in compose**](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-tests-in-compose.markdown)
 	- [**Adding metrics**](https://github.com/product-os/jellyfish-metrics/blob/master/doc/adding-metrics.markdown)
 	- [**Writing translate tests**](https://github.com/product-os/jellyfish-test-harness/blob/master/doc/writing-translate-tests.markdown)
 - **Links**

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,14 +7,6 @@ env:
   NODE_ENV: production
 
 tasks:
-  install-deps:
-    cmds:
-      - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      - make npm-install
-      - rm -f ~/.npmrc
-    env:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-
   catch-uncommitted:
     cmds:
       - make docs/assets/architecture.png ARCHITECTURE.md docker-compose.yml
@@ -93,7 +85,6 @@ tasks:
 
   test:
     cmds:
-      - task: install-deps
       - task: catch-uncommitted
       - task: lint
       - task: unit

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -40,7 +40,7 @@ services:
       - REDIS_PORT=6379
       - SCRUB=0
       - COVERAGE=0
-      - CI=1
+      - CI
       - FS_DRIVER
       - AWS_ACCESS_KEY_ID
       - AWS_S3_BUCKET_NAME

--- a/docs/developing/running-in-compose.markdown
+++ b/docs/developing/running-in-compose.markdown
@@ -1,22 +1,19 @@
-# Running in Docker Compose
+# Running in compose
 
-This is the easiest way to run Jellyfish locally given you have [Docker
-Compose](https://docs.docker.com/compose/) installed. First build all the
-containers:
+This is the easiest way to run Jellyfish locally given you have [`docker-compose`](https://docs.docker.com/compose/) installed.
 
+First build all of the containers:
 ```sh
-export NPM_TOKEN=xxxxx
-make compose-build
+$ export NPM_TOKEN=xxxxx
+$ make compose-build
 ```
 
-Run them with:
-
+Start the cluster with:
 ```sh
-make compose-up
+$ make compose-up
 ```
 
 Add endpoints to local hosts file:
-
 ```
 127.0.0.1 livechat.ly.fish.local api.ly.fish.local jel.ly.fish.local
 ```
@@ -28,10 +25,18 @@ Open `http://jel.ly.fish.local` and login as:
 - Password: `jellyfish`
 
 To include instances of Prometheus and Grafana, build and start your cluster with `MONITOR=1`:
-```
-make compose-build MONITOR=1
-make compose-up MONITOR=1
+```sh
+$ MONITOR=1 make compose-build
+$ MONITOR=1 make compose-up
 ```
 
 Prometheus can be accessed at `http://localhost:9090`.
 Grafana is available at `http://localhost:3000` with the Jellyfish graphs located under the `standard` folder.
+
+You can also include the `sut` container with `SUT=1`:
+```sh
+$ SUT=1 make compose-build
+$ SUT=1 make compose-up
+```
+
+The `sut` container is used to execute CI tests/tasks. Read [this doc](https://github.com/product-os/jellyfish/blob/master/docs/developing/running-tests-in-compose.markdown) for more on how to run these tests/tasks in a local `docker-compose` cluster.

--- a/docs/developing/running-tests-in-compose.markdown
+++ b/docs/developing/running-tests-in-compose.markdown
@@ -1,0 +1,51 @@
+# Running tests in compose
+
+This document outlines how developers can run CI tests/tasks in a local `docker-compose` cluster.
+This method closely emulates how tests/tasks are executed in balenaCI and may help tests that may be passing "natively", but are failing/flaky in balenaCI.
+
+First off, export an `NPM_TOKEN` so containers have access to private packages during build:
+```sh
+$ export NPM_TOKEN=xxxxx
+```
+
+Next, run a couple `make` commands to build images and start the cluster:
+```sh
+$ SUT=1 make compose-build
+$ SUT=1 make compose-up
+```
+
+All tests and tasks executed in CI are defined in `Taskfile.yml` and are executed with [task](https://github.com/go-task/task).
+We can execute the same exact tasks executed in balenaCI in a local compose cluster as shown in the examples below.
+
+Once the cluster is up and running, the `sut` container that runs all of our CI tests/tasks in balenaCI should be up and running, but asleep.
+We need to find the name of this container so we can execute these tests/tasks.
+```sh
+$ docker ps -a
+```
+
+Once we have the name, we can execute tasks from our local machine:
+```sh
+# Run the "unit" task
+$ docker exec <sut-container-name> task unit
+
+# Run the "lint" task
+$ docker exec <sut-container-name> task lint
+
+# Run the "e2e-ui" task
+$ docker exec <sut-container-name> task e2e-ui
+```
+
+Or, we can jump into the container and execute tasks directly.
+One benefit of this method is that once we are in the container, we can edit test files within it using `vim`/`nano` to more easily add debug logs, etc.
+```sh
+$ docker exec -ti <sut-container-name> bash
+
+# Run the "unit" task
+$ task unit
+
+# Run the "lint" task
+$ task lint
+
+# Run the "e2e-ui" task
+$ task e2e-ui
+```

--- a/docs/developing/running-tests.markdown
+++ b/docs/developing/running-tests.markdown
@@ -1,6 +1,6 @@
-# Running Tests
+# Running tests
 
-This document attempts to give an overview of the tests we currently have in Jellyfish and how they can be executed.
+This document attempts to give an overview of the tests we currently have in Jellyfish and how they can be executed locally.
 
 ## Test Types
 Jellyfish currently runs the following types of tests:
@@ -90,277 +90,27 @@ Below are a number of `make test` command examples. They assume that some variab
 It should be noted that in many cases the default values for the options set below are correct, meaning that they may be omitted when running `make test`. This is especially true for `SERVER_HOST`, `SERVER_PORT`, etc. when developing locally.
 
 ### Lint
-Run ESLint tests:
-```
-npm test
+Run lint checks:
+```sh
+$ make lint
 ```
 
 ### Unit
 Run unit tests:
-```
-make test-unit
-```
-
-### Front Mirror
-Run Front mirror tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/e2e/sync/front-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN \
-	INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN \
-	SERVER_HOST=http://api \
-	SERVER_PORT=8000 \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
+```sh
+$ make test-unit
 ```
 
-Run the same tests without keys and token set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/e2e/sync/front-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_FRONT_TOKEN= \
-	SERVER_HOST=http://api \
-	SERVER_PORT=8000 \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-### Front Translate
-Run Front translate tests with proper keys and token set:
-```
-make test \
-	FILES=./test/integration/sync/front-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_FRONT_TOKEN=$FRONT_TOKEN \
-	INTEGRATION_INTERCOM_TOKEN=$INTERCOM_TOKEN \
-	SERVER_HOST=http://api \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/sync/front-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_FRONT_TOKEN= \
-	SERVER_HOST=http://api \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-### Discourse Mirror
-Run Discourse mirror tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/e2e/sync/discourse-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN \
-	INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY \
-	INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME \
-	SERVER_HOST=http://api \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/e2e/sync/discourse-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_DISCOURSE_TOKEN= \
-	SERVER_HOST=http://api \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-### Discourse Translate
-Run Discourse translate tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/integration/sync/discourse-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_DISCOURSE_TOKEN=$DISCOURSE_TOKEN \
-	INTEGRATION_DISCOURSE_SIGNATURE_KEY=$DISCOURSE_SIGNATURE_KEY \
-	INTEGRATION_DISCOURSE_USERNAME=$DISCOURSE_USERNAME \
-	SERVER_HOST=http://api \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/sync/discourse-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_DISCOURSE_TOKEN= \
-	SERVER_HOST=http://api \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-### Outreach Mirror
-Run Outreach mirror tests with proper keys and tokens set.
-```
-make test \
-	FILES=./test/integration/server/outreach-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID \
-	INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET \
-	INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY \
-	SERVER_HOST=http://localhost \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE \
-	REDIS_HOST=localhost
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/server/outreach-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_OUTREACH_APP_ID= \
-	INTEGRATION_OUTREACH_APP_SECRET= \
-	INTEGRATION_OUTREACH_SIGNATURE_KEY=
-```
-
-### Outreach Translate
-Run Outreach translate tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/integration/sync/outreach-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_OUTREACH_APP_ID=$OUTREACH_APP_ID \
-	INTEGRATION_OUTREACH_APP_SECRET=$OUTREACH_APP_SECRET \
-	INTEGRATION_OUTREACH_SIGNATURE_KEY=$OUTREACH_SIGNATURE_KEY \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/sync/outreach-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_OUTREACH_APP_ID= \
-	INTEGRATION_OUTREACH_APP_SECRET= \
-	INTEGRATION_OUTREACH_SIGNATURE_KEY=
-```
-
-### Balena API Translate
-Run Balena API translate tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/integration/sync/balena-api-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION=$BALENA_API_PUBLIC_KEY_PRODUCTION \
-	INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING=$BALENA_API_PUBLIC_KEY_STAGING \
-	INTEGRATION_BALENA_API_PRIVATE_KEY=$BALENA_API_PRIVATE_KEY
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/sync/balena-api-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION= \
-	INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING= \
-	INTEGRATION_BALENA_API_PRIVATE_KEY=
-```
-
-### GitHub Mirror
-Run GitHub mirror tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/e2e/sync/github-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN \
-	INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY \
-	SERVER_HOST=http://api \
-	SERVER_PORT=8000 \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/e2e/sync/github-mirror.spec.js \
-	SCRUB=0 \
-	INTEGRATION_GITHUB_TOKEN= \
-	SERVER_HOST=http://api \
-	SERVER_PORT=8000 \
-	POSTGRES_HOST=$POSTGRES_HOST \
-	POSTGRES_USER=$POSTGRES_USER \
-	POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-	POSTGRES_DATABASE=$POSTGRES_DATABASE
-```
-
-### GitHub Translate
-Run GitHub translate tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/integration/sync/github-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN \
-	INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/sync/github-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_GITHUB_TOKEN=
-```
-
-### Flowdock Translate
-Run Flowdock translate tests with proper keys and tokens set:
-```
-make test \
-	FILES=./test/integration/sync/flowdock-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_FLOWDOCK_SIGNATURE_KEY=$FLOWDOCK_SIGNATURE_KEY \
-	INTEGRATION_FLOWDOCK_TOKEN=$FLOWDOCK_TOKEN
-```
-
-Run the same tests without keys and tokens set (cases requiring them should get skipped):
-```
-make test \
-	FILES=./test/integration/sync/flowdock-translate.spec.js \
-	SCRUB=0 \
-	INTEGRATION_FLOWDOCK_SIGNATURE_KEY= \
-	INTEGRATION_FLOWDOCK_TOKEN=
+### Server Integration
+Run server integration tests:
+```sh
+$ make test-integration-server
 ```
 
 ### E2E UI
 Run UI e2e tests, passing along variables indicating where all necessary services are located:
-```
-make test-e2e-ui \
+```sh
+sh make test-e2e-ui \
 	SCRUB=0 \
 	UI_HOST=http://ui \
 	UI_PORT=80 \
@@ -374,8 +124,8 @@ make test-e2e-ui \
 
 ### E2E Livechat
 Run Livechat e2e tests, passing along variables indicating where all necessary services are located:
-```
-make test-e2e-livechat \
+```sh
+$ make test-e2e-livechat \
 	SCRUB=0 \
 	LIVECHAT_HOST=http://livechat \
 	LIVECHAT_PORT=80 \
@@ -389,8 +139,8 @@ make test-e2e-livechat \
 
 ### E2E Server
 Run server e2e tests, passing along some external service keys as well as where all necessary local services are located:
-```
-make test-e2e-server \
+```sh
+$ make test-e2e-server \
 	SCRUB=0 \
 	INTEGRATION_GITHUB_TOKEN=$GITHUB_TOKEN \
 	INTEGRATION_GITHUB_SIGNATURE_KEY=$GITHUB_SIGNATURE_KEY \


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Update the `sut` container's `Dockerfile.ci` to:
  - Execute CI tests/tasks with `task test` if the `CI` environment variable is set
  - Go to sleep indefinitely if the `CI` environment variable is not set
- Add a `Makefile` flag to easily include `docker-compose.test.yml` on compose build and up
- Add documentation that explains everything with examples and link to it from the main README

### Usage overview
This should allow us to more easily debug tests locally that may be passing "natively", but are failing/flaky in balenaCI. Here is a quick rundown of what that local workflow might look like to run tests in a locally running `docker-compose` cluster complete with the sleeping `sut` container:
```
$ export NPM_TOKEN=xxxxx
$ SUT=1 make compose-build
$ SUT=1 make compose-up
$ docker ps -a (note the sut containers name)
$ docker exec -ti jellyfish_sut_1 bash
$ task lint
$ task unit
```