### PR TITLE
Remove SAMEORIGIN flag

### DIFF
--- a/apps/ui/conf/nginx.conf
+++ b/apps/ui/conf/nginx.conf
@@ -14,9 +14,6 @@ server {
 	# Remove as much server info as possible without recompiling
 	server_tokens off;
 
-	# Block clickjacking
-	add_header X-Frame-Options SAMEORIGIN;
-
 	# redirect server error pages to the static page /50x.html
 	error_page   500 502 503 504  /50x.html;
 	location = /50x.html {
@@ -43,8 +40,7 @@ server {
 		# Redirect unknown paths to index.html, to allow for paths handled by the UI
 		# to work on initial page load
 		try_files $uri /index.html;
-		# Block clickjacking
-		add_header X-Frame-Options SAMEORIGIN;
+
 		add_header Cache-Control "no-store, no-cache, must-revalidate";
 	}
 }


### PR DESCRIPTION
We are merging ui and livechat, so ui should be embedded inside iframe on dashboard. So, temporarly removing this restriction, until we set it properly to selected hosts.

Change-type: minor
