### PR TITLE
UI: Improve typings for Interleaved component

### DIFF
--- a/apps/ui/lib/lens/full/View/Content.tsx
+++ b/apps/ui/lib/lens/full/View/Content.tsx
@@ -4,13 +4,12 @@ import { Box, Flex, Txt } from 'rendition';
 import { Icon } from '@balena/jellyfish-ui-components';
 import { core } from '@balena/jellyfish-types';
 import { ViewFooter } from '../../common/ViewFooter';
-import {
-	BoundActionCreators,
-	ChannelContract,
-	LensContract,
-} from '../../../types';
+import { ChannelContract, LensContract } from '../../../types';
 
-const sortTail = (tail, options) => {
+const sortTail = (
+	tail: core.Contract[] | null,
+	options: { limit?: number; page?: number; sortBy: any; sortDir: any },
+) => {
 	if (!tail) {
 		return null;
 	}

--- a/apps/ui/lib/types.ts
+++ b/apps/ui/lib/types.ts
@@ -1,5 +1,6 @@
 import { JSONSchema } from '@balena/jellyfish-types';
-import { Contract } from '@balena/jellyfish-types/build/core';
+import { Contract, TypeContract } from '@balena/jellyfish-types/build/core';
+import React from 'react';
 
 // Utility type that allows you to change the return type of a function
 // From https://stackoverflow.com/a/50014868
@@ -28,12 +29,18 @@ export interface LensContract
 	data: {
 		label: string;
 		pathRegExp?: string;
-		type: 'view' | '*';
+		type?: 'view' | '*';
 		supportsSlices?: boolean;
 		icon: string;
-		format: 'full' | 'summary' | 'snippet';
-		renderer: any;
+		format: 'list' | 'full' | 'summary' | 'snippet';
+		renderer: React.ComponentType<LensRendererProps>;
 		filter: JSONSchema;
+		queryOptions: {
+			limit?: number;
+			sortBy?: string;
+			sortDir?: 'asc' | 'desc';
+			mask: (query: JSONSchema) => JSONSchema;
+		};
 	};
 }
 
@@ -45,4 +52,17 @@ export interface ChannelContract
 		head?: Contract;
 		cardType?: string;
 	};
+}
+
+export interface LensRendererProps {
+	channel: ChannelContract;
+	tail: null | Contract[];
+	setPage: (page: number) => Promise<void>;
+	pageOptions: {
+		page: number;
+		totalPages: number;
+	};
+	page: number;
+	totalPages: number;
+	tailTypes: TypeContract[];
 }

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -79,6 +79,7 @@
         "@emotion/cache": "^11.7.1",
         "@emotion/react": "^11.7.1",
         "@types/jest": "^26.0.24",
+        "@types/react-router-dom": "^5.3.3",
         "@types/sinon": "^10.0.8",
         "babel-loader": "^8.2.3",
         "browser-env": "^3.3.0",
@@ -4102,9 +4103,9 @@
       }
     },
     "node_modules/@types/history": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
-      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -4270,6 +4271,27 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -30631,9 +30653,9 @@
       }
     },
     "@types/history": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
-      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -30799,6 +30821,27 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/resolve": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -92,6 +92,7 @@
     "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.7.1",
     "@types/jest": "^26.0.24",
+    "@types/react-router-dom": "^5.3.3",
     "@types/sinon": "^10.0.8",
     "babel-loader": "^8.2.3",
     "browser-env": "^3.3.0",


### PR DESCRIPTION
This change improves the typings for the Interleaved lens, and tightens
up lens renderer types, although this hasn't been applied in all places.

This commit also introduces the pattern for typing redux connected
components, where three interfaces are defined:
- `StateProps`: The type for the props provided by `mapStateToProps()`
- `DispatchProps`: The type for the props provided by `mapDispatchToProps()`
- `OwnProps`: The type for the props provided by the parent component

These three types are combined for the code implementing the component:
```
type Props = StateProps & DispatchProps & OwnProps

interface State {
  internalComponentStateField: string
}

class MyComponent extends React.Component<Props, State> {
  ...
}
```

These three seperate types are then used as type paramaters to the
`connect` function, ensuring that the correct prop interface is exposed
to any parent component:

```
export default connect<StateProps, DispatchProps, OwnProps>
  (mapStateToProps, mapDispatchToProps)(MyComponent)
```

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
