### PR TITLE
Move generation make commands to npm scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,24 +126,6 @@ SENTRY_DSN_UI ?=
 # Rules
 # -----------------------------------------------
 
-.tmp:
-	mkdir -p $@
-
-.tmp/haproxy.manifest.json: haproxy.manifest.tpl.json | .tmp
-	node scripts/template $< > $@
-
-docker-compose.yml: docker-compose.tpl.yml .tmp/haproxy.manifest.json | .tmp
-	HAPROXY_CONFIG=$(shell cat $(word 2,$^) | base64 | tr -d '\n') \
-		node scripts/template $< > $@
-
-docs/assets/architecture.png: docs/diagrams/architecture.mmd
-	./node_modules/.bin/mmdc -i $< -o $@ -w 2560 -H 1600
-
-ARCHITECTURE.md: scripts/architecture-summary.sh \
-	apps/*/DESCRIPTION.markdown \
-	docs/assets/architecture.png
-	./$< > $@
-
 scrub:
 	$(SCRUB_COMMAND)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,8 +8,11 @@ env:
 tasks:
   catch-uncommitted:
     cmds:
-      - make docs/assets/architecture.png ARCHITECTURE.md docker-compose.yml
-      - npx catch-uncommitted --skip-node-versionbot-changes --exclude=VERSION,.versionbot/
+      - npm run docs:diagram
+      - npm run docs:summary
+      - npm run config:haproxy
+      - npm run config:compose
+      - npm run lint:catch
 
   lint-server:
     dir: apps/server

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -60,11 +60,11 @@ services:
       - NODE_ENV
       - POSTGRES_HOST=postgres
       - POSTGRES_PASSWORD=docker
-      - POSTGRES_PORT={{POSTGRES_PORT}}
+      - POSTGRES_PORT=5432
       - POSTGRES_USER=docker
       - REDIS_HOST=redis
       - REDIS_PASSWORD=
-      - REDIS_PORT={{REDIS_PORT}}
+      - REDIS_PORT=6379
       - SENTRY_DSN_SERVER
       - FS_DRIVER
       - AWS_ACCESS_KEY_ID
@@ -148,8 +148,8 @@ services:
       - balena-mdns-publisher
     ports:
       - '80:80'
-      - '{{POSTGRES_PORT}}:{{POSTGRES_PORT}}'
-      - '{{REDIS_PORT}}:{{REDIS_PORT}}'
+      - '5432:5432'
+      - '6379:6379'
     networks:
       internal:
         aliases:

--- a/haproxy.manifest.tpl.json
+++ b/haproxy.manifest.tpl.json
@@ -40,7 +40,7 @@
 	"redis": {
 		"backend": [
 			{
-				"url": "tcp://redis:{{REDIS_PORT}}",
+				"url": "tcp://redis:6379",
 				"server": {
 					"resolvers": "docker-bridge-resolver",
 					"resolve-prefer": "ipv4",
@@ -54,14 +54,14 @@
 				"protocol": "tcp",
 				"domain": "ly.fish.local",
 				"subdomain": "redis",
-				"port": "{{REDIS_PORT}}"
+				"port": "6379"
 			}
 		]
 	},
 	"postgres": {
 		"backend": [
 			{
-				"url": "tcp://postgres:{{POSTGRES_PORT}}",
+				"url": "tcp://postgres:5432",
 				"server": {
 					"resolvers": "docker-bridge-resolver",
 					"resolve-prefer": "ipv4",
@@ -75,7 +75,7 @@
 				"protocol": "tcp",
 				"domain": "ly.fish.local",
 				"subdomain": "postgres",
-				"port": "{{POSTGRES_PORT}}"
+				"port": "5432"
 			}
 		]
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2881,6 +2881,12 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "catch-uncommitted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/catch-uncommitted/-/catch-uncommitted-2.0.0.tgz",
+      "integrity": "sha512-AUYUPe6TVZFpTUp6fAR0Wz4NjKMx532ZWpuIbKMkNr7Ec7Co7TJAUgeV4aqRnsMLi2nmNpDNUD5iH9ir/28c5A==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,21 @@
     "node": ">=14.2.0"
   },
   "scripts": {
-    "lint": "eslint --ext .js,.jsx scripts test && ./scripts/lint/check-filenames.sh && shellcheck scripts/*.sh scripts/*/*.sh deploy-templates/*.sh && deplint && depcheck --ignore-bin-package --ignores=@balena/jellyfish-*",
+    "lint": "eslint --ext .js,.jsx scripts test && npm run lint:check && npm run lint:deps",
+    "lint:check": "./scripts/lint/check-filenames.sh && shellcheck scripts/*.sh scripts/*/*.sh deploy-templates/*.sh",
+    "lint:deps": "deplint && depcheck --ignore-bin-package --ignores=@balena/jellyfish-*",
+    "lint:catch": "catch-uncommitted --skip-node-versionbot-changes --exclude=VERSION,.versionbot/",
     "test:e2e:sdk": "ava ./test/e2e/sdk/*.spec.js",
     "test:e2e:livechat": "ava ./test/e2e/livechat/**/*.spec.js",
     "postgres": "docker run -i --rm -p5432:5432 balena/open-balena-db:4.1.0",
     "redis": "docker run -i --rm -p6379:6379 balena/balena-redis:0.0.3 sh -c \"redis-server /usr/local/etc/redis/redis.conf --save ''\"",
     "docs": "(cd apps/livechat && npm run doc); (cd apps/server && npm run doc); (cd apps/ui && npm run doc)",
+    "docs:diagram": "mmdc -i docs/diagrams/architecture.mmd -o docs/assets/architecture.png -w 2560 -H 1600",
+    "docs:summary": "./scripts/architecture-summary.sh > ARCHITECTURE.md",
     "clean": "rimraf apps/*/packages/*",
-    "postinstall": "(cd apps/livechat && npm i); (cd apps/server && npm i); (cd apps/ui && npm i)"
+    "postinstall": "(cd apps/livechat && npm i); (cd apps/server && npm i); (cd apps/ui && npm i)",
+    "config:haproxy": "mkdir -p .tmp && ./scripts/template.js haproxy.manifest.tpl.json > .tmp/haproxy.manifest.json",
+    "config:compose": "HAPROXY_CONFIG=$(cat .tmp/haproxy.manifest.json | base64 | tr -d '\\n') ./scripts/template.js docker-compose.tpl.yml > docker-compose.yml"
   },
   "deplint": {
     "files": [
@@ -83,6 +90,7 @@
     "ava": "^3.15.0",
     "aws-sdk": "^2.1043.0",
     "bluebird": "^3.7.2",
+    "catch-uncommitted": "^2.0.0",
     "cli-spinner": "^0.2.10",
     "date-fns": "^2.27.0",
     "depcheck": "^1.4.2",

--- a/scripts/template.js
+++ b/scripts/template.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const mustache = require('mustache')
 const fs = require('fs')
 const TEMPLATE = process.argv[2]


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Rename `scripts/template/index.js` to `scripts/template.js`
- Remove the now unnecessary `make .tmp` command
- Move the following `make` commands to `package.json` as npm scripts:
  - `make .tmp/haproxy.manifest.json`
  - `make docker-compose.yml`
  - `make docs/assets/architecture.png`
  - `make ARCHITECTURE.md`
