### PR TITLE
Remove use of $events keyword in formulas

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.18",
-        "@balena/jellyfish-core": "^16.0.7",
+        "@balena/jellyfish-core": "^16.0.10",
         "@balena/jellyfish-environment": "^9.1.3",
         "@balena/jellyfish-logger": "^5.0.6",
         "@balena/jellyfish-metrics": "^2.0.47",
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@balena/jellyfish-core": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.7.tgz",
-      "integrity": "sha512-z0NR1JjgRRFl49LKQP090LN49A/aTQC4A1MhgSwuPHQXnW8zadDojugvSzdleF0fMnyh0obbSL3OErTy/Gi4qA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.10.tgz",
+      "integrity": "sha512-Z8F/wjgpbRI2/+T/JKQYdQXxRq+9a1Td9299nscASfPNYZfiufybt5oAvsSz9fOVkrLWANUv6Hc7Ez/ejeULjQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.18",
         "@balena/jellyfish-environment": "^9.1.3",
@@ -12769,9 +12769,9 @@
       "requires": {}
     },
     "@balena/jellyfish-core": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.7.tgz",
-      "integrity": "sha512-z0NR1JjgRRFl49LKQP090LN49A/aTQC4A1MhgSwuPHQXnW8zadDojugvSzdleF0fMnyh0obbSL3OErTy/Gi4qA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.10.tgz",
+      "integrity": "sha512-Z8F/wjgpbRI2/+T/JKQYdQXxRq+9a1Td9299nscASfPNYZfiufybt5oAvsSz9fOVkrLWANUv6Hc7Ez/ejeULjQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.18",
         "@balena/jellyfish-environment": "^9.1.3",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.18",
-    "@balena/jellyfish-core": "^16.0.7",
+    "@balena/jellyfish-core": "^16.0.10",
     "@balena/jellyfish-environment": "^9.1.3",
     "@balena/jellyfish-logger": "^5.0.6",
     "@balena/jellyfish-metrics": "^2.0.47",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@balena/jellyfish-chat-widget": "^14.0.10",
         "@balena/jellyfish-client-sdk": "^10.1.8",
         "@balena/jellyfish-config": "^2.0.2",
-        "@balena/jellyfish-core": "^16.0.7",
+        "@balena/jellyfish-core": "^16.0.10",
         "@balena/jellyfish-environment": "^9.1.3",
         "@balena/jellyfish-plugin-balena-api": "^2.0.44",
         "@balena/jellyfish-plugin-channels": "^2.0.46",
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/@balena/jellyfish-core": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.7.tgz",
-      "integrity": "sha512-z0NR1JjgRRFl49LKQP090LN49A/aTQC4A1MhgSwuPHQXnW8zadDojugvSzdleF0fMnyh0obbSL3OErTy/Gi4qA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.10.tgz",
+      "integrity": "sha512-Z8F/wjgpbRI2/+T/JKQYdQXxRq+9a1Td9299nscASfPNYZfiufybt5oAvsSz9fOVkrLWANUv6Hc7Ez/ejeULjQ==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.18",
@@ -17033,9 +17033,9 @@
       "requires": {}
     },
     "@balena/jellyfish-core": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.7.tgz",
-      "integrity": "sha512-z0NR1JjgRRFl49LKQP090LN49A/aTQC4A1MhgSwuPHQXnW8zadDojugvSzdleF0fMnyh0obbSL3OErTy/Gi4qA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-16.0.10.tgz",
+      "integrity": "sha512-Z8F/wjgpbRI2/+T/JKQYdQXxRq+9a1Td9299nscASfPNYZfiufybt5oAvsSz9fOVkrLWANUv6Hc7Ez/ejeULjQ==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.18",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@balena/jellyfish-chat-widget": "^14.0.10",
     "@balena/jellyfish-client-sdk": "^10.1.8",
     "@balena/jellyfish-config": "^2.0.2",
-    "@balena/jellyfish-core": "^16.0.7",
+    "@balena/jellyfish-core": "^16.0.10",
     "@balena/jellyfish-environment": "^9.1.3",
     "@balena/jellyfish-plugin-balena-api": "^2.0.44",
     "@balena/jellyfish-plugin-channels": "^2.0.46",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
