### PR TITLE
Bump aws-sdk to 2.1062.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -30,7 +30,7 @@
         "@balena/jellyfish-sync": "^6.3.1",
         "@balena/jellyfish-worker": "^10.1.30",
         "@balena/socket-prometheus-metrics": "^0.0.3",
-        "aws-sdk": "^2.1058.0",
+        "aws-sdk": "^2.1062.0",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.1",
@@ -3700,14 +3700,14 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/aws-sdk": {
-      "version": "2.1058.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1058.0.tgz",
-      "integrity": "sha512-q6bTq1DBBeBaU6GKKoTHmJj16WOQHhOoK7jwV93IT8pO0P1XH99gesFofhew3eT0h8Ev7quVKutk4B1kfnIXPQ==",
+      "version": "2.1062.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
+      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -8930,9 +8930,9 @@
       }
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -16080,14 +16080,14 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.1058.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1058.0.tgz",
-      "integrity": "sha512-q6bTq1DBBeBaU6GKKoTHmJj16WOQHhOoK7jwV93IT8pO0P1XH99gesFofhew3eT0h8Ev7quVKutk4B1kfnIXPQ==",
+      "version": "2.1062.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
+      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -20110,9 +20110,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,7 +44,7 @@
     "@balena/jellyfish-sync": "^6.3.1",
     "@balena/jellyfish-worker": "^10.1.30",
     "@balena/socket-prometheus-metrics": "^0.0.3",
-    "aws-sdk": "^2.1058.0",
+    "aws-sdk": "^2.1062.0",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@octokit/plugin-throttling": "^3.5.2",
         "@octokit/rest": "^18.12.0",
         "ava": "^3.15.0",
-        "aws-sdk": "^2.1058.0",
+        "aws-sdk": "^2.1062.0",
         "bluebird": "^3.7.2",
         "catch-uncommitted": "^2.0.0",
         "cli-spinner": "^0.2.10",
@@ -3090,15 +3090,15 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1058.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1058.0.tgz",
-      "integrity": "sha512-q6bTq1DBBeBaU6GKKoTHmJj16WOQHhOoK7jwV93IT8pO0P1XH99gesFofhew3eT0h8Ev7quVKutk4B1kfnIXPQ==",
+      "version": "2.1062.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
+      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -7675,9 +7675,9 @@
       "dev": true
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -15362,15 +15362,15 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1058.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1058.0.tgz",
-      "integrity": "sha512-q6bTq1DBBeBaU6GKKoTHmJj16WOQHhOoK7jwV93IT8pO0P1XH99gesFofhew3eT0h8Ev7quVKutk4B1kfnIXPQ==",
+      "version": "2.1062.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
+      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -18901,9 +18901,9 @@
       "dev": true
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true
     },
     "js-string-escape": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/rest": "^18.12.0",
     "ava": "^3.15.0",
-    "aws-sdk": "^2.1058.0",
+    "aws-sdk": "^2.1062.0",
     "bluebird": "^3.7.2",
     "catch-uncommitted": "^2.0.0",
     "cli-spinner": "^0.2.10",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
