### PR TITLE
Enable failFast in ava options

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,6 @@ version: '3'
 output: 'prefixed'
 
 env:
-  AVA_OPTS: --fail-fast
   NODE_ENV: production
 
 tasks:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "verbose": true,
     "serial": true,
     "failWithoutAssertions": true,
+    "failFast": true,
     "files": [
       "test/**/*.spec.js"
     ]


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

The current `AVA_OPTS` environment variable in `Taskfile.yml` is not used, so setting `failFast` to `true` in ava options in `package.json` to apply to all ava executions. We do this with jest in lib repos and will be moving to TypeScript/jest in this repo as well at some point so may as well get on the same page test runner options wise.
