### PR TITLE
Don't run a full page load in e2e livechat tests if not necessary

### DIFF
--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -126,7 +126,7 @@ ava.serial('Initial short conversation list page', async (test) => {
 		page
 	} = context
 
-	const threads = await createThreads(context, 0, 2)
+	const threads1 = await createThreads(context, 0, 2)
 	await initChat(context)
 
 	await test.notThrowsAsync(
@@ -134,16 +134,16 @@ ava.serial('Initial short conversation list page', async (test) => {
 		'should be displayed initially when there is at least one conversation'
 	)
 
-	const conversationIds = await getRenderedConversationIds(context)
+	const conversationIds1 = await getRenderedConversationIds(context)
 
 	test.true(
-		threads.reverse().every((thread, index) => {
-			return conversationIds[index] === thread.id
+		threads1.reverse().every((thread, index) => {
+			return conversationIds1[index] === thread.id
 		}),
 		'should display latest two conversations'
 	)
 
-	const selectedConversationId = conversationIds[conversationIds.length - 1]
+	const selectedConversationId = conversationIds1[conversationIds1.length - 1]
 	await page.click(`[data-test-id="${selectedConversationId}"]`)
 
 	await test.notThrowsAsync(
@@ -198,13 +198,8 @@ ava.serial('Initial short conversation list page', async (test) => {
 		page.waitForSelector('[data-test="initial-short-conversation-page"]'),
 		'should navigate back to short conversation list page when pressing back button'
 	)
-})
 
-ava.serial('Full conversation list page', async (test) => {
-	const {
-		page
-	} = context
-
+	// Test Full conversation list page
 	const threads = await createThreads(context, 0, INITIAL_FETCH_CONVERSATIONS_LIMIT + 1)
 	await initChat(context)
 
@@ -303,13 +298,8 @@ ava.serial('Create conversation page', async (test) => {
 		page.waitForSelector('[data-test="initial-short-conversation-page"]'),
 		'should navigate back to short conversation list page when pressing back button'
 	)
-})
 
-ava.serial('Chat page', async (test) => {
-	const {
-		page
-	} = context
-
+	// Test Chat page
 	const thread = (await createThreads(context, 0, 1))[0]
 	await subscribeToThread(context, thread)
 
@@ -359,14 +349,8 @@ ava.serial('Chat page', async (test) => {
 		response.id,
 		'should receive notification'
 	)
-})
 
-ava.serial('External navigation request', async (test) => {
-	const {
-		page
-	} = context
-
-	const thread = (await createThreads(context, 0, 1))[0]
+	// External navigation request
 	await initChat(context)
 
 	await test.notThrowsAsync(

--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -299,6 +299,8 @@ ava.serial('Create conversation page', async (test) => {
 		'should navigate back to short conversation list page when pressing back button'
 	)
 
+	console.log('##################### STAGE 1 #####################')
+
 	// Test Chat page
 	const thread = (await createThreads(context, 0, 1))[0]
 	await subscribeToThread(context, thread)
@@ -311,7 +313,11 @@ ava.serial('Create conversation page', async (test) => {
 
 	await page.waitForSelector('[data-test="chat-page"]')
 
+	console.log('##################### STAGE 2 #####################')
+
 	await createChatMessage(page, '', 'Message from user')
+
+	console.log('##################### STAGE 3 #####################')
 
 	await test.notThrowsAsync(
 		waitForInnerText(
@@ -322,6 +328,8 @@ ava.serial('Create conversation page', async (test) => {
 		'should display support user\'s username'
 	)
 
+	console.log('##################### STAGE 4 #####################')
+
 	await context.page.evaluate(() => {
 		window.addEventListener('message', (event) => {
 			if (event.data.type === 'notifications-change') {
@@ -330,7 +338,11 @@ ava.serial('Create conversation page', async (test) => {
 		})
 	})
 
+	console.log('##################### STAGE 5 #####################')
+
 	const response = await insertAgentReply(context, thread, 'Response from agent')
+
+	console.log('##################### STAGE 6 #####################')
 
 	await test.notThrowsAsync(
 		waitForInnerText(
@@ -342,13 +354,19 @@ ava.serial('Create conversation page', async (test) => {
 		'should display support agent\'s username'
 	)
 
+	console.log('##################### STAGE 7 #####################')
+
 	const [ notification ] = await waitForNotifications(context, 1)
+
+	console.log('##################### STAGE 8 #####################')
 
 	test.is(
 		notification.links['is attached to'][0].id,
 		response.id,
 		'should receive notification'
 	)
+
+	console.log('##################### STAGE 9 #####################')
 
 	// External navigation request
 	await initChat(context)
@@ -358,7 +376,11 @@ ava.serial('Create conversation page', async (test) => {
 		'should be displayed initially when there is at least one conversation'
 	)
 
+	console.log('##################### STAGE 10 #####################')
+
 	await navigateTo(context, `/chat/${thread.id}`)
+
+	console.log('##################### STAGE 11 #####################')
 
 	await page.waitForSelector(`[data-test="chat-page"][data-test-id="${thread.id}"]`)
 	test.pass('should navigate to thread')

--- a/test/e2e/livechat/macros.js
+++ b/test/e2e/livechat/macros.js
@@ -164,9 +164,24 @@ exports.initChat = async (context) => {
 		inbox: 'paid'
 	})
 
-	await context.page.goto(
-		`${environment.livechat.host}:${environment.livechat.port}?${queryString}`
-	)
+	const url = `${environment.livechat.host}:${environment.livechat.port}?${queryString}`
+
+	if (context.page.url().includes(url)) {
+		// If puppeteer is already on the right URL, navigate back to the "home" panel of the chat widget
+		await context.page.click('[data-test="navigate-back-button"]')
+		try {
+			await context.page.waitForSelector('[data-test="navigate-back-button"]', {
+				timeout: 5000
+			})
+
+			await context.page.click('[data-test="navigate-back-button"]')
+		} catch (err) {
+			console.log('Already on initial page')
+		}
+		await context.page.waitForSelector('[data-test="initial-create-conversation-page"]')
+	} else {
+		await context.page.goto(url)
+	}
 }
 
 exports.navigateTo = async (context, to) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
