### PR TITLE
Katapult: Add deployment anti-affinity rules.

### DIFF
--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
@@ -14,5 +14,8 @@ data:
   UV_THREADPOOL_SIZE: "128"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
   name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -1,14 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
   name: jellyfish
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
-  labels:
-    app.kubernetes.io/name: jellyfish-api
 spec:
   selector:
     matchLabels:
-      app: jellyfish
+      app.kubernetes.io/instance: jellyfish-api
+      app.kubernetes.io/name: jellyfish-api
   replicas: 4
   strategy:
     type: RollingUpdate
@@ -18,8 +20,25 @@ spec:
   template:
     metadata:
       labels:
-        app: jellyfish
+        app.kubernetes.io/instance: jellyfish-api
+        app.kubernetes.io/name: jellyfish-api
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAntiAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - jellyfish-api
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - jellyfish-api
+              topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 120
       containers:
       - image: <<%&children.sw.containerized-application.jellyfish-api.data.assets.image.url%>>

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-ingress.tpl.yml
@@ -3,7 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    name: jellyfish-api
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
   namespace: '{{{KATAPULT_KUBE_NAMESPACE}}}'
   name: jellyfish-api
   # https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-ingress-for-echoserver

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-service.tpl.yml
@@ -7,7 +7,8 @@ metadata:
   name: jellyfish-api
 spec:
   selector:
-    app: jellyfish
+    app.kubernetes.io/instance: jellyfish-api
+    app.kubernetes.io/name: jellyfish-api
   ports:
   - port: 8000
   sessionAffinity: ClientIP


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Also updates the deployment labels. The anti-affinity rules
prefers spreading of the pods across the kubernetes nodes.