### PR TITLE
Don't restrict access to user created views

### DIFF
--- a/apps/ui/lib/lens/full/View/index.tsx
+++ b/apps/ui/lib/lens/full/View/index.tsx
@@ -783,7 +783,6 @@ export class ViewRenderer extends React.Component<any, any> {
 			name: USER_FILTER_NAME,
 		});
 		newView.data.actor = user.id;
-		newView.markers = [user.slug];
 		view.filters.forEach((filter) => {
 			newView.data.allOf.push({
 				name: USER_FILTER_NAME,


### PR DESCRIPTION
With this change, user created views no longer have the users marker and
will now be viewable by other users. This will have the side effect of
fixing the issue where users will unintentionally create contracts that
are viewable only by them when they create the contract in the context
of their custom view.

This change also bundles https://github.com/product-os/jellyfish-plugin-default/pull/631 which excludes other users custom views from your sidebar.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
