### PR TITLE
Move 'make deploy' to 'npm run push:lib'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,3 @@ push:
 		--env INTEGRATION_FRONT_TOKEN=$(INTEGRATION_FRONT_TOKEN) \
 		--env INTEGRATION_TYPEFORM_SIGNATURE_KEY=$(INTEGRATION_TYPEFORM_SIGNATURE_KEY) \
 		--env NODE_ENV=$(NODE_ENV)
-
-deploy-%:
-	./scripts/deploy-package.js jellyfish-$(subst deploy-,,$@)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ removing library dependencies is a bit different. The following is an example wh
 $ cd .libs/jellyfish-worker
 $ npm install new-dependency
 $ cd ../..
-$ make deploy-worker
+$ npm run push:lib jellyfish-worker
 ```
 
 What this does is create a local beta package for `.libs/jellyfish-worker` using `npm pack` and then

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "compose:up": "docker-compose up",
     "compose:test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up",
     "compose:monitor": "docker-compose -f docker-compose.yml -f docker-compose.monitor.yml up",
-    "compose:database": "docker-compose up postgres redis haproxy"
+    "compose:database": "docker-compose up postgres redis haproxy",
+    "push:lib": "./scripts/push-lib.js"
   },
   "deplint": {
     "files": [

--- a/scripts/push-lib.js
+++ b/scripts/push-lib.js
@@ -4,7 +4,7 @@
  * This script is a part of the Livepush development flow.
  * It creates an npm tarball of a library cloned under .libs
  * and copies it to package directories for apps that use it.
- * Usage: ./scripts/deploy-package.js <library-name>
+ * Usage: ./scripts/push-lib.js <library-name>
  */
 
 const childProcess = require('child_process')
@@ -22,7 +22,7 @@ if (pkg.length < 1) {
 const tarball = childProcess.execSync('npm pack', {
 	cwd: path.join(process.cwd(), '.libs', pkg),
 	stdio: 'pipe'
-}).toString().trim()
+}).toString().trim().split('\n').pop()
 const tarballPath = path.join(process.cwd(), '.libs', pkg, tarball)
 console.log(`Created ${tarballPath}`)
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move the `make deploy` command to `npm run push:lib` and update docs to match. Also fix a bug found during testing that prevents packed lib tars from being copied.