### PR TITLE
Remove NAME from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ MAKEFILE_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
 # Runtime Configuration
 # -----------------------------------------------
 
-# Project name
-NAME ?= jellyfish
-
 DATABASE ?= postgres
 export DATABASE
 
@@ -155,7 +152,7 @@ endif
 
 DOCKER_COMPOSE_OPTIONS = \
 	$(DOCKER_COMPOSE_FILES) \
-	--project-name $(NAME) \
+	--project-name jellyfish \
 	--compatibility
 
 ifeq ($(SCRUB),1)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Remove `NAME` from the root Makefile.
