### PR TITLE
Ensure streams are closed correctly when navigating through the UI

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -844,7 +844,15 @@ export const actionCreators = {
 			return createChannel(channel);
 		});
 
-		return (dispatch) => {
+		return (dispatch, getState) => {
+			const state = getState();
+			const currentChannels = selectors.getChannels(state);
+
+			// For each current channel that isn't in the new channels, remove the corresponding stream
+			const diff = _.differenceBy(currentChannels, channels, 'data.target');
+			for (const removedChannel of diff) {
+				dispatch(actionCreators.removeChannel(removedChannel));
+			}
 			dispatch({
 				type: actions.SET_CHANNELS,
 				value: channels,


### PR DESCRIPTION
Previously streams would only be closed if the `removeChannel` action
was called explicitly. Now streams are always tidied up after a navigation
event, when the `setChannels` action is called.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
