### PR TITLE
Update vulnerable engine.io sub-dependency

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -5412,9 +5412,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
-      "integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz",
+      "integrity": "sha512-AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -17341,9 +17341,9 @@
       }
     },
     "engine.io": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
-      "integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz",
+      "integrity": "sha512-AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==",
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",


### PR DESCRIPTION
This fixes an issue where a specially crafted HTTP request can
trigger an uncaught exception on the Engine.IO server (used by socket.io), thus killing the Node.js process.

See https://github.com/advisories/GHSA-273r-mgr4-v34f

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
