### PR TITLE
Do not show update confirmation popup if inside iframe

### DIFF
--- a/apps/ui/lib/pwa.ts
+++ b/apps/ui/lib/pwa.ts
@@ -32,6 +32,7 @@ export default class PWA {
 				this.wb.addEventListener('waiting', (event) => {
 					// eslint-disable-next-line no-alert
 					if (
+						!window.frameElement &&
 						window.confirm('New version of Jellyfish available. Update now?')
 					) {
 						// Set up a listener that will reload the page as soon as the previously waiting


### PR DESCRIPTION
Native `confirm` is used to ask for update confirmation, which is confusing for parent window users (balena users).

Change-type: minor

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
