### PR TITLE
Remove OAuth redirect ENV from Dockerfile

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -24,8 +24,6 @@ RUN npm run build
 # Production debugging scripts
 COPY ./scripts/production /usr/src/jellyfish/scripts/production
 
-ENV OAUTH_REDIRECT_BASE_URL https://jel.ly.fish
-
 RUN echo "#!/bin/sh" > run.sh && \
 	make --dry-run start-server >> run.sh && \
 	chmod +x run.sh && cat run.sh

--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -114,3 +114,5 @@ properties:
     type: number
   HTTP_TICK_PORT:
     type: number
+  OAUTH_REDIRECT_BASE_URL:
+    type: string?

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
@@ -13,6 +13,7 @@ data:
   TEST_USER_ROLE: "user-community"
   UV_THREADPOOL_SIZE: "128"
   QUEUE_CONCURRENCY: "4"
+  OAUTH_REDIRECT_BASE_URL: "https://jel.ly.fish"
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

We shouldn't be setting `ENV` in Dockerfiles as it only adds confusion and another place to manage environment variable values. Environment variables should be set in `jellyfish-environment` (if sane default for dev/testing), `product-os/secrets` (if secret), compose configs (probably not), or deploy templates (for now).
