### PR TITLE
Fix clipped dropdown by preventing the LinkModal from scrolling in Y

### DIFF
--- a/apps/ui/lib/components/LinkModal/LinkModal.tsx
+++ b/apps/ui/lib/components/LinkModal/LinkModal.tsx
@@ -151,6 +151,7 @@ export const LinkModal: React.FunctionComponent<LinkModalProps> = ({
 			}
 			action={submitting ? <Icon spin name="cog" /> : 'OK'}
 			done={onDone}
+			style={{ overflowY: 'inherit' }}
 		>
 			{!target && validTypes.length > 1 && (
 				<TypeFilter


### PR DESCRIPTION
This PR fixes the clipped dropdown issue in the link creation modal (`LinkModal`). This issue is due to the fact that `rendition` styles the modal with `overflow-y: auto`, but in this case we have a dropdown in it whose container is larger than the modal itself. By setting the `overflow-y` property to `inherit` the modal is no longer scrolling, and the dropdown is completely visible.

Change-type: patch

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
