### PR TITLE
UI: Disable full text search in timelines

### DIFF
--- a/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
@@ -757,7 +757,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 
 	loadViewWithFilters(filters) {
 		const { actions, card, query } = this.props;
-		const { searchFilter, eventSearchFilter } = this.state;
+		const { searchFilter } = this.state;
 
 		// Omnisearch runs a full text query over a large set of contracts, so we apply
 		// heuristics to make the query run faster. Firstly, we omit search in timelines.
@@ -768,10 +768,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 			query.allOf && query.allOf[0] && query.allOf[0].$id === 'omnisearch';
 
 		const targetFilters = _.compact(filters);
-		const searchFilters = _.compact([
-			isOmniSearch ? null : eventSearchFilter,
-			searchFilter,
-		]);
+		const searchFilters = _.compact([searchFilter]);
 		if (searchFilters.length === 1) {
 			targetFilters.push(searchFilters[0]);
 		} else if (searchFilters.length > 1) {


### PR DESCRIPTION
When using the search functionality, the default behaviour is to additionally search within contract timeline for matching messages or whispers.
This additional search appears to be causing huge memory consumption on the production database, so for the sake of platform stability, I'm disabling the behaviour until we can fix the root cause of the issue.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
