### PR TITLE
UI: Turn the check run graph into a generic component

### DIFF
--- a/apps/ui/lib/lens/common/ContractGraph/index.tsx
+++ b/apps/ui/lib/lens/common/ContractGraph/index.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Mermaid } from 'rendition/dist/extra/Mermaid';
+import { Contract } from '@balena/jellyfish-types/build/core';
+import * as _ from 'lodash';
+
+// Takes an expanded tree of contracts and converts them into a mermaidjs graph.
+// Each node in the graph shows the contracts name or slug and its version.
+const makeGraph = (
+	baseContracts: Contract[],
+	showVersion = false,
+	showType = false,
+) => {
+	const escapeMermaid = (s: string) => `"${s.replace(/"/g, "'")}"`;
+
+	const shorten = (s: string) => (s.length > 16 ? s.substr(0, 20) + '…' : s);
+
+	const formatContract = (contract: Contract) => {
+		const version = showVersion ? `<br/>v${shorten(contract.version)}` : '';
+		const type = showType ? `⟪${contract.type}⟫<br/>` : '';
+		const label = `${type}${contract.name || contract.slug}${version}`;
+		return `${contract.id}(${escapeMermaid(label)})`;
+	};
+
+	const buildGraphCode = (contract: Contract): string[] => {
+		const buf: string[] = [];
+		const contractNodeDeclaration = formatContract(contract);
+		// Always push add the contract to the output, even if it's not connected to anything
+		buf.push(contractNodeDeclaration);
+		_.forEach(contract.links, (nodes, verb) => {
+			for (const output of nodes) {
+				buf.push(
+					`${contractNodeDeclaration} -->|${verb}| ${formatContract(output)}`,
+				);
+				buf.push(...buildGraphCode(output));
+			}
+		});
+
+		buf.push(`click ${contract.id} "/${contract.slug}@${contract.version}"`);
+
+		return buf;
+	};
+
+	const graph = _.concat(
+		['graph TD'],
+		...baseContracts.map((b) => buildGraphCode(b)),
+	).join('\n');
+
+	console.log(graph);
+
+	return graph;
+};
+
+interface Props {
+	contracts: Contract[];
+	showVersion?: boolean;
+	showType?: boolean;
+}
+
+export default function ContractGraph(props: Props) {
+	const { contracts, showVersion, showType } = props;
+	const mermaidInput = makeGraph(contracts, showVersion, showType);
+	return <Mermaid value={mermaidInput} />;
+}

--- a/apps/ui/lib/lens/common/index.ts
+++ b/apps/ui/lib/lens/common/index.ts
@@ -2,3 +2,4 @@ export { default as Segment } from './Segment';
 export { ViewFooter } from './ViewFooter';
 export * from './RelationshipsTab';
 export * from './CustomQueryTab';
+export { default as ContractGraph } from './ContractGraph';

--- a/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
+++ b/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
@@ -8,9 +8,8 @@ import CardFields from '../../../components/CardFields';
 import CardLayout from '../../../layouts/CardLayout';
 import Timeline from '../../list/Timeline';
 import { UI_SCHEMA_MODE } from '../../schema-util';
-import { RelationshipsTab, customQueryTabs } from '../../common';
+import { ContractGraph, RelationshipsTab, customQueryTabs } from '../../common';
 import { sdk } from '../../../core';
-import { Mermaid } from 'rendition/dist/extra/Mermaid';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 
 export const SingleCardTabs = styled(Tabs)`
@@ -27,42 +26,6 @@ export const SingleCardTabs = styled(Tabs)`
 const GRAPH_DEPTH = 3;
 const BUILT_VERB = 'was built into';
 const MERGE_VERB = 'was merged as';
-
-// Takes an expanded tree of contracts and converts them into a mermaidjs graph.
-// Each node in the graph shows the contracts name or slug and its version.
-// TODO: Make this a generic tool
-const makeGraph = (baseContract: Contract) => {
-	const escapeMermaid = (s: string) => `"${s.replace(/"/g, "'")}"`;
-
-	const shorten = (s: string) => (s.length > 16 ? s.substr(0, 20) + '…' : s);
-
-	const formatContract = (contract: Contract) => {
-		const label = `⟪${contract.type}⟫<br/>${
-			contract.name || contract.slug
-		}<br/>v${shorten(contract.version)}`;
-		return `${contract.id}(${escapeMermaid(label)})`;
-	};
-
-	const buildGraphCode = (contract: Contract): string[] => {
-		const buf: string[] = [];
-		_.forEach(contract.links, (nodes, verb) => {
-			for (const output of nodes) {
-				buf.push(
-					`${formatContract(contract)} -->|${verb}| ${formatContract(output)}`,
-				);
-				buf.push(...buildGraphCode(output));
-			}
-		});
-
-		buf.push(`click ${contract.id} "/${contract.slug}@${contract.version}"`);
-
-		return buf;
-	};
-
-	const graph = ['graph TD'].concat(buildGraphCode(baseContract)).join('\n');
-
-	return graph;
-};
 
 const hourInMs = 60 * 60 * 1000;
 
@@ -231,7 +194,11 @@ export default class SingleCardFull extends React.Component<
 							</Txt>
 
 							{!!this.state.tree && (
-								<Mermaid value={makeGraph(this.state.tree)} />
+								<ContractGraph
+									contracts={[this.state.tree]}
+									showVersion
+									showType
+								/>
 							)}
 						</Box>
 					</Tab>


### PR DESCRIPTION
Previously, the check run lens would show a mermaid graph of
a contract's link structure. Since we want this sort of display
elsewhere, this change turns the graph into a re-usable component.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
