### PR TITLE
Katapult: Standardize the labels used for the K8s resources.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
@@ -2,3 +2,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    elbv2.k8s.aws/pod-readiness-gate-inject: enabled
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-configmap.tpl.yml
@@ -9,5 +9,7 @@ data:
   UV_THREADPOOL_SIZE: "128"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/name: jellyfish-action-server
   name: action-server
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/action-server-deployment.tpl.yml
@@ -14,11 +14,11 @@ spec:
        maxUnavailable: 0
   selector:
     matchLabels:
-      app: action-server
+      app.kubernetes.io/name: jellyfish-action-server
   template:
     metadata:
       labels:
-        app: action-server
+        app.kubernetes.io/name: jellyfish-action-server
     spec:
       terminationGracePeriodSeconds: 120
       containers:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
@@ -14,5 +14,7 @@ data:
   UV_THREADPOOL_SIZE: "128"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/name: jellyfish-api
   name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: jellyfish
+      app.kubernetes.io/name: jellyfish-api
   replicas: 4
   strategy:
     type: RollingUpdate
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish
+        app.kubernetes.io/name: jellyfish-api
     spec:
       terminationGracePeriodSeconds: 120
       containers:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
 spec:
   selector:
-    app: jellyfish
+    app.kubernetes.io/name: jellyfish-api
   ports:
   - port: 8000
   sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-configmap.tpl.yml
@@ -8,5 +8,7 @@ data:
   SERVER_PORT: "443"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/name: jellyfish-livechat
   name: jellyfish-livechat
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-deployment.tpl.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: jellyfish-livechat
+      app.kubernetes.io/name: jellyfish-livechat
   replicas: 3
   strategy:
     type: RollingUpdate
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish-livechat
+        app.kubernetes.io/name: jellyfish-livechat
     spec:
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-livechat.data.assets.image.url%>>

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-ingress.tpl.yml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-livechat
+    app.kubernetes.io/name: jellyfish-livechat
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-livechat
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-livechat-service.tpl.yml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-livechat
+    app.kubernetes.io/name: jellyfish-livechat
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-livechat
 spec:
   selector:
-    app: jellyfish-livechat
+    app.kubernetes.io/name: jellyfish-livechat
   ports:
   - port: 80
   sessionAffinity: ClientIP

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-configmap.tpl.yml
@@ -9,5 +9,7 @@ data:
   SERVER_PORT: "443"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/name: jellyfish-ui
   name: jellyfish-ui
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-deployment.tpl.yml
@@ -4,11 +4,12 @@ metadata:
   name: jellyfish-ui
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   labels:
+    app.kubernetes.io/instance: jellyfish-ui
     app.kubernetes.io/name: jellyfish-ui
 spec:
   selector:
     matchLabels:
-      app: jellyfish-ui
+      app.kubernetes.io/name: jellyfish-ui
   replicas: 4
   strategy:
     type: RollingUpdate
@@ -18,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish-ui
+        app.kubernetes.io/name: jellyfish-ui
     spec:
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-ui.data.assets.image.url%>>

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-ingress.tpl.yml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-ui
+    app.kubernetes.io/name: jellyfish-ui
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-ui
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-ui-service.tpl.yml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: jellyfish-ui
+    app.kubernetes.io/name: jellyfish-ui
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-ui
 spec:
   selector:
-    app: jellyfish-ui
+    app.kubernetes.io/name: jellyfish-ui
   ports:
   - port: 80
   sessionAffinity: ClientIP


### PR DESCRIPTION
This is to make sure that the labels used for the resources
follow a standard format.  This also adds necessary labels
for the namespace resource to make sure that ALB ingress
controller detects the new pods and injects the needed
readiness gates.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
