### PR TITLE
Bump jellyfish-plugin-outreach to v1.0.370

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1348,16 +1348,62 @@
       }
     },
     "@balena/jellyfish-plugin-outreach": {
-      "version": "1.0.367",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.367.tgz",
-      "integrity": "sha512-yAXCpXtWaUMNT+nWCdTVU0NVRy32F3Q6cJY4U5OSkHr4Fc2iRR53dHN6DTCRuViNjpsLFDtbrtdswosRxJgYzQ==",
+      "version": "1.0.370",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.370.tgz",
+      "integrity": "sha512-EQfuk0Q9mn+MAcgMXohN4++XOXKnIaPhPfXyFNW6LouIp2jWHt+olH0kt0wz3UjwvkOdaWtSo+nPwuOlmCIT0g==",
       "requires": {
         "@balena/jellyfish-action-library": "^15.1.209",
-        "@balena/jellyfish-assert": "^1.2.4",
-        "@balena/jellyfish-environment": "^6.0.6",
-        "@balena/jellyfish-plugin-base": "^2.2.15",
+        "@balena/jellyfish-assert": "^1.2.5",
+        "@balena/jellyfish-environment": "^6.0.7",
+        "@balena/jellyfish-plugin-base": "^2.2.19",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@balena/jellyfish-environment": {
+          "version": "6.0.7",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-6.0.7.tgz",
+          "integrity": "sha512-r6xoKSeuPVgDYqVJR8Gn3FQq4pwj91dhKdQ/Cdmc2p04AkSBKIzvVs64Y2Q1tN5d53D/pQ9Ko27leKqUyZ1UdQ==",
+          "requires": {
+            "@humanwhocodes/env": "^2.2.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "4.0.12",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.12.tgz",
+          "integrity": "sha512-8G2iiK09sl7mR3k8C5pOKPSXnL0bj7pq4J8t5JmjurKPQOGivaBVnOQvq1hjdCFjpbVPiLNKIzssyhjNMrIQuw==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.2.5",
+            "@balena/jellyfish-environment": "^6.0.7",
+            "@sentry/node": "^6.16.1",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.1"
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.2.19",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.2.19.tgz",
+          "integrity": "sha512-YxhOK/W9tDvgghI3kkKyLSul8WlE1Qys7faknJn61je7+mCHcjsPc+3BHgjCxFROvEbHic6dB6kFkYhC4KcGsg==",
+          "requires": {
+            "@balena/jellyfish-logger": "^4.0.12",
+            "json-schema": "^0.4.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-product-os": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,7 +37,7 @@
     "@balena/jellyfish-plugin-flowdock": "^1.0.261",
     "@balena/jellyfish-plugin-front": "^1.3.137",
     "@balena/jellyfish-plugin-github": "^1.11.270",
-    "@balena/jellyfish-plugin-outreach": "^1.0.367",
+    "@balena/jellyfish-plugin-outreach": "^1.0.370",
     "@balena/jellyfish-plugin-product-os": "^2.9.34",
     "@balena/jellyfish-plugin-typeform": "^4.0.22",
     "@balena/jellyfish-queue": "^1.0.395",

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,15 +943,15 @@
       }
     },
     "@balena/jellyfish-plugin-outreach": {
-      "version": "1.0.367",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.367.tgz",
-      "integrity": "sha512-yAXCpXtWaUMNT+nWCdTVU0NVRy32F3Q6cJY4U5OSkHr4Fc2iRR53dHN6DTCRuViNjpsLFDtbrtdswosRxJgYzQ==",
+      "version": "1.0.370",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.370.tgz",
+      "integrity": "sha512-EQfuk0Q9mn+MAcgMXohN4++XOXKnIaPhPfXyFNW6LouIp2jWHt+olH0kt0wz3UjwvkOdaWtSo+nPwuOlmCIT0g==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-action-library": "^15.1.209",
-        "@balena/jellyfish-assert": "^1.2.4",
-        "@balena/jellyfish-environment": "^6.0.6",
-        "@balena/jellyfish-plugin-base": "^2.2.15",
+        "@balena/jellyfish-assert": "^1.2.5",
+        "@balena/jellyfish-environment": "^6.0.7",
+        "@balena/jellyfish-plugin-base": "^2.2.19",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       },
@@ -963,6 +963,65 @@
           "dev": true,
           "requires": {
             "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-environment": {
+          "version": "6.0.7",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-6.0.7.tgz",
+          "integrity": "sha512-r6xoKSeuPVgDYqVJR8Gn3FQq4pwj91dhKdQ/Cdmc2p04AkSBKIzvVs64Y2Q1tN5d53D/pQ9Ko27leKqUyZ1UdQ==",
+          "dev": true,
+          "requires": {
+            "@humanwhocodes/env": "^2.2.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@balena/jellyfish-logger": {
+          "version": "4.0.12",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.12.tgz",
+          "integrity": "sha512-8G2iiK09sl7mR3k8C5pOKPSXnL0bj7pq4J8t5JmjurKPQOGivaBVnOQvq1hjdCFjpbVPiLNKIzssyhjNMrIQuw==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.2.5",
+            "@balena/jellyfish-environment": "^6.0.7",
+            "@sentry/node": "^6.16.1",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.3.3",
+            "winston-transport": "^4.4.1"
+          }
+        },
+        "@balena/jellyfish-plugin-base": {
+          "version": "2.2.19",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-base/-/jellyfish-plugin-base-2.2.19.tgz",
+          "integrity": "sha512-YxhOK/W9tDvgghI3kkKyLSul8WlE1Qys7faknJn61je7+mCHcjsPc+3BHgjCxFROvEbHic6dB6kFkYhC4KcGsg==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-logger": "^4.0.12",
+            "json-schema": "^0.4.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.5",
+            "skhema": "^5.3.4"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "winston-transport": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+          "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
+          "dev": true,
+          "requires": {
+            "logform": "^2.2.0",
+            "readable-stream": "^3.4.0",
+            "triple-beam": "^1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@balena/jellyfish-plugin-flowdock": "^1.0.261",
     "@balena/jellyfish-plugin-front": "^1.3.137",
     "@balena/jellyfish-plugin-github": "^1.11.270",
-    "@balena/jellyfish-plugin-outreach": "^1.0.367",
+    "@balena/jellyfish-plugin-outreach": "^1.0.370",
     "@balena/jellyfish-plugin-product-os": "^2.9.34",
     "@balena/jellyfish-plugin-typeform": "^4.0.22",
     "@balena/jellyfish-queue": "^1.0.395",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This bump increases log verbosity when mirroring out to Outreach, which should help in debugging silently failing mirrors.