### PR TITLE
Don't limit the results of the /type endpoint

### DIFF
--- a/apps/server/lib/http/routes.ts
+++ b/apps/server/lib/http/routes.ts
@@ -394,24 +394,17 @@ export const attachRoutes = (
 			.measureHttpType(() => {
 				const [base, version] = request.params.type.split('@');
 				return jellyfish
-					.query(
-						request.context,
-						request.sessionToken,
-						{
-							type: 'object',
-							additionalProperties: true,
-							required: ['type'],
-							properties: {
-								type: {
-									type: 'string',
-									const: `${base}@${version || '1.0.0'}`,
-								},
+					.query(request.context, request.sessionToken, {
+						type: 'object',
+						additionalProperties: true,
+						required: ['type'],
+						properties: {
+							type: {
+								type: 'string',
+								const: `${base}@${version || '1.0.0'}`,
 							},
 						},
-						{
-							limit: 100,
-						},
-					)
+					})
 					.then((results) => {
 						return response.status(200).json(results);
 					});

--- a/test/e2e/server/index.spec.js
+++ b/test/e2e/server/index.spec.js
@@ -173,29 +173,6 @@ ava.serial('should fail with a user error given no input card', async (test) => 
 	test.true(result.response.error)
 })
 
-ava.serial('should limit the amount of get elements by type endpoint', async (test) => {
-	for (const time of _.range(0, 101)) {
-		const card = await test.context.sdk.card.create({
-			type: 'card',
-			slug: test.context.generateRandomSlug({
-				prefix: `test-card-${time}`
-			}),
-			version: '1.0.0',
-			data: {}
-		})
-
-		test.truthy(card.id)
-	}
-
-	const result = await test.context.http(
-		'GET', '/api/v2/type/card', null, {
-			Authorization: `Bearer ${test.context.token}`
-		})
-
-	test.is(result.code, 200)
-	test.is(result.response.length, 100)
-})
-
 ava.serial('should fail to query with single quotes JSON object', async (test) => {
 	const result = await test.context.http(
 		'POST', '/api/v2/query', '{\'foo\':bar}', {
@@ -251,8 +228,6 @@ ava.serial('should get all elements by type', async (test) => {
 				const: 'user@1.0.0'
 			}
 		}
-	}, {
-		limit: 100
 	})
 
 	test.is(result.response.length, users.length)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

There are now over 100 types in the production system, and the limit on this endpoint is causing issues. Ideally we need a standard way for pagination to occur, but for now I'd like to extend the limit to prevent bugs in the short term.

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
