### PR TITLE
Ignore falsey notification events in livechat e2e tests

### DIFF
--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -336,7 +336,7 @@ ava.serial('Create conversation page', async (test) => {
 
 	await context.page.evaluate(() => {
 		window.addEventListener('message', (event) => {
-			if (event.data.type === 'notifications-change') {
+			if (event.data.type === 'notifications-change' && event.data.payload.data) {
 				window.notifications = event.data.payload.data
 			}
 		})


### PR DESCRIPTION
This change should fix a source of flakiness where a falsey event is
emitted shortly after the first emission, resulting in no notifications
being found.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
