### PR TITLE
Stop skipping numerous e2e ui tests

### DIFF
--- a/test/e2e/ui/helpers.js
+++ b/test/e2e/ui/helpers.js
@@ -14,7 +14,8 @@ exports.puppeteerOptions = {
 
 		// Set extra flags so puppeteer runs on docker
 		'--no-sandbox',
-		'--disable-setuid-sandbox'
+		'--disable-setuid-sandbox',
+		'--disable-dev-shm-usage'
 	]
 }
 

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -651,18 +651,17 @@ ava.serial('file upload: Users should be able to upload an image', async (test) 
 		})
 	})
 
-	// Navigate to the user profile page
-	await page.goto(`${environment.ui.host}:${environment.ui.port}/${thread.id}`)
+	// Navigate to the thread page
+	await macros.goto(page, `/${thread.id}`)
 
-	await page.waitForSelector(`.column--slug-${thread.slug}`)
+	const selector = '.column--thread'
 
-	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
-
+	await page.waitForSelector(selector)
 	await page.waitForSelector('input[type="file"]')
 	const input = await page.$('input[type="file"]')
 	await input.uploadFile(path.join(__dirname, 'assets', 'test.png'))
 
-	await page.waitForSelector('.column--thread [data-test="event-card__image"]')
+	await page.waitForSelector(`${selector} [data-test="event-card__image"]`)
 
 	test.pass()
 })
@@ -717,14 +716,14 @@ ava.serial('file upload: Users should be able to upload a text file', async (tes
 	// Navigate to the user profile page
 	await macros.goto(page, `/${thread.id}`)
 
-	await page.waitForSelector(`.column--slug-${thread.slug}`)
-	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
+	const selector = '.column--thread'
 
+	await page.waitForSelector(selector)
 	await page.waitForSelector('input[type="file"]')
 	const input = await page.$('input[type="file"]')
 	await input.uploadFile(path.join(__dirname, 'assets', 'test.txt'))
 
-	await page.waitForSelector('.column--thread [data-test="event-card__file"]')
+	await page.waitForSelector(`${selector} [data-test="event-card__file"]`)
 
 	test.pass()
 })
@@ -972,7 +971,7 @@ ava.serial('Chat: A notice should be displayed when another user is typing', asy
 
 	const messageText = await macros.getElementText(incognitoPage, '[data-test="typing-notice"]')
 
-	test.is(messageText, `${users.community2.username} is typing...`)
+	test.is(messageText, `${users.community.username} is typing...`)
 
 	test.pass()
 })
@@ -1245,7 +1244,7 @@ ava.serial('Chat: Messages that alert a user\'s group should appear in their inb
 
 ava.serial('Chat: One-to-one messages to a user should appear in their inbox', async (test) => {
 	const {
-		user1,
+		user,
 		user2,
 		page,
 		incognitoPage
@@ -1259,7 +1258,7 @@ ava.serial('Chat: One-to-one messages to a user should appear in their inbox', a
 			type: 'thread@1.0.0',
 			markers: [ `${u1.slug}+${u2.slug}` ]
 		})
-	}, user1, user2)
+	}, user, user2)
 
 	// Navigate to the thread page
 	await macros.goto(page, `/${thread.id}`)
@@ -1421,9 +1420,9 @@ ava.serial(
 		test.pass()
 	})
 
-ava.serial.skip('Chat: When having two chats side-by-side both should update with new messages', async (test) => {
+ava.serial('Chat: When having two chats side-by-side both should update with new messages', async (test) => {
 	const {
-		user1,
+		user,
 		page
 	} = context
 
@@ -1442,7 +1441,7 @@ ava.serial.skip('Chat: When having two chats side-by-side both should update wit
 
 	await page.waitForSelector('.new-message-input')
 
-	const msg = `@${user1.slug.slice(5)} ${uuid()}`
+	const msg = `@${user.slug.slice(5)} ${uuid()}`
 	await macros.createChatMessage(page, columnSelector, msg)
 
 	await bluebird.delay(5000)
@@ -1513,20 +1512,19 @@ ava.serial('Chat: Users should be able to mark all messages as read from their i
 	// Navigate to the thread page
 	await macros.goto(page, `/${thread.id}`)
 
-	const columnSelector = `.column--slug-${thread.slug}`
-	await page.waitForSelector(columnSelector)
+	const selector = '.column--thread'
+	await page.waitForSelector(selector)
 
 	const msg = `@${user2.slug.slice(5)} ${uuid()}`
-
 	await page.waitForSelector('.new-message-input')
 
-	await macros.createChatMessage(page, columnSelector, msg)
+	await macros.createChatMessage(page, selector, msg)
 
 	await macros.goto(incognitoPage, '/inbox')
 	await incognitoPage.waitForSelector(selectors.chat.message)
 	await macros.waitForThenClickSelector(incognitoPage, selectors.chat.markAsReadButton)
 	await macros.waitForSelectorToDisappear(incognitoPage, selectors.chat.message)
-	const messages = await page.$$(selectors.chat.message)
+	const messages = await incognitoPage.$$(selectors.chat.message)
 
 	// Assert that there are no longer messages in the inbox
 	test.is(messages.length, 0)
@@ -1596,7 +1594,7 @@ ava.serial('Chat: When filtering unread messages, only filtered messages can be 
 	await macros.waitForSelectorToDisappear(incognitoPage, `[id="event-${messages[2].id}]`)
 	messageElements = await incognitoPage.$$(selectors.chat.message)
 	test.is(messageElements.length, 1)
-	markAsReadButtonText = await macros.getElementText(incognitoPage, selectors.chat.message)
+	markAsReadButtonText = await macros.getElementText(incognitoPage, selectors.chat.markAsReadButton)
 	test.is(markAsReadButtonText, 'Mark 1 as read')
 
 	// Mark just the filtered message as read

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -667,7 +667,7 @@ ava.serial('file upload: Users should be able to upload an image', async (test) 
 	test.pass()
 })
 
-ava.serial.only('file upload: Users should be able to upload an image to a support thread', async (test) => {
+ava.serial('file upload: Users should be able to upload an image to a support thread', async (test) => {
 	const {
 		page
 	} = context

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -107,7 +107,7 @@ ava.serial('Updates to support threads should be reflected in the support thread
 	// Wait for the new support thread to appear in view
 	const summarySelector = `[data-test-component="card-chat-summary"][data-test-id="${supportThread.id}"]`
 	await macros.waitForThenClickSelector(page, summarySelector)
-
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 	await macros.waitForThenClickSelector(page, '.rta__textarea')
 
 	const rand = uuid()
@@ -154,6 +154,9 @@ ava.serial('Updates to messages should be reflected in the thread\'s timeline', 
 	}, messageEvent)
 
 	await macros.goto(page, `/${supportThread.id}`)
+	const columnSelector = '.column--support-thread'
+	await page.waitForSelector(columnSelector)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 
 	// Verify the message text
 	const messageText = await macros.getElementText(page, '[data-test="event-card__message"]')
@@ -211,6 +214,9 @@ ava.serial('A message\'s mirror icon is automatically updated when the message i
 	}, messageEvent)
 
 	await macros.goto(page, `/${supportThread.id}`)
+	const columnSelector = '.column--support-thread'
+	await page.waitForSelector(columnSelector)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 
 	// Verify the mirror icon is present but not synced
 	await page.waitForSelector('.unsynced[data-test="mirror-icon"]')
@@ -254,6 +260,7 @@ ava.serial('Support thread timeline should default to sending whispers', async (
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 
 	const rand = uuid()
 
@@ -283,6 +290,7 @@ ava.serial('Support thread timeline should send a message if the input is prefix
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 
 	const rand = uuid()
 
@@ -312,6 +320,7 @@ ava.serial('Support thread timeline should send a message if the whisper button 
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 
 	await macros.waitForThenClickSelector(page, '[data-test="timeline__whisper-toggle"]')
 
@@ -343,6 +352,7 @@ ava.serial('Support thread timeline should revert to "whisper" mode after sendin
 
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 
 	const rand = uuid()
 
@@ -373,6 +383,7 @@ ava.serial.skip('Users should be able to audit a support thread', async (test) =
 	await macros.goto(page, `/${supportThread.id}`)
 	const columnSelector = '.column--support-thread'
 	await page.waitForSelector(columnSelector)
+
 	await page.waitForSelector('[data-test="audit-panel"]')
 
 	test.pass('A closed support thread should display the audit panel')
@@ -656,6 +667,7 @@ ava.serial('A user can edit their own message', async (test) => {
 
 	// Navigate to the thread and wait for the message event to be displayed
 	await macros.goto(page, `/${supportThread.id}`)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 	const eventSelector = '.column--support-thread .event-card--message'
 	await page.waitForSelector(eventSelector)
 
@@ -697,6 +709,7 @@ ava.serial('You can trigger a quick search for cards from the message input', as
 
 	// Navigate to the thread and wait for the thread to be displayed
 	await macros.goto(page, `/${supportThread.id}`)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 	const threadSelector = '.column--support-thread'
 	await page.waitForSelector(threadSelector)
 
@@ -754,6 +767,7 @@ ava.serial('You can select a user and a group from the auto-complete options', a
 
 	// Navigate to the thread and wait for the thread to be displayed
 	await macros.goto(page, `/${supportThread.id}`)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 	const threadSelector = '.column--support-thread'
 	await page.waitForSelector(threadSelector)
 
@@ -842,6 +856,7 @@ ava.serial('Only users with a name matching the search string are returned by th
 
 	// Navigate to the thread and wait for the thread to be displayed
 	await macros.goto(page, `/${supportThread.id}`)
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 	const threadSelector = '.column--support-thread'
 	await page.waitForSelector(threadSelector)
 
@@ -943,6 +958,7 @@ ava.serial('Closed support threads should be re-opened on new message', async (t
 	test.is(thread.data.status, 'closed')
 
 	// Add new message to the closed support thread
+	await macros.waitForThenClickSelector(page, '[data-test="timeline-tab"]')
 	await macros.waitForThenClickSelector(page, '.rta__textarea')
 	await macros.createChatMessage(page, '.column--support-thread', `%${uuid()}`)
 

--- a/test/e2e/ui/support.spec.js
+++ b/test/e2e/ui/support.spec.js
@@ -1064,7 +1064,7 @@ ava.serial('Should be able to filter support threads by timeline message', async
 	test.pass()
 })
 
-ava.serial.only('Should be able to filter support threads by a field in a linked contract', async (test) => {
+ava.serial('Should be able to filter support threads by a field in a linked contract', async (test) => {
 	const {
 		page
 	} = context


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Apparently we've been skipping a large number of E2E UI tests for a while because of some `.only`s. I believe this is a mistake and we should be running these tests.

### Failing e2e-ui tests
#### `test/e2e/ui/index.spec.js`
- views: Should be able to save a new view
- chat-widget: A user can start a Jellyfish support thread from the chat widget
- outreach: A user should be able to connect their account to outreach
  - just missing a nocked endpoint?
- Chat: When having two chats side-by-side both should update with new messages
#### `test/e2e/ui/support.spec.js`
- My Participation shows only support threads that the logged-in user has participated in