### PR TITLE
Use single purpose endpoints for actions performed by anonymous users

### DIFF
--- a/apps/livechat/package-lock.json
+++ b/apps/livechat/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/jellyfish-chat-widget": "^12.5.102",
-        "@balena/jellyfish-client-sdk": "^7.0.33",
+        "@balena/jellyfish-client-sdk": "^8.0.0",
         "@balena/jellyfish-ui-components": "^13.1.19",
         "@use-it/event-listener": "^0.1.7",
         "css-loader": "^5.2.7",
@@ -281,12 +281,12 @@
       }
     },
     "node_modules/@balena/jellyfish-client-sdk": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.33.tgz",
-      "integrity": "sha512-rqXbPJs54udMlPxA0LiRZYL8PSgIfa2DI25ssYxgbuRHm9UPMttJZF4shaTSZo0FiB56W6PChUFcABXZgfNHvw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "dependencies": {
-        "axios": "^0.24.0",
-        "bluebird": "^3.7.2",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -1772,11 +1772,20 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/babel-loader": {
@@ -5956,9 +5965,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -7465,6 +7474,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -13749,12 +13769,12 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.33.tgz",
-      "integrity": "sha512-rqXbPJs54udMlPxA0LiRZYL8PSgIfa2DI25ssYxgbuRHm9UPMttJZF4shaTSZo0FiB56W6PChUFcABXZgfNHvw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "requires": {
-        "axios": "^0.24.0",
-        "bluebird": "^3.7.2",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -15030,11 +15050,20 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "babel-loader": {
@@ -18363,9 +18392,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -19446,6 +19475,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-stream": {
       "version": "1.1.0",

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -21,7 +21,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@balena/jellyfish-chat-widget": "^12.5.102",
-    "@balena/jellyfish-client-sdk": "^7.0.33",
+    "@balena/jellyfish-client-sdk": "^8.0.0",
     "@balena/jellyfish-ui-components": "^13.1.19",
     "@use-it/event-listener": "^0.1.7",
     "css-loader": "^5.2.7",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -49,7 +49,7 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "@balena/jellyfish-client-sdk": "^7.0.34",
+        "@balena/jellyfish-client-sdk": "^8.0.0",
         "@balena/jellyfish-config": "^2.0.2",
         "@balena/jellyfish-types": "^1.2.42",
         "@balena/lint": "^6.2.0",
@@ -1017,6 +1017,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
@@ -1210,12 +1222,13 @@
       }
     },
     "node_modules/@balena/jellyfish-client-sdk": {
-      "version": "7.0.34",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.34.tgz",
-      "integrity": "sha512-QEfhood0ci350+Ev1MJo9O910RyOZzplAPqiVzhXb0WwWXSyR8mlWpGBTNBfHH+jfhoY2ou7OqWcPbzLs6a6dw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "dev": true,
       "dependencies": {
-        "axios": "^0.24.0",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -1226,6 +1239,15 @@
       },
       "engines": {
         "node": ">=12.15.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-client-sdk/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/@balena/jellyfish-config": {
@@ -3750,6 +3772,16 @@
         "follow-redirects": "^1.14.4"
       }
     },
+    "node_modules/axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.6.tgz",
@@ -6020,9 +6052,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -7106,6 +7138,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.0",
@@ -10929,6 +10973,12 @@
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
       "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
     "node_modules/registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -13784,6 +13834,15 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
+    "@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
@@ -13940,12 +13999,13 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "7.0.34",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.34.tgz",
-      "integrity": "sha512-QEfhood0ci350+Ev1MJo9O910RyOZzplAPqiVzhXb0WwWXSyR8mlWpGBTNBfHH+jfhoY2ou7OqWcPbzLs6a6dw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "dev": true,
       "requires": {
-        "axios": "^0.24.0",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -13953,6 +14013,17 @@
         "lodash": "^4.17.21",
         "socket.io-client": "^4.4.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.7"
+          }
+        }
       }
     },
     "@balena/jellyfish-config": {
@@ -16069,6 +16140,16 @@
         "follow-redirects": "^1.14.4"
       }
     },
+    "axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
     "babel-jest": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.6.tgz",
@@ -17858,9 +17939,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -18672,6 +18753,12 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
       "dev": true
     },
     "is-stream": {
@@ -21623,6 +21710,12 @@
       "requires": {
         "redis-errors": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "registry-auth-token": {
       "version": "4.2.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -63,7 +63,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@balena/jellyfish-client-sdk": "^7.0.34",
+    "@balena/jellyfish-client-sdk": "^8.0.0",
     "@balena/jellyfish-config": "^2.0.2",
     "@balena/jellyfish-types": "^1.2.42",
     "@balena/lint": "^6.2.0",

--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -1359,44 +1359,19 @@ export const actionCreators = {
 	requestPasswordReset({ username }) {
 		return async (dispatch, getState, { sdk }) => {
 			const userType = await sdk.getBySlug('user@latest');
-			return sdk.action({
-				card: userType.id,
-				action: 'action-request-password-reset@1.0.0',
-				type: userType.type,
-				arguments: {
-					username,
-				},
-			});
+			return sdk.auth.requestPasswordReset(username);
 		};
 	},
 
 	completePasswordReset({ password, resetToken }) {
 		return async (dispatch, getState, { sdk }) => {
-			const userType = await sdk.getBySlug('user@latest');
-			return sdk.action({
-				card: userType.id,
-				action: 'action-complete-password-reset@1.0.0',
-				type: userType.type,
-				arguments: {
-					newPassword: password,
-					resetToken,
-				},
-			});
+			return sdk.auth.completePasswordReset(password, resetToken);
 		};
 	},
 
 	completeFirstTimeLogin({ password, firstTimeLoginToken }) {
 		return async (dispatch, getState, { sdk }) => {
-			const userType = await sdk.getBySlug('user@latest');
-			return sdk.action({
-				card: userType.id,
-				action: 'action-complete-first-time-login@1.0.0',
-				type: userType.type,
-				arguments: {
-					newPassword: password,
-					firstTimeLoginToken,
-				},
-			});
+			return sdk.auth.completeFirstTimeLogin(password, firstTimeLoginToken);
 		};
 	},
 

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/jellyfish-chat-widget": "^12.5.102",
-        "@balena/jellyfish-client-sdk": "^7.0.33",
+        "@balena/jellyfish-client-sdk": "^8.0.0",
         "@balena/jellyfish-environment": "^6.0.9",
         "@balena/jellyfish-ui-components": "^13.1.19",
         "analytics-client": "^1.7.0",
@@ -1947,11 +1947,14 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime-corejs2": {
@@ -2036,12 +2039,12 @@
       }
     },
     "node_modules/@balena/jellyfish-client-sdk": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.33.tgz",
-      "integrity": "sha512-rqXbPJs54udMlPxA0LiRZYL8PSgIfa2DI25ssYxgbuRHm9UPMttJZF4shaTSZo0FiB56W6PChUFcABXZgfNHvw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "dependencies": {
-        "axios": "^0.24.0",
-        "bluebird": "^3.7.2",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -5459,11 +5462,20 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/babel-jest": {
@@ -12044,9 +12056,9 @@
       "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -14753,6 +14765,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -21027,17 +21050,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-redux/node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/react-redux/node_modules/react-is": {
@@ -28855,9 +28867,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -28924,12 +28936,12 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.33.tgz",
-      "integrity": "sha512-rqXbPJs54udMlPxA0LiRZYL8PSgIfa2DI25ssYxgbuRHm9UPMttJZF4shaTSZo0FiB56W6PChUFcABXZgfNHvw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "requires": {
-        "axios": "^0.24.0",
-        "bluebird": "^3.7.2",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -31815,11 +31827,20 @@
       "dev": true
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "babel-jest": {
@@ -37113,9 +37134,9 @@
       "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "font-atlas": {
       "version": "2.1.0",
@@ -39279,6 +39300,11 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.1",
@@ -44289,14 +44315,6 @@
         "react-is": "^17.0.2"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "react-is": {
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -23,7 +23,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@balena/jellyfish-chat-widget": "^12.5.102",
-    "@balena/jellyfish-client-sdk": "^7.0.33",
+    "@balena/jellyfish-client-sdk": "^8.0.0",
     "@balena/jellyfish-environment": "^6.0.9",
     "@balena/jellyfish-ui-components": "^13.1.19",
     "analytics-client": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@balena/jellyfish-action-library": "^16.2.4",
         "@balena/jellyfish-chat-widget": "^12.5.102",
-        "@balena/jellyfish-client-sdk": "^7.0.33",
+        "@balena/jellyfish-client-sdk": "^8.0.0",
         "@balena/jellyfish-config": "^2.0.2",
         "@balena/jellyfish-core": "^8.2.7",
         "@balena/jellyfish-environment": "^6.0.9",
@@ -473,13 +473,13 @@
       }
     },
     "node_modules/@balena/jellyfish-client-sdk": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.33.tgz",
-      "integrity": "sha512-rqXbPJs54udMlPxA0LiRZYL8PSgIfa2DI25ssYxgbuRHm9UPMttJZF4shaTSZo0FiB56W6PChUFcABXZgfNHvw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "dev": true,
       "dependencies": {
-        "axios": "^0.24.0",
-        "bluebird": "^3.7.2",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -490,6 +490,15 @@
       },
       "engines": {
         "node": ">=12.15.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-client-sdk/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/@balena/jellyfish-config": {
@@ -578,6 +587,26 @@
         "object-deep-search": "0.0.7",
         "object-hash": "^2.2.0",
         "static-eval": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.15.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-jellyscript/node_modules/@balena/jellyfish-client-sdk": {
+      "version": "7.0.37",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.37.tgz",
+      "integrity": "sha512-xkKPAtl097C1xZ1xaM8H3Tgt/vw+U/S1KZE5or2oeIs5Lq7iYfpMh3fWq16qVHuOTbPAdpF3CePjKtGQvKmqnA==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.24.0",
+        "axios-retry": "^3.2.4",
+        "common-tags": "^1.8.2",
+        "deep-copy": "^1.4.2",
+        "fast-json-patch": "^3.1.0",
+        "is-uuid": "^1.0.2",
+        "lodash": "^4.17.21",
+        "socket.io-client": "^4.4.1",
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=12.15.0"
@@ -3139,6 +3168,16 @@
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/babel-plugin-styled-components": {
@@ -6132,9 +6171,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true,
       "funding": [
         {
@@ -7495,6 +7534,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -13086,13 +13137,13 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.33.tgz",
-      "integrity": "sha512-rqXbPJs54udMlPxA0LiRZYL8PSgIfa2DI25ssYxgbuRHm9UPMttJZF4shaTSZo0FiB56W6PChUFcABXZgfNHvw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-8.0.0.tgz",
+      "integrity": "sha512-CZ3UBuDYjIVAw1u0zLWpjaUPRwBXdBQrux+a9bfx6b9np+stgXSK3l4zFOW9y2I8cc2n3UNee1EN6+xurC8F8g==",
       "dev": true,
       "requires": {
-        "axios": "^0.24.0",
-        "bluebird": "^3.7.2",
+        "axios": "^0.25.0",
+        "axios-retry": "^3.2.4",
         "common-tags": "^1.8.2",
         "deep-copy": "^1.4.2",
         "fast-json-patch": "^3.1.0",
@@ -13100,6 +13151,17 @@
         "lodash": "^4.17.21",
         "socket.io-client": "^4.4.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.7"
+          }
+        }
       }
     },
     "@balena/jellyfish-config": {
@@ -13176,6 +13238,25 @@
         "object-deep-search": "0.0.7",
         "object-hash": "^2.2.0",
         "static-eval": "^2.1.0"
+      },
+      "dependencies": {
+        "@balena/jellyfish-client-sdk": {
+          "version": "7.0.37",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-7.0.37.tgz",
+          "integrity": "sha512-xkKPAtl097C1xZ1xaM8H3Tgt/vw+U/S1KZE5or2oeIs5Lq7iYfpMh3fWq16qVHuOTbPAdpF3CePjKtGQvKmqnA==",
+          "dev": true,
+          "requires": {
+            "axios": "^0.24.0",
+            "axios-retry": "^3.2.4",
+            "common-tags": "^1.8.2",
+            "deep-copy": "^1.4.2",
+            "fast-json-patch": "^3.1.0",
+            "is-uuid": "^1.0.2",
+            "lodash": "^4.17.21",
+            "socket.io-client": "^4.4.1",
+            "uuid": "^8.3.2"
+          }
+        }
       }
     },
     "@balena/jellyfish-logger": {
@@ -15347,6 +15428,16 @@
       "dev": true,
       "requires": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "babel-plugin-styled-components": {
@@ -17688,9 +17779,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
     "forever-agent": {
@@ -18705,6 +18796,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
       "dev": true
     },
     "is-shared-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@balena/jellyfish-action-library": "^16.2.4",
     "@balena/jellyfish-chat-widget": "^12.5.102",
-    "@balena/jellyfish-client-sdk": "^7.0.33",
+    "@balena/jellyfish-client-sdk": "^8.0.0",
     "@balena/jellyfish-config": "^2.0.2",
     "@balena/jellyfish-core": "^8.2.7",
     "@balena/jellyfish-environment": "^6.0.9",


### PR DESCRIPTION
Using single purpose endpoints for actions performed by anonymous users
allow us to run the actions using a privileged user session and remove
the ability for the guest user to do it directly. This allows us to
reduce the scope of access that the guest user has, and therefore
anonymous users that the guest user represents.

Split out from https://github.com/product-os/jellyfish/pull/7774

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
