### PR TITLE
Migrate make commands to npm scripts

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,6 +6,6 @@ COPY . ./
 # Delete image archives created during CI build stage
 RUN rm -f balena-jellyfish-*.tar
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true make npm-install
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install --unsafe-perm
 
 CMD /bin/bash -c "if [ "$CI" ]; then task test; else trap : TERM INT; sleep infinity; fi"

--- a/README.md
+++ b/README.md
@@ -45,13 +45,8 @@ Many parts of Jellyfish are still under development, and this document aims to c
 Installing dependencies
 -----------------------
 
-In order to develop Jellyfish, you must have an [npmjs](https://npmjs.com) account
-that has read access to the private Jellyfish packages. Provide your npmjs account
-information with ops and request access.
-
 ```sh
-npm login
-make npm-install
+$ npm i
 ```
 
 Developing with Livepush
@@ -66,7 +61,7 @@ To start developing, you must first install [balenaCLI](https://github.com/balen
 ### Deploy code
 Now that the device is up and running in local mode, we need to get its local IP address:
 ```
-sudo balena scan | grep address
+$ sudo balena scan | grep address
   address:       <DEVICE-IP-ADDRESS>
 ```
 
@@ -85,10 +80,10 @@ removing library dependencies is a bit different. The following is an example wh
 `jellyfish-worker` library:
 
 ```sh
-cd .libs/jellyfish-worker
-npm install new-dependency
-cd ../..
-make deploy-worker
+$ cd .libs/jellyfish-worker
+$ npm install new-dependency
+$ cd ../..
+$ make deploy-worker
 ```
 
 What this does is create a local beta package for `.libs/jellyfish-worker` using `npm pack` and then
@@ -131,8 +126,7 @@ Testing
 You can run the linter like this:
 
 ```sh
-make lint
-make lint FIX=1 # Optionally try to fix some of the linting issues
+$ npm run lint
 ```
 
 The tests live in `test/<type>/**/*.spec.js` and `apps/server/test/<type>/**/*.spec.js`.
@@ -141,9 +135,8 @@ Frontend components store their unit tests along with the production code (compa
 We provide GNU Make utility rules to run different test suites, for example:
 
 ```sh
-make test-e2e-server                             # Run all the server end to end tests
-make test-e2e                                    # Run all the end to end tests
-make test FILES=./test/e2e/sdk/card.spec.js      # Run a specific test file
+$ make test-e2e-server                             # Run all the server end to end tests
+$ make test FILES=./test/e2e/sdk/card.spec.js      # Run a specific test file
 ```
 
 Some suites may provide or require various options. Consult the corresponding

--- a/docs/developing/frontend.markdown
+++ b/docs/developing/frontend.markdown
@@ -18,5 +18,5 @@ make build-ui test-e2e-ui VISUAL=1
 You can run the unit and end to end SDK tests as follows:
 
 ```sh
-make test-e2e-sdk
+npm run test:e2e:sdk
 ```

--- a/docs/developing/local-development.markdown
+++ b/docs/developing/local-development.markdown
@@ -2,27 +2,24 @@
 
 If you want to develop Jellyfish on your local machine, the pre-requisites are:
 
-- Redis (`brew install redis` on macOS)
-- PostgreSQL (`brew install postgresql` on macOS)
+- Docker
+- Docker Compose
 - Node.js
-- Python 2
 
 Install the dependencies:
 
 ```sh
-make npm-install
+$ npm i
 ```
 
 You can then run these commands in different terminal emulators, which will run
 all services in non-daemon mode:
 
 ```sh
-make start-postgres
-make start-redis
-make dev-ui
-make dev-livechat
-make start-server
-make start-worker # Run more than once for more workers
+$ npm run backend
+$ make dev-ui
+$ make dev-livechat
+$ make start-server
 ```
 
 The API will listen on `8000` and the UI will listen on `9000`. Open

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx scripts test && ./scripts/lint/check-filenames.sh && shellcheck scripts/*.sh scripts/*/*.sh deploy-templates/*.sh && deplint && depcheck --ignore-bin-package --ignores=@balena/jellyfish-*",
-    "test:e2e:sdk": "ava ./test/e2e/sdk/*.spec.js"
+    "test:e2e:sdk": "ava ./test/e2e/sdk/*.spec.js",
+    "backend": "docker-compose up redis postgres haproxy",
+    "docs": "(cd apps/livechat && npm run doc); (cd apps/server && npm run doc); (cd apps/ui && npm run doc)",
+    "clean": "rimraf apps/*/packages/*",
+    "postinstall": "(cd apps/livechat && npm i); (cd apps/server && npm i); (cd apps/ui && npm i)"
   },
   "deplint": {
     "files": [
@@ -97,6 +101,7 @@
     "node-jose": "^2.0.0",
     "puppeteer": "^12.0.1",
     "request": "^2.88.2",
+    "rimraf": "^3.0.2",
     "shellcheck": "^1.0.0",
     "simple-git-hooks": "^2.7.0",
     "uuid": "^8.3.2"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Convert a number of make commands to npm scripts
- Remove more unneeded options in Makefile