### PR TITLE
Cache svg files

### DIFF
--- a/apps/ui/conf/nginx.conf
+++ b/apps/ui/conf/nginx.conf
@@ -27,7 +27,7 @@ server {
 		add_header Cache-Control "no-store, no-cache, must-revalidate";
 	}
 
-	location ~\.(js|css)$ {
+	location ~\.(js|css|svg)$ {
 		root /usr/share/nginx/html;
 
 		 expires 1y;


### PR DESCRIPTION
Change-type: minor

***

Cache static svg files like `jellyfish.svg` that is displayed while bootstrapping and lazy loading content.
