### PR TITLE
Login as specific user

### DIFF
--- a/apps/ui/lib/components/Livechat.tsx
+++ b/apps/ui/lib/components/Livechat.tsx
@@ -17,7 +17,7 @@ const Livechat = () => {
 		return rest;
 	}, [location.search]);
 
-	const { product, productTitle, username, inbox } = queryParams;
+	const { product, productTitle, inbox } = queryParams;
 
 	const onClose = React.useCallback(() => {
 		window.parent.postMessage(
@@ -66,7 +66,6 @@ const Livechat = () => {
 			product={product}
 			productTitle={productTitle}
 			inbox={inbox}
-			oauthProvider={'balena-api'}
 			initialUrl={initialUrl}
 			onClose={onClose}
 			onNotificationsChange={onNotificationsChange}

--- a/apps/ui/lib/components/LoginAs.tsx
+++ b/apps/ui/lib/components/LoginAs.tsx
@@ -6,7 +6,7 @@ import { useTask } from '@balena/jellyfish-chat-widget/build/hooks';
 import { selectors } from '../core';
 import { slugify } from '@balena/jellyfish-ui-components/build/services/helpers';
 
-export const LOGIN_AS_SEARCH_PARAM_NAME = 'login-as';
+export const LOGIN_AS_SEARCH_PARAM_NAME = 'loginAs';
 
 const LoginAs = () => {
 	const store = useStore();

--- a/apps/ui/lib/components/LoginAs.tsx
+++ b/apps/ui/lib/components/LoginAs.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useStore } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import { Task } from '@balena/jellyfish-chat-widget/build/components/task';
+import { useTask } from '@balena/jellyfish-chat-widget/build/hooks';
+import { selectors } from '../core';
+import { slugify } from '@balena/jellyfish-ui-components/build/services/helpers';
+
+export const LOGIN_AS_SEARCH_PARAM_NAME = 'login-as';
+
+const LoginAs = () => {
+	const store = useStore();
+	const urlRef = React.useRef(new URL(location.href));
+
+	const authenticationTask = useTask(async () => {
+		const state = store.getState();
+		const user = selectors.getCurrentUser(state);
+		const loginAs = urlRef.current.searchParams.get(
+			LOGIN_AS_SEARCH_PARAM_NAME,
+		)!;
+
+		if (user && user.slug === `user-${slugify(loginAs)}`) {
+			urlRef.current.searchParams.delete(LOGIN_AS_SEARCH_PARAM_NAME);
+			return;
+		}
+
+		const oauthUrl = `https://dashboard.balena-cloud.com/login/oauth/jellyfish?state=${encodeURIComponent(
+			urlRef.current.href,
+		)}`;
+		location.href = oauthUrl;
+	});
+
+	React.useEffect(() => {
+		authenticationTask.exec();
+	}, []);
+
+	return (
+		<Task task={authenticationTask}>
+			{() => {
+				return (
+					<Redirect to={urlRef.current.pathname + urlRef.current.search} />
+				);
+			}}
+		</Task>
+	);
+};
+
+export default LoginAs;

--- a/apps/ui/lib/components/OauthCallback.tsx
+++ b/apps/ui/lib/components/OauthCallback.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useStore } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { Task } from '@balena/jellyfish-chat-widget/build/components/task';
+import { useTask } from '@balena/jellyfish-chat-widget/build/hooks';
+import { actionCreators } from '../core';
+import { useSetup } from '@balena/jellyfish-ui-components';
+import { LOGIN_AS_SEARCH_PARAM_NAME } from './LoginAs';
+import { slugify } from '@balena/jellyfish-ui-components/build/services/helpers';
+
+const OauthCallback = () => {
+	const store = useStore();
+	const { sdk, analytics } = useSetup()!;
+	const history = useHistory();
+
+	const exchangeCodeTask = useTask(async () => {
+		const url = new URL(location.href);
+		const code = url.searchParams.get('code');
+
+		if (!code) {
+			throw new Error('Auth code missing');
+		}
+
+		const state = url.searchParams.get('state');
+
+		if (!state) {
+			throw new Error('state (returnUrl) missing');
+		}
+
+		const returnUrl = new URL(state);
+		const username = returnUrl.searchParams.get(LOGIN_AS_SEARCH_PARAM_NAME);
+
+		if (!username) {
+			throw new Error('login-as parameter missing');
+		}
+
+		const { access_token: token } = await sdk.post<{ access_token: string }>(
+			'/oauth/balena-api',
+			{
+				slug: `user-${slugify(username)}`,
+				code,
+			},
+		);
+
+		if (!token) {
+			throw new Error('Could not fetch auth token');
+		}
+
+		await actionCreators.loginWithToken(token)(store.dispatch, store.getState, {
+			sdk,
+			analytics,
+		});
+
+		returnUrl.searchParams.delete(LOGIN_AS_SEARCH_PARAM_NAME);
+		history.replace(returnUrl.pathname + returnUrl.search);
+	});
+
+	React.useEffect(() => {
+		exchangeCodeTask.exec();
+	}, []);
+
+	return <Task task={exchangeCodeTask}>{() => null}</Task>;
+};
+
+export default OauthCallback;

--- a/apps/ui/lib/components/OauthCallback.tsx
+++ b/apps/ui/lib/components/OauthCallback.tsx
@@ -31,7 +31,7 @@ const OauthCallback = () => {
 		const username = returnUrl.searchParams.get(LOGIN_AS_SEARCH_PARAM_NAME);
 
 		if (!username) {
-			throw new Error('login-as parameter missing');
+			throw new Error(`${LOGIN_AS_SEARCH_PARAM_NAME} parameter missing`);
 		}
 
 		const { access_token: token } = await sdk.post<{ access_token: string }>(

--- a/apps/ui/lib/components/OauthCallback.tsx
+++ b/apps/ui/lib/components/OauthCallback.tsx
@@ -28,7 +28,9 @@ const OauthCallback = () => {
 		}
 
 		const returnUrl = new URL(state);
-		const username = returnUrl.searchParams.get(LOGIN_AS_SEARCH_PARAM_NAME);
+		const username =
+			returnUrl.searchParams.get(LOGIN_AS_SEARCH_PARAM_NAME) ||
+			returnUrl.searchParams.get('username'); // TODO: Remove this when ui and livechat are merged
 
 		if (!username) {
 			throw new Error(`${LOGIN_AS_SEARCH_PARAM_NAME} parameter missing`);

--- a/test/e2e/ui/login-as.spec.js
+++ b/test/e2e/ui/login-as.spec.js
@@ -1,0 +1,84 @@
+const {
+	test, expect
+} = require('@playwright/test')
+const sdkHelpers = require('../sdk/helpers')
+const livechatMacros = require('../livechat/macros')
+const {
+	v4: uuid
+} = require('uuid')
+
+let sdk = {}
+let user = {}
+
+test.beforeAll(async () => {
+	sdk = await sdkHelpers.login()
+	user = await livechatMacros.prepareUser(sdk, await sdk.card.get('org-balena'), 'user-community', 'User')
+})
+
+test.beforeEach(async ({
+	page,
+	baseURL
+}) => {
+	const oauthUrl = 'https://dashboard.balena-cloud.com/login/oauth/jellyfish'
+	const code = uuid()
+
+	await page.route('**/*', async (route) => {
+		const url = new URL(route.request().url())
+
+		if (url.href.startsWith(oauthUrl)) {
+			const state = url.searchParams.get('state')
+
+			await route.fulfill({
+				status: 301,
+				headers: {
+					Location: `${baseURL}/oauth/callback?state=${encodeURIComponent(state)}&code=${code}`
+				}
+			})
+		} else if (url.pathname === '/api/v2/oauth/balena-api') {
+			const body = route.request().postDataJSON()
+			expect(body.slug).toBe(user.card.slug)
+			expect(body.code).toBe(code)
+
+			await route.fulfill({
+				contentType: 'application/json',
+				headers: {
+					'access-control-allow-origin': '*'
+				},
+				status: 200,
+				body: JSON.stringify({
+					error: false,
+					data: {
+						access_token: user.sdk.getAuthToken()
+					}
+				})
+			})
+		} else {
+			await route.continue()
+		}
+	})
+})
+
+test.afterEach(async ({
+	page
+}) => {
+	sdkHelpers.afterEach(sdk)
+	await page.unroute('**/*')
+	await page.close()
+})
+
+test.describe('Login as', () => {
+	test('Should initiate oauth process if not logged in', async ({
+		page
+	}) => {
+		// 1. Reuqest livechat page with specific user
+		await page.goto(`/livechat?login-as=${user.card.slug.replace('user-', '')}`)
+
+		// 2. Redirected to /oauth/callback page
+		await page.waitForURL((url) => {
+			return url.pathname === '/oauth/callback'
+		})
+
+		// 3. Log in with oauth code and redirect back to livechat page
+		await page.waitForURL('/livechat')
+	})
+})

--- a/test/e2e/ui/login-as.spec.js
+++ b/test/e2e/ui/login-as.spec.js
@@ -71,7 +71,7 @@ test.describe('Login as', () => {
 		page
 	}) => {
 		// 1. Reuqest livechat page with specific user
-		await page.goto(`/livechat?login-as=${user.card.slug.replace('user-', '')}`)
+		await page.goto(`/livechat?loginAs=${user.card.slug.replace('user-', '')}`)
 
 		// 2. Redirected to /oauth/callback page
 		await page.waitForURL((url) => {


### PR DESCRIPTION
Change-type: minor

***

User should be able to log in with different oauth providers like balena or outreach, we also can force to log in with specific user (need to embed livechat to dashboard, where we need to make sure that same users are logged in dashboard and in jellyfish). If jellyfish is loaded with `?login-as=user-karaxuna`, we make sure that current logged in user is `user-karaxuna`, otherwise we initiate oauth process with `balena` (hardcoded for now).
