### PR TITLE
Generate slugs in kernel instead of action-create-card

### DIFF
--- a/apps/action-server/package-lock.json
+++ b/apps/action-server/package-lock.json
@@ -829,28 +829,148 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "15.1.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.33.tgz",
-      "integrity": "sha512-5j1OATmIulvNKrkCv+LT9sQJGqnY0PbI9zaA9FZnZua8GbPNSlagXkAeT3be9GevDcAuJQF6rvThI0VD/LIbKg==",
+      "version": "15.1.47",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.47.tgz",
+      "integrity": "sha512-U1b00M7PFEhdOn4X7/eGGgXKUMVvsiK/glbDdVKP3OXWvMuWkRbMQqYLxvx3YKZca6YsFYLUJw4+5xUODbSuWg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.67",
         "@balena/jellyfish-environment": "^5.0.3",
-        "@balena/jellyfish-logger": "^3.0.66",
+        "@balena/jellyfish-logger": "^3.0.67",
         "@balena/jellyfish-mail": "^2.0.84",
         "@balena/jellyfish-metrics": "^1.0.341",
-        "@balena/jellyfish-plugin-base": "^2.1.234",
-        "axios": "^0.21.1",
+        "@balena/jellyfish-plugin-base": "^2.1.235",
+        "axios": "^0.21.3",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "blueimp-md5": "^2.18.0",
         "date-fns": "^2.23.0",
-        "googleapis": "^84.0.0",
+        "googleapis": "^85.0.0",
         "is-base64": "^1.1.0",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
         "semver": "^7.3.5",
         "skhema": "^5.3.4",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-logger": {
+          "version": "3.0.67",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.67.tgz",
+          "integrity": "sha512-gADMPu+FjYyQUDsl5CM/3WQl09L1LSZwmCHbM7RMyJv52ZOR7jnE+OH2mrAkqzYk2YVaIc2AdwMNteAPIvkAHw==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@sentry/node": "^6.12.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.235",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.235.tgz",
+          "integrity": "sha512-J42sxc11MlBiYC/vzkNUO24qecPdKEgOEG7Cx+PgPwxPE4JoXl3/7Ab2fh6COLtcVYgjCgscRPsWUZT+7xPE6A==",
+          "requires": {
+            "@balena/jellyfish-logger": "^3.0.66",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4"
+          }
+        },
+        "@sentry/core": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
+          "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/minimal": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
+          "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+          "requires": {
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
+          "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/node": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
+          "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+          "requires": {
+            "@sentry/core": "6.12.0",
+            "@sentry/hub": "6.12.0",
+            "@sentry/tracing": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
+          "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/minimal": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
+          "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
+        },
+        "@sentry/utils": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
+          "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+          "requires": {
+            "@sentry/types": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "axios": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.3.tgz",
+          "integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "googleapis": {
+          "version": "85.0.0",
+          "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-85.0.0.tgz",
+          "integrity": "sha512-9zFsCbxz/642PROcYJsg/CCm89U1qe15c0Wtv7bmZ8cWYLD1Jszc5z+xTNoXZxnomLbvQaHeKBCPh7RdAccYOA==",
+          "requires": {
+            "google-auth-library": "^7.0.2",
+            "googleapis-common": "^5.0.2"
+          }
+        }
       }
     },
     "@balena/jellyfish-assert": {
@@ -1086,6 +1206,31 @@
         "native-url": "^0.3.4"
       },
       "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
         "fast-json-patch": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
@@ -1109,6 +1254,33 @@
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-outreach": {
@@ -1123,6 +1295,33 @@
         "bluebird": "^3.7.2",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-product-os": {
@@ -3338,9 +3537,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -5333,21 +5532,21 @@
       }
     },
     "gaxios": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-      "integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.1.tgz",
+      "integrity": "sha512-9qXV7yrMCGzTrphl9/YGMVH41oSg0rhn1j3wJWed4Oqk45/hXDD2wBT5J1NjQcqTCcv4g3nFnyQ7reSRHNgBgw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
+        "node-fetch": "^2.6.1"
       }
     },
     "gcp-metadata": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-      "integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
       "requires": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
@@ -5480,9 +5679,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.8.0.tgz",
-      "integrity": "sha512-I2DPwbBbQicoLqPbUOcq7oxtWewbLO6Za2jZ5QM9Lz1hXxPJVXYXBUrb8lP9626SRTQQWIzNSWJuEDtu0pI4ag==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.9.1.tgz",
+      "integrity": "sha512-cWGykH2WBR+UuYPGRnGVZ6Cjq2ftQiEIFjQWNIRIauZH7hUWoYTr/lkKUqLTYt5dex77nlWWVQ8aPV80mhfp5w==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",

--- a/apps/action-server/package.json
+++ b/apps/action-server/package.json
@@ -20,7 +20,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@balena/jellyfish-action-library": "^15.1.33",
+    "@balena/jellyfish-action-library": "^15.1.47",
     "@balena/jellyfish-core": "^5.4.1",
     "@balena/jellyfish-environment": "^5.0.3",
     "@balena/jellyfish-logger": "^3.0.66",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -501,22 +501,22 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "15.1.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.33.tgz",
-      "integrity": "sha512-5j1OATmIulvNKrkCv+LT9sQJGqnY0PbI9zaA9FZnZua8GbPNSlagXkAeT3be9GevDcAuJQF6rvThI0VD/LIbKg==",
+      "version": "15.1.47",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.47.tgz",
+      "integrity": "sha512-U1b00M7PFEhdOn4X7/eGGgXKUMVvsiK/glbDdVKP3OXWvMuWkRbMQqYLxvx3YKZca6YsFYLUJw4+5xUODbSuWg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.67",
         "@balena/jellyfish-environment": "^5.0.3",
-        "@balena/jellyfish-logger": "^3.0.66",
+        "@balena/jellyfish-logger": "^3.0.67",
         "@balena/jellyfish-mail": "^2.0.84",
         "@balena/jellyfish-metrics": "^1.0.341",
-        "@balena/jellyfish-plugin-base": "^2.1.234",
-        "axios": "^0.21.1",
+        "@balena/jellyfish-plugin-base": "^2.1.235",
+        "axios": "^0.21.3",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "blueimp-md5": "^2.18.0",
         "date-fns": "^2.23.0",
-        "googleapis": "^84.0.0",
+        "googleapis": "^85.0.0",
         "is-base64": "^1.1.0",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
@@ -525,6 +525,129 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@balena/jellyfish-logger": {
+          "version": "3.0.67",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.67.tgz",
+          "integrity": "sha512-gADMPu+FjYyQUDsl5CM/3WQl09L1LSZwmCHbM7RMyJv52ZOR7jnE+OH2mrAkqzYk2YVaIc2AdwMNteAPIvkAHw==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@sentry/node": "^6.12.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.235",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.235.tgz",
+          "integrity": "sha512-J42sxc11MlBiYC/vzkNUO24qecPdKEgOEG7Cx+PgPwxPE4JoXl3/7Ab2fh6COLtcVYgjCgscRPsWUZT+7xPE6A==",
+          "requires": {
+            "@balena/jellyfish-logger": "^3.0.66",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4"
+          }
+        },
+        "@sentry/core": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
+          "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/minimal": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
+          "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+          "requires": {
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
+          "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/node": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
+          "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+          "requires": {
+            "@sentry/core": "6.12.0",
+            "@sentry/hub": "6.12.0",
+            "@sentry/tracing": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
+          "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/minimal": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
+          "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
+        },
+        "@sentry/utils": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
+          "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+          "requires": {
+            "@sentry/types": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "axios": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.3.tgz",
+          "integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "googleapis": {
+          "version": "85.0.0",
+          "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-85.0.0.tgz",
+          "integrity": "sha512-9zFsCbxz/642PROcYJsg/CCm89U1qe15c0Wtv7bmZ8cWYLD1Jszc5z+xTNoXZxnomLbvQaHeKBCPh7RdAccYOA==",
+          "requires": {
+            "google-auth-library": "^7.0.2",
+            "googleapis-common": "^5.0.2"
+          }
+        },
+        "json-schema": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ=="
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -802,10 +925,43 @@
         "native-url": "^0.3.4"
       },
       "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
         "fast-json-patch": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
           "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -825,6 +981,41 @@
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-outreach": {
@@ -839,6 +1030,41 @@
         "bluebird": "^3.7.2",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-product-os": {
@@ -2758,9 +2984,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -4904,21 +5130,21 @@
       }
     },
     "gaxios": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-      "integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.1.tgz",
+      "integrity": "sha512-9qXV7yrMCGzTrphl9/YGMVH41oSg0rhn1j3wJWed4Oqk45/hXDD2wBT5J1NjQcqTCcv4g3nFnyQ7reSRHNgBgw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
+        "node-fetch": "^2.6.1"
       }
     },
     "gcp-metadata": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-      "integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
       "requires": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
@@ -5061,9 +5287,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.8.0.tgz",
-      "integrity": "sha512-I2DPwbBbQicoLqPbUOcq7oxtWewbLO6Za2jZ5QM9Lz1hXxPJVXYXBUrb8lP9626SRTQQWIzNSWJuEDtu0pI4ag==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.9.1.tgz",
+      "integrity": "sha512-cWGykH2WBR+UuYPGRnGVZ6Cjq2ftQiEIFjQWNIRIauZH7hUWoYTr/lkKUqLTYt5dex77nlWWVQ8aPV80mhfp5w==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,7 +21,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@balena/jellyfish-action-library": "^15.1.33",
+    "@balena/jellyfish-action-library": "^15.1.47",
     "@balena/jellyfish-assert": "^1.1.67",
     "@balena/jellyfish-core": "^5.4.1",
     "@balena/jellyfish-environment": "^5.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -781,23 +781,23 @@
       }
     },
     "@balena/jellyfish-action-library": {
-      "version": "15.1.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.33.tgz",
-      "integrity": "sha512-5j1OATmIulvNKrkCv+LT9sQJGqnY0PbI9zaA9FZnZua8GbPNSlagXkAeT3be9GevDcAuJQF6rvThI0VD/LIbKg==",
+      "version": "15.1.47",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.47.tgz",
+      "integrity": "sha512-U1b00M7PFEhdOn4X7/eGGgXKUMVvsiK/glbDdVKP3OXWvMuWkRbMQqYLxvx3YKZca6YsFYLUJw4+5xUODbSuWg==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.67",
         "@balena/jellyfish-environment": "^5.0.3",
-        "@balena/jellyfish-logger": "^3.0.66",
+        "@balena/jellyfish-logger": "^3.0.67",
         "@balena/jellyfish-mail": "^2.0.84",
         "@balena/jellyfish-metrics": "^1.0.341",
-        "@balena/jellyfish-plugin-base": "^2.1.234",
-        "axios": "^0.21.1",
+        "@balena/jellyfish-plugin-base": "^2.1.235",
+        "axios": "^0.21.3",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "blueimp-md5": "^2.18.0",
         "date-fns": "^2.23.0",
-        "googleapis": "^84.0.0",
+        "googleapis": "^85.0.0",
         "is-base64": "^1.1.0",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
@@ -807,14 +807,14 @@
       },
       "dependencies": {
         "@balena/jellyfish-logger": {
-          "version": "3.0.66",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.66.tgz",
-          "integrity": "sha512-dDWGn7M+YrA8OWZkFHkf2ejmFM7EFgkHsuQtnSdV9EXPxIbF6aa4y0t8N954XCnR8FrHiJ7tF5UKqcjRKavz4g==",
+          "version": "3.0.67",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.67.tgz",
+          "integrity": "sha512-gADMPu+FjYyQUDsl5CM/3WQl09L1LSZwmCHbM7RMyJv52ZOR7jnE+OH2mrAkqzYk2YVaIc2AdwMNteAPIvkAHw==",
           "dev": true,
           "requires": {
             "@balena/jellyfish-assert": "^1.1.67",
             "@balena/jellyfish-environment": "^5.0.3",
-            "@sentry/node": "^6.11.0",
+            "@sentry/node": "^6.12.0",
             "errio": "^1.2.2",
             "lodash": "^4.17.21",
             "typed-error": "^3.2.1",
@@ -834,6 +834,74 @@
             "express": "^4.17.1",
             "lodash": "^4.17.21"
           }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.1.235",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.1.235.tgz",
+          "integrity": "sha512-J42sxc11MlBiYC/vzkNUO24qecPdKEgOEG7Cx+PgPwxPE4JoXl3/7Ab2fh6COLtcVYgjCgscRPsWUZT+7xPE6A==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-logger": "^3.0.66",
+            "json-schema": "^0.3.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4"
+          }
+        },
+        "@sentry/node": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
+          "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "6.12.0",
+            "@sentry/hub": "6.12.0",
+            "@sentry/tracing": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
+          "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "6.12.0",
+            "@sentry/minimal": "6.12.0",
+            "@sentry/types": "6.12.0",
+            "@sentry/utils": "6.12.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "axios": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.3.tgz",
+          "integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "googleapis": {
+          "version": "85.0.0",
+          "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-85.0.0.tgz",
+          "integrity": "sha512-9zFsCbxz/642PROcYJsg/CCm89U1qe15c0Wtv7bmZ8cWYLD1Jszc5z+xTNoXZxnomLbvQaHeKBCPh7RdAccYOA==",
+          "dev": true,
+          "requires": {
+            "google-auth-library": "^7.0.2",
+            "googleapis-common": "^5.0.2"
+          }
+        },
+        "json-schema": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
+          "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+          "dev": true
         },
         "semver": {
           "version": "7.3.5",
@@ -1270,11 +1338,75 @@
         "native-url": "^0.3.4"
       },
       "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "3.0.66",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.66.tgz",
+          "integrity": "sha512-dDWGn7M+YrA8OWZkFHkf2ejmFM7EFgkHsuQtnSdV9EXPxIbF6aa4y0t8N954XCnR8FrHiJ7tF5UKqcjRKavz4g==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@sentry/node": "^6.11.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "@balena/jellyfish-metrics": {
+          "version": "1.0.341",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.341.tgz",
+          "integrity": "sha512-K3h8hUoYQtrNuJYHBhE8pHtqIroFE7uCIyGCPvalK2uUZqhjLMIU0EKlwa+/QuKGsi0gR0c0NpRFYUYdYLg1vQ==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/node-metrics-gatherer": "^5.7.5",
+            "express": "^4.17.1",
+            "lodash": "^4.17.21"
+          }
+        },
         "fast-json-patch": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
           "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==",
           "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -1295,6 +1427,72 @@
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "3.0.66",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.66.tgz",
+          "integrity": "sha512-dDWGn7M+YrA8OWZkFHkf2ejmFM7EFgkHsuQtnSdV9EXPxIbF6aa4y0t8N954XCnR8FrHiJ7tF5UKqcjRKavz4g==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@sentry/node": "^6.11.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "@balena/jellyfish-metrics": {
+          "version": "1.0.341",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.341.tgz",
+          "integrity": "sha512-K3h8hUoYQtrNuJYHBhE8pHtqIroFE7uCIyGCPvalK2uUZqhjLMIU0EKlwa+/QuKGsi0gR0c0NpRFYUYdYLg1vQ==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/node-metrics-gatherer": "^5.7.5",
+            "express": "^4.17.1",
+            "lodash": "^4.17.21"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-outreach": {
@@ -1310,6 +1508,72 @@
         "bluebird": "^3.7.2",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@balena/jellyfish-action-library": {
+          "version": "15.1.38",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-action-library/-/jellyfish-action-library-15.1.38.tgz",
+          "integrity": "sha512-nEg8V/2z3hPTbTRHrJe5rYwdRd9p0wH5oBZpu04QqVvBPFuMXkiMIWnl3nE/dzqRYpUu+DSzsKOkGzgwnJNL5Q==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/jellyfish-mail": "^2.0.84",
+            "@balena/jellyfish-metrics": "^1.0.341",
+            "@balena/jellyfish-plugin-base": "^2.1.234",
+            "axios": "^0.21.1",
+            "bcrypt": "^5.0.1",
+            "bluebird": "^3.7.2",
+            "blueimp-md5": "^2.18.0",
+            "date-fns": "^2.23.0",
+            "googleapis": "^84.0.0",
+            "is-base64": "^1.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "3.0.66",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-3.0.66.tgz",
+          "integrity": "sha512-dDWGn7M+YrA8OWZkFHkf2ejmFM7EFgkHsuQtnSdV9EXPxIbF6aa4y0t8N954XCnR8FrHiJ7tF5UKqcjRKavz4g==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.1.67",
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@sentry/node": "^6.11.0",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "@balena/jellyfish-metrics": {
+          "version": "1.0.341",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-1.0.341.tgz",
+          "integrity": "sha512-K3h8hUoYQtrNuJYHBhE8pHtqIroFE7uCIyGCPvalK2uUZqhjLMIU0EKlwa+/QuKGsi0gR0c0NpRFYUYdYLg1vQ==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-environment": "^5.0.3",
+            "@balena/jellyfish-logger": "^3.0.66",
+            "@balena/node-metrics-gatherer": "^5.7.5",
+            "express": "^4.17.1",
+            "lodash": "^4.17.21"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-product-os": {
@@ -4052,9 +4316,9 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -8224,22 +8488,22 @@
       }
     },
     "gaxios": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-      "integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.1.tgz",
+      "integrity": "sha512-9qXV7yrMCGzTrphl9/YGMVH41oSg0rhn1j3wJWed4Oqk45/hXDD2wBT5J1NjQcqTCcv4g3nFnyQ7reSRHNgBgw==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
+        "node-fetch": "^2.6.1"
       }
     },
     "gcp-metadata": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-      "integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
       "dev": true,
       "requires": {
         "gaxios": "^4.0.0",
@@ -8408,9 +8672,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.8.0.tgz",
-      "integrity": "sha512-I2DPwbBbQicoLqPbUOcq7oxtWewbLO6Za2jZ5QM9Lz1hXxPJVXYXBUrb8lP9626SRTQQWIzNSWJuEDtu0pI4ag==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.9.1.tgz",
+      "integrity": "sha512-cWGykH2WBR+UuYPGRnGVZ6Cjq2ftQiEIFjQWNIRIauZH7hUWoYTr/lkKUqLTYt5dex77nlWWVQ8aPV80mhfp5w==",
       "dev": true,
       "requires": {
         "arrify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "devDependencies": {
-    "@balena/jellyfish-action-library": "^15.1.33",
+    "@balena/jellyfish-action-library": "^15.1.47",
     "@balena/jellyfish-chat-widget": "^12.1.14",
     "@balena/jellyfish-client-sdk": "^6.0.0",
     "@balena/jellyfish-config": "^1.4.8",


### PR DESCRIPTION
https://github.com/product-os/jellyfish-action-library/pull/1262

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
