### PR TITLE
Redirect livechat.ly.fish to jel.ly.fish

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -57,7 +57,7 @@ backend livechat_backend
 mode http
 option forwardfor
 balance roundrobin
-server livechat livechat:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
+server livechat ui:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
 
 backend api_backend
 mode http


### PR DESCRIPTION
Support widget will be loaded in iframe with `livechat.ly.fish` in order to have isolated localStorage.

Change-type: minor
