### PR TITLE
Update haproxy and mdns services

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -206,7 +206,7 @@ services:
       - 923{{idx}}:9229
   {{/workers}}
   balena-mdns-publisher:
-    image: 'balena/balena-mdns-publisher:master'
+    image: 'balena/balena-mdns-publisher:v1.10.1'
     network_mode: host
     cap_add:
       - SYS_RESOURCE
@@ -226,15 +226,7 @@ services:
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   haproxy:
-    image: 'balena/open-balena-haproxy:2.11.3'
-    cap_add:
-      - SYS_RESOURCE
-      - SYS_ADMIN
-    security_opt:
-      - 'apparmor=unconfined'
-    tmpfs:
-      - /run
-      - /sys/fs/cgroup
+    image: 'balena/open-balena-haproxy:v4.0.1'
     depends_on:
       {{#workers}}
       - worker_{{idx}}

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -206,16 +206,10 @@ services:
       - 923{{idx}}:9229
   {{/workers}}
   balena-mdns-publisher:
-    image: 'balena/balena-mdns-publisher:v1.10.1'
+    image: 'balena/balena-mdns-publisher:v1.11.0'
     network_mode: host
-    cap_add:
-      - SYS_RESOURCE
-      - SYS_ADMIN
-    security_opt:
-      - 'apparmor=unconfined'
-    tmpfs:
-      - /run
-      - /sys/fs/cgroup
+    volumes:
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     labels:
       io.balena.features.dbus: '1'
       io.balena.features.supervisor-api: '1'
@@ -223,7 +217,7 @@ services:
       MDNS_TLD: ly.fish.local
       MDNS_SUBDOMAINS: >-
         ["jel", "livechat", "api", "registry"]
-      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
+      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/var/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   haproxy:
     image: 'balena/open-balena-haproxy:v4.0.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,16 +267,10 @@ services:
     ports:
       - 9232:9229
   balena-mdns-publisher:
-    image: 'balena/balena-mdns-publisher:v1.10.1'
+    image: 'balena/balena-mdns-publisher:v1.11.0'
     network_mode: host
-    cap_add:
-      - SYS_RESOURCE
-      - SYS_ADMIN
-    security_opt:
-      - 'apparmor=unconfined'
-    tmpfs:
-      - /run
-      - /sys/fs/cgroup
+    volumes:
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     labels:
       io.balena.features.dbus: '1'
       io.balena.features.supervisor-api: '1'
@@ -284,7 +278,7 @@ services:
       MDNS_TLD: ly.fish.local
       MDNS_SUBDOMAINS: >-
         ["jel", "livechat", "api", "registry"]
-      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
+      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/var/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   haproxy:
     image: 'balena/open-balena-haproxy:v4.0.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,7 @@ services:
     ports:
       - 9232:9229
   balena-mdns-publisher:
-    image: 'balena/balena-mdns-publisher:master'
+    image: 'balena/balena-mdns-publisher:v1.10.1'
     network_mode: host
     cap_add:
       - SYS_RESOURCE
@@ -287,15 +287,7 @@ services:
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
       CONFD_BACKEND: 'ENV'
   haproxy:
-    image: 'balena/open-balena-haproxy:2.11.3'
-    cap_add:
-      - SYS_RESOURCE
-      - SYS_ADMIN
-    security_opt:
-      - 'apparmor=unconfined'
-    tmpfs:
-      - /run
-      - /sys/fs/cgroup
+    image: 'balena/open-balena-haproxy:v4.0.1'
     depends_on:
       - worker_1
       - worker_2


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Update `haproxy` and `mdns-publisher` services to most recent tags, replacing older versions that were based on systemd which has problems with hosts using cgroups v2: https://github.com/balena-io/balena-mdns-publisher/pull/78