### PR TITLE
Drop Postgres vars from Makefile/compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,6 @@ MAKEFILE_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
 # Runtime Configuration
 # -----------------------------------------------
 
-# The default postgres user is your local user
-POSTGRES_USER ?= $(shell whoami)
-export POSTGRES_USER
-POSTGRES_PASSWORD ?=
-export POSTGRES_PASSWORD
-POSTGRES_PORT ?= 5432
-export POSTGRES_PORT
-POSTGRES_HOST ?= localhost
-export POSTGRES_HOST
-
 # silence graphile-worker logs
 NO_LOG_SUCCESS = 1
 export NO_LOG_SUCCESS

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,9 +16,6 @@ services:
       - LOGLEVEL=crit
       - LIVECHAT_HOST=http://livechat
       - LIVECHAT_PORT=80
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_USER=docker
       - SERVER_HOST=http://api
       - SERVER_PORT=80
       - UI_HOST=http://ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,10 +57,6 @@ services:
     environment:
       - LOGLEVEL=crit
       - NODE_ENV
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_PORT=5432
-      - POSTGRES_USER=docker
       - REDIS_HOST=redis
       - REDIS_PASSWORD=
       - REDIS_PORT=6379
@@ -119,10 +115,6 @@ services:
     environment:
       - LOGLEVEL=crit
       - NODE_ENV
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_PORT=5432
-      - POSTGRES_USER=docker
       - REDIS_HOST=redis
       - REDIS_PASSWORD=
       - REDIS_PORT=6379


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Drop `POSTGRES_*` vars from the root Makefile and docker compose configs.
