### PR TITLE
Bump jellyfish-assert to v1.2.7

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/jellyfish-action-library": "^16.2.0",
-        "@balena/jellyfish-assert": "^1.2.6",
+        "@balena/jellyfish-assert": "^1.2.7",
         "@balena/jellyfish-core": "^8.2.7",
         "@balena/jellyfish-environment": "^6.0.8",
         "@balena/jellyfish-logger": "^4.0.15",
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@balena/jellyfish-assert": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.6.tgz",
-      "integrity": "sha512-NmtwJv/J6mqEdSsHQY+pU8WDMGK473eEaYIF5tx4xcNQQgYz8HAwhkqhsOYbOgUQZ/pDl2SbCUEzGZtYRJVkqA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.7.tgz",
+      "integrity": "sha512-fyYkXz2kvE/p95yfanReQi8ysb3Ini7svoiCww/I8qhF6Q0x3bPwHrequux23qPf7Ry/uxOSCwx+Sk2iXpTDHw==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -13893,9 +13893,9 @@
       }
     },
     "@balena/jellyfish-assert": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.6.tgz",
-      "integrity": "sha512-NmtwJv/J6mqEdSsHQY+pU8WDMGK473eEaYIF5tx4xcNQQgYz8HAwhkqhsOYbOgUQZ/pDl2SbCUEzGZtYRJVkqA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.7.tgz",
+      "integrity": "sha512-fyYkXz2kvE/p95yfanReQi8ysb3Ini7svoiCww/I8qhF6Q0x3bPwHrequux23qPf7Ry/uxOSCwx+Sk2iXpTDHw==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@balena/jellyfish-action-library": "^16.2.0",
-    "@balena/jellyfish-assert": "^1.2.6",
+    "@balena/jellyfish-assert": "^1.2.7",
     "@balena/jellyfish-core": "^8.2.7",
     "@balena/jellyfish-environment": "^6.0.8",
     "@balena/jellyfish-logger": "^4.0.15",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
