### PR TITLE
Fix `dev-ui` command to work locally

### DIFF
--- a/apps/ui/Makefile
+++ b/apps/ui/Makefile
@@ -39,10 +39,11 @@ test:
 
 .PHONY: dev-ui
 dev-ui:
+	mkdir -p ./dist/ui && \
 	SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) \
+	PUBLIC_DIR="./" \
 	NODE_ENV=development \
 	NODE_OPTIONS=--max-old-space-size=8192 \
-	mkdir -p ./dist/ui && \
 	./conf/env.sh && \
 	cp ./env-config.js ./dist/ui/ && \
 	./node_modules/.bin/webpack serve \

--- a/apps/ui/conf/env.sh
+++ b/apps/ui/conf/env.sh
@@ -17,7 +17,7 @@
 echo "Generating env-config.js file..."
 
 BASE_FILENAME="env-config.js"
-PUBLIC_DIR="/usr/share/nginx/html"
+PUBLIC_DIR="${PUBLIC_DIR:-/usr/share/nginx/html}"
 
 # Recreate config file
 rm -rf "./$BASE_FILENAME"
@@ -34,10 +34,12 @@ touch "./$BASE_FILENAME"
 	echo "}"
 } >> "./$BASE_FILENAME"
 
-HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
-mv "./$BASE_FILENAME" "$PUBLIC_DIR/$HASHED_FILENAME"
+if [ "$NODE_ENV" != "development" ]; then
+	HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
+	mv "./$BASE_FILENAME" "$PUBLIC_DIR/$HASHED_FILENAME"
 
-echo "$HASHED_FILENAME file generated:"
-cat "$PUBLIC_DIR/$HASHED_FILENAME"
+	echo "$HASHED_FILENAME file generated:"
+	cat "$PUBLIC_DIR/$HASHED_FILENAME"
 
-sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" "$PUBLIC_DIR/index.html"
+	sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" "$PUBLIC_DIR/index.html"
+fi


### PR DESCRIPTION
Recent changes for cache busting prevented the `dev-ui` command from
working on your local machine. This change fixes this by only applying
the cachebusting suffix to the filename if the current node environment
isn't "development".

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
