### PR TITLE
Renovate: Add resinci/jellyfish-test group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,10 @@
       "groupName": "puppeteer"
     },
     {
+      "matchPackageNames": ["resinci/jellyfish-test"],
+      "groupName": "jellyfish-test-image"
+    },
+    {
       "groupName": "non-major-frontend",
       "matchPackageNames": [
         "@balena/jellyfish-ui-components",


### PR DESCRIPTION
The latest version of the resinci/jellyfish-test image
uses node v16 which is still too new for this repo.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
