### PR TITLE
Fix broken mermaid charts

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -18980,9 +18980,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.18.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.3.tgz",
-          "integrity": "sha512-tReEhtMReZaPFVw7dajMx0vlsz3oOb8ajgPoHVYGxr8ErnZ6PcYEvvmjGmXlfpnxpkYSdOQttjB+MvVbCGfvLw=="
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.0.tgz",
+          "integrity": "sha512-L1TpFRWXZ76vH1yLM+z6KssLZrP8Z6GxxW4auoCj+XiViOzNPJCAuTIkn03BGdFe6Z5clX5t64wRIRypsZQrUg=="
         }
       }
     },
@@ -19964,9 +19964,9 @@
       }
     },
     "rendition": {
-      "version": "21.9.1",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.9.1.tgz",
-      "integrity": "sha512-FRjMJ8hUp2bIiKztgJWuryftJczPOPhMDXGrfrQFptGfmB3GA8a0c71wm1+Ko0qSOA7YjguSIOg6KPaKSimEyA==",
+      "version": "21.9.3",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-21.9.3.tgz",
+      "integrity": "sha512-CLoh9wVqsd8aZpdu4tSGE7VCShV/g+4nZKMIqw+9PYbxA2X9cXcq4VHxOnPWplstJhq29amoXpUuGRNHTL7t0A==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -72,7 +72,7 @@
     "redux": "^4.1.1",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
-    "rendition": "^21.9.1",
+    "rendition": "^21.9.3",
     "skhema": "^5.3.4",
     "style-loader": "^2.0.0",
     "styled-components": "^5.3.3",


### PR DESCRIPTION
This change updates to the latest version of rendition that fixes as an
incorrect import of the mermaid API, used to render charts in Jellyfish.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
