### PR TITLE
Drop AWS vars from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,6 @@ export OAUTH_REDIRECT_BASE_URL
 HTTP_WORKER_PORT ?= 8002
 export HTTP_WORKER_PORT
 
-AWS_ACCESS_KEY_ID ?=
-export AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY ?=
-export AWS_SECRET_ACCESS_KEY
-AWS_S3_BUCKET_NAME ?=
-export AWS_S3_BUCKET_NAME
-
 # -----------------------------------------------
 # Build Configuration
 # -----------------------------------------------


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Drop AWS vars from the root Makefile.
