### PR TITLE
Update @balena/jellyfish-logger from 4.0.37 to 4.0.38

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -12,7 +12,7 @@
         "@balena/jellyfish-assert": "^1.2.15",
         "@balena/jellyfish-core": "^14.3.8",
         "@balena/jellyfish-environment": "^7.0.1",
-        "@balena/jellyfish-logger": "^4.0.37",
+        "@balena/jellyfish-logger": "^4.0.38",
         "@balena/jellyfish-metrics": "^2.0.37",
         "@balena/jellyfish-plugin-balena-api": "^2.0.26",
         "@balena/jellyfish-plugin-channels": "^2.0.20",
@@ -621,12 +621,12 @@
       }
     },
     "node_modules/@balena/jellyfish-logger": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.37.tgz",
-      "integrity": "sha512-1hAaQRgVdn2ai2RRYmdamwKFDJ+c8K/wpra/tWDCI04YKXfKs9WWb7JmvSiB3nYQy24zN6S511py1Bkz6jJJcg==",
+      "version": "4.0.38",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.38.tgz",
+      "integrity": "sha512-1PUqBbz4WXCSYE1EcKhOdI2H5RgCQjQ9hDpmJc+d7NAcSdAqd1m1IaReCfnlpLBdobpCJUK+oZVGZOkZWePbgQ==",
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.14",
-        "@balena/jellyfish-environment": "^7.0.0",
+        "@balena/jellyfish-assert": "^1.2.15",
+        "@balena/jellyfish-environment": "^7.0.1",
         "@sentry/node": "^6.17.7",
         "errio": "^1.2.2",
         "lodash": "^4.17.21",
@@ -722,6 +722,24 @@
       },
       "engines": {
         "node": ">=14.2.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-plugin-default/node_modules/@balena/jellyfish-logger": {
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.37.tgz",
+      "integrity": "sha512-1hAaQRgVdn2ai2RRYmdamwKFDJ+c8K/wpra/tWDCI04YKXfKs9WWb7JmvSiB3nYQy24zN6S511py1Bkz6jJJcg==",
+      "dependencies": {
+        "@balena/jellyfish-assert": "^1.2.14",
+        "@balena/jellyfish-environment": "^7.0.0",
+        "@sentry/node": "^6.17.7",
+        "errio": "^1.2.2",
+        "lodash": "^4.17.21",
+        "typed-error": "^3.2.1",
+        "winston": "^3.6.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.15.0"
       }
     },
     "node_modules/@balena/jellyfish-plugin-default/node_modules/semver": {
@@ -12085,12 +12103,12 @@
       }
     },
     "@balena/jellyfish-logger": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.37.tgz",
-      "integrity": "sha512-1hAaQRgVdn2ai2RRYmdamwKFDJ+c8K/wpra/tWDCI04YKXfKs9WWb7JmvSiB3nYQy24zN6S511py1Bkz6jJJcg==",
+      "version": "4.0.38",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.38.tgz",
+      "integrity": "sha512-1PUqBbz4WXCSYE1EcKhOdI2H5RgCQjQ9hDpmJc+d7NAcSdAqd1m1IaReCfnlpLBdobpCJUK+oZVGZOkZWePbgQ==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.2.14",
-        "@balena/jellyfish-environment": "^7.0.0",
+        "@balena/jellyfish-assert": "^1.2.15",
+        "@balena/jellyfish-environment": "^7.0.1",
         "@sentry/node": "^6.17.7",
         "errio": "^1.2.2",
         "lodash": "^4.17.21",
@@ -12172,6 +12190,21 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@balena/jellyfish-logger": {
+          "version": "4.0.37",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-4.0.37.tgz",
+          "integrity": "sha512-1hAaQRgVdn2ai2RRYmdamwKFDJ+c8K/wpra/tWDCI04YKXfKs9WWb7JmvSiB3nYQy24zN6S511py1Bkz6jJJcg==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.2.14",
+            "@balena/jellyfish-environment": "^7.0.0",
+            "@sentry/node": "^6.17.7",
+            "errio": "^1.2.2",
+            "lodash": "^4.17.21",
+            "typed-error": "^3.2.1",
+            "winston": "^3.6.0",
+            "winston-transport": "^4.5.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -26,7 +26,7 @@
     "@balena/jellyfish-assert": "^1.2.15",
     "@balena/jellyfish-core": "^14.3.8",
     "@balena/jellyfish-environment": "^7.0.1",
-    "@balena/jellyfish-logger": "^4.0.37",
+    "@balena/jellyfish-logger": "^4.0.38",
     "@balena/jellyfish-metrics": "^2.0.37",
     "@balena/jellyfish-plugin-balena-api": "^2.0.26",
     "@balena/jellyfish-plugin-channels": "^2.0.20",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
