### PR TITLE
Bump plugin-product-os to 2.9.53

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -24,7 +24,7 @@
         "@balena/jellyfish-plugin-front": "^1.3.147",
         "@balena/jellyfish-plugin-github": "^1.11.284",
         "@balena/jellyfish-plugin-outreach": "^1.0.386",
-        "@balena/jellyfish-plugin-product-os": "^2.9.51",
+        "@balena/jellyfish-plugin-product-os": "^2.9.53",
         "@balena/jellyfish-plugin-typeform": "^4.0.31",
         "@balena/jellyfish-queue": "^1.0.395",
         "@balena/jellyfish-sync": "^6.3.1",
@@ -1735,13 +1735,13 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-product-os": {
-      "version": "2.9.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.51.tgz",
-      "integrity": "sha512-uhtNmFLXBfLF1emkU8VUI8HBvnRXpc8V0R7GB5+LRrVlLKRyYTKDdxSfrf+Eqp4wIAKTI/W7x1g3wrcG3KNbxg==",
+      "version": "2.9.60",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.60.tgz",
+      "integrity": "sha512-Of09ud5eWM0eUStkAXvG0pIq4WQ4Kbb3fhMplRstLZhkPsYpkkWrFKQqMTyHCy4VGspeSokAHDUgy5tGWV6vdA==",
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.7",
-        "@balena/jellyfish-logger": "^4.0.16",
-        "@balena/jellyfish-plugin-base": "^2.2.24",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-logger": "^4.0.22",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "lodash": "^4.17.21",
         "skhema": "^6.0.2"
       },
@@ -14419,13 +14419,13 @@
       }
     },
     "@balena/jellyfish-plugin-product-os": {
-      "version": "2.9.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.51.tgz",
-      "integrity": "sha512-uhtNmFLXBfLF1emkU8VUI8HBvnRXpc8V0R7GB5+LRrVlLKRyYTKDdxSfrf+Eqp4wIAKTI/W7x1g3wrcG3KNbxg==",
+      "version": "2.9.60",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.60.tgz",
+      "integrity": "sha512-Of09ud5eWM0eUStkAXvG0pIq4WQ4Kbb3fhMplRstLZhkPsYpkkWrFKQqMTyHCy4VGspeSokAHDUgy5tGWV6vdA==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.2.7",
-        "@balena/jellyfish-logger": "^4.0.16",
-        "@balena/jellyfish-plugin-base": "^2.2.24",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-logger": "^4.0.22",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "lodash": "^4.17.21",
         "skhema": "^6.0.2"
       },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -38,7 +38,7 @@
     "@balena/jellyfish-plugin-front": "^1.3.147",
     "@balena/jellyfish-plugin-github": "^1.11.284",
     "@balena/jellyfish-plugin-outreach": "^1.0.386",
-    "@balena/jellyfish-plugin-product-os": "^2.9.51",
+    "@balena/jellyfish-plugin-product-os": "^2.9.53",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",
     "@balena/jellyfish-sync": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@balena/jellyfish-plugin-front": "^1.3.147",
         "@balena/jellyfish-plugin-github": "^1.11.284",
         "@balena/jellyfish-plugin-outreach": "^1.0.386",
-        "@balena/jellyfish-plugin-product-os": "^2.9.51",
+        "@balena/jellyfish-plugin-product-os": "^2.9.53",
         "@balena/jellyfish-plugin-typeform": "^4.0.31",
         "@balena/jellyfish-queue": "^1.0.395",
         "@balena/jellyfish-sync": "^6.3.1",
@@ -924,14 +924,14 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-product-os": {
-      "version": "2.9.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.51.tgz",
-      "integrity": "sha512-uhtNmFLXBfLF1emkU8VUI8HBvnRXpc8V0R7GB5+LRrVlLKRyYTKDdxSfrf+Eqp4wIAKTI/W7x1g3wrcG3KNbxg==",
+      "version": "2.9.60",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.60.tgz",
+      "integrity": "sha512-Of09ud5eWM0eUStkAXvG0pIq4WQ4Kbb3fhMplRstLZhkPsYpkkWrFKQqMTyHCy4VGspeSokAHDUgy5tGWV6vdA==",
       "dev": true,
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.7",
-        "@balena/jellyfish-logger": "^4.0.16",
-        "@balena/jellyfish-plugin-base": "^2.2.24",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-logger": "^4.0.22",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "lodash": "^4.17.21",
         "skhema": "^6.0.2"
       },
@@ -940,13 +940,13 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-product-os/node_modules/@balena/jellyfish-logger": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.17.tgz",
-      "integrity": "sha512-nLqaFKbeBON5wHDPMqgIrXoHHH8x+Rd4IaHoJnuFnRF1boJruxa8A8Gh60CaYryMi3WnMrNjejqgnWpP+eh08w==",
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.22.tgz",
+      "integrity": "sha512-nwzeyKe3Gi+4h+9MeP07Xvh8dRqmHwmkQmCOV/qGSQxS8vYJUGXQu0DDmgob9p6tW5k0k3UfCHjeBXJlz+jAGA==",
       "dev": true,
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.7",
-        "@balena/jellyfish-environment": "^6.0.9",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-environment": "^6.0.11",
         "@sentry/node": "^6.16.1",
         "errio": "^1.2.2",
         "lodash": "^4.17.21",
@@ -13468,26 +13468,26 @@
       }
     },
     "@balena/jellyfish-plugin-product-os": {
-      "version": "2.9.51",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.51.tgz",
-      "integrity": "sha512-uhtNmFLXBfLF1emkU8VUI8HBvnRXpc8V0R7GB5+LRrVlLKRyYTKDdxSfrf+Eqp4wIAKTI/W7x1g3wrcG3KNbxg==",
+      "version": "2.9.60",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-product-os/-/jellyfish-plugin-product-os-2.9.60.tgz",
+      "integrity": "sha512-Of09ud5eWM0eUStkAXvG0pIq4WQ4Kbb3fhMplRstLZhkPsYpkkWrFKQqMTyHCy4VGspeSokAHDUgy5tGWV6vdA==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-assert": "^1.2.7",
-        "@balena/jellyfish-logger": "^4.0.16",
-        "@balena/jellyfish-plugin-base": "^2.2.24",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-logger": "^4.0.22",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "lodash": "^4.17.21",
         "skhema": "^6.0.2"
       },
       "dependencies": {
         "@balena/jellyfish-logger": {
-          "version": "4.0.17",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.17.tgz",
-          "integrity": "sha512-nLqaFKbeBON5wHDPMqgIrXoHHH8x+Rd4IaHoJnuFnRF1boJruxa8A8Gh60CaYryMi3WnMrNjejqgnWpP+eh08w==",
+          "version": "4.0.22",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.22.tgz",
+          "integrity": "sha512-nwzeyKe3Gi+4h+9MeP07Xvh8dRqmHwmkQmCOV/qGSQxS8vYJUGXQu0DDmgob9p6tW5k0k3UfCHjeBXJlz+jAGA==",
           "dev": true,
           "requires": {
-            "@balena/jellyfish-assert": "^1.2.7",
-            "@balena/jellyfish-environment": "^6.0.9",
+            "@balena/jellyfish-assert": "^1.2.9",
+            "@balena/jellyfish-environment": "^6.0.11",
             "@sentry/node": "^6.16.1",
             "errio": "^1.2.2",
             "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@balena/jellyfish-plugin-front": "^1.3.147",
     "@balena/jellyfish-plugin-github": "^1.11.284",
     "@balena/jellyfish-plugin-outreach": "^1.0.386",
-    "@balena/jellyfish-plugin-product-os": "^2.9.51",
+    "@balena/jellyfish-plugin-product-os": "^2.9.53",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",
     "@balena/jellyfish-sync": "^6.3.1",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
