### PR TITLE
Revert "Katapult: Add deployment anti-affinity rules."

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
@@ -14,8 +14,5 @@ data:
   UV_THREADPOOL_SIZE: "128"
 kind: ConfigMap
 metadata:
-  labels:
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/name: jellyfish-api
   name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -1,16 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/name: jellyfish-api
   name: jellyfish
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
+  labels:
+    app.kubernetes.io/name: jellyfish-api
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/instance: jellyfish-api
-      app.kubernetes.io/name: jellyfish-api
+      app: jellyfish
   replicas: 4
   strategy:
     type: RollingUpdate
@@ -20,25 +18,8 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: jellyfish-api
-        app.kubernetes.io/name: jellyfish-api
+        app: jellyfish
     spec:
-      affinity:
-        podAntiAffinity: 
-          preferredDuringSchedulingIgnoredDuringExecution: 
-          - weight: 100  
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/instance 
-                  operator: In 
-                  values:
-                  - jellyfish-api
-                - key: app.kubernetes.io/name 
-                  operator: In 
-                  values:
-                  - jellyfish-api
-              topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 120
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-api.data.assets.image.url%>>

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -3,8 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/name: jellyfish-api
+    name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -7,8 +7,7 @@ metadata:
   name: jellyfish-api
 spec:
   selector:
-    app.kubernetes.io/instance: jellyfish-api
-    app.kubernetes.io/name: jellyfish-api
+    app: jellyfish
   ports:
   - port: 8000
   sessionAffinity: ClientIP


### PR DESCRIPTION
Reverts product-os/jellyfish#7401

These changes broke production, reverting for now.