### PR TITLE
UI: Always show the link tab for the next entity type in the loop

### DIFF
--- a/apps/ui/lib/lens/common/CustomQueryTab/index.tsx
+++ b/apps/ui/lib/lens/common/CustomQueryTab/index.tsx
@@ -27,6 +27,43 @@ export const CustomQueryTab = connect(
 )(InnerCustomQueryTab);
 
 const getCustomQueries = memoize((typeCard) => {
+	// TODO: Don't hardcode these queries for loop contracts
+	if (typeCard.slug === 'support-thread') {
+		return [
+			{
+				title: 'Patterns',
+				type: 'pattern',
+				link: 'has attached',
+			},
+		];
+	}
+	if (typeCard.slug === 'pattern') {
+		return [
+			{
+				title: 'Improvements',
+				type: 'improvement',
+				link: 'has attached',
+			},
+		];
+	}
+	if (typeCard.slug === 'improvement') {
+		return [
+			{
+				title: 'Milestones',
+				type: 'milestone',
+				link: 'has attached',
+			},
+		];
+	}
+	if (typeCard.slug === 'milestone') {
+		return [
+			{
+				title: 'Issues',
+				type: 'issue',
+				link: 'is attached to',
+			},
+		];
+	}
 	return _.filter(
 		_.get(typeCard, ['data', 'meta', 'relationships'], []),
 		'query',


### PR DESCRIPTION
When viewing a contract, if that contract is part of the loop structure,
always show the link tab for the next type in the loop flow. E.g. if
looking at a pattern, the link tab for improvements will always be shown

Fixes https://github.com/product-os/jellyfish/issues/7853

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>