### PR TITLE
Fix sentry variable name for apps/ui

### DIFF
--- a/apps/ui/conf/env.sh
+++ b/apps/ui/conf/env.sh
@@ -26,7 +26,7 @@ touch ./env-config.js
 	# Append configuration property to JS file
 	echo "  SERVER_HOST: \"$SERVER_HOST\","
 	echo "  SERVER_PORT: \"$SERVER_PORT\","
-	echo "  SENTRY_DSN: \"$SENTRY_DSN\","
+	echo "  SENTRY_DSN_UI: \"$SENTRY_DSN_UI\","
 
 	echo "}"
 } >> ./env-config.js

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -134,7 +134,7 @@ services:
       - api
       - balena-mdns-publisher
     environment:
-      - SENTRY_DSN_UI='0'
+      - SENTRY_DSN_UI=0
       - SERVER_HOST=http://api.ly.fish.local
       - SERVER_PORT=80
       - NGINX_PORT=80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       - api
       - balena-mdns-publisher
     environment:
-      - SENTRY_DSN_UI='0'
+      - SENTRY_DSN_UI=0
       - SERVER_HOST=http://api.ly.fish.local
       - SERVER_PORT=80
       - NGINX_PORT=80


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

The sentry environment variable name is slightly off, resulting in the following incorrect `env-config.js` in production:
```javascript
window._env_ = {
  SERVER_HOST: "https://api.ly.fish",
  SERVER_PORT: "443",
  SENTRY_DSN: "",
}
```

The expected name is `SENTRY_DSN_UI`:
```
root@jellyfish-ui-fd4cbf6f5-4nrvc:/usr/share/nginx/html# env | grep -i sentry
SENTRY_DSN_UI=https://ff836b1e4abc4d0699bcaaf07ce4ea08@sentry.io/1366139
```

```
$ grep -i sentry apps/ui/lib/environment.ts
export const sentry = {
        dsn: windowEnv.SENTRY_DSN_UI || '0',
```