### PR TITLE
Add a simple UI for check-runs

### DIFF
--- a/apps/ui/jest.config.js
+++ b/apps/ui/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
 		env: {}
 	},
 	transform: {
+		'node_modules/entity-decode/(.*)': 'jest-esm-transformer',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$':
 			'<rootDir>/file-transformer.js'
 	}

--- a/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
+++ b/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { circularDeepEqual } from 'fast-equals';
+import _ from 'lodash';
+import React from 'react';
+import { Box, Divider, Tab, Tabs, Theme } from 'rendition';
+import styled from 'styled-components';
+import { helpers } from '@balena/jellyfish-ui-components';
+import CardFields from '../../../components/CardFields';
+import CardLayout from '../../../layouts/CardLayout';
+import Timeline from '../../list/Timeline';
+import { UI_SCHEMA_MODE } from '../../schema-util';
+import { RelationshipsTab, customQueryTabs } from '../../common';
+import { sdk } from '../../../core';
+import { Mermaid } from 'rendition/dist/extra/Mermaid';
+import { Contract } from '@balena/jellyfish-types/build/core';
+
+export const SingleCardTabs = styled(Tabs)`
+	flex: 1;
+	> [role='tablist'] {
+		height: 100%;
+	}
+	> [role='tabpanel'] {
+		flex: 1;
+	}
+`;
+
+// The maximum depth to explore the graph
+const GRAPH_DEPTH = 3;
+const BUILT_VERB = 'was built into';
+const MERGE_VERB = 'was merged as';
+
+// Takes an expanded tree of contracts and converts them into a mermaidjs graph.
+// Each node in the graph shows the contracts name or slug and its version.
+// TODO: Make this a generic tool
+const makeGraph = (baseContract: Contract) => {
+	const formatContract = (contract: Contract) => {
+		return `${contract.id}(${contract.name || contract.slug}<br/>v${
+			contract.version
+		})`;
+	};
+
+	const buildGraphCode = (contract: Contract): string[] => {
+		const buf: string[] = [];
+		_.forEach(contract.links, (nodes, verb) => {
+			for (const output of nodes) {
+				buf.push(
+					`${formatContract(contract)} -->|${verb}| ${formatContract(output)}`,
+				);
+				buf.push(...buildGraphCode(output));
+			}
+		});
+
+		buf.push(`click ${contract.id} "/${contract.slug}"`);
+
+		return buf;
+	};
+
+	const graph = ['graph TD'].concat(buildGraphCode(baseContract)).join('\n');
+
+	return graph;
+};
+
+export default class SingleCardFull extends React.Component<any, any> {
+	constructor(props) {
+		super(props);
+
+		const tail = _.get(this.props.card.links, ['has attached element'], []);
+
+		const comms = _.filter(tail, (item) => {
+			const typeBase = item.type.split('@')[0];
+			return typeBase === 'message' || typeBase === 'whisper';
+		});
+
+		this.state = {
+			activeIndex: comms.length ? 1 : 0,
+			tree: null,
+		};
+
+		this.setActiveIndex = this.setActiveIndex.bind(this);
+	}
+
+	shouldComponentUpdate(nextProps, nextState) {
+		return (
+			!circularDeepEqual(nextState, this.state) ||
+			!circularDeepEqual(nextProps, this.props)
+		);
+	}
+
+	setActiveIndex(activeIndex) {
+		this.setState({
+			activeIndex,
+		});
+	}
+
+	componentDidMount() {
+		this.loadTransformerData();
+	}
+
+	// Loads the commit contract attached to this check run and then recursively loads all
+	// contracts that it was built into, creating a tree of contracts that can be used to
+	// represent a chain of transformers
+	async loadTransformerData() {
+		const { card } = this.props;
+		const withCommit = await sdk.card.getWithLinks(card.id, [
+			'is attached to commit',
+		]);
+		if (!withCommit || !withCommit.links) {
+			return;
+		}
+		const commit = withCommit.links['is attached to commit'][0];
+
+		const getWasBuiltInto = async (contract: Contract) => {
+			// Build a recursive links query to a maximum depth
+			let fragment = {};
+			_.times(GRAPH_DEPTH, () => {
+				fragment = {
+					anyOf: [
+						{
+							$$links: {
+								[MERGE_VERB]: {
+									type: 'object',
+								},
+								[BUILT_VERB]: {
+									type: 'object',
+									...fragment,
+								},
+							},
+						},
+						true,
+					],
+				};
+			});
+
+			const [contractWithLinks] = await sdk.query({
+				type: 'object',
+				properties: {
+					id: {
+						const: contract.id,
+					},
+				},
+				...fragment,
+			});
+
+			return contractWithLinks;
+		};
+
+		const result = await getWasBuiltInto(commit);
+
+		this.setState({
+			tree: result,
+		});
+	}
+
+	render() {
+		const { card, channel, types, actionItems } = this.props;
+
+		const type = helpers.getType(card.type, types);
+
+		const tail = _.get(card.links, ['has attached element'], []);
+
+		return (
+			<CardLayout
+				overflowY
+				card={card}
+				channel={channel}
+				actionItems={actionItems}
+			>
+				<Divider width="100%" color={helpers.colorHash(card.type)} />
+
+				<SingleCardTabs
+					activeIndex={this.state.activeIndex}
+					onActive={this.setActiveIndex}
+				>
+					<Tab title="Info">
+						<Box
+							p={3}
+							flex={1}
+							style={{
+								maxWidth: Theme.breakpoints[2],
+							}}
+						>
+							<CardFields
+								card={card}
+								type={type}
+								viewMode={UI_SCHEMA_MODE.fields}
+							/>
+							{!!this.state.tree && (
+								<Mermaid value={makeGraph(this.state.tree)} />
+							)}
+						</Box>
+					</Tab>
+
+					<Tab title="Timeline">
+						<Timeline.data.renderer card={card} allowWhispers tail={tail} />
+					</Tab>
+
+					{customQueryTabs(card, type)}
+					<RelationshipsTab card={card} />
+				</SingleCardTabs>
+			</CardLayout>
+		);
+	}
+}

--- a/apps/ui/lib/lens/full/CheckRun/index.tsx
+++ b/apps/ui/lib/lens/full/CheckRun/index.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import * as _ from 'lodash';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { actionCreators, selectors } from '../../../core';
+import CheckRun from './CheckRun';
+
+const mapStateToProps = (state) => {
+	return {
+		types: selectors.getTypes(state),
+	};
+};
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		actions: bindActionCreators(
+			_.pick(actionCreators, [
+				'createLink',
+				'addChannel',
+				'getLinks',
+				'queryAPI',
+			]),
+			dispatch,
+		),
+	};
+};
+
+const lens = {
+	slug: 'lens-full-default',
+	type: 'lens',
+	version: '1.0.0',
+	name: 'Default lens',
+	data: {
+		format: 'full',
+		icon: 'address-card',
+		renderer: connect(mapStateToProps, mapDispatchToProps)(CheckRun),
+		filter: {
+			type: 'object',
+			properties: {
+				type: {
+					const: 'check-run@1.0.0',
+				},
+			},
+		},
+	},
+};
+
+export default lens;

--- a/apps/ui/lib/lens/full/index.ts
+++ b/apps/ui/lib/lens/full/index.ts
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+import CheckRun from './CheckRun';
 import MyUser from './MyUser';
 import Repository from './Repository';
 import SingleCard from './SingleCard';
@@ -14,6 +15,7 @@ import User from './User';
 import TransformerWorker from './TransformerWorker';
 
 export default [
+	CheckRun,
 	MyUser,
 	Repository,
 	SingleCard,

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -14488,6 +14488,16 @@
         "jest-util": "^26.6.2"
       }
     },
+    "jest-esm-transformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-esm-transformer/-/jest-esm-transformer-1.0.0.tgz",
+      "integrity": "sha512-FoPgeMMwy1/CEsc8tBI41i83CEO3x85RJuZi5iAMmWoARXhfgk6Jd7y+4d+z+HCkTKNVDvSWKGRhwjzU9PUbrw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.4.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.4"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -107,6 +107,7 @@
     "eslint": "^7.32.0",
     "grommet": "^2.17.4",
     "jest": "^26.6.3",
+    "jest-esm-transformer": "^1.0.0",
     "json-schema": "^0.3.0",
     "redux-mock-store": "^1.5.4",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
This commit adds a basic UI for check runs that shows all of the
contracts created by transformers from the commit the check run is
attached to. The graph is generated using mermaidJS, so doesn't add any
additional dependencies to the system. In the future I'd like to develop
this concept into a generic graph visualisation features, however there
are behavioural issues that need to be resolved, such as which links you
expand/display and to what depth.

![image](https://user-images.githubusercontent.com/15064535/129900644-12c6d2ba-ea05-498f-8d80-cbaea9e51583.png)


Resolves https://github.com/product-os/product-os/issues/1180