### PR TITLE
UI: Don't lazy load widgets

### DIFF
--- a/apps/ui/lib/components/Widgets/index.ts
+++ b/apps/ui/lib/components/Widgets/index.ts
@@ -3,14 +3,8 @@ import { JellyfishLinkWidget } from './JellyfishLinkWidget';
 import { JellyfishUserWidget } from './JellyfishUserWidget';
 import { createLazyComponent } from '../SafeLazy';
 export { LoopSelectWidget } from './LoopSelectWidget';
-
-export const MarkdownWidget = createLazyComponent(
-	() => import(/* webpackChunkName: "markdown-widget" */ './MarkdownWidget'),
-);
-
-export const MermaidWidget = createLazyComponent(
-	() => import(/* webpackChunkName: "mermaid-widget" */ './MermaidWidget'),
-);
+import MarkdownWidget from './MarkdownWidget';
+import MermaidWidget from './MarkdownWidget';
 
 export const JellyfishWidgets = [
 	{


### PR DESCRIPTION
Fixes https://github.com/product-os/jellyfish/issues/7954

Lazy loading widgets doesn't work correctly, resulting in markdown and
mermaid formats not being rendered correctly in the UI. This change
rolls back the lazyloading. We need to resolve this in rendition, by adding support for lazy loading widgets

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
