### PR TITLE
Move graphile-worker NO_LOG_SUCCESS var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ MAKEFILE_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
 # Runtime Configuration
 # -----------------------------------------------
 
-# silence graphile-worker logs
-NO_LOG_SUCCESS = 1
-export NO_LOG_SUCCESS
-
 PORT ?= 8000
 export PORT
 LOGLEVEL ?= info

--- a/deploy-templates/jellyfish-product/product/config-manifest.yml
+++ b/deploy-templates/jellyfish-product/product/config-manifest.yml
@@ -32,6 +32,8 @@ properties:
     type: string?
   NODE_ENV:
     type: string
+  NO_LOG_SUCCESS:
+    type: string?
   SENTRY_DSN_SERVER:
     type: string?
   LOGENTRIES_TOKEN:

--- a/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
+++ b/deploy-templates/jellyfish-product/product/deploy/kubernetes/generators/jellyfish-api-configmap.tpl.yml
@@ -14,6 +14,7 @@ data:
   UV_THREADPOOL_SIZE: "128"
   QUEUE_CONCURRENCY: "4"
   OAUTH_REDIRECT_BASE_URL: "https://jel.ly.fish"
+  NO_LOG_SUCCESS: "1"
 kind: ConfigMap
 metadata:
   labels:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,6 +14,7 @@ services:
       - balena-mdns-publisher
     environment:
       - LOGLEVEL=crit
+      - NO_LOG_SUCCESS=1
       - LIVECHAT_HOST=http://livechat
       - LIVECHAT_PORT=80
       - SERVER_HOST=http://api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - balena-mdns-publisher
     environment:
       - LOGLEVEL=crit
+      - NO_LOG_SUCCESS=1
       - NODE_ENV
       - SENTRY_DSN_SERVER
       - FS_DRIVER
@@ -108,6 +109,7 @@ services:
       - balena-mdns-publisher
     environment:
       - LOGLEVEL=crit
+      - NO_LOG_SUCCESS=1
       - NODE_ENV
       - SENTRY_DSN_SERVER
       - FS_DRIVER


### PR DESCRIPTION
Move the NO_LOG_SUCCESS environment variable used
by graphile worker. Without this variable being set
graphile worker will output all success logs, which
is unnecessary and noisy.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
