### PR TITLE
Bump jellyfish-worker to v10.1.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1463,14 +1463,13 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "10.0.147",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-10.0.147.tgz",
-      "integrity": "sha512-kzpd4Ttg6+R5aKgKDMSPgKaQqsnQXcXzPQ8EyxoXIPJYpLMrFFmQT0+69CEhxqSh+Di6OtyAL7PWN0qGuYLyAg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-10.1.0.tgz",
+      "integrity": "sha512-lAcTO9DIqzLunvxvOJx3DMUXGwPkzwJLnZ88JCqLrFe8efZ7gBfUvYB1TqnGT+BS93rT+60DEjqjKmAMY4Tk6Q==",
       "requires": {
         "@balena/jellyfish-assert": "^1.1.101",
         "@balena/jellyfish-jellyscript": "^4.9.151",
         "@balena/jellyfish-logger": "^3.0.163",
-        "bluebird": "^3.7.2",
         "errio": "^1.2.2",
         "fast-equals": "^2.0.3",
         "fast-json-patch": "^3.1.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -40,7 +40,7 @@
     "@balena/jellyfish-plugin-typeform": "^3.0.410",
     "@balena/jellyfish-queue": "^1.0.380",
     "@balena/jellyfish-sync": "^6.1.126",
-    "@balena/jellyfish-worker": "^10.0.147",
+    "@balena/jellyfish-worker": "^10.1.0",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "aws-sdk": "^2.1043.0",
     "bluebird": "^3.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -749,15 +749,14 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "10.0.147",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-10.0.147.tgz",
-      "integrity": "sha512-kzpd4Ttg6+R5aKgKDMSPgKaQqsnQXcXzPQ8EyxoXIPJYpLMrFFmQT0+69CEhxqSh+Di6OtyAL7PWN0qGuYLyAg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-10.1.0.tgz",
+      "integrity": "sha512-lAcTO9DIqzLunvxvOJx3DMUXGwPkzwJLnZ88JCqLrFe8efZ7gBfUvYB1TqnGT+BS93rT+60DEjqjKmAMY4Tk6Q==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.1.101",
         "@balena/jellyfish-jellyscript": "^4.9.151",
         "@balena/jellyfish-logger": "^3.0.163",
-        "bluebird": "^3.7.2",
         "errio": "^1.2.2",
         "fast-equals": "^2.0.3",
         "fast-json-patch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@balena/jellyfish-queue": "^1.0.380",
     "@balena/jellyfish-sync": "^6.1.126",
     "@balena/jellyfish-ui-components": "^13.1.1",
-    "@balena/jellyfish-worker": "^10.0.147",
+    "@balena/jellyfish-worker": "^10.1.0",
     "@balena/lint": "^6.2.0",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.5.2",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bringing in these changes (drop Bluebird): https://github.com/product-os/jellyfish-worker/pull/1200
