### PR TITLE
Katapult: Increase Jellyfish server pod count to 8.

### DIFF
--- a/deploy-templates/cloudformation/jellyfish-db.yml
+++ b/deploy-templates/cloudformation/jellyfish-db.yml
@@ -47,6 +47,7 @@ Parameters:
     - db.r6g.xlarge
     - db.r6g.2xlarge
     - db.r6g.4xlarge
+    - db.r6g.8xlarge
     - db.r6g.12xlarge
     - db.r6g.16xlarge
     - db.x1e.xlarge
@@ -158,7 +159,7 @@ Mappings:
     postgres11:
       EngineVersion: 11.6
     postgres12:
-      EngineVersion: 12.5
+      EngineVersion: 12.7
 
 
 Resources:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-deployment.tpl.yml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: jellyfish-api
       app.kubernetes.io/name: jellyfish-api
-  replicas: 4
+  replicas: 8
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Katapult: Increase Jellyfish server pod count to 8.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>