### PR TITLE
patch: bump up open-balena-base Docker image version 12.2.0 => 13.0.3

### DIFF
--- a/apps/livechat/Dockerfile
+++ b/apps/livechat/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v12.2.0 as base
+FROM balena/open-balena-base:v13.0.3 as base
 
 WORKDIR /usr/src/jellyfish/apps/livechat
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v12.2.0
+FROM balena/open-balena-base:v13.0.3
 
 WORKDIR /usr/src/jellyfish/apps/server
 

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 ###########################################################
 
-FROM balena/open-balena-base:v12.2.0 as base
+FROM balena/open-balena-base:v13.0.3 as base
 
 WORKDIR /usr/src/jellyfish/apps/ui
 


### PR DESCRIPTION
***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
