### PR TITLE
Improve webpack performance

### DIFF
--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -31,7 +31,7 @@ console.log(`Generating bundle from ${uiRoot}`)
 const config = {
 	entry: path.join(uiRoot, 'index.tsx'),
 	target: 'web',
-	devtool: 'source-map',
+	devtool: process.env.NODE_ENV === 'production' ? 'eval' : 'eval-cheap-module-source-map',
 	mode: process.env.NODE_ENV || 'production',
 
 	output: {


### PR DESCRIPTION
Change-type: minor

***

`source-map` is slowest both in terms of build and rebuild: https://webpack.js.org/configuration/devtool/ .
`eval` works well for build, excluding devtools field should have worked faster, but it does NOT for some reason. It decreased build time for me locally from 90s to 20s.

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
