### PR TITLE
CloudFormation: allow PostgreSQL 13 RDS instances.

### DIFF
--- a/deploy-templates/cloudformation/jellyfish-db.yml
+++ b/deploy-templates/cloudformation/jellyfish-db.yml
@@ -79,11 +79,10 @@ Parameters:
   JellyfishDBParameterGroupFamily:
     Description: RDS PostgreSQL engine version
     Type: String
-    Default: postgres10
+    Default: postgres13
     AllowedValues:
-    - postgres10
-    - postgres11
     - postgres12
+    - postgres13
     ConstraintDescription: must select a valid database engine version
 
   JellyfishDBName:
@@ -150,16 +149,16 @@ Conditions:
   HasSnapshot: !Not [ !Equals [ '', !Ref JellyfishDBSnapshotIdentifier ]]
   HasIOPS: !Not [ !Equals [ '', !Ref JellyfishDBStorageIops ]]
   HasMultiAZEnabled: !Equals [ 'true', !Ref MultiAZ ]
+  IsPostgres12: !Equals [ 'postgres12', !Ref JellyfishDBParameterGroupFamily ]
+  IsPostgres13: !Equals [ 'postgres13', !Ref JellyfishDBParameterGroupFamily ]
 
 
 Mappings:
   EngineMap:
-    postgres10:
-      EngineVersion: 10.6
-    postgres11:
-      EngineVersion: 11.6
     postgres12:
       EngineVersion: 12.7
+    postgres13:
+      EngineVersion: 13.6
 
 
 Resources:
@@ -196,7 +195,8 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole
 
-  JellyfishDBParameterGroup:
+  JellyfishDBParameterGroup12:
+    Condition: IsPostgres12
     Type: 'AWS::RDS::DBParameterGroup'
     Properties:
       Description: Jellyfish DB Parameter group
@@ -216,6 +216,40 @@ Resources:
         # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PostgreSQL.Replication.ReadReplicas.html#USER_PostgreSQL.Replication.ReadReplicas.Interruptions
         # https://aws.amazon.com/blogs/database/best-practices-for-amazon-rds-postgresql-replication/
         wal_keep_segments: '256'
+
+  JellyfishDBParameterGroup13:
+    Condition: IsPostgres13
+    Type: 'AWS::RDS::DBParameterGroup'
+    Properties:
+      Description: Jellyfish DB Parameter group
+      Family: !Ref JellyfishDBParameterGroupFamily
+      Parameters:
+        autovacuum_analyze_scale_factor: '0.1'
+        autovacuum_naptime: '60'
+        autovacuum_vacuum_scale_factor: '0.2'
+        autovacuum_vacuum_insert_scale_factor: '0.2'
+        autovacuum_vacuum_insert_threshold: '1000'
+        effective_io_concurrency: '200'
+        enable_incremental_sort: 'on'
+        hash_mem_multiplier: '1'
+        log_autovacuum_min_duration: '100'
+        log_min_duration_statement: '500'
+        log_min_duration_sample: '-1'
+        log_parameter_max_length_on_error: '0'
+        log_parameter_max_length: '-1'
+        log_statement_sample_rate: '1'
+        logical_decoding_work_mem: '65536'
+        maintenance_io_concurrency: '10'
+        max_connections: '5000'
+        max_slot_wal_keep_size: '-1'
+        pg_stat_statements.track: 'ALL'
+        pg_stat_statements.track_planning: '1'
+        random_page_cost: '1.1'
+        rds.accepted_password_auth_method: 'md5+scram'
+        statement_timeout: '30000'
+        wal_keep_size: '8192'
+        wal_skip_threshold: '2048'
+        work_mem: '65536'
 
   JellyfishDB:
     Type: 'AWS::RDS::DBInstance'
@@ -268,8 +302,10 @@ Resources:
         - HasIOPS
         - !Ref JellyfishDBStorageIops
         - !Ref AWS::NoValue
-      DBParameterGroupName:
-        Ref: JellyfishDBParameterGroup
+      DBParameterGroupName: !If
+        - IsPostgres13
+        - Ref: JellyfishDBParameterGroup13
+        - Ref: JellyfishDBParameterGroup12
       Tags:
       - Key: Name
         Value: jellyfish


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
