### PR TITLE
Only generate a webpack bundle report if the ANALYZE env var is used

### DIFF
--- a/apps/livechat/webpack.config.js
+++ b/apps/livechat/webpack.config.js
@@ -112,11 +112,7 @@ const config = {
 	]
 }
 
-if (process.env.NODE_ENV === 'production') {
-	config.mode = 'production'
-	config.optimization = {
-		minimize: true
-	}
+if (process.env.ANALYZE) {
 	config.plugins.push(
 		new BundleAnalyzerPlugin({
 			analyzerMode: 'static',
@@ -124,6 +120,13 @@ if (process.env.NODE_ENV === 'production') {
 			openAnalyzer: false
 		})
 	)
+}
+
+if (process.env.NODE_ENV === 'production') {
+	config.mode = 'production'
+	config.optimization = {
+		minimize: true
+	}
 } else {
 	config.plugins.push(
 		new WatchIgnorePlugin([

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -189,7 +189,7 @@ if (process.env.NODE_ENV === 'production' ||
 	)
 }
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.ANALYZE) {
 	appConfig.plugins.push(
 		new BundleAnalyzerPlugin({
 			analyzerMode: 'static',


### PR DESCRIPTION
Generating the bundle report on every production build is unnecessary
and time consuming.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
