### PR TITLE
Fix omnisearch

### DIFF
--- a/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
@@ -487,7 +487,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 					eventSearchFilter: createEventSearchFilter(
 						this.props.types,
 						initialSearchTerm,
-						this.state.tailTypes,
+						tailTypes,
 					),
 					searchFilter: createSearchFilter(tailTypes, initialSearchTerm),
 					searchTerm: initialSearchTerm,

--- a/apps/ui/lib/lens/misc/OmniSearch.tsx
+++ b/apps/ui/lib/lens/misc/OmniSearch.tsx
@@ -69,7 +69,9 @@ const OmniSearchLens = (props) => {
 
 	const lens = getLens('full', omniSearchView, props.user);
 
-	return <lens.data.renderer {...props} channel={channel} />;
+	return (
+		<lens.data.renderer {...props} card={omniSearchView} channel={channel} />
+	);
 };
 
 export default {


### PR DESCRIPTION
Change-type: patch

***

omnisearch was not working, displaying error: `Oh no, Something went wrong!`. In console:

```
TypeError: Cannot read properties of undefined (reading 'allOf')
    at new ViewRenderer (webpack://jellyfish-ui/./lib/lens/full/View/ViewRenderer.tsx_+_1_modules?:155:45)
    at Lg (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:135:171)
    at fi (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:177:149)
    at Rj (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:264:193)
    at Qj (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:247:265)
    at Kj (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:247:194)
    at yj (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:240:172)
    at eval (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:124:115)
    at exports.unstable_runWithPriority (webpack://jellyfish-ui/./node_modules/scheduler/cjs/scheduler.production.min.js?:20:467)
    at cg (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:123:325)
    at fg (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:124:61)
    at gg (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:123:496)
    at Ga (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:288:95)
    at gd (webpack://jellyfish-ui/./node_modules/react-dom/cjs/react-dom.production.min.js?:69:371)
    at HTMLDocument.sentryWrapped (webpack://jellyfish-ui/./node_modules/@sentry/browser/esm/index.js_+_57_modules?:5349:23)
```

The reason is that `card={}` was passed to `ViewRenderer`.