### PR TITLE
Bump jellyfish-sync to v6.2.14

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1578,9 +1578,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.13.tgz",
-      "integrity": "sha512-Kt6aTmKwIF/tCFcgPVZ5vPcGfXbjBW5vewCJtf9UFFvbRFxTMz9PgOIr7s+yLibWq02jKza43ebLoPEDdOqc9w==",
+      "version": "6.2.14",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.14.tgz",
+      "integrity": "sha512-+3Z5X15Bk1d4dmDz8N3HJsHtY9WhgZoZNWwftQ319Y02lR9ccTVbWlkCCcKOFiKfGV4lc9ujFPPs0/WcKDOv8A==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.5",
         "@balena/jellyfish-logger": "4.0.12",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,7 +41,7 @@
     "@balena/jellyfish-plugin-product-os": "^2.9.34",
     "@balena/jellyfish-plugin-typeform": "^4.0.22",
     "@balena/jellyfish-queue": "^1.0.395",
-    "@balena/jellyfish-sync": "^6.2.13",
+    "@balena/jellyfish-sync": "^6.2.14",
     "@balena/jellyfish-worker": "^10.1.24",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "aws-sdk": "^2.1048.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1360,9 +1360,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.13.tgz",
-      "integrity": "sha512-Kt6aTmKwIF/tCFcgPVZ5vPcGfXbjBW5vewCJtf9UFFvbRFxTMz9PgOIr7s+yLibWq02jKza43ebLoPEDdOqc9w==",
+      "version": "6.2.14",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.14.tgz",
+      "integrity": "sha512-+3Z5X15Bk1d4dmDz8N3HJsHtY9WhgZoZNWwftQ319Y02lR9ccTVbWlkCCcKOFiKfGV4lc9ujFPPs0/WcKDOv8A==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@balena/jellyfish-plugin-product-os": "^2.9.34",
     "@balena/jellyfish-plugin-typeform": "^4.0.22",
     "@balena/jellyfish-queue": "^1.0.395",
-    "@balena/jellyfish-sync": "^6.2.13",
+    "@balena/jellyfish-sync": "^6.2.14",
     "@balena/jellyfish-ui-components": "^13.1.14",
     "@balena/jellyfish-worker": "^10.1.24",
     "@balena/lint": "^6.2.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
