### PR TITLE
Fix scrolling issue in JF chat

### DIFF
--- a/apps/ui/lib/lens/full/View/index.tsx
+++ b/apps/ui/lib/lens/full/View/index.tsx
@@ -589,7 +589,7 @@ export class ViewRenderer extends React.Component<ViewRendererProps, any> {
 		return this.props.actions
 			.loadMoreViewData(syntheticViewCard, queryOptions)
 			.then((data) => {
-				if (data.length < options.limit) {
+				if (data.length < queryOptions.limit) {
 					this.setState({
 						options: {
 							...options,


### PR DESCRIPTION
This PR proposes a fix to the infinite scrolling issue in the Jellyfish chat. 

The total page count is determined dynamically by the app based on the number of items returned by a query. Previously this number was compared against a hardcoded limit of 100, and if it was smaller than this value, the app inferred that it had reached the last page, thus setting `totalPages` to the index of the current page and preventing further queries. The problem was that the Interleaved lens used for implementing the chat box defined its own limit of 30 objects in the lens' contract (probably to avoid a high memory usage due to the fact that the message list is NOT virtualized). This discrepancy in the limits used by the query and for comparison was causing the app to believe it had reached the last page after the first loading of older messages.

In this PR the hardcoded limit used for comparison was replaced with the limit actually used in the query.

Change-type: patch

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
