### PR TITLE
Ignore status menu item if no access to user type

### DIFF
--- a/apps/ui/lib/components/UserStatusMenuItem.tsx
+++ b/apps/ui/lib/components/UserStatusMenuItem.tsx
@@ -9,6 +9,10 @@ export default function UserStatusMenuItem({ user, actions, types, ...rest }) {
 	});
 	const userStatusOptions = helpers.getUserStatuses(userType);
 
+	if (!Object.keys(userStatusOptions).length) {
+		return null;
+	}
+
 	const status = _.get(user, ['data', 'status'], userStatusOptions.Available);
 	const isDnd = status.value === userStatusOptions.DoNotDisturb.value;
 	const toggleStatus = () => {


### PR DESCRIPTION
Change-type: patch

***

Can't read user status options when opening top left menu if user does not have access to `user` type and ui breaks.
