### PR TITLE
Bump jellyfish-plugin-outreach to 1.0.398

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-flowdock": "^1.0.273",
         "@balena/jellyfish-plugin-front": "^1.3.147",
         "@balena/jellyfish-plugin-github": "^1.11.284",
-        "@balena/jellyfish-plugin-outreach": "^1.0.386",
+        "@balena/jellyfish-plugin-outreach": "^1.0.398",
         "@balena/jellyfish-plugin-product-os": "^2.9.53",
         "@balena/jellyfish-plugin-typeform": "^4.0.31",
         "@balena/jellyfish-queue": "^1.0.395",
@@ -1719,14 +1719,14 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-outreach": {
-      "version": "1.0.386",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.386.tgz",
-      "integrity": "sha512-zN1a2V5zwNlmRtipiGyR+ChgnWzbnFgSKP8OqoqUPsLKCUlCQeBsgDov/PvQ271UhVk7G7zJS97b8K2K7UtQvg==",
+      "version": "1.0.403",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.403.tgz",
+      "integrity": "sha512-zAp1dgXESq/IPM9ECWVdCLhUcyy2kqg8D0JxC9q1UzAcjnyNH2lxLAilMWjNwXrsqc3GlLyP/m8f31dsOHdoWQ==",
       "dependencies": {
-        "@balena/jellyfish-action-library": "^16.1.21",
-        "@balena/jellyfish-assert": "^1.2.6",
-        "@balena/jellyfish-environment": "^6.0.8",
-        "@balena/jellyfish-plugin-base": "^2.2.22",
+        "@balena/jellyfish-action-library": "^16.2.11",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-environment": "^6.0.11",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       },
@@ -14406,14 +14406,14 @@
       }
     },
     "@balena/jellyfish-plugin-outreach": {
-      "version": "1.0.386",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.386.tgz",
-      "integrity": "sha512-zN1a2V5zwNlmRtipiGyR+ChgnWzbnFgSKP8OqoqUPsLKCUlCQeBsgDov/PvQ271UhVk7G7zJS97b8K2K7UtQvg==",
+      "version": "1.0.403",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.403.tgz",
+      "integrity": "sha512-zAp1dgXESq/IPM9ECWVdCLhUcyy2kqg8D0JxC9q1UzAcjnyNH2lxLAilMWjNwXrsqc3GlLyP/m8f31dsOHdoWQ==",
       "requires": {
-        "@balena/jellyfish-action-library": "^16.1.21",
-        "@balena/jellyfish-assert": "^1.2.6",
-        "@balena/jellyfish-environment": "^6.0.8",
-        "@balena/jellyfish-plugin-base": "^2.2.22",
+        "@balena/jellyfish-action-library": "^16.2.11",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-environment": "^6.0.11",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,7 +37,7 @@
     "@balena/jellyfish-plugin-flowdock": "^1.0.273",
     "@balena/jellyfish-plugin-front": "^1.3.147",
     "@balena/jellyfish-plugin-github": "^1.11.284",
-    "@balena/jellyfish-plugin-outreach": "^1.0.386",
+    "@balena/jellyfish-plugin-outreach": "^1.0.398",
     "@balena/jellyfish-plugin-product-os": "^2.9.53",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@balena/jellyfish-plugin-flowdock": "^1.0.273",
         "@balena/jellyfish-plugin-front": "^1.3.147",
         "@balena/jellyfish-plugin-github": "^1.11.284",
-        "@balena/jellyfish-plugin-outreach": "^1.0.386",
+        "@balena/jellyfish-plugin-outreach": "^1.0.398",
         "@balena/jellyfish-plugin-product-os": "^2.9.53",
         "@balena/jellyfish-plugin-typeform": "^4.0.31",
         "@balena/jellyfish-queue": "^1.0.395",
@@ -907,15 +907,15 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-outreach": {
-      "version": "1.0.386",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.386.tgz",
-      "integrity": "sha512-zN1a2V5zwNlmRtipiGyR+ChgnWzbnFgSKP8OqoqUPsLKCUlCQeBsgDov/PvQ271UhVk7G7zJS97b8K2K7UtQvg==",
+      "version": "1.0.403",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.403.tgz",
+      "integrity": "sha512-zAp1dgXESq/IPM9ECWVdCLhUcyy2kqg8D0JxC9q1UzAcjnyNH2lxLAilMWjNwXrsqc3GlLyP/m8f31dsOHdoWQ==",
       "dev": true,
       "dependencies": {
-        "@balena/jellyfish-action-library": "^16.1.21",
-        "@balena/jellyfish-assert": "^1.2.6",
-        "@balena/jellyfish-environment": "^6.0.8",
-        "@balena/jellyfish-plugin-base": "^2.2.22",
+        "@balena/jellyfish-action-library": "^16.2.11",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-environment": "^6.0.11",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       },
@@ -13454,15 +13454,15 @@
       }
     },
     "@balena/jellyfish-plugin-outreach": {
-      "version": "1.0.386",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.386.tgz",
-      "integrity": "sha512-zN1a2V5zwNlmRtipiGyR+ChgnWzbnFgSKP8OqoqUPsLKCUlCQeBsgDov/PvQ271UhVk7G7zJS97b8K2K7UtQvg==",
+      "version": "1.0.403",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-1.0.403.tgz",
+      "integrity": "sha512-zAp1dgXESq/IPM9ECWVdCLhUcyy2kqg8D0JxC9q1UzAcjnyNH2lxLAilMWjNwXrsqc3GlLyP/m8f31dsOHdoWQ==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-action-library": "^16.1.21",
-        "@balena/jellyfish-assert": "^1.2.6",
-        "@balena/jellyfish-environment": "^6.0.8",
-        "@balena/jellyfish-plugin-base": "^2.2.22",
+        "@balena/jellyfish-action-library": "^16.2.11",
+        "@balena/jellyfish-assert": "^1.2.9",
+        "@balena/jellyfish-environment": "^6.0.11",
+        "@balena/jellyfish-plugin-base": "^2.2.25",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@balena/jellyfish-plugin-flowdock": "^1.0.273",
     "@balena/jellyfish-plugin-front": "^1.3.147",
     "@balena/jellyfish-plugin-github": "^1.11.284",
-    "@balena/jellyfish-plugin-outreach": "^1.0.386",
+    "@balena/jellyfish-plugin-outreach": "^1.0.398",
     "@balena/jellyfish-plugin-product-os": "^2.9.53",
     "@balena/jellyfish-plugin-typeform": "^4.0.31",
     "@balena/jellyfish-queue": "^1.0.395",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
