### PR TITLE
Update aws-sdk from 2.1062.0 to 2.1066.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -30,7 +30,7 @@
         "@balena/jellyfish-sync": "^6.3.1",
         "@balena/jellyfish-worker": "^10.1.30",
         "@balena/socket-prometheus-metrics": "^0.0.3",
-        "aws-sdk": "^2.1062.0",
+        "aws-sdk": "^2.1066.0",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.1",
@@ -3716,9 +3716,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/aws-sdk": {
-      "version": "2.1062.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
-      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
+      "version": "2.1066.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+      "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -16112,9 +16112,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.1062.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
-      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
+      "version": "2.1066.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+      "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,7 +44,7 @@
     "@balena/jellyfish-sync": "^6.3.1",
     "@balena/jellyfish-worker": "^10.1.30",
     "@balena/socket-prometheus-metrics": "^0.0.3",
-    "aws-sdk": "^2.1062.0",
+    "aws-sdk": "^2.1066.0",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@octokit/plugin-throttling": "^3.5.2",
         "@octokit/rest": "^18.12.0",
         "ava": "^3.15.0",
-        "aws-sdk": "^2.1062.0",
+        "aws-sdk": "^2.1066.0",
         "bluebird": "^3.7.2",
         "catch-uncommitted": "^2.0.0",
         "cli-spinner": "^0.2.10",
@@ -3115,9 +3115,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1062.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
-      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
+      "version": "2.1066.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+      "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -15362,9 +15362,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1062.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
-      "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
+      "version": "2.1066.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+      "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/rest": "^18.12.0",
     "ava": "^3.15.0",
-    "aws-sdk": "^2.1062.0",
+    "aws-sdk": "^2.1066.0",
     "bluebird": "^3.7.2",
     "catch-uncommitted": "^2.0.0",
     "cli-spinner": "^0.2.10",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
