### PR TITLE
UI: Optimize query for number of linked contracts

### DIFF
--- a/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.spec.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.spec.tsx
@@ -1,32 +1,5 @@
-import { getWrapper } from '../../../../test/ui-setup';
-import sinon from 'sinon';
-import React from 'react';
 import _ from 'lodash';
-import { mount } from 'enzyme';
-import { RelationshipsTab, getRelationships } from './RelationshipsTab';
-
-const wrappingComponent = getWrapper().wrapper;
-
-const sandbox = sinon.createSandbox();
-
-const type1 = {
-	slug: 'user',
-	name: 'User',
-};
-
-const type2 = {
-	slug: 'org',
-	name: 'Organization',
-};
-
-const card = {
-	slug: 'user-1',
-	type: 'user@1.0.0',
-};
-
-const types = [type1, type2];
-
-let context: any = {};
+import { getRelationships } from './RelationshipsTab';
 
 describe('getRelationships', () => {
 	it('should return all relevant relationships', () => {
@@ -46,38 +19,5 @@ describe('getRelationships', () => {
 	it('should return an empty array for unknown contract types', () => {
 		const relationships = getRelationships('this-is-not-a-type');
 		expect(relationships).toEqual([]);
-	});
-});
-
-// NOTE: Unit testing RelationshipsTab is limited because:
-//       1. The Grommet Select component doesn't seem to play nicely
-//          with enzyme - throwing an unhandled error 'onActivate is not a function'
-//          when the tab component is clicked.
-//       2. Enzyme can't access the state hook values of a functional
-//          component so you can't even test that the state is correct.
-describe('RelationshipsTab', () => {
-	beforeEach(() => {
-		context = {
-			defaultProps: {
-				viewData: undefined,
-				types,
-				card,
-				actions: {
-					loadViewData: sandbox.stub(),
-				},
-			},
-		};
-	});
-
-	afterEach(() => {
-		sandbox.restore();
-	});
-
-	it('loads view data when mounted', async () => {
-		const { defaultProps } = context;
-		await mount(<RelationshipsTab {...defaultProps} />, {
-			wrappingComponent,
-		});
-		expect(defaultProps.actions.loadViewData.callCount).toBe(1);
 	});
 });

--- a/apps/ui/lib/lens/common/RelationshipsTab/index.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/index.tsx
@@ -1,11 +1,9 @@
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { bindActionCreators } from '../../../bindactioncreators';
-import { selectors, actionCreators } from '../../../core';
+import { selectors } from '../../../core';
 import {
 	getViewId,
 	RelationshipsTab as InnerRelationshipsTab,
-	DispatchProps,
 	StateProps,
 	OwnProps,
 } from './RelationshipsTab';
@@ -20,21 +18,6 @@ const mapStateToProps = (state, props): StateProps => {
 	};
 };
 
-const mapDispatchToProps = (dispatch): DispatchProps => {
-	return {
-		actions: bindActionCreators(
-			_.pick(actionCreators, [
-				'loadViewData',
-				'getLinks',
-				'queryAPI',
-				'addChannel',
-			]),
-			dispatch,
-		),
-	};
-};
-
-export const RelationshipsTab = connect<StateProps, DispatchProps, OwnProps>(
+export const RelationshipsTab = connect<StateProps, {}, OwnProps>(
 	mapStateToProps,
-	mapDispatchToProps,
 )(InnerRelationshipsTab);


### PR DESCRIPTION
When loading relationship tabs, the UI would previously make a single
request for all linked contracts. This approach is very expensive and on
our production system would consistently time out for contract with more
than a handful of relationships. This change splits the query up into
a single request per relationship, which is much more performant and
significantly less memory consuming on the database.
This change also fixes an issue where the count would be incorrect if
the same link verb is used for multiple contract types.
Ideally we resolve this issue in the compiler, but for now this is
a sane patch.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
