### PR TITLE
Add puppeteer Renovate group, bump grommet

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,10 @@
 {
   "extends": [
     "github>product-os/jellyfish-config//config/renovate"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["puppeteer"]
+    }
   ]
 }

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -12276,21 +12276,20 @@
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "grommet": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.17.4.tgz",
-      "integrity": "sha512-RUdYExaaFQvNkAPEixPm1LxiZ6Bejek5w5t7yI3+QhjCBmQNmfSoQfpopJntTL8IuX1aZR4XGVyT8hcnxmhapQ==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.17.5.tgz",
+      "integrity": "sha512-ld8nvuEqBDXiUiMybX2yuMH94KC1LxGhHKaDyqQI8HZrzgUpOB/GuQ2VcvB2YSB62Zpt7NuBjsghlLPKG5l8gQ==",
       "requires": {
-        "grommet-icons": "^4.6.0",
+        "grommet-icons": "^4.6.2",
         "hoist-non-react-statics": "^3.2.0",
         "markdown-to-jsx": "^7.1.3",
-        "prop-types": "^15.7.2",
-        "react-desc": "^4.1.3"
+        "prop-types": "^15.7.2"
       }
     },
     "grommet-icons": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.6.0.tgz",
-      "integrity": "sha512-ytnFHPvCEDv7dUZddXUDxG/r/2Mbiq1MDy+kbmCelLXZ09B2zyC2N9KQPKHsm/XbJV6LnOnwchz2pobdz0OITQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.6.2.tgz",
+      "integrity": "sha512-3wTRQsmwrSFM7FvruULNWwi5dWp8MtYCimWeJW0zaJxkq35iPHMTZCzBrVfuRL6pOja3KegNC9b8rvdXVMct6Q==",
       "requires": {
         "grommet-styles": "^0.2.0"
       }
@@ -18737,11 +18736,6 @@
       "requires": {
         "prop-types": "^15.6.2"
       }
-    },
-    "react-desc": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-4.1.3.tgz",
-      "integrity": "sha512-XqfNsg+nvAO77ja5+v3J6bMS7drnWozpiA64bUTyhqvSCJRkq45FiONl7/+74OjPw4Id6qbqVX6xkER/yTU8+w=="
     },
     "react-dnd": {
       "version": "11.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -105,7 +105,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",
-    "grommet": "^2.17.4",
+    "grommet": "^2.17.5",
     "jest": "^26.6.3",
     "jest-esm-transformer": "^1.0.0",
     "json-schema": "^0.3.0",


### PR DESCRIPTION
Add Renovate group for puppeteer 

The latest version of puppeteer is currently breaking some of our E2E
tests. Delegating puppeteer to its own Renovate group until this issue
is resolved.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
***
Bump grommet to v2.17.5 

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
