### PR TITLE
Bump jellyfish-sync to v6.2.22

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1345,9 +1345,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "6.2.21",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.21.tgz",
-      "integrity": "sha512-W4ruiPVGXIgINXHYyUxsT08/WF1G70hNVhTwL0KQvcnUBqz3bJLgg5Y0EdP863F9MrS6NJlxjn5JA4VnCzDtOg==",
+      "version": "6.2.22",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.22.tgz",
+      "integrity": "sha512-PlmKNYx1oManpnCCuN2qa7iq7w/Q+ZuIHTgOCMOEWYp9UhKp/sG+RQXzPRXbilBE4vvN8iDM6YjwFWLXZPdPbQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.6",
         "@balena/jellyfish-logger": "4.0.15",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,7 +41,7 @@
     "@balena/jellyfish-plugin-product-os": "^2.9.45",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",
-    "@balena/jellyfish-sync": "^6.2.21",
+    "@balena/jellyfish-sync": "^6.2.22",
     "@balena/jellyfish-worker": "^10.1.30",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "aws-sdk": "^2.1053.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,9 +1306,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "6.2.21",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.21.tgz",
-      "integrity": "sha512-W4ruiPVGXIgINXHYyUxsT08/WF1G70hNVhTwL0KQvcnUBqz3bJLgg5Y0EdP863F9MrS6NJlxjn5JA4VnCzDtOg==",
+      "version": "6.2.22",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.22.tgz",
+      "integrity": "sha512-PlmKNYx1oManpnCCuN2qa7iq7w/Q+ZuIHTgOCMOEWYp9UhKp/sG+RQXzPRXbilBE4vvN8iDM6YjwFWLXZPdPbQ==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.6",
@@ -1401,6 +1401,14 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "express": {
@@ -1454,11 +1462,18 @@
             "toidentifier": "1.0.1"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+        "logform": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
+          "integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
+          "dev": true,
+          "requires": {
+            "colors": "1.4.0",
+            "fecha": "^4.2.0",
+            "ms": "^2.1.1",
+            "safe-stable-stringify": "^1.1.0",
+            "triple-beam": "^1.3.0"
+          }
         },
         "qs": {
           "version": "6.9.6",
@@ -1532,12 +1547,12 @@
           "dev": true
         },
         "winston-transport": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
-          "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.2.tgz",
+          "integrity": "sha512-9jmhltAr5ygt5usgUTQbEiw/7RYXpyUbEAFRCSicIacpUzPkrnQsQZSPGEI12aLK9Jth4zNcYJx3Cvznwrl8pw==",
           "dev": true,
           "requires": {
-            "logform": "^2.2.0",
+            "logform": "^2.3.2",
             "readable-stream": "^3.4.0",
             "triple-beam": "^1.2.0"
           }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@balena/jellyfish-plugin-product-os": "^2.9.45",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",
-    "@balena/jellyfish-sync": "^6.2.21",
+    "@balena/jellyfish-sync": "^6.2.22",
     "@balena/jellyfish-ui-components": "^13.1.18",
     "@balena/jellyfish-worker": "^10.1.30",
     "@balena/lint": "^6.2.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
