### PR TITLE
Add livechat as a page to JF

### DIFF
--- a/apps/ui/lib/JellyfishUI.tsx
+++ b/apps/ui/lib/JellyfishUI.tsx
@@ -18,6 +18,7 @@ import PageTitle from './components/PageTitle';
 import RequestPasswordReset from './components/Auth/RequestPasswordReset';
 import CompletePasswordReset from './components/Auth/CompletePasswordReset';
 import CompleteFirstTimeLogin from './components/Auth/CompleteFirstTimeLogin';
+import { Livechat } from './components/Livechat';
 import AuthContainer from './components/Auth';
 import Splash from './components/Splash';
 import { actionCreators, selectors } from './core';
@@ -27,6 +28,7 @@ import {
 	Route,
 	Redirect,
 	Switch,
+	matchPath,
 } from 'react-router-dom';
 import manifestJSON from './manifest.json';
 import { isProduction } from './environment';
@@ -115,10 +117,16 @@ const JellyfishUI = ({ actions, status, channels, isChatWidgetOpen }) => {
 	}
 	const [home] = channels;
 
+	if (isLegacyPath(path)) {
+		return <Redirect to={transformLegacyPath(path)} />;
+	}
+
+	if (matchPath(location.pathname, '/livechat')) {
+		return <Livechat />;
+	}
+
 	return (
 		<React.Fragment>
-			{isLegacyPath(path) && <Redirect to={transformLegacyPath(path)} />}
-
 			<Flex
 				flex="1"
 				style={{

--- a/apps/ui/lib/components/Livechat.tsx
+++ b/apps/ui/lib/components/Livechat.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import useEventListener from '@use-it/event-listener';
+import { JellyfishSDK } from '@balena/jellyfish-client-sdk';
+import { App } from '@balena/jellyfish-chat-widget';
+declare const window: Window & { sdk: JellyfishSDK };
+
+const Livechat = () => {
+	const queryParams = React.useMemo(() => {
+		const { state, ...rest } = Object.fromEntries(
+			new URLSearchParams(location.search).entries(),
+		);
+
+		if (state) {
+			return JSON.parse(state);
+		}
+
+		return rest;
+	}, [location.search]);
+
+	const { product, productTitle, username, inbox } = queryParams;
+
+	const onClose = React.useCallback(() => {
+		window.parent.postMessage(
+			{
+				type: 'close',
+			},
+			'*',
+		);
+	}, []);
+
+	const onNotificationsChange = React.useCallback((notifications) => {
+		window.parent.postMessage(
+			{
+				type: 'notifications-change',
+				payload: {
+					data: notifications,
+				},
+			},
+			'*',
+		);
+	}, []);
+
+	const [initialUrl, setInitialUrl] = React.useState();
+
+	const handleMessage = React.useCallback(
+		(event) => {
+			if (!event.data) {
+				return;
+			}
+
+			switch (event.data.type) {
+				case 'navigate':
+					setInitialUrl(event.data.payload);
+					break;
+				default:
+					break;
+			}
+		},
+		[setInitialUrl],
+	);
+
+	useEventListener('message', handleMessage, window);
+
+	return (
+		<App
+			product={product}
+			productTitle={productTitle}
+			inbox={inbox}
+			oauthProvider={'balena-api'}
+			initialUrl={initialUrl}
+			onClose={onClose}
+			onNotificationsChange={onNotificationsChange}
+		/>
+	);
+};
+
+/*
+ * Init livechat.
+ */
+console.log('Initializing livechat:', location.href);
+
+export { Livechat };

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -13,6 +13,7 @@
         "@balena/jellyfish-client-sdk": "^8.3.6",
         "@balena/jellyfish-environment": "^6.1.1",
         "@balena/jellyfish-ui-components": "^14.1.4",
+        "@use-it/event-listener": "^0.1.7",
         "analytics-client": "^1.7.0",
         "assert": "^2.0.0",
         "bluebird": "^3.7.2",
@@ -4447,6 +4448,14 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
+    },
+    "node_modules/@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.30",
@@ -28690,6 +28699,12 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
+    },
+    "@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "requires": {}
     },
     "@vue/compiler-core": {
       "version": "3.2.30",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -26,6 +26,7 @@
     "@balena/jellyfish-client-sdk": "^8.3.6",
     "@balena/jellyfish-environment": "^6.1.1",
     "@balena/jellyfish-ui-components": "^14.1.4",
+    "@use-it/event-listener": "^0.1.7",
     "analytics-client": "^1.7.0",
     "assert": "^2.0.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
Change-type: minor

***

Add `/livechat` route. This is part of [ui and livechat merge](https://jel.ly.fish/improvement-merge-ui-livechat-services-3e61550).

![tmp](https://user-images.githubusercontent.com/2152815/150165722-d5ec28ea-80b2-4c46-bcaf-3e0db0112dd0.png)


