### PR TITLE
Set explicit version for mdns service image

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -206,7 +206,7 @@ services:
       - 923{{idx}}:9229
   {{/workers}}
   balena-mdns-publisher:
-    image: 'balena/balena-mdns-publisher:master'
+    image: 'balena/balena-mdns-publisher:1.10.1'
     network_mode: host
     cap_add:
       - SYS_RESOURCE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,7 @@ services:
     ports:
       - 9232:9229
   balena-mdns-publisher:
-    image: 'balena/balena-mdns-publisher:master'
+    image: 'balena/balena-mdns-publisher:1.10.1'
     network_mode: host
     cap_add:
       - SYS_RESOURCE


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Setting an explicit image tag for the `mdns-publisher` service to reduce confusion and possible CI/dev interruptions caused by unexpected image updates.