### PR TITLE
Bump aws-sdk to 2.1037.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -3063,9 +3063,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.1033.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1033.0.tgz",
-      "integrity": "sha512-cgcjiuR82bhfBWTffqt6e9+Cn/UgeC6QPQTrlJy3GxwPxChthyrt/h5pekj2l4PLFvETsG10Y6CqQysJEMsncw==",
+      "version": "2.1037.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1037.0.tgz",
+      "integrity": "sha512-z1IfFFvKg1ZKikyExhLeiax0jIe/YwFrBjIUhcPjBfh+c4otvuqp9RBp2iyXt3GamhEkKoPyvd6a5K7IGsTBMw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -42,7 +42,7 @@
     "@balena/jellyfish-sync": "^6.1.112",
     "@balena/jellyfish-worker": "^10.0.121",
     "@balena/socket-prometheus-metrics": "^0.0.3",
-    "aws-sdk": "^2.1033.0",
+    "aws-sdk": "^2.1037.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",
     "errio": "^1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2539,9 +2539,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1033.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1033.0.tgz",
-      "integrity": "sha512-cgcjiuR82bhfBWTffqt6e9+Cn/UgeC6QPQTrlJy3GxwPxChthyrt/h5pekj2l4PLFvETsG10Y6CqQysJEMsncw==",
+      "version": "2.1037.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1037.0.tgz",
+      "integrity": "sha512-z1IfFFvKg1ZKikyExhLeiax0jIe/YwFrBjIUhcPjBfh+c4otvuqp9RBp2iyXt3GamhEkKoPyvd6a5K7IGsTBMw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/rest": "^18.12.0",
     "ava": "^3.15.0",
-    "aws-sdk": "^2.1033.0",
+    "aws-sdk": "^2.1037.0",
     "bluebird": "^3.7.2",
     "cli-spinner": "^0.2.10",
     "date-fns": "^2.26.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
