### PR TITLE
Include md5sum hash in env-config.js filename

### DIFF
--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -32,11 +32,11 @@ RUN make build-livechat NODE_ENV=production
 FROM nginx:1.21.3
 WORKDIR /usr/share/nginx/html
 COPY --from=base /usr/src/jellyfish/apps/livechat/dist/livechat /usr/share/nginx/html
-COPY apps/livechat/conf/env.sh /usr/share/nginx/html
+COPY apps/livechat/conf/env.sh /tmp
 COPY apps/livechat/conf/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Make our shell script executable
-RUN chmod +x /usr/share/nginx/html/env.sh
+RUN chmod +x /tmp/env.sh
 
 # Start Nginx server
-CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]
+CMD ["/bin/bash", "-c", "/tmp/env.sh && nginx -g \"daemon off;\""]

--- a/apps/livechat/conf/env.sh
+++ b/apps/livechat/conf/env.sh
@@ -16,9 +16,11 @@
 
 echo "Generating env-config.js file..."
 
+BASE_FILENAME="env-config.js"
+
 # Recreate config file
-rm -rf ./env-config.js
-touch ./env-config.js
+rm -rf "./$BASE_FILENAME"
+touch "./$BASE_FILENAME"
 
 {
 	echo "window._env_ = {"
@@ -29,7 +31,12 @@ touch ./env-config.js
 	echo "  SENTRY_DSN_UI: \"$SENTRY_DSN_UI\","
 
 	echo "}"
-} >> ./env-config.js
+} >> "./$BASE_FILENAME"
 
-echo "env-config.js file generated:"
-cat ./env-config.js
+HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
+mv "./$BASE_FILENAME" "./$HASHED_FILENAME"
+
+echo "$HASHED_FILENAME file generated:"
+cat "./$HASHED_FILENAME"
+
+sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" index.html

--- a/apps/livechat/conf/env.sh
+++ b/apps/livechat/conf/env.sh
@@ -17,6 +17,7 @@
 echo "Generating env-config.js file..."
 
 BASE_FILENAME="env-config.js"
+PUBLIC_DIR="/usr/share/nginx/html"
 
 # Recreate config file
 rm -rf "./$BASE_FILENAME"
@@ -34,9 +35,9 @@ touch "./$BASE_FILENAME"
 } >> "./$BASE_FILENAME"
 
 HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
-mv "./$BASE_FILENAME" "./$HASHED_FILENAME"
+mv "./$BASE_FILENAME" "$PUBLIC_DIR/$HASHED_FILENAME"
 
 echo "$HASHED_FILENAME file generated:"
-cat "./$HASHED_FILENAME"
+cat "$PUBLIC_DIR/$HASHED_FILENAME"
 
-sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" index.html
+sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" "$PUBLIC_DIR/index.html"

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -34,11 +34,11 @@ RUN make build-ui \
 FROM nginx:1.21.3
 WORKDIR /usr/share/nginx/html
 COPY --from=base /usr/src/jellyfish/apps/ui/dist/ui /usr/share/nginx/html
-COPY apps/ui/conf/env.sh /usr/share/nginx/html
+COPY apps/ui/conf/env.sh /tmp
 COPY apps/ui/conf/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Make our shell script executable
-RUN chmod +x /usr/share/nginx/html/env.sh
+RUN chmod +x /tmp/env.sh
 
 # Start Nginx server
-CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]
+CMD ["/bin/bash", "-c", "/tmp/env.sh && nginx -g \"daemon off;\""]

--- a/apps/ui/conf/env.sh
+++ b/apps/ui/conf/env.sh
@@ -17,6 +17,7 @@
 echo "Generating env-config.js file..."
 
 BASE_FILENAME="env-config.js"
+PUBLIC_DIR="/usr/share/nginx/html"
 
 # Recreate config file
 rm -rf "./$BASE_FILENAME"
@@ -34,9 +35,9 @@ touch "./$BASE_FILENAME"
 } >> "./$BASE_FILENAME"
 
 HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
-mv "./$BASE_FILENAME" "./$HASHED_FILENAME"
+mv "./$BASE_FILENAME" "$PUBLIC_DIR/$HASHED_FILENAME"
 
 echo "$HASHED_FILENAME file generated:"
-cat "./$HASHED_FILENAME"
+cat "$PUBLIC_DIR/$HASHED_FILENAME"
 
-sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" index.html
+sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" "$PUBLIC_DIR/index.html"

--- a/apps/ui/conf/env.sh
+++ b/apps/ui/conf/env.sh
@@ -8,7 +8,7 @@
 
 # Injecting environment variables using a shell script allows the UI docker
 # container to be parameterised at runtime, which means we can create a single
-# UI container and point it at differnet backends as required.
+# UI container and point it at different backends as required.
 # This is very useful for testing, where we build containers (that may be
 # deployed to production) and also test these containers in CI.
 # For a more in-depth explanation of this approach take a look at:
@@ -16,9 +16,11 @@
 
 echo "Generating env-config.js file..."
 
+BASE_FILENAME="env-config.js"
+
 # Recreate config file
-rm -rf ./env-config.js
-touch ./env-config.js
+rm -rf "./$BASE_FILENAME"
+touch "./$BASE_FILENAME"
 
 {
 	echo "window._env_ = {"
@@ -29,7 +31,12 @@ touch ./env-config.js
 	echo "  SENTRY_DSN_UI: \"$SENTRY_DSN_UI\","
 
 	echo "}"
-} >> ./env-config.js
+} >> "./$BASE_FILENAME"
 
-echo "env-config.js file generated:"
-cat ./env-config.js
+HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
+mv "./$BASE_FILENAME" "./$HASHED_FILENAME"
+
+echo "$HASHED_FILENAME file generated:"
+cat "./$HASHED_FILENAME"
+
+sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" index.html


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

We had [an incident](https://www.flowdock.com/app/rulemotion/resin-devops/threads/qhU0CLuemFfHxdrR1dtY4JzUT1M) caused by a broken version of Livechat's `env-config.js` being cached by CloudFlare. We have been able to resolve the problem by manually purging the broken cached version from CloudFlare. This isn't a long term solution however, and in order to force downloads of the most recent version this PR adds in the md5sum hash of the file in the filename. This means `env-config.js` file will now be something like `env-config.f8a5badce1d2a93432bc3a04bdbbcbfb.js` (reference in `index.html` is also updated). This same problem also exists for `apps/ui` so including the same fix for that as well.

Also stop copying `env.sh` to the public html directory. Instead copy to `/tmp` and execute it from there to generate `env-config.<hash>.js`.