### PR TITLE
Fix dev-livechat make command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ custom.env
 # Typedoc generated docs
 docs/typedoc/*
 
+# Front app environment configuration files
+apps/ui/env-config.js
+apps/livechat/env-config.js
+
 # Decrypted secret files
 .balena/secrets/integration_typeform_signature_key
 .balena/secrets/integration_balena_api_private_key

--- a/apps/livechat/Makefile
+++ b/apps/livechat/Makefile
@@ -4,19 +4,16 @@ SERVER_HOST ?= http://localhost
 export SERVER_HOST
 SERVER_PORT ?= 8000
 export SERVER_PORT
+API_URL ?= $(SERVER_HOST):$(SERVER_PORT)
+export API_URL
 SENTRY_DSN_UI ?= https://ff836b1e4abc4d0699bcaaf07ce4ea08@sentry.io/1366139
 
 .PHONY: dev-livechat
 dev-livechat:
-	API_URL=$(SERVER_HOST):$(SERVER_PORT) \
-	SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) \
-	NODE_ENV=development \
 	mkdir -p ./dist/livechat && \
-	./conf/env.sh && \
+	NODE_ENV=development PUBLIC_DIR="./" ./conf/env.sh && \
 	cp ./env-config.js ./dist/livechat/ && \
-	./node_modules/.bin/webpack serve \
-		--config=./webpack.config.js \
-		--color
+	NODE_ENV=development npx webpack serve --config=./webpack.config.js --color
 
 .PHONY: build-livechat
 build-livechat:

--- a/apps/livechat/conf/env.sh
+++ b/apps/livechat/conf/env.sh
@@ -11,7 +11,7 @@
 echo "Generating env-config.js file..."
 
 BASE_FILENAME="env-config.js"
-PUBLIC_DIR="/usr/share/nginx/html"
+PUBLIC_DIR="${PUBLIC_DIR:-/usr/share/nginx/html}"
 
 # Recreate config file
 rm -rf "./$BASE_FILENAME"
@@ -28,10 +28,12 @@ touch "./$BASE_FILENAME"
 	echo "}"
 } >> "./$BASE_FILENAME"
 
-HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
-mv "./$BASE_FILENAME" "$PUBLIC_DIR/$HASHED_FILENAME"
+if [ "$NODE_ENV" != "development" ]; then
+	HASHED_FILENAME="env-config.$(md5sum "./$BASE_FILENAME" | cut -f1 -d" ").js"
+	mv "./$BASE_FILENAME" "$PUBLIC_DIR/$HASHED_FILENAME"
 
-echo "$HASHED_FILENAME file generated:"
-cat "$PUBLIC_DIR/$HASHED_FILENAME"
+	echo "$HASHED_FILENAME file generated:"
+	cat "$PUBLIC_DIR/$HASHED_FILENAME"
 
-sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" "$PUBLIC_DIR/index.html"
+	sed -i "s/${BASE_FILENAME}/${HASHED_FILENAME}/" "$PUBLIC_DIR/index.html"
+fi

--- a/apps/livechat/webpack.config.js
+++ b/apps/livechat/webpack.config.js
@@ -63,6 +63,8 @@ const config = {
 	devtool: 'source-map',
 
 	devServer: {
+		/* https://stackoverflow.com/a/69247166/1559300 */
+		sockPort: 'location',
 		host: '0.0.0.0',
 		port: process.env.LIVECHAT_PORT,
 		compress: true,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Fix `make dev-livechat` command, it currently fails when ran locally
- Clean up `apps/livechat/Makefile` a bit
- Remove `apps/ui/env-config.js` and `apps/livechat/env-config.js` from source control
  - These are generated when running ui/livechat locally, but they shouldn't be committed

`make dev-livechat` command currently fails with:
```
$ make dev-livechat
cd apps/livechat && \
        API_URL=http://localhost:8000 \
        SERVER_HOST=http://localhost SERVER_PORT=8000 \
        NODE_ENV=development \
        mkdir -p ./dist/livechat && \
        ./conf/env.sh && \
        cp ./env-config.js ./dist/livechat/ && \
        ./node_modules/.bin/webpack serve \
                --config=./webpack.config.js \
                --color
Generating env-config.js file...
mv: cannot move './env-config.js' to '/usr/share/nginx/html/env-config.1732b9deef8e0136bc75ce36a7f9b0b5.js': No such file or directory
env-config.1732b9deef8e0136bc75ce36a7f9b0b5.js file generated:
cat: /usr/share/nginx/html/env-config.1732b9deef8e0136bc75ce36a7f9b0b5.js: No such file or directory
sed: can't read /usr/share/nginx/html/index.html: No such file or directory
make: *** [Makefile:438: dev-livechat] Error 2
```