### PR TITLE
show larger transformer graph

### DIFF
--- a/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
+++ b/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
@@ -24,7 +24,7 @@ export const SingleCardTabs = styled(Tabs)`
 `;
 
 // The maximum depth to explore the graph
-const GRAPH_DEPTH = 3;
+const GRAPH_DEPTH = 10;
 const BUILT_VERB = 'was built into';
 const MERGE_VERB = 'was merged as';
 


### PR DESCRIPTION
Three levels deep is definitely not enough for transformers. Currently just a draft/stub, but my current thinking is that we'll need to stop using nested link queries as very deep queries tend to be slow (while we can't show anything to the user) and fragile.

Also the current code doesn't show anything in some cases. (I think, it's when the initial contract isn't picked up by a transformer)