### PR TITLE
Move make compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,19 +101,6 @@ else
 NOCACHE_FLAG =
 endif
 
-DOCKER_COMPOSE_FILES = --file docker-compose.yml
-ifdef MONITOR
-DOCKER_COMPOSE_FILES += --file docker-compose.monitor.yml
-endif
-ifdef SUT
-DOCKER_COMPOSE_FILES += --file docker-compose.test.yml
-endif
-
-DOCKER_COMPOSE_OPTIONS = \
-	$(DOCKER_COMPOSE_FILES) \
-	--project-name jellyfish \
-	--compatibility
-
 ifeq ($(SCRUB),1)
 SCRUB_COMMAND = ./scripts/postgres-delete-test-databases.js
 else
@@ -165,9 +152,6 @@ build-livechat:
 # -----------------------------------------------
 # Development
 # -----------------------------------------------
-
-compose-%: docker-compose.yml
-	docker-compose $(DOCKER_COMPOSE_OPTIONS) $(subst compose-,,$@)
 
 dev-%:
 	cd apps/$(subst dev-,,$@) && SERVER_HOST=$(SERVER_HOST) SERVER_PORT=$(SERVER_PORT) make dev-$(subst dev-,,$@)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "clean": "rimraf apps/*/packages/*",
     "postinstall": "(cd apps/livechat && npm i); (cd apps/server && npm i); (cd apps/ui && npm i)",
     "config:haproxy": "mkdir -p .tmp && ./scripts/template.js haproxy.manifest.tpl.json > .tmp/haproxy.manifest.json",
-    "config:compose": "HAPROXY_CONFIG=$(cat .tmp/haproxy.manifest.json | base64 | tr -d '\\n') ./scripts/template.js docker-compose.tpl.yml > docker-compose.yml"
+    "config:compose": "HAPROXY_CONFIG=$(cat .tmp/haproxy.manifest.json | base64 | tr -d '\\n') ./scripts/template.js docker-compose.tpl.yml > docker-compose.yml",
+    "compose:build": "docker-compose --file docker-compose.yml build",
+    "compose:up": "docker-compose --file docker-compose.yml up",
+    "compose:test": "docker-compose --file docker-compose.yml --file docker-compose.test.yml up"
   },
   "deplint": {
     "files": [


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move docker compose `make` command to npm script equivalents.
