### PR TITLE
Fix NODE_OPTIONS --max-old-space-size config var

### DIFF
--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -40,7 +40,7 @@ test:
 .PHONY: dev-ui
 dev-ui:
 	SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) \
-	NODE_ENV=development \ NODE_OPTIONS=--max-old-space-size=8192 \
+	NODE_ENV=development NODE_OPTIONS=--max-old-space-size=8192 \
 	mkdir -p ./dist/ui && \
 	./conf/env.sh && \
 	cp ./env-config.js ./dist/ui/ && \


### PR DESCRIPTION
Fix NODE_OPTIONS --max-old-space-size config var

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
