### PR TITLE
Update @balena/jellyfish-plugin-typeform from 5.0.26 to 5.0.27

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-github": "^2.1.27",
         "@balena/jellyfish-plugin-outreach": "^2.0.35",
         "@balena/jellyfish-plugin-product-os": "^4.0.30",
-        "@balena/jellyfish-plugin-typeform": "^5.0.26",
+        "@balena/jellyfish-plugin-typeform": "^5.0.27",
         "@balena/jellyfish-queue": "^4.1.10",
         "@balena/jellyfish-worker": "^19.0.2",
         "@balena/socket-prometheus-metrics": "^0.0.3",
@@ -1189,11 +1189,11 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-typeform": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.26.tgz",
-      "integrity": "sha512-rQ1rndKWdYgWMLPAKX1P1lHwjqWdyKdQK58jW5DAdMEA6t/EC0wLWtO+3zIWUaemHSEqyBz5sGZ5J2oywJkiJQ==",
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.27.tgz",
+      "integrity": "sha512-E9RRueq6W7JbHoMyyeQ3N7l2kGb5cKGuXTYQB5qHexXIMmIhLTGYWZuHvXLGdxnHsu79jfSJLdb0B8I2YWrYuQ==",
       "dependencies": {
-        "@balena/jellyfish-worker": "^19.0.2",
+        "@balena/jellyfish-worker": "^19.0.3",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -1266,12 +1266,12 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.2.tgz",
-      "integrity": "sha512-r3qSyJ90QOavgcGcfP32LQyQFOBpWIACvdiZ7+dsTNxJ2ns0OZE28pGXs9tEfOXPQ5CA9z2kEyMR5/4R4lmDqA==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.3.tgz",
+      "integrity": "sha512-LpyWXCThnKV4vQ4ceFaQhbS2CT8NklT0k1oKsXAV34HGEkWLBwtAthdD3aOilHhdtkP99+Z0PTSbgjpZ8Z/PJQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.16",
-        "@balena/jellyfish-core": "^15.1.0",
+        "@balena/jellyfish-core": "^16.0.0",
         "@balena/jellyfish-jellyscript": "^5.1.43",
         "@balena/jellyfish-logger": "^5.0.2",
         "@balena/jellyfish-queue": "^4.1.10",
@@ -1296,43 +1296,6 @@
       "engines": {
         "node": ">=14.2.0"
       }
-    },
-    "node_modules/@balena/jellyfish-worker/node_modules/@balena/jellyfish-core": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-15.1.0.tgz",
-      "integrity": "sha512-HcD7TleN7djGo/8vSN5OglWG5YLlN2roiiDUtwTcm122m+m8mZlquq32eipzQiRMNsHcJoc+DYhQ6FUv/G92wA==",
-      "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.16",
-        "@balena/jellyfish-environment": "^9.1.1",
-        "@balena/jellyfish-logger": "^5.0.1",
-        "@balena/jellyfish-metrics": "^2.0.42",
-        "bluebird": "^3.7.2",
-        "fast-equals": "^2.0.4",
-        "fast-json-patch": "^3.1.0",
-        "json-e": "^4.4.3",
-        "json-schema": "^0.4.0",
-        "json-schema-deref-sync": "^0.14.0",
-        "lodash": "^4.17.21",
-        "pg": "^8.7.3",
-        "pg-format": "^1.0.4",
-        "redis": "^4.0.4",
-        "redis-mock": "^0.56.3",
-        "semver": "^7.3.5",
-        "skhema": "^6.0.3",
-        "stopword": "^1.0.11",
-        "traverse": "^0.6.6",
-        "typed-error": "^3.2.1",
-        "uuid": "^8.3.2",
-        "uuid-v4-regex": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=14.2.0"
-      }
-    },
-    "node_modules/@balena/jellyfish-worker/node_modules/@balena/jellyfish-core/node_modules/fast-equals": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
-      "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
     },
     "node_modules/@balena/jellyfish-worker/node_modules/fast-equals": {
       "version": "3.0.0",
@@ -13521,11 +13484,11 @@
       }
     },
     "@balena/jellyfish-plugin-typeform": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.26.tgz",
-      "integrity": "sha512-rQ1rndKWdYgWMLPAKX1P1lHwjqWdyKdQK58jW5DAdMEA6t/EC0wLWtO+3zIWUaemHSEqyBz5sGZ5J2oywJkiJQ==",
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.27.tgz",
+      "integrity": "sha512-E9RRueq6W7JbHoMyyeQ3N7l2kGb5cKGuXTYQB5qHexXIMmIhLTGYWZuHvXLGdxnHsu79jfSJLdb0B8I2YWrYuQ==",
       "requires": {
-        "@balena/jellyfish-worker": "^19.0.2",
+        "@balena/jellyfish-worker": "^19.0.3",
         "lodash": "^4.17.21"
       }
     },
@@ -13588,12 +13551,12 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.2.tgz",
-      "integrity": "sha512-r3qSyJ90QOavgcGcfP32LQyQFOBpWIACvdiZ7+dsTNxJ2ns0OZE28pGXs9tEfOXPQ5CA9z2kEyMR5/4R4lmDqA==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.3.tgz",
+      "integrity": "sha512-LpyWXCThnKV4vQ4ceFaQhbS2CT8NklT0k1oKsXAV34HGEkWLBwtAthdD3aOilHhdtkP99+Z0PTSbgjpZ8Z/PJQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.16",
-        "@balena/jellyfish-core": "^15.1.0",
+        "@balena/jellyfish-core": "^16.0.0",
         "@balena/jellyfish-jellyscript": "^5.1.43",
         "@balena/jellyfish-logger": "^5.0.2",
         "@balena/jellyfish-queue": "^4.1.10",
@@ -13616,42 +13579,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@balena/jellyfish-core": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-15.1.0.tgz",
-          "integrity": "sha512-HcD7TleN7djGo/8vSN5OglWG5YLlN2roiiDUtwTcm122m+m8mZlquq32eipzQiRMNsHcJoc+DYhQ6FUv/G92wA==",
-          "requires": {
-            "@balena/jellyfish-assert": "^1.2.16",
-            "@balena/jellyfish-environment": "^9.1.1",
-            "@balena/jellyfish-logger": "^5.0.1",
-            "@balena/jellyfish-metrics": "^2.0.42",
-            "bluebird": "^3.7.2",
-            "fast-equals": "^2.0.4",
-            "fast-json-patch": "^3.1.0",
-            "json-e": "^4.4.3",
-            "json-schema": "^0.4.0",
-            "json-schema-deref-sync": "^0.14.0",
-            "lodash": "^4.17.21",
-            "pg": "^8.7.3",
-            "pg-format": "^1.0.4",
-            "redis": "^4.0.4",
-            "redis-mock": "^0.56.3",
-            "semver": "^7.3.5",
-            "skhema": "^6.0.3",
-            "stopword": "^1.0.11",
-            "traverse": "^0.6.6",
-            "typed-error": "^3.2.1",
-            "uuid": "^8.3.2",
-            "uuid-v4-regex": "^1.0.2"
-          },
-          "dependencies": {
-            "fast-equals": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
-              "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
-            }
-          }
-        },
         "fast-equals": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-3.0.0.tgz",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,7 +37,7 @@
     "@balena/jellyfish-plugin-github": "^2.1.27",
     "@balena/jellyfish-plugin-outreach": "^2.0.35",
     "@balena/jellyfish-plugin-product-os": "^4.0.30",
-    "@balena/jellyfish-plugin-typeform": "^5.0.26",
+    "@balena/jellyfish-plugin-typeform": "^5.0.27",
     "@balena/jellyfish-queue": "^4.1.10",
     "@balena/jellyfish-worker": "^19.0.2",
     "@balena/socket-prometheus-metrics": "^0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@balena/jellyfish-plugin-github": "^2.1.27",
         "@balena/jellyfish-plugin-outreach": "^2.0.35",
         "@balena/jellyfish-plugin-product-os": "^4.0.30",
-        "@balena/jellyfish-plugin-typeform": "^5.0.26",
+        "@balena/jellyfish-plugin-typeform": "^5.0.27",
         "@balena/jellyfish-queue": "^4.1.10",
         "@balena/jellyfish-ui-components": "^15.0.1",
         "@balena/jellyfish-worker": "^19.0.2",
@@ -1522,12 +1522,12 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-typeform": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.26.tgz",
-      "integrity": "sha512-rQ1rndKWdYgWMLPAKX1P1lHwjqWdyKdQK58jW5DAdMEA6t/EC0wLWtO+3zIWUaemHSEqyBz5sGZ5J2oywJkiJQ==",
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.27.tgz",
+      "integrity": "sha512-E9RRueq6W7JbHoMyyeQ3N7l2kGb5cKGuXTYQB5qHexXIMmIhLTGYWZuHvXLGdxnHsu79jfSJLdb0B8I2YWrYuQ==",
       "dev": true,
       "dependencies": {
-        "@balena/jellyfish-worker": "^19.0.2",
+        "@balena/jellyfish-worker": "^19.0.3",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -1676,13 +1676,13 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.2.tgz",
-      "integrity": "sha512-r3qSyJ90QOavgcGcfP32LQyQFOBpWIACvdiZ7+dsTNxJ2ns0OZE28pGXs9tEfOXPQ5CA9z2kEyMR5/4R4lmDqA==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.3.tgz",
+      "integrity": "sha512-LpyWXCThnKV4vQ4ceFaQhbS2CT8NklT0k1oKsXAV34HGEkWLBwtAthdD3aOilHhdtkP99+Z0PTSbgjpZ8Z/PJQ==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.16",
-        "@balena/jellyfish-core": "^15.1.0",
+        "@balena/jellyfish-core": "^16.0.0",
         "@balena/jellyfish-jellyscript": "^5.1.43",
         "@balena/jellyfish-logger": "^5.0.2",
         "@balena/jellyfish-queue": "^4.1.10",
@@ -1707,45 +1707,6 @@
       "engines": {
         "node": ">=14.2.0"
       }
-    },
-    "node_modules/@balena/jellyfish-worker/node_modules/@balena/jellyfish-core": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-15.1.0.tgz",
-      "integrity": "sha512-HcD7TleN7djGo/8vSN5OglWG5YLlN2roiiDUtwTcm122m+m8mZlquq32eipzQiRMNsHcJoc+DYhQ6FUv/G92wA==",
-      "dev": true,
-      "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.16",
-        "@balena/jellyfish-environment": "^9.1.1",
-        "@balena/jellyfish-logger": "^5.0.1",
-        "@balena/jellyfish-metrics": "^2.0.42",
-        "bluebird": "^3.7.2",
-        "fast-equals": "^2.0.4",
-        "fast-json-patch": "^3.1.0",
-        "json-e": "^4.4.3",
-        "json-schema": "^0.4.0",
-        "json-schema-deref-sync": "^0.14.0",
-        "lodash": "^4.17.21",
-        "pg": "^8.7.3",
-        "pg-format": "^1.0.4",
-        "redis": "^4.0.4",
-        "redis-mock": "^0.56.3",
-        "semver": "^7.3.5",
-        "skhema": "^6.0.3",
-        "stopword": "^1.0.11",
-        "traverse": "^0.6.6",
-        "typed-error": "^3.2.1",
-        "uuid": "^8.3.2",
-        "uuid-v4-regex": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=14.2.0"
-      }
-    },
-    "node_modules/@balena/jellyfish-worker/node_modules/@balena/jellyfish-core/node_modules/fast-equals": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
-      "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==",
-      "dev": true
     },
     "node_modules/@balena/jellyfish-worker/node_modules/fast-equals": {
       "version": "3.0.0",
@@ -17843,12 +17804,12 @@
       }
     },
     "@balena/jellyfish-plugin-typeform": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.26.tgz",
-      "integrity": "sha512-rQ1rndKWdYgWMLPAKX1P1lHwjqWdyKdQK58jW5DAdMEA6t/EC0wLWtO+3zIWUaemHSEqyBz5sGZ5J2oywJkiJQ==",
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-typeform/-/jellyfish-plugin-typeform-5.0.27.tgz",
+      "integrity": "sha512-E9RRueq6W7JbHoMyyeQ3N7l2kGb5cKGuXTYQB5qHexXIMmIhLTGYWZuHvXLGdxnHsu79jfSJLdb0B8I2YWrYuQ==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-worker": "^19.0.2",
+        "@balena/jellyfish-worker": "^19.0.3",
         "lodash": "^4.17.21"
       }
     },
@@ -17980,13 +17941,13 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.2.tgz",
-      "integrity": "sha512-r3qSyJ90QOavgcGcfP32LQyQFOBpWIACvdiZ7+dsTNxJ2ns0OZE28pGXs9tEfOXPQ5CA9z2kEyMR5/4R4lmDqA==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-19.0.3.tgz",
+      "integrity": "sha512-LpyWXCThnKV4vQ4ceFaQhbS2CT8NklT0k1oKsXAV34HGEkWLBwtAthdD3aOilHhdtkP99+Z0PTSbgjpZ8Z/PJQ==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.16",
-        "@balena/jellyfish-core": "^15.1.0",
+        "@balena/jellyfish-core": "^16.0.0",
         "@balena/jellyfish-jellyscript": "^5.1.43",
         "@balena/jellyfish-logger": "^5.0.2",
         "@balena/jellyfish-queue": "^4.1.10",
@@ -18009,44 +17970,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@balena/jellyfish-core": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-15.1.0.tgz",
-          "integrity": "sha512-HcD7TleN7djGo/8vSN5OglWG5YLlN2roiiDUtwTcm122m+m8mZlquq32eipzQiRMNsHcJoc+DYhQ6FUv/G92wA==",
-          "dev": true,
-          "requires": {
-            "@balena/jellyfish-assert": "^1.2.16",
-            "@balena/jellyfish-environment": "^9.1.1",
-            "@balena/jellyfish-logger": "^5.0.1",
-            "@balena/jellyfish-metrics": "^2.0.42",
-            "bluebird": "^3.7.2",
-            "fast-equals": "^2.0.4",
-            "fast-json-patch": "^3.1.0",
-            "json-e": "^4.4.3",
-            "json-schema": "^0.4.0",
-            "json-schema-deref-sync": "^0.14.0",
-            "lodash": "^4.17.21",
-            "pg": "^8.7.3",
-            "pg-format": "^1.0.4",
-            "redis": "^4.0.4",
-            "redis-mock": "^0.56.3",
-            "semver": "^7.3.5",
-            "skhema": "^6.0.3",
-            "stopword": "^1.0.11",
-            "traverse": "^0.6.6",
-            "typed-error": "^3.2.1",
-            "uuid": "^8.3.2",
-            "uuid-v4-regex": "^1.0.2"
-          },
-          "dependencies": {
-            "fast-equals": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
-              "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==",
-              "dev": true
-            }
-          }
-        },
         "fast-equals": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@balena/jellyfish-plugin-github": "^2.1.27",
     "@balena/jellyfish-plugin-outreach": "^2.0.35",
     "@balena/jellyfish-plugin-product-os": "^4.0.30",
-    "@balena/jellyfish-plugin-typeform": "^5.0.26",
+    "@balena/jellyfish-plugin-typeform": "^5.0.27",
     "@balena/jellyfish-queue": "^4.1.10",
     "@balena/jellyfish-ui-components": "^15.0.1",
     "@balena/jellyfish-worker": "^19.0.2",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
