### PR TITLE
Fix exception in chart lens caused by missing contract type

### DIFF
--- a/apps/ui/lib/lens/misc/Chart/Chart.tsx
+++ b/apps/ui/lib/lens/misc/Chart/Chart.tsx
@@ -64,6 +64,7 @@ export const Chart = React.memo<any>(
 
 				const defaultChartConfig = {
 					id: NEW_CHART_CONFIGURATION_ID,
+					type: `${chartConfigurationType.slug}@${chartConfigurationType.version}`,
 					name: 'New chart',
 					data: {
 						settings: stringifySettings({


### PR DESCRIPTION
The chart lens uses a in memory default contract for setting up the
initial chart configuration. This contract did not have a type set,
which caused a downstream error that made the lens crash.
A long term fix for this kind of problem is to add correct type
annotations to the UI, but I will leave a later PR.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
