### PR TITLE
Make security test for user create events more targeted.

### DIFF
--- a/test/e2e/server/security/index.spec.js
+++ b/test/e2e/server/security/index.spec.js
@@ -782,14 +782,29 @@ ava.serial('Users should not be able to view create cards that create users', as
 	const user2Details = createUserDetails()
 
 	await sdk.auth.signup(user1Details)
-	await sdk.auth.signup(user2Details)
+	const user2 = await sdk.auth.signup(user2Details)
 
 	await sdk.auth.login(user1Details)
 
-	const user2 = await sdk.card.getWithTimeline(`user-${user1Details.username}`)
-	const createCard = _.find(user2.links['has attached element'], {
-		type: 'create@1.0.0'
+	// The create event for user 2 should not be visible to user 1
+	const results = await sdk.query({
+		$$links: {
+			'is attached to': {
+				type: 'object',
+				properties: {
+					id: {
+						const: user2.id
+					}
+				}
+			}
+		},
+		type: 'object',
+		properties: {
+			type: {
+				const: 'create@1.0.0'
+			}
+		}
 	})
 
-	test.falsy(createCard)
+	test.is(results.length, 0)
 })


### PR DESCRIPTION
The previous version of this test did not query for the create contract
directly, which exposed it to subtle bugs, such as `.getWithTimeline()`
returning null. This change makes the test more targeted and explicitly
tests that *other* users cannot read the create event, which is more
close to the intention of the test.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
