### PR TITLE
UI: Add lens for visualizing dependencies between milestones 

### DIFF
--- a/apps/ui/lib/lens/common/ContractGraph/index.tsx
+++ b/apps/ui/lib/lens/common/ContractGraph/index.tsx
@@ -64,7 +64,10 @@ const ContractGraph = (props: Props) => {
 	const mermaidInput = makeGraph(contracts, showVersion, showType);
 	const callbackFunctions = {
 		[ONCLICK_CALLBACK]: (id: string) => {
-			props.history.push(`${props.location.pathname}/${id}`);
+			const { pathname } = props.location;
+			if (_.last(pathname.split('/')) !== id) {
+				props.history.push(`${props.location.pathname}/${id}`);
+			}
 		},
 	};
 	return <Mermaid value={mermaidInput} callbackFunctions={callbackFunctions} />;

--- a/apps/ui/lib/lens/common/LiveCollection/LiveCollection.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/LiveCollection.tsx
@@ -78,21 +78,26 @@ export default class LiveCollection extends React.Component<Props, State> {
 
 	async setupStream() {
 		const { query, user, lens } = this.props;
+		let lenses = this.state.lenses;
 
 		if (query === true) {
 			console.error('Query schema cannot be a boolean value');
 			return;
 		}
 
+		// If there is no active lens set, pick the first of the lens options, as that is what will be used to render the results.
+		const activeLens = lens || _.first(lenses);
+
 		const options = {
 			...this.props.options,
-			..._.get(lens, ['data', 'queryOptions'], {}),
+			..._.get(activeLens, ['data', 'queryOptions'], {}),
 		};
 
 		const maskedQuery =
 			options.mask && typeof options.mask === 'function'
 				? options.mask(clone(query))
 				: query;
+
 		const cursor = sdk.getCursor(maskedQuery, _.omit(options, 'mask'));
 		this.cursor = cursor;
 
@@ -100,7 +105,6 @@ export default class LiveCollection extends React.Component<Props, State> {
 
 		// With the full result set we can now get a more accurate set of lenses
 		// but only if there wee items returned (otherwise we stick to the ones found with the mock data set)
-		let lenses = this.state.lenses;
 		if (results.length > 0) {
 			const { getLenses } = require('../../');
 			lenses = getLenses('list', results, user, 'data.icon');

--- a/apps/ui/lib/lens/common/LiveCollection/LiveCollection.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/LiveCollection.tsx
@@ -46,7 +46,7 @@ export default class LiveCollection extends React.Component<Props, State> {
 	}
 
 	componentDidMount() {
-		this.setupStream();
+		this.setupStream().catch(console.error);
 	}
 
 	componentWillUnmount() {
@@ -66,7 +66,7 @@ export default class LiveCollection extends React.Component<Props, State> {
 				this.setState({ results: null });
 				this.cursor = null;
 			}
-			this.setupStream();
+			this.setupStream().catch(console.error);
 		}
 		if (
 			this.props.onResultsChange &&

--- a/apps/ui/lib/lens/misc/MilestoneGraph/MilestoneGraph.tsx
+++ b/apps/ui/lib/lens/misc/MilestoneGraph/MilestoneGraph.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Flex } from 'rendition';
+import { Mermaid } from 'rendition/dist/extra/Mermaid';
+import { Contract } from '@balena/jellyfish-types/build/core';
+import * as _ from 'lodash';
+import { LensRendererProps } from '../../../types';
+import { ContractGraph } from '../../common';
+
+export type Props = LensRendererProps;
+
+export default class MilestoneGraph extends React.Component<Props> {
+	render() {
+		const { channel, tail } = this.props;
+		if (!tail) {
+			return null;
+		}
+		const contracts = tail.slice();
+		// If the head contract is also a milestone, include it in the ouput
+		if (
+			channel.data.head &&
+			channel.data.head.type.split('@')[0] === 'milestone'
+		) {
+			contracts.push(channel.data.head);
+		}
+
+		if (contracts.length === 0) {
+			return null;
+		}
+
+		// We're only interesting in displaying the "is required by" links
+		const processedContracts = contracts.map((t) => {
+			return {
+				...t,
+				links: {
+					['is required by']: t.links?.['is required by'] || [],
+				},
+			};
+		});
+		console.log(processedContracts);
+		return (
+			<Flex justifyContent="center" py={2}>
+				<ContractGraph contracts={processedContracts} />
+			</Flex>
+		);
+	}
+}

--- a/apps/ui/lib/lens/misc/MilestoneGraph/index.ts
+++ b/apps/ui/lib/lens/misc/MilestoneGraph/index.ts
@@ -1,0 +1,66 @@
+import _ from 'lodash';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { createLazyComponent } from '../../../components/SafeLazy';
+import { actionCreators, selectors } from '../../../core';
+import { LensContract } from '../../../types';
+
+const LensRenderer = createLazyComponent(
+	() =>
+		import(/* webpackChunkName: "lens-contract-table" */ './MilestoneGraph'),
+);
+
+const lens: LensContract = {
+	slug: 'lens-milestone-graph',
+	type: 'lens',
+	version: '1.0.0',
+	name: 'Graph of milestone dependencies',
+	data: {
+		renderer: LensRenderer,
+		label: 'Milestone graph',
+		icon: 'project-diagram',
+		format: 'list',
+		type: '*',
+		filter: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					type: {
+						type: 'string',
+						const: 'milestone@1.0.0',
+					},
+					slug: {
+						type: 'string',
+					},
+				},
+			},
+		},
+		queryOptions: {
+			mask: (query: any) => {
+				if (query.anyOf) {
+					query.anyOf.push({
+						$$links: {
+							'is required by': {
+								type: 'object',
+								properties: {
+									type: {
+										const: 'milestone@1.0.0',
+									},
+								},
+							},
+						},
+					});
+
+					if (!_.some(query.anyOf, _.isBoolean)) {
+						query.anyOf.push(true);
+					}
+				}
+
+				return query;
+			},
+		},
+	},
+};
+
+export default lens;

--- a/apps/ui/lib/lens/misc/index.ts
+++ b/apps/ui/lib/lens/misc/index.ts
@@ -1,8 +1,17 @@
-import Kanban from './Kanban';
-import Table from './Table';
 import CRMTable from './CRMTable';
 import Chart from './Chart';
 import Inbox from './Inbox';
+import Kanban from './Kanban';
+import MilestoneGraph from './MilestoneGraph';
 import OmniSearch from './OmniSearch';
+import Table from './Table';
 
-export default [Kanban, Table, CRMTable, Chart, Inbox, OmniSearch];
+export default [
+	CRMTable,
+	Chart,
+	Inbox,
+	Kanban,
+	MilestoneGraph,
+	OmniSearch,
+	Table,
+];

--- a/apps/ui/lib/types.ts
+++ b/apps/ui/lib/types.ts
@@ -38,7 +38,7 @@ export interface LensContract
 		format: 'list' | 'full' | 'summary' | 'snippet';
 		renderer: React.ComponentType<LensRendererProps>;
 		filter: JsonSchema;
-		queryOptions: {
+		queryOptions?: {
 			limit?: number;
 			sortBy?: string;
 			sortDir?: 'asc' | 'desc';


### PR DESCRIPTION
Adds a lens that will display milestones in a mermaid graph, connected
with the `depends on` link.

Fixes https://github.com/product-os/jellyfish/issues/7901

![image](https://user-images.githubusercontent.com/15064535/156355483-83e30931-a6a8-4b5f-8706-bc2461a5527d.png)


Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>