### PR TITLE
Improve reliability of e2e livechat tests

### DIFF
--- a/test/e2e/livechat/index.spec.js
+++ b/test/e2e/livechat/index.spec.js
@@ -336,7 +336,11 @@ ava.serial('Create conversation page', async (test) => {
 
 	await context.page.evaluate(() => {
 		window.addEventListener('message', (event) => {
-			if (event.data.type === 'notifications-change' && event.data.payload.data) {
+			if (
+				event.data.type === 'notifications-change' &&
+				event.data.payload.data &&
+				event.data.payload.data.length > 0
+			) {
 				window.notifications = event.data.payload.data
 			}
 		})


### PR DESCRIPTION
This change prevents the situation where the stored notifications get
overwritten by an empty array before the test can check them.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
