### PR TITLE
Avoid full page loads in e2e UI tests by using router programatically

### DIFF
--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -40,7 +40,8 @@ test:
 .PHONY: dev-ui
 dev-ui:
 	SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) \
-	NODE_ENV=development \ NODE_OPTIONS=--max-old-space-size=8192 \
+	NODE_ENV=development \
+	NODE_OPTIONS=--max-old-space-size=8192 \
 	mkdir -p ./dist/ui && \
 	./conf/env.sh && \
 	cp ./env-config.js ./dist/ui/ && \

--- a/apps/ui/lib/JellyfishUI.tsx
+++ b/apps/ui/lib/JellyfishUI.tsx
@@ -27,7 +27,13 @@ import CompleteFirstTimeLogin from './components/Auth/CompleteFirstTimeLogin';
 import AuthContainer from './components/Auth';
 import Splash from './components/Splash';
 import { actionCreators, selectors } from './core';
-import { useLocation, Route, Redirect, Switch } from 'react-router-dom';
+import {
+	useLocation,
+	useHistory,
+	Route,
+	Redirect,
+	Switch,
+} from 'react-router-dom';
 import { name } from './manifest.json';
 import { isProduction } from './environment';
 
@@ -60,6 +66,10 @@ const webTracker = createWebTracker(analyticsClient, 'UI');
 
 const JellyfishUI = ({ actions, status, channels, isChatWidgetOpen }) => {
 	const location = useLocation();
+
+	// Expose the router history object on the window so that UI navigation
+	// can be driven from puppeteer, without having to reload the page
+	(window as any).routerHistory = useHistory();
 
 	React.useEffect(() => {
 		webTracker.trackPageView();

--- a/test/e2e/ui/chat-widget.spec.js
+++ b/test/e2e/ui/chat-widget.spec.js
@@ -11,7 +11,6 @@ const {
 } = require('uuid')
 const helpers = require('./helpers')
 const macros = require('./macros')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 
 const context = {
 	context: {
@@ -34,7 +33,7 @@ ava.serial.before(async () => {
 		page
 	} = context
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}`)
+	await macros.goto(page, '/')
 	const user1 = await context.createUser(userDetails1)
 	await macros.loginUser(page, userDetails1)
 	await context.addUserToBalenaOrg(user1.id)

--- a/test/e2e/ui/chat.spec.js
+++ b/test/e2e/ui/chat.spec.js
@@ -12,7 +12,6 @@ const {
 } = require('uuid')
 const helpers = require('./helpers')
 const macros = require('./macros')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 
 const messageSelector = '[data-test="event-card__message"]'
 const searchSelector = '.inbox__search input'
@@ -57,7 +56,7 @@ ava.serial.before(async () => {
 		browser
 	} = context
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}`)
+	await macros.goto(page, '/')
 	const user1 = await context.createUser(userDetails1)
 	await macros.loginUser(page, userDetails1)
 	await context.addUserToBalenaOrg(user1.id)
@@ -76,7 +75,7 @@ ava.serial.before(async () => {
 		console.log(err)
 	})
 
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}`)
+	await macros.goto(incognitoPage, '/')
 	const user2 = await context.createUser(userDetails2)
 	await macros.loginUser(incognitoPage, userDetails2)
 	await context.addUserToBalenaOrg(user2.id)
@@ -117,8 +116,8 @@ ava.serial('A notice should be displayed when another user is typing', async (te
 	})
 
 	// Navigate to the thread page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(incognitoPage, `/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	await page.waitForSelector('.column--thread')
 	await incognitoPage.waitForSelector('.column--thread')
@@ -153,7 +152,7 @@ ava.serial('Messages typed but not sent should be preserved when navigating away
 	})
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread1.id}`)
+	await macros.goto(page, `/${thread1.id}`)
 	await page.waitForSelector(`.column--slug-${thread1.slug}`)
 
 	const rand = uuid()
@@ -165,10 +164,10 @@ ava.serial('Messages typed but not sent should be preserved when navigating away
 	// to the message preservation being debounced in the UI
 	await Bluebird.delay(5000)
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread2.id}`)
+	await macros.goto(page, `/${thread2.id}`)
 	await page.waitForSelector(`.column--slug-${thread2.slug}`)
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread1.id}`)
+	await macros.goto(page, `/${thread1.id}`)
 	await page.waitForSelector(`.column--slug-${thread1.slug}`)
 
 	const messageText = await macros.getElementText(page, 'textarea')
@@ -192,7 +191,7 @@ ava.serial('Messages that mention a user should appear in their inbox', async (t
 	})
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -204,7 +203,7 @@ ava.serial('Messages that mention a user should appear in their inbox', async (t
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="event-card__message"]')
 
@@ -227,7 +226,7 @@ ava.serial('Messages that alert a user should appear in their inbox', async (tes
 	})
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -239,7 +238,7 @@ ava.serial('Messages that alert a user should appear in their inbox', async (tes
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="event-card__message"]')
 
@@ -262,7 +261,7 @@ ava.serial('Messages that alert a user should appear in their inbox and in the h
 	})
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -274,7 +273,7 @@ ava.serial('Messages that alert a user should appear in their inbox and in the h
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	await incognitoPage.waitForSelector('[data-test="event-card__message"]')
 	const inboxmessages = await incognitoPage.$$('[data-test="event-card__message"]')
@@ -313,7 +312,7 @@ ava.serial('Messages that mention a user\'s group should appear in their inbox',
 	}, group, user2)
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -325,7 +324,7 @@ ava.serial('Messages that mention a user\'s group should appear in their inbox',
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="event-card__message"]')
 
@@ -361,7 +360,7 @@ ava.serial('Messages that alert a user\'s group should appear in their inbox', a
 	}, group, user2)
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -373,7 +372,7 @@ ava.serial('Messages that alert a user\'s group should appear in their inbox', a
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="event-card__message"]')
 
@@ -398,7 +397,7 @@ ava.serial('One-to-one messages to a user should appear in their inbox', async (
 	}, user1, user2)
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -410,7 +409,7 @@ ava.serial('One-to-one messages to a user should appear in their inbox', async (
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="event-card__message"]')
 
@@ -476,7 +475,7 @@ ava.serial(
 		})
 
 		// Then we send 2 tagged messages to the user
-		await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+		await macros.goto(page, `/${thread.id}`)
 
 		const columnSelector = `.column--slug-${thread.slug}`
 		await page.waitForSelector(columnSelector)
@@ -490,7 +489,7 @@ ava.serial(
 		await macros.createChatMessage(page, columnSelector, msg)
 
 		// And send a message to our own group
-		await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+		await macros.goto(incognitoPage, `/${thread.id}`)
 
 		await incognitoPage.waitForSelector(columnSelector)
 
@@ -501,7 +500,7 @@ ava.serial(
 		await macros.createChatMessage(incognitoPage, columnSelector, ownGroupMsg)
 
 		// Navigate to the inbox page
-		await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+		await macros.goto(incognitoPage, '/inbox')
 
 		await Bluebird.delay(10000)
 
@@ -566,7 +565,7 @@ ava.serial.skip('When having two chats side-by-side both should update with new 
 		})
 	})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -601,7 +600,7 @@ ava.skip('Username pings should be case insensitive', async (test) => {
 	})
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -613,7 +612,7 @@ ava.skip('Username pings should be case insensitive', async (test) => {
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	// Navigate to the inbox page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="event-card__message"]')
 
@@ -636,7 +635,7 @@ ava.serial('Users should be able to mark all messages as read from their inbox',
 	})
 
 	// Navigate to the thread page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const columnSelector = `.column--slug-${thread.slug}`
 	await page.waitForSelector(columnSelector)
@@ -647,7 +646,7 @@ ava.serial('Users should be able to mark all messages as read from their inbox',
 
 	await macros.createChatMessage(page, columnSelector, msg)
 
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 	await incognitoPage.waitForSelector(messageSelector)
 	await markAllAsRead(test, incognitoPage)
 })
@@ -660,7 +659,7 @@ ava.serial('When filtering unread messages, only filtered messages can be marked
 	} = context
 
 	// Start by marking all messages as read
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 	await markAllAsRead(test, incognitoPage)
 
 	// Create three new messages
@@ -691,7 +690,7 @@ ava.serial('When filtering unread messages, only filtered messages can be marked
 	}, messageDetails)
 
 	// Navigate to the inbox page and reload
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	// All three messages should appear in the inbox
 	await incognitoPage.waitForSelector(messageSelector)
@@ -718,7 +717,7 @@ ava.serial('When filtering unread messages, only filtered messages can be marked
 	await macros.waitForSelectorToDisappear(incognitoPage, `[id="event-${messages[1].id}]`)
 
 	// Reload the page
-	await incognitoPage.goto(`${environment.ui.host}:${environment.ui.port}/inbox`)
+	await macros.goto(incognitoPage, '/inbox')
 
 	// And wait for the other two messages to re-appear (still unread)
 	await incognitoPage.waitForSelector(`[id="event-${messages[0].id}"]`)

--- a/test/e2e/ui/file-upload.spec.js
+++ b/test/e2e/ui/file-upload.spec.js
@@ -122,7 +122,7 @@ ava.serial.only('file upload: Users should be able to upload an image to a suppo
 	})
 
 	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const selector = '.column--support-thread'
 
@@ -151,7 +151,7 @@ ava.serial('file upload: Users should be able to upload a text file', async (tes
 	})
 
 	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	await page.waitForSelector(`.column--slug-${thread.slug}`)
 
@@ -182,7 +182,7 @@ ava.serial('file upload: Users should be able to upload a text file to a support
 	})
 
 	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	await macros.goto(page, `/${thread.id}`)
 
 	const selector = '.column--support-thread'
 

--- a/test/e2e/ui/guided-flow-utils.js
+++ b/test/e2e/ui/guided-flow-utils.js
@@ -5,7 +5,6 @@
  */
 
 const macros = require('./macros')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 
 const selectors = {
 	nextBtn: '[data-test="steps-flow__next-btn"]',
@@ -42,6 +41,6 @@ exports.createSupportThreadAndNavigate = async (page, owner = null) => {
 			supportThread, owner
 		})
 	}
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 	return supportThread
 }

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -119,8 +119,7 @@ ava.serial.skip('card actions: should let users copy a working permalink', async
 		type: 'thread@1.0.0'
 	})
 
-	await context.page.goto(
-		`${environment.ui.host}:${environment.ui.port}/${card.id}`)
+	await macros.goto(page, `/${card.id}`)
 
 	await context.page.waitForSelector('.column--thread')
 	await macros.waitForThenClickSelector(page, '[data-test="card-action-menu"]')
@@ -153,8 +152,7 @@ ava.serial.skip('card actions: should let users copy a card as JSON', async (tes
 		type: 'thread@1.0.0'
 	})
 
-	await context.page.goto(
-		`${environment.ui.host}:${environment.ui.port}/${card.id}`)
+	await macros.goto(page, `/${card.id}`)
 
 	await macros.waitForThenClickSelector(page, '[data-test="card-action-menu"]')
 	await macros.waitForThenClickSelector(page, '[data-test="card-action-menu__json"]')
@@ -184,8 +182,7 @@ ava.serial.skip('card actions: should let users delete a card', async (test) => 
 		type: 'thread@1.0.0'
 	})
 
-	await context.page.goto(
-		`${environment.ui.host}:${environment.ui.port}/${card.id}`)
+	await macros.goto(page, `/${card.id}`)
 
 	await macros.waitForThenClickSelector(page, '[data-test="card-action-menu__delete"]')
 	await macros.waitForThenClickSelector(page, '[data-test="card-delete__submit"]')
@@ -212,8 +209,7 @@ ava.serial('card actions: should let users add a custom field to a card', async 
 		type: 'thread@1.0.0'
 	})
 
-	await context.page.goto(
-		`${environment.ui.host}:${environment.ui.port}/${card.id}`)
+	await macros.goto(page, `/${card.id}`)
 
 	// Edit the card
 	await macros.waitForThenClickSelector(page, '.card-actions__btn--edit')
@@ -331,7 +327,7 @@ ava.serial('user profile: The send command should default to "shift+enter"', asy
 	})
 
 	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${user.id}/${thread.id}`)
+	await macros.goto(page, `/${user.id}/${thread.id}`)
 
 	await page.waitForSelector('[data-test="lens--lens-my-user"]')
 
@@ -379,7 +375,7 @@ ava.serial('user profile: You should be able to change the send command to "ente
 	})
 
 	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${user.id}/${thread.id}`)
+	await macros.goto(page, `/${user.id}/${thread.id}`)
 
 	await page.waitForSelector('[data-test="lens--lens-my-user"]')
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(3)')
@@ -422,7 +418,7 @@ ava.serial.skip('views: Should be able to save a new view', async (test) => {
 	const name = `test-view-${uuid()}`
 
 	// Navigate to the all messages view
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/view-all-messages`)
+	await macros.goto(page, '/view-all-messages')
 
 	await page.waitForSelector('.column--view-all-messages')
 

--- a/test/e2e/ui/loops.spec.js
+++ b/test/e2e/ui/loops.spec.js
@@ -8,7 +8,6 @@ const ava = require('ava')
 const {
 	v4: uuid
 } = require('uuid')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 const helpers = require('./helpers')
 const macros = require('./macros')
 
@@ -62,7 +61,7 @@ ava.serial.before(async () => {
 	await setLoop(context.sdk, 'view-all-faqs', `${context.loop2.slug}@${context.loop2.version}`)
 
 	// Navigate to the home page again (to force the sidebar views to be refreshed)
-	await context.page.goto(`${environment.ui.host}:${environment.ui.port}`)
+	await macros.goto(context.page, '/')
 
 	// Open up the balena sidebar menu section
 	await macros.navigateToHomeChannelItem(context.page, [
@@ -157,7 +156,7 @@ ava.serial('The selected loop is persisted and selected next time Jellyfish is l
 	await page.waitForSelector(selectors.loopSelectValue(loop1), macros.WAIT_OPTS)
 
 	// Refresh the page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}`)
+	await macros.goto(page, '/')
 
 	// Verify that loop1 is still selected in the loop selector
 	await page.waitForSelector(selectors.loopSelectValue(loop1), macros.WAIT_OPTS)

--- a/test/e2e/ui/oauth.spec.js
+++ b/test/e2e/ui/oauth.spec.js
@@ -60,7 +60,7 @@ outreachTest('A user should be able to connect their account to outreach', async
 		page
 	} = context
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}`)
+	await macros.goto(page, '/')
 	const user = await context.createUser(userDetails)
 
 	await context.addUserToBalenaOrg(user.id)
@@ -68,7 +68,7 @@ outreachTest('A user should be able to connect their account to outreach', async
 	await macros.loginUser(page, userDetails)
 
 	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${user.slug}`)
+	await macros.goto(page, `/${user.slug}`)
 
 	await macros.waitForThenClickSelector(page, 'button[role="tab"]:nth-of-type(4)')
 
@@ -127,7 +127,7 @@ outreachTest('A user should be able to connect their account to outreach', async
 			} ])
 		})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/oauth/outreach?code=123456&state=${user.slug}`)
+	await macros.goto(page, `/oauth/outreach?code=123456&state=${user.slug}`)
 
 	await page.waitForSelector('[data-test="lens--lens-my-user"]')
 

--- a/test/e2e/ui/repository.spec.js
+++ b/test/e2e/ui/repository.spec.js
@@ -8,7 +8,6 @@ const ava = require('ava')
 const {
 	v4: uuid
 } = require('uuid')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 const helpers = require('./helpers')
 const macros = require('./macros')
 
@@ -107,7 +106,7 @@ ava.serial('Messages can be filtered by searching for them', async (test) => {
 	const msg1 = await addMessageToThread(page, thread1, 'First message')
 	const msg2 = await addMessageToThread(page, thread1, 'Second message')
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${repo.id}`)
+	await macros.goto(page, `/${repo.id}`)
 
 	// Initially both messages are displayed in the repo list
 	await page.waitForSelector(`#event-${msg1.id}`)

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -11,7 +11,6 @@ const {
 } = require('uuid')
 const helpers = require('./helpers')
 const macros = require('./macros')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 
 const context = {
 	context: {
@@ -160,7 +159,7 @@ ava.serial('Updates to messages should be reflected in the thread\'s timeline', 
 		return window.sdk.event.create(event)
 	}, messageEvent)
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 
 	// Verify the message text
 	const messageText = await macros.getElementText(page, '[data-test="event-card__message"]')
@@ -217,7 +216,7 @@ ava.serial('A message\'s mirror icon is automatically updated when the message i
 		return window.sdk.event.create(event)
 	}, messageEvent)
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 
 	// Verify the mirror icon is present but not synced
 	await page.waitForSelector('.unsynced[data-test="mirror-icon"]')
@@ -257,7 +256,7 @@ ava.serial('Support thread timeline should default to sending whispers', async (
 		})
 	})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
@@ -286,7 +285,7 @@ ava.serial('Support thread timeline should send a message if the input is prefix
 		})
 	})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
@@ -315,7 +314,7 @@ ava.serial('Support thread timeline should send a message if the whisper button 
 		})
 	})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
@@ -346,7 +345,7 @@ ava.serial('Support thread timeline should revert to "whisper" mode after sendin
 		})
 	})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
@@ -377,7 +376,7 @@ ava.serial.skip('Users should be able to audit a support thread', async (test) =
 		})
 	})
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
 	await page.waitForSelector('[data-test="audit-panel"]')
@@ -501,8 +500,9 @@ ava.serial('Support threads should close correctly in the UI even when being upd
 		})
 	})
 
-	await page.goto(
-		`${environment.ui.host}:${environment.ui.port}/view-paid-support-threads...properties.data.properties.status+is+open`
+	await macros.goto(
+		page,
+		'/view-paid-support-threads...properties.data.properties.status+is+open'
 	)
 	await page.waitForSelector('[data-test="lens--lens-support-threads"]')
 
@@ -588,7 +588,7 @@ ava.serial('My Participation shows only support threads that the logged-in user 
 	await page.waitForSelector('[data-test="home-channel__group-toggle--org-balena"]')
 
 	// Go to the My Participation view and verify there are no threads listed
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/view-support-threads-participation`)
+	await macros.goto(page, '/view-support-threads-participation')
 	await page.waitForSelector('[data-test="alt-text--no-results"]')
 
 	// Add a new support thread and send a message in it
@@ -661,7 +661,7 @@ ava.serial('A user can edit their own message', async (test) => {
 	}, messageEvent)
 
 	// Navigate to the thread and wait for the message event to be displayed
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 	const eventSelector = '.column--support-thread .event-card--message'
 	await page.waitForSelector(eventSelector)
 
@@ -702,7 +702,7 @@ ava.serial('You can trigger a quick search for cards from the message input', as
 	})
 
 	// Navigate to the thread and wait for the thread to be displayed
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 	const threadSelector = '.column--support-thread'
 	await page.waitForSelector(threadSelector)
 
@@ -759,7 +759,7 @@ ava.serial('You can select a user and a group from the auto-complete options', a
 	})
 
 	// Navigate to the thread and wait for the thread to be displayed
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 	const threadSelector = '.column--support-thread'
 	await page.waitForSelector(threadSelector)
 
@@ -847,7 +847,7 @@ ava.serial('Only users with a name matching the search string are returned by th
 	})
 
 	// Navigate to the thread and wait for the thread to be displayed
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${supportThread.id}`)
+	await macros.goto(page, `/${supportThread.id}`)
 	const threadSelector = '.column--support-thread'
 	await page.waitForSelector(threadSelector)
 

--- a/test/e2e/ui/views.spec.js
+++ b/test/e2e/ui/views.spec.js
@@ -10,7 +10,6 @@ const {
 } = require('uuid')
 const helpers = require('./helpers')
 const macros = require('./macros')
-const environment = require('@balena/jellyfish-environment').defaultEnvironment
 
 const context = {
 	context: {
@@ -83,7 +82,7 @@ ava.serial('the filter summary displays the search term correctly', async (test)
 
 	const opportunityCardSelector = `[data-test-id="snippet-card-${opportunity.id}"]`
 
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/view-all-opportunities`)
+	await macros.goto(page, '/view-all-opportunities')
 	await macros.waitForThenClickSelector(page, '[data-test="lens-selector--lens-list"]')
 	await page.waitForSelector('.view__search')
 


### PR DESCRIPTION
This change exposes the react router `history` object on the browser
window as `routerHistory`. This allows us to make navigation changes
from puppeteer without having to reload the page using `page.goto`,
which is an expensive process.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
