### PR TITLE
Bump jellyfish-core to v5.1.18

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -582,9 +582,9 @@
       "dev": true
     },
     "@balena/jellyfish-core": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-5.1.16.tgz",
-      "integrity": "sha512-J3+hDbkeTQKFVA5KBxYemetrcO2FhlGQ5/uUA1qr7ZSa/mNTCZawnK+vtBk9/zdEZpQJgai5KfvIC67jrJZ/Ug==",
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-5.1.18.tgz",
+      "integrity": "sha512-M68ovLp8/a/SnjS+Wae72bJCjjLfn3gfEGz8b6upH6S7h7ROZ2qBQoG4YD1lgFbmAS2ZZaj7pK7L6Ax08Oeh6g==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.62",
         "@balena/jellyfish-environment": "^4.3.13",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@balena/jellyfish-action-library": "^15.0.69",
-    "@balena/jellyfish-core": "^5.1.16",
+    "@balena/jellyfish-core": "^5.1.18",
     "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-logger": "^3.0.60",
     "@balena/jellyfish-metrics": "^1.0.333",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -388,9 +388,9 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-5.1.16.tgz",
-      "integrity": "sha512-J3+hDbkeTQKFVA5KBxYemetrcO2FhlGQ5/uUA1qr7ZSa/mNTCZawnK+vtBk9/zdEZpQJgai5KfvIC67jrJZ/Ug==",
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-5.1.18.tgz",
+      "integrity": "sha512-M68ovLp8/a/SnjS+Wae72bJCjjLfn3gfEGz8b6upH6S7h7ROZ2qBQoG4YD1lgFbmAS2ZZaj7pK7L6Ax08Oeh6g==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.62",
         "@balena/jellyfish-environment": "^4.3.13",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@balena/jellyfish-action-library": "^15.0.69",
     "@balena/jellyfish-assert": "^1.1.67",
-    "@balena/jellyfish-core": "^5.1.16",
+    "@balena/jellyfish-core": "^5.1.18",
     "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-logger": "^3.0.60",
     "@balena/jellyfish-metrics": "^1.0.333",

--- a/package-lock.json
+++ b/package-lock.json
@@ -966,9 +966,9 @@
       "dev": true
     },
     "@balena/jellyfish-core": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-5.1.16.tgz",
-      "integrity": "sha512-J3+hDbkeTQKFVA5KBxYemetrcO2FhlGQ5/uUA1qr7ZSa/mNTCZawnK+vtBk9/zdEZpQJgai5KfvIC67jrJZ/Ug==",
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-5.1.18.tgz",
+      "integrity": "sha512-M68ovLp8/a/SnjS+Wae72bJCjjLfn3gfEGz8b6upH6S7h7ROZ2qBQoG4YD1lgFbmAS2ZZaj7pK7L6Ax08Oeh6g==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.62",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@balena/jellyfish-chat-widget": "^12.1.7",
     "@balena/jellyfish-client-sdk": "^5.5.2",
     "@balena/jellyfish-config": "^1.4.8",
-    "@balena/jellyfish-core": "^5.1.16",
+    "@balena/jellyfish-core": "^5.1.18",
     "@balena/jellyfish-environment": "^4.4.0",
     "@balena/jellyfish-plugin-balena-api": "^1.0.39",
     "@balena/jellyfish-plugin-base": "^2.1.222",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
