### PR TITLE
Bump jellyfish-sync to v6.2.23

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -1345,9 +1345,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "6.2.22",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.22.tgz",
-      "integrity": "sha512-PlmKNYx1oManpnCCuN2qa7iq7w/Q+ZuIHTgOCMOEWYp9UhKp/sG+RQXzPRXbilBE4vvN8iDM6YjwFWLXZPdPbQ==",
+      "version": "6.2.23",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.23.tgz",
+      "integrity": "sha512-ezecz/U4s840slMptXgZW2IoUfSsQI09xQ5HlkPiaQjtNfA23GNA0DG73BOl/yLgUSi62z6LZCJyn3reFjGx9Q==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.6",
         "@balena/jellyfish-logger": "4.0.15",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,7 +41,7 @@
     "@balena/jellyfish-plugin-product-os": "^2.9.45",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",
-    "@balena/jellyfish-sync": "^6.2.22",
+    "@balena/jellyfish-sync": "^6.2.23",
     "@balena/jellyfish-worker": "^10.1.30",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "aws-sdk": "^2.1053.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,9 +1306,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "6.2.22",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.22.tgz",
-      "integrity": "sha512-PlmKNYx1oManpnCCuN2qa7iq7w/Q+ZuIHTgOCMOEWYp9UhKp/sG+RQXzPRXbilBE4vvN8iDM6YjwFWLXZPdPbQ==",
+      "version": "6.2.23",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-6.2.23.tgz",
+      "integrity": "sha512-ezecz/U4s840slMptXgZW2IoUfSsQI09xQ5HlkPiaQjtNfA23GNA0DG73BOl/yLgUSi62z6LZCJyn3reFjGx9Q==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@balena/jellyfish-plugin-product-os": "^2.9.45",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",
-    "@balena/jellyfish-sync": "^6.2.22",
+    "@balena/jellyfish-sync": "^6.2.23",
     "@balena/jellyfish-ui-components": "^13.1.18",
     "@balena/jellyfish-worker": "^10.1.30",
     "@balena/lint": "^6.2.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
