### PR TITLE
Bump jellyfish-environment to v4.4.0

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -610,9 +610,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.19.tgz",
-      "integrity": "sha512-OkpgBdn/r9FOr4GAVFEkPqyWTu6acAfBkKUP/q6n6x8hX0jilouSqaLKvtEk0rabx/nIn6hPczx09OUUF41+MA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.4.0.tgz",
+      "integrity": "sha512-PhZDqVGS4FlJSIiSNH9Rzn2jiWt4SUn5RcsTZvkTmYJPrGGWcyhOClNlDMIvE5nb6fO4Cdg16MOXOWKgQknnew==",
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "lodash": "^4.17.21"

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@balena/jellyfish-action-library": "^15.0.69",
     "@balena/jellyfish-core": "^5.1.16",
-    "@balena/jellyfish-environment": "^4.3.19",
+    "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-logger": "^3.0.58",
     "@balena/jellyfish-metrics": "^1.0.333",
     "@balena/jellyfish-plugin-balena-api": "^1.0.39",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -423,9 +423,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.19.tgz",
-      "integrity": "sha512-OkpgBdn/r9FOr4GAVFEkPqyWTu6acAfBkKUP/q6n6x8hX0jilouSqaLKvtEk0rabx/nIn6hPczx09OUUF41+MA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.4.0.tgz",
+      "integrity": "sha512-PhZDqVGS4FlJSIiSNH9Rzn2jiWt4SUn5RcsTZvkTmYJPrGGWcyhOClNlDMIvE5nb6fO4Cdg16MOXOWKgQknnew==",
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "lodash": "^4.17.21"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,7 +22,7 @@
     "@balena/jellyfish-action-library": "^15.0.69",
     "@balena/jellyfish-assert": "^1.1.67",
     "@balena/jellyfish-core": "^5.1.16",
-    "@balena/jellyfish-environment": "^4.3.19",
+    "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-logger": "^3.0.58",
     "@balena/jellyfish-metrics": "^1.0.333",
     "@balena/jellyfish-plugin-balena-api": "^1.0.39",

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -2954,9 +2954,9 @@
       "dev": true
     },
     "@balena/jellyfish-environment": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.19.tgz",
-      "integrity": "sha512-OkpgBdn/r9FOr4GAVFEkPqyWTu6acAfBkKUP/q6n6x8hX0jilouSqaLKvtEk0rabx/nIn6hPczx09OUUF41+MA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.4.0.tgz",
+      "integrity": "sha512-PhZDqVGS4FlJSIiSNH9Rzn2jiWt4SUn5RcsTZvkTmYJPrGGWcyhOClNlDMIvE5nb6fO4Cdg16MOXOWKgQknnew==",
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "lodash": "^4.17.21"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@balena/jellyfish-chat-widget": "^12.1.5",
     "@balena/jellyfish-client-sdk": "^5.5.1",
-    "@balena/jellyfish-environment": "^4.3.19",
+    "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-ui-components": "^10.1.12",
     "@primer/styled-octicons": "^14.2.2",
     "analytics-client": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,9 +1018,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.3.19.tgz",
-      "integrity": "sha512-OkpgBdn/r9FOr4GAVFEkPqyWTu6acAfBkKUP/q6n6x8hX0jilouSqaLKvtEk0rabx/nIn6hPczx09OUUF41+MA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-4.4.0.tgz",
+      "integrity": "sha512-PhZDqVGS4FlJSIiSNH9Rzn2jiWt4SUn5RcsTZvkTmYJPrGGWcyhOClNlDMIvE5nb6fO4Cdg16MOXOWKgQknnew==",
       "dev": true,
       "requires": {
         "@humanwhocodes/env": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@balena/jellyfish-client-sdk": "^5.5.1",
     "@balena/jellyfish-config": "^1.4.8",
     "@balena/jellyfish-core": "^5.1.16",
-    "@balena/jellyfish-environment": "^4.3.19",
+    "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-plugin-balena-api": "^1.0.39",
     "@balena/jellyfish-plugin-base": "^2.1.222",
     "@balena/jellyfish-plugin-channels": "^1.1.261",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `@balena/jellyfish-environment` to v4.4.0. Was originally scheduled to be bumped in https://github.com/product-os/jellyfish/pull/7082, but for whatever reason Renovate didn't properly update all `package-lock.json` files.