### PR TITLE
Change jellyfish-core to autumndb

### DIFF
--- a/apps/server/lib/bootstrap.ts
+++ b/apps/server/lib/bootstrap.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import * as core from '@balena/jellyfish-core';
+import * as core from 'autumndb';
 import { Producer, Consumer } from '@balena/jellyfish-queue';
 import {
 	Sync,

--- a/apps/server/lib/card-loader.ts
+++ b/apps/server/lib/card-loader.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import Bluebird from 'bluebird';
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
 import { getLogger } from '@balena/jellyfish-logger';
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 
 const logger = getLogger(__filename);
 

--- a/apps/server/lib/http/auth.ts
+++ b/apps/server/lib/http/auth.ts
@@ -1,4 +1,4 @@
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import type { LogContext } from '@balena/jellyfish-logger';
 import type { SessionContract } from '@balena/jellyfish-types/build/core';
 import bcrypt from 'bcrypt';

--- a/apps/server/lib/http/facades/auth.ts
+++ b/apps/server/lib/http/facades/auth.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from '@balena/jellyfish-core';
+import { errors as coreErrors } from 'autumndb';
 import type {
 	Contract,
 	SessionContract,

--- a/apps/server/lib/http/facades/query.ts
+++ b/apps/server/lib/http/facades/query.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Bluebird from 'bluebird';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
-import { Kernel, errors as coreErrors } from '@balena/jellyfish-core';
+import { Kernel, errors as coreErrors } from 'autumndb';
 
 const logger = getLogger(__filename);
 

--- a/apps/server/lib/http/facades/view.ts
+++ b/apps/server/lib/http/facades/view.ts
@@ -3,7 +3,7 @@ import jsone from 'json-e';
 import skhema from 'skhema';
 import * as assert from '@balena/jellyfish-assert';
 import type { QueryFacade } from './query';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 
 export class ViewFacade {
 	kernel: Kernel;

--- a/apps/server/lib/http/index.ts
+++ b/apps/server/lib/http/index.ts
@@ -7,7 +7,7 @@ import type { Sync, Worker } from '@balena/jellyfish-worker';
 import type { Producer } from '@balena/jellyfish-queue';
 import { attachMiddlewares } from './middlewares';
 import { attachRoutes } from './routes';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 
 const logger = getLogger(__filename);
 

--- a/apps/server/lib/http/middlewares.ts
+++ b/apps/server/lib/http/middlewares.ts
@@ -4,7 +4,7 @@ import responseTime from 'response-time';
 import { v4 as uuidv4 } from 'uuid';
 import { getLogger } from '@balena/jellyfish-logger';
 import { authMiddleware } from './auth';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 
 // Avoid including package.json in the build output!
 // tslint:disable-next-line: no-var-requires

--- a/apps/server/lib/http/registry.ts
+++ b/apps/server/lib/http/registry.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import _ from 'lodash';
 import Bluebird from 'bluebird';
 import { getLogger } from '@balena/jellyfish-logger';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 
 const logger = getLogger(__filename);

--- a/apps/server/lib/http/routes.ts
+++ b/apps/server/lib/http/routes.ts
@@ -10,7 +10,7 @@ import { defaultEnvironment as environment } from '@balena/jellyfish-environment
 import * as metrics from '@balena/jellyfish-metrics';
 import { v4 as uuidv4 } from 'uuid';
 import * as facades from './facades';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 import type { SessionContract } from '@balena/jellyfish-types/build/core';
 import type { Sync, Worker } from '@balena/jellyfish-worker';
 import type { Producer } from '@balena/jellyfish-queue';

--- a/apps/server/lib/socket/index.ts
+++ b/apps/server/lib/socket/index.ts
@@ -8,7 +8,7 @@ import basicAuth from 'express-basic-auth';
 import * as prometheus from '@balena/socket-prometheus-metrics';
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
 import { getLogger } from '@balena/jellyfish-logger';
-import type { Kernel } from '@balena/jellyfish-core';
+import type { Kernel } from 'autumndb';
 
 // Avoid including package.json in the build output!
 // tslint:disable-next-line: no-var-requires

--- a/apps/server/nodemon.json
+++ b/apps/server/nodemon.json
@@ -5,7 +5,6 @@
     "lib/",
     "node_modules/@balena/jellyfish-action-library/build/**/*.js",
     "node_modules/@balena/jellyfish-assert/build/*.js",
-    "node_modules/@balena/jellyfish-core/build/**/*.js",
     "node_modules/@balena/jellyfish-environment/build/**/*.js",
     "node_modules/@balena/jellyfish-jellyscript/build/**/*.js",
     "node_modules/@balena/jellyfish-logger/build/**/*.js",
@@ -21,7 +20,8 @@
     "node_modules/@balena/jellyfish-plugin-github/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-typeform/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-outreach/build/**/*.js",
-    "node_modules/@balena/jellyfish-plugin-front/build/**/*.js"
+    "node_modules/@balena/jellyfish-plugin-front/build/**/*.js",
+    "node_modules/autumndb/build/**/*.js"
   ],
   "execMap": {
     "ts": "node -r ts-node/register"

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -10,7 +10,6 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.18",
-        "@balena/jellyfish-core": "^16.0.13",
         "@balena/jellyfish-environment": "^9.1.3",
         "@balena/jellyfish-logger": "^5.0.6",
         "@balena/jellyfish-metrics": "^2.0.47",
@@ -27,6 +26,7 @@
         "@balena/jellyfish-queue": "^4.1.21",
         "@balena/jellyfish-worker": "^20.0.2",
         "@balena/socket-prometheus-metrics": "^0.0.3",
+        "autumndb": "^17.0.3",
         "aws-sdk": "^2.1092.0",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.18",
-    "@balena/jellyfish-core": "^16.0.13",
     "@balena/jellyfish-environment": "^9.1.3",
     "@balena/jellyfish-logger": "^5.0.6",
     "@balena/jellyfish-metrics": "^2.0.47",
@@ -41,6 +40,7 @@
     "@balena/jellyfish-queue": "^4.1.21",
     "@balena/jellyfish-worker": "^20.0.2",
     "@balena/socket-prometheus-metrics": "^0.0.3",
+    "autumndb": "^17.0.3",
     "aws-sdk": "^2.1092.0",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "devDependencies": {
         "@balena/jellyfish-client-sdk": "^10.1.11",
         "@balena/jellyfish-config": "^2.0.3",
-        "@balena/jellyfish-core": "^16.0.13",
         "@balena/jellyfish-environment": "^9.1.3",
         "@balena/jellyfish-plugin-balena-api": "^2.0.54",
         "@balena/jellyfish-plugin-channels": "^2.0.55",
@@ -28,6 +27,7 @@
         "@balena/jellyfish-worker": "^20.0.2",
         "@balena/lint": "^6.2.0",
         "@playwright/test": "^1.19.2",
+        "autumndb": "^17.0.3",
         "ava": "^4.1.0",
         "aws-sdk": "^2.1092.0",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "lint": "eslint --ext .js,.jsx scripts test && npm run lint:check && npm run lint:deps &&  npm run lint:server && npm run lint:ui",
     "lint:check": "./scripts/lint/check-filenames.sh && shellcheck scripts/*.sh scripts/*/*.sh deploy-templates/*.sh",
-    "lint:deps": "deplint && depcheck --ignore-bin-package --ignores=@balena/jellyfish-*,shellcheck",
+    "lint:deps": "deplint && depcheck --ignore-bin-package --ignores=@balena/jellyfish-*,shellcheck,autumndb",
     "lint:catch": "catch-uncommitted --skip-node-versionbot-changes --exclude=VERSION,.versionbot/",
     "lint:server": "(cd apps/server && npm run lint)",
     "lint:ui": "(cd apps/ui && npm run lint)",
@@ -78,7 +78,6 @@
   "devDependencies": {
     "@balena/jellyfish-client-sdk": "^10.1.11",
     "@balena/jellyfish-config": "^2.0.3",
-    "@balena/jellyfish-core": "^16.0.13",
     "@balena/jellyfish-environment": "^9.1.3",
     "@balena/jellyfish-plugin-balena-api": "^2.0.54",
     "@balena/jellyfish-plugin-channels": "^2.0.55",
@@ -94,6 +93,7 @@
     "@balena/jellyfish-worker": "^20.0.2",
     "@balena/lint": "^6.2.0",
     "@playwright/test": "^1.19.2",
+    "autumndb": "^17.0.3",
     "ava": "^4.1.0",
     "aws-sdk": "^2.1092.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
The `@balena/jellyfish-core` package has been renamed to `autumndb`.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
