### PR TITLE
Add push:lib npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "compose:monitor": "docker-compose -f docker-compose.yml -f docker-compose.monitor.yml up",
     "compose:database": "docker-compose up postgres redis haproxy",
     "push": "./scripts/push.sh",
+    "push:lib": "./scripts/push-lib.js",
     "build:livechat": "(cd apps/livechat && npm run build)",
     "build:server": "(cd apps/server && npm run build)",
     "build:ui": "(cd apps/ui && npm run build)",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add missing `npm run push:lib` script. Should have already existed, but might have been lost during a botched rebase or something.
