### PR TITLE
UI: Add heuristic to improve performance of OmniSearch

### DIFF
--- a/apps/ui/lib/lens/misc/OmniSearch.tsx
+++ b/apps/ui/lib/lens/misc/OmniSearch.tsx
@@ -40,6 +40,7 @@ const generateOmniSearchView = memoize((typeSlugs: string[]) => {
 				{
 					name: 'Search',
 					schema: {
+						$id: 'omnisearch',
 						type: 'object',
 						required: ['type'],
 						properties: {


### PR DESCRIPTION
This adds certain heuristics to OmniSearch to remove the potential for
the queries it generates to cause massive DB consumption on our RDS
based system. In experiments we found that the base enum used on the
virtual omnisearch view caused huge slowdown and stability issues, and
to a lesser extent the timeline search also cause problems.
With this change, omnisearch will no longer look for results in
a contracts timeline.
This is not the ideal solution, but will buy us time whilst we do
further investigation into why the query planning is so poor for this
request.
See http://localhost:8080/pattern-omnisearch-causes-massive-db-memory-consumption-8022ce1

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
