### PR TITLE
Update @balena/jellyfish-assert from 1.2.14 to 1.2.15

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.14",
+        "@balena/jellyfish-assert": "^1.2.15",
         "@balena/jellyfish-core": "^14.3.8",
         "@balena/jellyfish-environment": "^7.0.0",
         "@balena/jellyfish-logger": "^4.0.37",
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@balena/jellyfish-assert": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.14.tgz",
-      "integrity": "sha512-CIkWVTniAcPwESzLQsEZn8CN3/w5ZvXXxER/1SzyWomk5UoO69RujkFXnOeDs4BV9b5TKwey+UxyuERhleac8w==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.15.tgz",
+      "integrity": "sha512-oUO6VK/pc3e2ommhqPYZXfYPELIyplLgjbtTX/CTYL6Lj4iv96gzJTNLOdz49XIz8v11JmdmT8zpMyp7AQK/kg==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -11990,9 +11990,9 @@
       }
     },
     "@balena/jellyfish-assert": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.14.tgz",
-      "integrity": "sha512-CIkWVTniAcPwESzLQsEZn8CN3/w5ZvXXxER/1SzyWomk5UoO69RujkFXnOeDs4BV9b5TKwey+UxyuERhleac8w==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.15.tgz",
+      "integrity": "sha512-oUO6VK/pc3e2ommhqPYZXfYPELIyplLgjbtTX/CTYL6Lj4iv96gzJTNLOdz49XIz8v11JmdmT8zpMyp7AQK/kg==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,7 +23,7 @@
     "dev": "nodemon --inspect=0.0.0.0 ./lib/index.ts"
   },
   "dependencies": {
-    "@balena/jellyfish-assert": "^1.2.14",
+    "@balena/jellyfish-assert": "^1.2.15",
     "@balena/jellyfish-core": "^14.3.8",
     "@balena/jellyfish-environment": "^7.0.0",
     "@balena/jellyfish-logger": "^4.0.37",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
