### PR TITLE
Bump typescript to 4.5.5

### DIFF
--- a/apps/livechat/package-lock.json
+++ b/apps/livechat/package-lock.json
@@ -33,7 +33,7 @@
         "eslint": "^7.32.0",
         "rimraf": "^3.0.2",
         "typedoc": "^0.22.11",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^3.11.3"
       },
@@ -11964,9 +11964,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23069,9 +23069,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typo-js": {

--- a/apps/livechat/package.json
+++ b/apps/livechat/package.json
@@ -44,7 +44,7 @@
     "eslint": "^7.32.0",
     "rimraf": "^3.0.2",
     "typedoc": "^0.22.11",
-    "typescript": "^4.5.4",
+    "typescript": "^4.5.5",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^3.11.3"
   }

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -65,7 +65,7 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typedoc": "^0.22.11",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -12471,9 +12471,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -22832,9 +22832,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uid2": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -79,6 +79,6 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.4.0",
     "typedoc": "^0.22.11",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   }
 }

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -100,7 +100,7 @@
         "sinon": "^11.1.2",
         "ts-jest": "^26.5.6",
         "typedoc": "^0.22.11",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "webpack": "^5.66.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.1",
@@ -25466,9 +25466,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -47893,9 +47893,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typo-js": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -113,7 +113,7 @@
     "sinon": "^11.1.2",
     "ts-jest": "^26.5.6",
     "typedoc": "^0.22.11",
-    "typescript": "^4.5.4",
+    "typescript": "^4.5.5",
     "webpack": "^5.66.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.1",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
