### PR TITLE
Update frontend build config/scripts

### DIFF
--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "balena-lint --fix lib",
     "doc": "typedoc lib/",
     "prepack": "npm run build",
-    "dev": "mkdir -p ./dist/livechat && NODE_ENV=development PUBLIC_DIR='./' ./conf/env.sh && cp ./env-config.js ./dist/livechat/ && NODE_ENV=development webpack serve --config=./webpack.config.js --color"
+    "env": "mkdir -p ./dist/livechat && NODE_ENV=development PUBLIC_DIR='./' ./conf/env.sh && cp ./env-config.js ./dist/livechat/",
+    "dev": "npm run env && NODE_ENV=development webpack serve --config=./webpack.config.js --color"
   },
   "author": "Balena.io. <hello@balena.io>",
   "license": "AGPL-3.0",

--- a/apps/livechat/webpack.config.js
+++ b/apps/livechat/webpack.config.js
@@ -108,7 +108,6 @@ const config = {
 
 		new DefinePlugin({
 			env: {
-				API_URL: JSON.stringify(process.env.API_URL),
 				NODE_ENV: JSON.stringify(process.env.NODE_ENV),
 				SENTRY_DSN_UI: JSON.stringify(process.env.SENTRY_DSN_UI)
 			}

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -20,7 +20,7 @@ COPY ./apps/ui /usr/src/jellyfish/apps/ui
 #dev-cmd-live=cd /usr/src/jellyfish/apps/ui && npm run dev
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/ui/node_modules/@balena/
 
-RUN NODE_ENV=production NODE_OPTIONS=--max-old-space-size=6144 npm run webpack
+RUN NODE_ENV=production NODE_OPTIONS=--max-old-space-size=6144 npm run build
 
 ###########################################################
 # Runtime

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -8,16 +8,16 @@
     "node": ">=14.2.0"
   },
   "scripts": {
-    "clean": "rimraf build",
-    "build": "npm run clean && tsc",
+    "clean": "rimraf dist",
+    "build": "npm run clean && webpack --config=./webpack.config.js",
     "lint": "balena-lint lib test && depcheck --ignore-bin-package --ignores=@babel/*,@types/jest,assert,babel-loader,canvas,history,typedoc",
     "lint:fix": "balena-lint --fix lib test",
     "test": "catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run test:unit",
     "test:unit": "jest",
     "doc": "typedoc lib/",
     "prepack": "npm run build",
-    "webpack": "webpack --config=./webpack.config.js",
-    "dev": "mkdir -p ./dist/ui && PUBLIC_DIR='./' NODE_ENV=development ./conf/env.sh && cp ./env-config.js ./dist/ui/ && webpack serve --config=./webpack.config.js --color"
+    "env": "mkdir -p ./dist/ui && NODE_ENV=development PUBLIC_DIR='./' ./conf/env.sh && cp ./env-config.js ./dist/ui/",
+    "dev": "npm run env && NODE_ENV=development webpack serve --config=./webpack.config.js --color"
   },
   "author": "Balena.io. <hello@balena.io>",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "push": "./scripts/push.sh",
     "build:livechat": "(cd apps/livechat && npm run build)",
     "build:server": "(cd apps/server && npm run build)",
-    "build:ui": "(cd apps/ui && npm run webpack)",
+    "build:ui": "(cd apps/ui && npm run build)",
     "dev:livechat": "(cd apps/livechat && npm run dev)",
     "dev:server": "(cd apps/server && npm run dev)",
     "dev:ui": "(cd apps/ui && npm run dev)"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Clean up some old cruft leftover in `webpack.config.js`
- Use `webpack` for `apps/ui`'s `npm run build` (livechat is already doing this)
