### PR TITLE
Bump jellyfish-test to v1.4.11

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM resinci/jellyfish-test:v1.4.10
+FROM resinci/jellyfish-test:v1.4.11
 
 WORKDIR /usr/src/jellyfish
 COPY . ./


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This brings in the latest chromium binary provided by puppeteer v11. Not sure if this will help with e2e-ui test flakiness, but this should be updated anyway.
