### PR TITLE
Fix livechat timeline not visible

### DIFF
--- a/apps/ui/lib/index.tsx
+++ b/apps/ui/lib/index.tsx
@@ -128,6 +128,8 @@ ReactDOM.render(
 		widgets={widgets}
 		style={{
 			height: '100%',
+			display: 'flex',
+			flexDirection: 'column',
 			fontSize: 14,
 		}}
 	>


### PR DESCRIPTION
Livechat container is not flex, this causes timeline to have 0 height.

Change-type: patch