### PR TITLE
Update request password reset notification

### DIFF
--- a/apps/ui/lib/components/Auth/RequestPasswordReset/RequestPasswordReset.spec.tsx
+++ b/apps/ui/lib/components/Auth/RequestPasswordReset/RequestPasswordReset.spec.tsx
@@ -90,10 +90,7 @@ describe('RequestPasswordReset', () => {
 		expect(requestPasswordResetAction.callCount).toBe(1);
 		expect(addNotification.callCount).toBe(1);
 		expect(addNotification.args).toEqual([
-			[
-				'success',
-				'Thanks! Please check your email for a link to reset your password',
-			],
+			['info', 'If this user exists, we have sent you a password reset email'],
 		]);
 	});
 

--- a/apps/ui/lib/components/Auth/RequestPasswordReset/RequestPasswordReset.tsx
+++ b/apps/ui/lib/components/Auth/RequestPasswordReset/RequestPasswordReset.tsx
@@ -48,8 +48,8 @@ export default class RequestPasswordReset extends React.Component<any, any> {
 			})
 			.then(() => {
 				notifications.addNotification(
-					'success',
-					'Thanks! Please check your email for a link to reset your password',
+					'info',
+					'If this user exists, we have sent you a password reset email',
 				);
 			})
 			.catch(() => {


### PR DESCRIPTION
Update the notification type and message to reflect actual action logic.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

The current notification type and message tells the user that an email has already been sent, but that isn't always the case. The action actually fails silently in a number of cases, presumably for security reasons, but the notification doesn't reflect this. The updated notification type and message will better reflect action logic, not promising that an email has been or will be sent.

Also working on an update to the `action-request-password-reset` action to error out when an email address is provided as the username so an error notification is visible to the user. This isn't necessarily a security issue as all we're doing is not accepting email address as usernames.