### PR TITLE
Re-use images generated in build step in docker-compose phase

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: balena/jellyfish
     build:
       context: .
       dockerfile: ./apps/server/Dockerfile
@@ -122,6 +123,7 @@ services:
     networks:
       - internal
   ui:
+    image: balena/jellyfish-ui
     build:
       args:
         - NPM_TOKEN
@@ -141,6 +143,7 @@ services:
       - internal
   {{#workers}}
   worker_{{idx}}:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.1'
 
 services:
   api:
+    image: balena/jellyfish
     build:
       context: .
       dockerfile: ./apps/server/Dockerfile
@@ -121,6 +122,7 @@ services:
     networks:
       - internal
   ui:
+    image: balena/jellyfish-ui
     build:
       args:
         - NPM_TOKEN
@@ -139,6 +141,7 @@ services:
     networks:
       - internal
   worker_1:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile
@@ -203,6 +206,7 @@ services:
     ports:
       - 9231:9229
   worker_2:
+    image: balena/jellyfish-action-server
     build:
       context: .
       dockerfile: ./apps/action-server/Dockerfile


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
