### PR TITLE
Update @balena/jellyfish-plugin-discourse from 2.0.58 to 2.1.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -17,7 +17,7 @@
         "@balena/jellyfish-plugin-balena-api": "^2.0.39",
         "@balena/jellyfish-plugin-channels": "^2.0.42",
         "@balena/jellyfish-plugin-default": "^23.3.26",
-        "@balena/jellyfish-plugin-discourse": "^2.0.58",
+        "@balena/jellyfish-plugin-discourse": "^2.1.0",
         "@balena/jellyfish-plugin-flowdock": "^2.0.39",
         "@balena/jellyfish-plugin-front": "^2.0.63",
         "@balena/jellyfish-plugin-github": "^2.1.39",
@@ -959,9 +959,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-discourse": {
-      "version": "2.0.58",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.0.58.tgz",
-      "integrity": "sha512-bJW4s1PGyWXJsjk8Cir1kpiAIbWh8Zfu6Gqyb+1L7ICwuwbIl6sLknSUOq6Qv1daGpDJUQbvvIymzTpSKCgZJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.1.0.tgz",
+      "integrity": "sha512-36xkd83DpCqA0Mw78CMm491v835YN4IZaQwracE64yqs2jp29lAwpzuiLEG2Ou1jGCHwOv9sC5fqd3QDJmS0aw==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.17",
         "@balena/jellyfish-core": "^16.0.3",
@@ -13116,9 +13116,9 @@
       }
     },
     "@balena/jellyfish-plugin-discourse": {
-      "version": "2.0.58",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.0.58.tgz",
-      "integrity": "sha512-bJW4s1PGyWXJsjk8Cir1kpiAIbWh8Zfu6Gqyb+1L7ICwuwbIl6sLknSUOq6Qv1daGpDJUQbvvIymzTpSKCgZJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.1.0.tgz",
+      "integrity": "sha512-36xkd83DpCqA0Mw78CMm491v835YN4IZaQwracE64yqs2jp29lAwpzuiLEG2Ou1jGCHwOv9sC5fqd3QDJmS0aw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.17",
         "@balena/jellyfish-core": "^16.0.3",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@balena/jellyfish-plugin-balena-api": "^2.0.39",
     "@balena/jellyfish-plugin-channels": "^2.0.42",
     "@balena/jellyfish-plugin-default": "^23.3.26",
-    "@balena/jellyfish-plugin-discourse": "^2.0.58",
+    "@balena/jellyfish-plugin-discourse": "^2.1.0",
     "@balena/jellyfish-plugin-flowdock": "^2.0.39",
     "@balena/jellyfish-plugin-front": "^2.0.63",
     "@balena/jellyfish-plugin-github": "^2.1.39",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@balena/jellyfish-plugin-balena-api": "^2.0.39",
         "@balena/jellyfish-plugin-channels": "^2.0.42",
         "@balena/jellyfish-plugin-default": "^23.3.26",
-        "@balena/jellyfish-plugin-discourse": "^2.0.58",
+        "@balena/jellyfish-plugin-discourse": "^2.1.0",
         "@balena/jellyfish-plugin-flowdock": "^2.0.39",
         "@balena/jellyfish-plugin-front": "^2.0.63",
         "@balena/jellyfish-plugin-github": "^2.1.39",
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-discourse": {
-      "version": "2.0.58",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.0.58.tgz",
-      "integrity": "sha512-bJW4s1PGyWXJsjk8Cir1kpiAIbWh8Zfu6Gqyb+1L7ICwuwbIl6sLknSUOq6Qv1daGpDJUQbvvIymzTpSKCgZJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.1.0.tgz",
+      "integrity": "sha512-36xkd83DpCqA0Mw78CMm491v835YN4IZaQwracE64yqs2jp29lAwpzuiLEG2Ou1jGCHwOv9sC5fqd3QDJmS0aw==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.17",
@@ -17421,9 +17421,9 @@
       }
     },
     "@balena/jellyfish-plugin-discourse": {
-      "version": "2.0.58",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.0.58.tgz",
-      "integrity": "sha512-bJW4s1PGyWXJsjk8Cir1kpiAIbWh8Zfu6Gqyb+1L7ICwuwbIl6sLknSUOq6Qv1daGpDJUQbvvIymzTpSKCgZJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.1.0.tgz",
+      "integrity": "sha512-36xkd83DpCqA0Mw78CMm491v835YN4IZaQwracE64yqs2jp29lAwpzuiLEG2Ou1jGCHwOv9sC5fqd3QDJmS0aw==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.17",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@balena/jellyfish-plugin-balena-api": "^2.0.39",
     "@balena/jellyfish-plugin-channels": "^2.0.42",
     "@balena/jellyfish-plugin-default": "^23.3.26",
-    "@balena/jellyfish-plugin-discourse": "^2.0.58",
+    "@balena/jellyfish-plugin-discourse": "^2.1.0",
     "@balena/jellyfish-plugin-flowdock": "^2.0.39",
     "@balena/jellyfish-plugin-front": "^2.0.63",
     "@balena/jellyfish-plugin-github": "^2.1.39",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
