### PR TITLE
Update @balena/jellyfish-plugin-discourse from 2.2.0 to 2.2.1

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -17,7 +17,7 @@
         "@balena/jellyfish-plugin-balena-api": "^2.0.40",
         "@balena/jellyfish-plugin-channels": "^2.0.43",
         "@balena/jellyfish-plugin-default": "^24.0.0",
-        "@balena/jellyfish-plugin-discourse": "^2.2.0",
+        "@balena/jellyfish-plugin-discourse": "^2.2.1",
         "@balena/jellyfish-plugin-flowdock": "^2.0.41",
         "@balena/jellyfish-plugin-front": "^2.0.64",
         "@balena/jellyfish-plugin-github": "^2.1.40",
@@ -836,9 +836,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-discourse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.0.tgz",
-      "integrity": "sha512-kfFtv3ZptTVDms5CF5YFMvN60HMFNp784Ka/5xcoJfFoElcty8dgzU5LRA03M3cyZQ9EWdLiyXcTnIv3rvptpA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.1.tgz",
+      "integrity": "sha512-4t7kAwyLV3NZimhLAQgQ3/8JSzDQWCm+NNSuE3ohfmTNAs8zU16I5Dj/CHOxAz+bntFIuD9a83U62pzK35q06A==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.17",
         "@balena/jellyfish-core": "^16.0.5",
@@ -12879,9 +12879,9 @@
       }
     },
     "@balena/jellyfish-plugin-discourse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.0.tgz",
-      "integrity": "sha512-kfFtv3ZptTVDms5CF5YFMvN60HMFNp784Ka/5xcoJfFoElcty8dgzU5LRA03M3cyZQ9EWdLiyXcTnIv3rvptpA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.1.tgz",
+      "integrity": "sha512-4t7kAwyLV3NZimhLAQgQ3/8JSzDQWCm+NNSuE3ohfmTNAs8zU16I5Dj/CHOxAz+bntFIuD9a83U62pzK35q06A==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.17",
         "@balena/jellyfish-core": "^16.0.5",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@balena/jellyfish-plugin-balena-api": "^2.0.40",
     "@balena/jellyfish-plugin-channels": "^2.0.43",
     "@balena/jellyfish-plugin-default": "^24.0.0",
-    "@balena/jellyfish-plugin-discourse": "^2.2.0",
+    "@balena/jellyfish-plugin-discourse": "^2.2.1",
     "@balena/jellyfish-plugin-flowdock": "^2.0.41",
     "@balena/jellyfish-plugin-front": "^2.0.64",
     "@balena/jellyfish-plugin-github": "^2.1.40",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@balena/jellyfish-plugin-balena-api": "^2.0.40",
         "@balena/jellyfish-plugin-channels": "^2.0.43",
         "@balena/jellyfish-plugin-default": "^24.0.0",
-        "@balena/jellyfish-plugin-discourse": "^2.2.0",
+        "@balena/jellyfish-plugin-discourse": "^2.2.1",
         "@balena/jellyfish-plugin-flowdock": "^2.0.41",
         "@balena/jellyfish-plugin-front": "^2.0.64",
         "@balena/jellyfish-plugin-github": "^2.1.40",
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-discourse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.0.tgz",
-      "integrity": "sha512-kfFtv3ZptTVDms5CF5YFMvN60HMFNp784Ka/5xcoJfFoElcty8dgzU5LRA03M3cyZQ9EWdLiyXcTnIv3rvptpA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.1.tgz",
+      "integrity": "sha512-4t7kAwyLV3NZimhLAQgQ3/8JSzDQWCm+NNSuE3ohfmTNAs8zU16I5Dj/CHOxAz+bntFIuD9a83U62pzK35q06A==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.17",
@@ -17172,9 +17172,9 @@
       }
     },
     "@balena/jellyfish-plugin-discourse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.0.tgz",
-      "integrity": "sha512-kfFtv3ZptTVDms5CF5YFMvN60HMFNp784Ka/5xcoJfFoElcty8dgzU5LRA03M3cyZQ9EWdLiyXcTnIv3rvptpA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-2.2.1.tgz",
+      "integrity": "sha512-4t7kAwyLV3NZimhLAQgQ3/8JSzDQWCm+NNSuE3ohfmTNAs8zU16I5Dj/CHOxAz+bntFIuD9a83U62pzK35q06A==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.17",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@balena/jellyfish-plugin-balena-api": "^2.0.40",
     "@balena/jellyfish-plugin-channels": "^2.0.43",
     "@balena/jellyfish-plugin-default": "^24.0.0",
-    "@balena/jellyfish-plugin-discourse": "^2.2.0",
+    "@balena/jellyfish-plugin-discourse": "^2.2.1",
     "@balena/jellyfish-plugin-flowdock": "^2.0.41",
     "@balena/jellyfish-plugin-front": "^2.0.64",
     "@balena/jellyfish-plugin-github": "^2.1.40",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
