### PR TITLE
Katapult: Remove namespace from deployment templates.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/01_namespace.tpl.yml
@@ -1,4 +1,0 @@
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: '{{{KATAPULT_KUBE_NAMESPACE}}}'


### PR DESCRIPTION
We can assume that the namespace already exists before a component
is deployed.  Deploying the namespace configuration affects the
required labels of the namespace.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
