### PR TITLE
Re-enable deployments

### DIFF
--- a/deploy-templates/deploy.sh
+++ b/deploy-templates/deploy.sh
@@ -40,6 +40,6 @@ KATAPULT_KUBE_CONFIG="$(cat ~/.kube/config)"
 export KATAPULT_KUBE_CONFIG
 
 # deploy with katapult
-#katapult deploy -t kubernetes \
-#  -e jellyfish-product \
-#  -k jellyfish-product/product/"${1}"
+katapult deploy -t kubernetes \
+  -e jellyfish-product \
+  -k jellyfish-product/product/"${1}"


### PR DESCRIPTION
These were temporarily disabled whilst we investigated a production
issue.

Reverts the change originally made here https://github.com/product-os/jellyfish/pull/8046/files

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
