### PR TITLE
Watch Rendition node module and fix "JavaScript heap out of memory" FATAL ERROR

### DIFF
--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -40,7 +40,7 @@ test:
 .PHONY: dev-ui
 dev-ui:
 	SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) \
-	NODE_ENV=development \
+	NODE_ENV=development \ NODE_OPTIONS=--max-old-space-size=8192 \
 	mkdir -p ./dist/ui && \
 	./conf/env.sh && \
 	cp ./env-config.js ./dist/ui/ && \

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -103,7 +103,7 @@ const appConfig = {
 		disableHostCheck: true,
 		publicPath: '/',
 		watchOptions: {
-			ignored: /node_modules\/(?!(@balena\/jellyfish-(ui-components|chat-widget|client-sdk|environment))\/).*/
+			ignored: /node_modules\/(?!(\/@balena\/jellyfish-(ui-components|chat-widget|client-sdk|environment))\/|rendition\/).*/
 		}
 	},
 


### PR DESCRIPTION
Watch Rendition node module and fix "JavaScript heap out of memory" FATAL ERROR

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
