### PR TITLE
Aggregate user created views by ID instead of marker

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -200,7 +200,7 @@ const cleanPath = (location) => {
 };
 
 const groupViews = memoize<any>(
-	(tail, bookmarks, userSlug, repos: core.Contract[], orgs) => {
+	(tail, bookmarks, userId, repos: core.Contract[], orgs) => {
 		const sortedTail = _.sortBy(tail, ['data.namespace', 'name']);
 		const groups: any = {
 			defaults: [],
@@ -258,7 +258,7 @@ const groupViews = memoize<any>(
 			(acc, view) => {
 				if (view.slug.startsWith('view-121')) {
 					acc.oneToOneViews.push(view);
-				} else if (view.markers.includes(userSlug)) {
+				} else if (view.data.actor === userId) {
 					acc.myViews.push(view);
 				} else {
 					acc.otherViews.push(view);
@@ -583,7 +583,7 @@ export default class HomeChannel extends React.Component<any, any> {
 				</Box>
 			);
 		}
-		const groupedViews = groupViews(tail, bookmarks, user.slug, repos, orgs);
+		const groupedViews = groupViews(tail, bookmarks, user.id, repos, orgs);
 		const groups = groupedViews.main;
 		const defaultViews = groupedViews.defaults;
 		const activeChannelTarget = _.get(activeChannel, ['data', 'target']);


### PR DESCRIPTION
A recent means that custom views no longer have the users marker set on
them, and instead we need to recently on the `data.actor` field to find
custom views.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
