### PR TITLE
Update to latest version of rendition

### DIFF
--- a/apps/livechat/package-lock.json
+++ b/apps/livechat/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "@types/react-helmet": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.2.tgz",
-      "integrity": "sha512-dcfAZNlWb5JYFbO9CGfrPWLJAyFcT6UeR3u35eBbv8liY2Rg4K7fM1G5+HnwVgot+C+kVwXAZ8pLEn2jsMfTDg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.3.tgz",
+      "integrity": "sha512-U4onVxaZxAp78KpXsfmyCIhLjsvJJ3goG3CYFOo+xW0cPYAz9oe5cBAUSAcN7l35OTbrFvu9TuE0YkcZMKGr4A==",
       "requires": {
         "@types/react": "*"
       }
@@ -767,14 +767,6 @@
         "redux": "^4.0.0"
       }
     },
-    "@types/recompose": {
-      "version": "0.26.5",
-      "resolved": "https://registry.npmjs.org/@types/recompose/-/recompose-0.26.5.tgz",
-      "integrity": "sha512-Il5stz/Z3pVIMl48pyggl6nnhRLQ8N8YN8hi0Anm0M5UjVh2uMSY0ah2vzwZZKxnca4NzyJArloSjsJ9fL2vWw==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -786,9 +778,9 @@
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
     },
     "@types/styled-components": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.14.tgz",
-      "integrity": "sha512-d6P1/tyNytqKwam3cQXq7a9uPtovc/mdAs7dBiz1YbDdNIT3X4WmuFU78YdSYh84TXVuhOwezZ3EeKuNBhwsHQ==",
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.15.tgz",
+      "integrity": "sha512-4evch8BRI3AKgb0GAZ/sn+mSeB+Dq7meYtMi7J/0Mg98Dt1+r8fySOek7Sjw1W+Wskyjc93565o5xWAT/FdY0Q==",
       "requires": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -1998,11 +1990,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -2164,9 +2151,9 @@
       }
     },
     "codemirror": {
-      "version": "5.63.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.0.tgz",
-      "integrity": "sha512-KlLWRPggDg2rBD1Mx7/EqEhaBdy+ybBCVh/efgjBDsPpMeEu6MbTAJzIT4TuCzvmbTEgvKOGzVT6wdBTNusqrg=="
+      "version": "5.63.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.1.tgz",
+      "integrity": "sha512-baivaNZreZOGh1/tYyTvCupC9NeWk7qlZeGUDi4nFKj/J0JU8FYKZND4QqLw70P7HOttlCt4JJAOj9GoIhHEkA=="
     },
     "codemirror-spell-checker": {
       "version": "1.1.2",
@@ -2577,9 +2564,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "d3": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.0.4.tgz",
-      "integrity": "sha512-ruRiyPYZEGeJBOOjVS5pHliNUZM2HAllEY7HKB2ff+9ENxOti4N+S+WZqo9ggUMr8tSPMm+riqKpJd1oYEDN5Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.1.1.tgz",
+      "integrity": "sha512-8zkLMwSvUAnfN9pcJDfkuxU0Nvg4RLUD0A4BZN1KxJPtlnCGzMx3xM5cRl4m8fym/Vy8rlq52tl90UF3m91OnA==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -2614,9 +2601,9 @@
       }
     },
     "d3-array": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.0.4.tgz",
-      "integrity": "sha512-ShFl90cxNqDaSynDF/Bik/kTzISqePqU3qo2fv6kSJEvF7y7tDCDpcU6WiT01rPO6zngZnrvJ/0j4q6Qg+5EQg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.1.tgz",
+      "integrity": "sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==",
       "requires": {
         "internmap": "1 - 2"
       }
@@ -3664,14 +3651,6 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -4446,35 +4425,6 @@
         "websocket-driver": ">=0.5.1"
       }
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
-    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -4792,9 +4742,9 @@
       }
     },
     "grommet": {
-      "version": "2.17.5",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.17.5.tgz",
-      "integrity": "sha512-ld8nvuEqBDXiUiMybX2yuMH94KC1LxGhHKaDyqQI8HZrzgUpOB/GuQ2VcvB2YSB62Zpt7NuBjsghlLPKG5l8gQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.18.0.tgz",
+      "integrity": "sha512-e7w3EJT2+TkJEHa+lB2BWcPbOixVk3X6hUl0hxRITMVqEFyjzU5NY5dzoRs50uMtHF4/tksyBWOKyvdsjJwMVg==",
       "requires": {
         "grommet-icons": "^4.6.2",
         "hoist-non-react-statics": "^3.2.0",
@@ -5701,7 +5651,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -5759,15 +5710,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "joycon": {
       "version": "3.0.1",
@@ -6136,9 +6078,9 @@
       "dev": true
     },
     "mermaid": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.0.tgz",
-      "integrity": "sha512-/b8tCqyGhb+yiCQQ5cwpGcaesAfZV057kRBaUx+g6LHctebWaMvo5WmIPN+/jMHfLtAgCJIaQDZ1EsECz7FJIQ==",
+      "version": "8.13.2",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.2.tgz",
+      "integrity": "sha512-qTFI7MfC2d+x0Hft5gx063EH9tZg36lERG8o7Zq0Ag+MnO8CgVaMZEU6oA8gzTtTn9upMdy4UlYSLVmavu27cQ==",
       "requires": {
         "@braintree/sanitize-url": "^3.1.0",
         "d3": "^7.0.0",
@@ -6306,9 +6248,9 @@
       "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
     },
     "monaco-editor": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.28.1.tgz",
-      "integrity": "sha512-P1vPqxB4B1ZFzTeR1ScggSp9/5NoQrLCq88fnlNUsuRAP1usEBN4TIpI2lw0AYIZNVIanHk0qwjze2uJwGOHUw=="
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
+      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -6440,15 +6382,6 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "requires": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -7340,9 +7273,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.18.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.1.tgz",
-          "integrity": "sha512-vJlUi/7YdlCZeL6fXvWNaLUPh/id12WXj3MbkMw5uOyF0PfWPBNOCNbs53YqgrvtujLNlt9JQpruyIKkUZ+PKA=="
+          "version": "3.18.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+          "integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ=="
         }
       }
     },
@@ -7415,17 +7348,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-monaco-editor": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.40.0.tgz",
-      "integrity": "sha512-IG322vOwKc/yjhn91xbqHONyAVxjv5L0YOUBU+hDwfswlglm/sGsqGhK9n1lD5d3l3kegMO/ZeZaMHC2LGgNRw==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.45.0.tgz",
+      "integrity": "sha512-QgAFXdXm5e9QRCnjFBt5fHqmUWL2qIMHZuZSLR6rU9E3Bbo2pQO7FSqgVmB5trc5U+hs7KdIWVoWIOzQvZMu3w==",
       "requires": {
-        "monaco-editor": "*",
+        "monaco-editor": "^0.27.0",
         "prop-types": "^15.7.2"
       }
     },
@@ -7575,26 +7503,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
-      }
-    },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
       }
     },
     "redux": {
@@ -7795,9 +7703,9 @@
       }
     },
     "rendition": {
-      "version": "21.7.7",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.7.7.tgz",
-      "integrity": "sha512-ul+PY/Rw34vVqLi8x2fcEIt+kq8xfiKFum+JQY5fPcCumFdktXxZctJ3RfsVQoyXIuQKQs1xsIxiEC1JhT/+HA==",
+      "version": "21.8.2",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.8.2.tgz",
+      "integrity": "sha512-glYJIRjdPDifoYPu6HPxBawuVoVVLVzPRuN2XGntq8LsIp5TJ6cp3MjloNSXB8yilWLQYLVUFHzdQJrOdeYfEg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -7805,7 +7713,7 @@
         "@fortawesome/react-fontawesome": "^0.1.14",
         "@mapbox/rehype-prism": "^0.5.0",
         "@react-google-maps/api": "^1.13.0",
-        "@rjsf/core": "^2.2.1",
+        "@rjsf/core": "^2.5.1",
         "@types/ajv-keywords": "^3.4.0",
         "@types/color": "^3.0.0",
         "@types/history": "^4.7.8",
@@ -7814,30 +7722,28 @@
         "@types/node": "^14.14.35",
         "@types/prop-types": "^15.7.0",
         "@types/react-helmet": "^6.1.0",
-        "@types/recompose": "^0.26.2",
         "@types/styled-components": "^5.1.9",
         "@types/styled-system": "^4.0.0",
         "@types/uuid": "^3.4.3",
         "ajv": "^6.12.3",
         "ajv-keywords": "^3.5.2",
-        "color": "^3.1.3",
-        "color-hash": "^1.0.3",
+        "color": "^3.2.1",
+        "color-hash": "^1.1.1",
         "copy-to-clipboard": "^3.3.1",
         "date-fns": "^2.24.0",
         "grommet": "^2.16.3",
         "hast-util-sanitize": "^3.0.2",
         "json-e": "^4.4.1",
         "lodash": "^4.17.21",
-        "mermaid": "^8.13.0",
+        "mermaid": "^8.13.2",
         "prismjs": "^1.21.0",
         "prop-types": "^15.7.2",
         "qs": "^6.10.1",
         "react-google-recaptcha": "^2.1.0",
-        "react-helmet": "^6.0.0",
-        "react-monaco-editor": "^0.40.0",
+        "react-helmet": "^6.1.0",
+        "react-monaco-editor": "^0.45.0",
         "react-notifications-component": "^2.4.1",
-        "react-simplemde-editor": "^4.1.3",
-        "recompose": "0.30.0",
+        "react-simplemde-editor": "^4.1.5",
         "regex-parser": "^2.2.11",
         "regexp-match-indices": "^1.0.2",
         "rehype-autolink-headings": "^5.1.0",
@@ -7848,14 +7754,14 @@
         "remark-breaks": "^2.0.1",
         "remark-parse": "^8.0.3",
         "remark-rehype": "^7.0.0",
-        "resize-observer": "^1.0.0",
+        "resize-observer": "^1.0.2",
         "skhema": "^5.3.4",
-        "styled-components": "^5.2.1",
-        "styled-system": "^4.1.0",
+        "styled-components": "^5.3.1",
+        "styled-system": "^4.2.4",
         "tslib": "^2.3.1",
         "unified": "^9.2.2",
         "unist-util-visit-parents": "^3.1.0",
-        "uuid": "^3.2.1",
+        "uuid": "^3.4.0",
         "xterm": "^4.8.1",
         "xterm-addon-fit": "^0.4.0"
       },
@@ -8943,11 +8849,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "table": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
@@ -9345,11 +9246,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.2.0.tgz",
       "integrity": "sha512-dELuLBVa2jvWdU/CHTKi2L/POYaRupv942k+vRsFXsM17acXesQGAiGCio82RW7fvcr7bkuD/Zj8XpUh6aPC2A=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
       "version": "3.14.2",

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -28,7 +28,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.3.0",
-    "rendition": "^21.6.8",
+    "rendition": "^21.7.16",
     "style-loader": "^2.0.0",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^4.4.2"

--- a/apps/ui/jest.config.js
+++ b/apps/ui/jest.config.js
@@ -9,12 +9,13 @@ const base = require('@balena/jellyfish-config/config/jest.config')
 module.exports = {
 	preset: base.preset,
 	testEnvironment: 'jsdom',
-	transformIgnorePatterns: [],
+	transformIgnorePatterns: [
+	],
 	globals: {
 		env: {}
 	},
 	transform: {
-		'node_modules/entity-decode/(.*)': 'jest-esm-transformer',
+		'node_modules/(entity-decode/(.*)|d3|internmap|delaunator|robust-predicates)': 'jest-esm-transformer',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$':
 			'<rootDir>/file-transformer.js'
 	}

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -5556,14 +5556,6 @@
         "redux": "^4.0.0"
       }
     },
-    "@types/recompose": {
-      "version": "0.26.5",
-      "resolved": "https://registry.npmjs.org/@types/recompose/-/recompose-0.26.5.tgz",
-      "integrity": "sha512-Il5stz/Z3pVIMl48pyggl6nnhRLQ8N8YN8hi0Anm0M5UjVh2uMSY0ah2vzwZZKxnca4NzyJArloSjsJ9fL2vWw==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -7577,11 +7569,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -7991,15 +7978,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      }
-    },
     "color-alpha": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
@@ -8078,15 +8056,6 @@
       "requires": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
-      }
-    },
-    "color-string": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
       }
     },
     "colorette": {
@@ -8932,6 +8901,276 @@
         "type": "^1.0.1"
       }
     },
+    "d3": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.1.1.tgz",
+      "integrity": "sha512-8zkLMwSvUAnfN9pcJDfkuxU0Nvg4RLUD0A4BZN1KxJPtlnCGzMx3xM5cRl4m8fym/Vy8rlq52tl90UF3m91OnA==",
+      "requires": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "3",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        },
+        "d3-array": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.1.tgz",
+          "integrity": "sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==",
+          "requires": {
+            "internmap": "1 - 2"
+          }
+        },
+        "d3-axis": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+          "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+        },
+        "d3-brush": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+          "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+          "requires": {
+            "d3-dispatch": "1 - 3",
+            "d3-drag": "2 - 3",
+            "d3-interpolate": "1 - 3",
+            "d3-selection": "3",
+            "d3-transition": "3"
+          }
+        },
+        "d3-chord": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+          "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+          "requires": {
+            "d3-path": "1 - 3"
+          }
+        },
+        "d3-color": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
+          "integrity": "sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw=="
+        },
+        "d3-contour": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-3.0.1.tgz",
+          "integrity": "sha512-0Oc4D0KyhwhM7ZL0RMnfGycLN7hxHB8CMmwZ3+H26PWAG0ozNuYG5hXSDNgmP1SgJkQMrlG6cP20HoaSbvcJTQ==",
+          "requires": {
+            "d3-array": "2 - 3"
+          }
+        },
+        "d3-dispatch": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+          "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+        },
+        "d3-drag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+          "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+          "requires": {
+            "d3-dispatch": "1 - 3",
+            "d3-selection": "3"
+          }
+        },
+        "d3-dsv": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+          "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+          "requires": {
+            "commander": "7",
+            "iconv-lite": "0.6",
+            "rw": "1"
+          }
+        },
+        "d3-ease": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+          "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+        },
+        "d3-fetch": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+          "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+          "requires": {
+            "d3-dsv": "1 - 3"
+          }
+        },
+        "d3-force": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+          "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+          "requires": {
+            "d3-dispatch": "1 - 3",
+            "d3-quadtree": "1 - 3",
+            "d3-timer": "1 - 3"
+          }
+        },
+        "d3-format": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.0.1.tgz",
+          "integrity": "sha512-hdL7+HBIohpgfolhBxr1KX47VMD6+vVD/oEFrxk5yhmzV2prk99EkFKYpXuhVkFpTgHdJ6/4bYcjdLPPXV4tIA=="
+        },
+        "d3-geo": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
+          "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+          "requires": {
+            "d3-array": "2.5.0 - 3"
+          }
+        },
+        "d3-hierarchy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.0.1.tgz",
+          "integrity": "sha512-RlLTaofEoOrMK1JoXYIGhKTkJFI/6rFrYPgxy6QlZo2BcVc4HGTqEU0rPpzuMq5T/5XcMtAzv1XiLA3zRTfygw=="
+        },
+        "d3-interpolate": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+          "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+          "requires": {
+            "d3-color": "1 - 3"
+          }
+        },
+        "d3-path": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
+          "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w=="
+        },
+        "d3-polygon": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+          "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+        },
+        "d3-quadtree": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+          "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+        },
+        "d3-random": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+          "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+        },
+        "d3-scale": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+          "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+          "requires": {
+            "d3-array": "2.10.0 - 3",
+            "d3-format": "1 - 3",
+            "d3-interpolate": "1.2.0 - 3",
+            "d3-time": "2.1.1 - 3",
+            "d3-time-format": "2 - 4"
+          }
+        },
+        "d3-scale-chromatic": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+          "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+          "requires": {
+            "d3-color": "1 - 3",
+            "d3-interpolate": "1 - 3"
+          }
+        },
+        "d3-selection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+          "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+        },
+        "d3-shape": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.0.1.tgz",
+          "integrity": "sha512-HNZNEQoDhuCrDWEc/BMbF/hKtzMZVoe64TvisFLDp2Iyj0UShB/E6/lBsLlJTfBMbYgftHj90cXJ0SEitlE6Xw==",
+          "requires": {
+            "d3-path": "1 - 3"
+          }
+        },
+        "d3-time": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
+          "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+          "requires": {
+            "d3-array": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.0.0.tgz",
+          "integrity": "sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==",
+          "requires": {
+            "d3-time": "1 - 3"
+          }
+        },
+        "d3-timer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+          "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+        },
+        "d3-transition": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+          "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+          "requires": {
+            "d3-color": "1 - 3",
+            "d3-dispatch": "1 - 3",
+            "d3-ease": "1 - 3",
+            "d3-interpolate": "1 - 3",
+            "d3-timer": "1 - 3"
+          }
+        },
+        "d3-zoom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+          "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+          "requires": {
+            "d3-dispatch": "1 - 3",
+            "d3-drag": "2 - 3",
+            "d3-interpolate": "1 - 3",
+            "d3-selection": "2 - 3",
+            "d3-transition": "2 - 3"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
@@ -8979,6 +9218,14 @@
       "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
       "requires": {
         "d3-array": "^1.1.1"
+      }
+    },
+    "d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "requires": {
+        "delaunator": "5"
       }
     },
     "d3-dispatch": {
@@ -9436,6 +9683,14 @@
             "glob": "^7.1.3"
           }
         }
+      }
+    },
+    "delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "requires": {
+        "robust-predicates": "^3.0.0"
       }
     },
     "delaunay-triangulate": {
@@ -10038,24 +10293,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -11277,35 +11514,6 @@
         "bser": "2.1.1"
       }
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
-    },
     "fbjs-css-vars": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
@@ -11875,6 +12083,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "github-slugger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
+      "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ=="
     },
     "gl-axes3d": {
       "version": "1.5.3",
@@ -12813,6 +13026,16 @@
         "web-namespaces": "^1.0.0"
       }
     },
+    "hast-util-has-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
+    },
+    "hast-util-heading-rank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-1.0.1.tgz",
+      "integrity": "sha512-P6Hq7RCky9syMevlrN90QWpqWDXCxwIVOfQR2rK6P4GpY4bqjKEuCzoWSRORZ7vz+VgRpLnXimh+mkwvVFjbyQ=="
+    },
     "hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
@@ -13483,6 +13706,11 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+    },
     "interpret": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -13876,7 +14104,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.6",
@@ -13965,15 +14194,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -16556,6 +16776,22 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
+    "mermaid": {
+      "version": "8.13.2",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.2.tgz",
+      "integrity": "sha512-qTFI7MfC2d+x0Hft5gx063EH9tZg36lERG8o7Zq0Ag+MnO8CgVaMZEU6oA8gzTtTn9upMdy4UlYSLVmavu27cQ==",
+      "requires": {
+        "@braintree/sanitize-url": "^3.1.0",
+        "d3": "^7.0.0",
+        "dagre": "^0.8.5",
+        "dagre-d3": "^0.6.4",
+        "dompurify": "2.3.1",
+        "graphlib": "^2.1.8",
+        "khroma": "^1.4.1",
+        "moment-mini": "^2.24.0",
+        "stylis": "^4.0.10"
+      }
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -17117,15 +17353,6 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "requires": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -19645,6 +19872,17 @@
         "regl-scatter2d": "^3.2.3"
       }
     },
+    "rehype-autolink-headings": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-5.1.0.tgz",
+      "integrity": "sha512-ujU4/ALnWLJQubobQaMdC0h9nkzi7HlW9SOuCxZOkkJqhc/TrQ1cigIjMFQ2Tfc/es0KiFopKvwCUGw7Gw+mFw==",
+      "requires": {
+        "extend": "^3.0.0",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-heading-rank": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
     "rehype-raw": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-5.1.0.tgz",
@@ -19678,6 +19916,18 @@
             "xtend": "^4.0.0"
           }
         }
+      }
+    },
+    "rehype-slug": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-4.0.1.tgz",
+      "integrity": "sha512-KIlJALf9WfHFF21icwTd2yI2IP+RQRweaxH9ChVGQwRYy36+hiomG4ZSe0yQRyCt+D/vE39LbAcOI/h4O4GPhA==",
+      "requires": {
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-heading-rank": "^1.0.0",
+        "hast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
       }
     },
     "relateurl": {
@@ -19742,9 +19992,9 @@
       }
     },
     "rendition": {
-      "version": "21.6.8",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.6.8.tgz",
-      "integrity": "sha512-7Ccgu4lgrKRJNXba0z9e8loqZVa+ore/3SED3iihTPXUeXz4UHpNDzWqwo5wosLuqOBXVqQJKtdldhSZGIczVw==",
+      "version": "21.7.16",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.7.16.tgz",
+      "integrity": "sha512-IWj4rERZWWgwYHuRAX7SAbwee2lbZ7UWYNZfY1MISQGAn8tCu8KxhzbgHIMpaYiSAgN+cXZwRX02CgXLdHnQgQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -19761,21 +20011,20 @@
         "@types/node": "^14.14.35",
         "@types/prop-types": "^15.7.0",
         "@types/react-helmet": "^6.1.0",
-        "@types/recompose": "^0.26.2",
         "@types/styled-components": "^5.1.9",
         "@types/styled-system": "^4.0.0",
         "@types/uuid": "^3.4.3",
         "ajv": "^6.12.3",
         "ajv-keywords": "^3.5.2",
-        "color": "^3.1.3",
-        "color-hash": "^1.0.3",
-        "copy-to-clipboard": "^3.0.8",
-        "date-fns": "^2.16.1",
+        "color": "^3.2.1",
+        "color-hash": "^1.1.1",
+        "copy-to-clipboard": "^3.3.1",
+        "date-fns": "^2.24.0",
         "grommet": "^2.16.3",
-        "hast-util-sanitize": "^3.0.0",
+        "hast-util-sanitize": "^3.0.2",
         "json-e": "^4.4.1",
         "lodash": "^4.17.21",
-        "mermaid": "^8.12.0",
+        "mermaid": "^8.13.0",
         "prismjs": "^1.21.0",
         "prop-types": "^15.7.2",
         "qs": "^6.10.1",
@@ -19784,85 +20033,50 @@
         "react-monaco-editor": "^0.40.0",
         "react-notifications-component": "^2.4.1",
         "react-simplemde-editor": "^4.1.3",
-        "recompose": "0.30.0",
         "regex-parser": "^2.2.11",
         "regexp-match-indices": "^1.0.2",
+        "rehype-autolink-headings": "^5.1.0",
         "rehype-raw": "^5.0.0",
         "rehype-react": "^6.1.0",
         "rehype-sanitize": "^3.0.1",
+        "rehype-slug": "^4.0.1",
         "remark-breaks": "^2.0.1",
         "remark-parse": "^8.0.3",
         "remark-rehype": "^7.0.0",
-        "resize-observer": "^1.0.0",
+        "resize-observer": "^1.0.2",
         "skhema": "^5.3.4",
-        "styled-components": "^5.2.1",
-        "styled-system": "^4.1.0",
-        "tslib": "^2.1.0",
-        "unified": "^9.1.0",
+        "styled-components": "^5.3.1",
+        "styled-system": "^4.2.4",
+        "tslib": "^2.3.1",
+        "unified": "^9.2.2",
         "unist-util-visit-parents": "^3.1.0",
-        "uuid": "^3.2.1",
+        "uuid": "^3.4.0",
         "xterm": "^4.8.1",
         "xterm-addon-fit": "^0.4.0"
       },
       "dependencies": {
-        "d3": {
-          "version": "5.16.0",
-          "resolved": "https://registry.npmjs.org/d3/-/d3-5.16.0.tgz",
-          "integrity": "sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==",
+        "color": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+          "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
           "requires": {
-            "d3-array": "1",
-            "d3-axis": "1",
-            "d3-brush": "1",
-            "d3-chord": "1",
-            "d3-collection": "1",
-            "d3-color": "1",
-            "d3-contour": "1",
-            "d3-dispatch": "1",
-            "d3-drag": "1",
-            "d3-dsv": "1",
-            "d3-ease": "1",
-            "d3-fetch": "1",
-            "d3-force": "1",
-            "d3-format": "1",
-            "d3-geo": "1",
-            "d3-hierarchy": "1",
-            "d3-interpolate": "1",
-            "d3-path": "1",
-            "d3-polygon": "1",
-            "d3-quadtree": "1",
-            "d3-random": "1",
-            "d3-scale": "2",
-            "d3-scale-chromatic": "1",
-            "d3-selection": "1",
-            "d3-shape": "1",
-            "d3-time": "1",
-            "d3-time-format": "2",
-            "d3-timer": "1",
-            "d3-transition": "1",
-            "d3-voronoi": "1",
-            "d3-zoom": "1"
+            "color-convert": "^1.9.3",
+            "color-string": "^1.6.0"
           }
         },
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        },
-        "mermaid": {
-          "version": "8.12.1",
-          "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.12.1.tgz",
-          "integrity": "sha512-0UCcSF0FLoNcPBsRF4f9OIV32t41fV18//z8o3S+FDz2PbDA1CRGKdQF9IX84VP4Tv9kcgJI/oqJdcBEtB/GPA==",
+        "color-string": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+          "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
           "requires": {
-            "@braintree/sanitize-url": "^3.1.0",
-            "d3": "^5.16.0",
-            "dagre": "^0.8.5",
-            "dagre-d3": "^0.6.4",
-            "dompurify": "2.3.1",
-            "graphlib": "^2.1.8",
-            "khroma": "^1.4.1",
-            "moment-mini": "^2.24.0",
-            "stylis": "^4.0.10"
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
           }
+        },
+        "date-fns": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+          "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
         },
         "qs": {
           "version": "6.10.1",
@@ -19870,19 +20084,6 @@
           "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
           "requires": {
             "side-channel": "^1.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-          "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
           }
         },
         "tslib": {
@@ -20139,6 +20340,11 @@
         "robust-sum": "^1.0.0",
         "two-product": "^1.0.2"
       }
+    },
+    "robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
     },
     "robust-product": {
       "version": "1.0.0",
@@ -21876,11 +22082,6 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -22787,9 +22988,9 @@
       "dev": true
     },
     "unified": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
-      "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -72,7 +72,7 @@
     "redux": "^4.1.1",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
-    "rendition": "^21.6.8",
+    "rendition": "^21.7.16",
     "skhema": "^5.3.4",
     "style-loader": "^2.0.0",
     "styled-components": "^5.3.1",


### PR DESCRIPTION
This update notably drops the `recompose` package, which is deprecated
and causes React to issue warnings.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
