### PR TITLE
Fix mode in webpack build config

### DIFF
--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -20,7 +20,7 @@ COPY ./apps/livechat /usr/src/jellyfish/apps/livechat
 #dev-cmd-live=cd /usr/src/jellyfish/apps/livechat && npm run dev
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/livechat/node_modules/@balena/
 
-RUN NODE_ENV=production npm run build
+RUN npm run build
 
 ###########################################################
 # Runtime

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && webpack --config=./webpack.config.js",
+    "build": "npm run clean && NODE_ENV=production webpack --config=./webpack.config.js",
     "lint": "balena-lint lib && depcheck --ignore-bin-package --ignores=@balena/*,babel-loader,typedoc",
     "lint:fix": "balena-lint --fix lib",
     "doc": "typedoc lib/",

--- a/apps/livechat/webpack.config.js
+++ b/apps/livechat/webpack.config.js
@@ -19,7 +19,7 @@ const outDir = path.join(root, 'dist/livechat')
 console.log(`Generating bundle from ${uiRoot}`)
 
 const config = {
-	mode: 'development',
+	mode: process.env.NODE_ENV || 'production',
 	target: 'web',
 
 	resolve: {

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -20,7 +20,7 @@ COPY ./apps/ui /usr/src/jellyfish/apps/ui
 #dev-cmd-live=cd /usr/src/jellyfish/apps/ui && npm run dev
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/ui/node_modules/@balena/
 
-RUN NODE_ENV=production NODE_OPTIONS=--max-old-space-size=6144 npm run build
+RUN npm run build
 
 ###########################################################
 # Runtime

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && webpack --config=./webpack.config.js",
+    "build": "npm run clean && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=6144 webpack --config=./webpack.config.js",
     "lint": "balena-lint lib test && depcheck --ignore-bin-package --ignores=@babel/*,@types/jest,assert,babel-loader,canvas,history,typedoc",
     "lint:fix": "balena-lint --fix lib test",
     "test": "catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run test:unit",

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -32,7 +32,7 @@ const config = {
 	entry: path.join(uiRoot, 'index.tsx'),
 	target: 'web',
 	devtool: 'source-map',
-	mode: 'development',
+	mode: process.env.NODE_ENV || 'production',
 
 	output: {
 		filename: '[name].[contenthash].js',


### PR DESCRIPTION
Fallback to production mode when building with webpack.
Explicitly set NODE_ENV for both prod and dev build commands.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
