### PR TITLE
Run e2e sdk tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,6 +51,10 @@ tasks:
     cmds:
       - make test FILES=./test/e2e/sync/github-mirror.spec.js
 
+  e2e-sdk:
+    cmds:
+      - make test-e2e-sdk
+
   e2e-livechat:
     cmds:
       - make test-e2e-livechat
@@ -95,6 +99,7 @@ tasks:
       - task: front-mirror
       - task: discourse-mirror
       - task: github-mirror
+      - task: e2e-sdk
       - task: e2e-livechat
       - task: e2e-ui
       - task: e2e-server

--- a/test/e2e/sdk/card.spec.js
+++ b/test/e2e/sdk/card.spec.js
@@ -30,13 +30,14 @@ const createSupportThread = async (sdk) => {
 	})
 }
 
-const createSupportIssue = async (sdk) => {
+const createIssue = async (sdk) => {
 	return sdk.card.create({
-		type: 'support-issue@1.0.0',
-		name: `test-support-issue-${uuid()}`,
+		type: 'issue@1.0.0',
+		name: `test-issue-${uuid()}`,
 		data: {
 			inbox: 'S/Paid_Support',
-			status: 'open'
+			status: 'open',
+			repository: 'foobar'
 		}
 	})
 }
@@ -73,13 +74,13 @@ ava('If you call card.link twice with the same params you will get the same link
 	// Create a support thread and support issue
 	const supportThread = await createSupportThread(sdk)
 
-	const supportIssue = await createSupportIssue(sdk)
+	const issue = await createIssue(sdk)
 
-	// Link the support thread to the support issue
-	await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+	// Link the support thread to the issue
+	await sdk.card.link(supportThread, issue, 'support thread is attached to issue')
 
-	// Try to link the same support thread to the same support issue
-	const link = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+	// Try to link the same support thread to the same issue
+	const link = await sdk.card.link(supportThread, issue, 'support thread is attached to issue')
 
 	// Verify the link ID is the same
 	test.is(link, true)
@@ -90,19 +91,19 @@ ava('card.link will create a new link if the previous one was deleted', async (t
 		sdk
 	} = context
 
-	// Create a support thread and support issue
+	// Create a support thread and issue
 	const supportThread = await createSupportThread(sdk)
 
-	const supportIssue = await createSupportIssue(sdk)
+	const issue = await createIssue(sdk)
 
-	// Link the support thread to the support issue
-	const link1 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+	// Link the support thread to the issue
+	const link1 = await sdk.card.link(supportThread, issue, 'support thread is attached to issue')
 
 	// Now remove the link
-	await sdk.card.unlink(supportThread, supportIssue, 'support thread is attached to support issue')
+	await sdk.card.unlink(supportThread, issue, 'support thread is attached to issue')
 
-	// Try to link the same support thread to the same support issue
-	const link2 = await sdk.card.link(supportThread, supportIssue, 'support thread is attached to support issue')
+	// Try to link the same support thread to the same issue
+	const link2 = await sdk.card.link(supportThread, issue, 'support thread is attached to issue')
 
 	// Verify the link ID is not the same
 	test.not(link1.id, link2.id)

--- a/test/e2e/sdk/event.spec.js
+++ b/test/e2e/sdk/event.spec.js
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+const Bluebird = require('bluebird')
 const ava = require('ava')
 const {
 	v4: uuid
@@ -81,6 +82,7 @@ ava('Editing a message triggers an update to the edited_at field', async (test) 
 	let msg = await createMessage(sdk, supportThread, {
 		message: messageBefore
 	})
+	await Bluebird.delay(1000)
 
 	// Verify that initiall the edited_at field is undefined
 	test.is(typeof msg.data.edited_at, 'undefined')
@@ -91,6 +93,7 @@ ava('Editing a message triggers an update to the edited_at field', async (test) 
 		path: '/data/payload/message',
 		value: update1
 	} ])
+	await Bluebird.delay(1000)
 	msg = await sdk.card.get(msg.id)
 
 	// And check that the edited_at field now has a valid date-time value
@@ -104,6 +107,7 @@ ava('Editing a message triggers an update to the edited_at field', async (test) 
 		path: '/data/payload/message',
 		value: update2
 	} ])
+	await Bluebird.delay(1000)
 	msg = await sdk.card.get(msg.id)
 
 	// And check that the edited_at field has been updated again
@@ -126,6 +130,7 @@ ava('Updating a meta field in the message payload triggers an update to the edit
 		message: 'test',
 		mentionsUser: mentionsUserBefore
 	})
+	await Bluebird.delay(1000)
 
 	// Verify that initiall the edited_at field is undefined
 	test.is(typeof msg.data.edited_at, 'undefined')
@@ -136,6 +141,7 @@ ava('Updating a meta field in the message payload triggers an update to the edit
 		path: '/data/payload/mentionsUser/0',
 		value: user1
 	} ])
+	await Bluebird.delay(1000)
 	msg = await sdk.card.get(msg.id)
 
 	// And check that the edited_at field now has a valid date-time value
@@ -148,6 +154,7 @@ ava('Updating a meta field in the message payload triggers an update to the edit
 		op: 'remove',
 		path: '/data/payload/mentionsUser/0'
 	} ])
+	await Bluebird.delay(1000)
 	msg = await sdk.card.get(msg.id)
 
 	// And check that the edited_at field has been updated again


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Noticed we aren't running a couple tests defined under `test/e2e/sdk/`. Not sure if we need to be running these or if just keeping the `helper.js` around is enough.