### PR TITLE
Update aws-sdk from 2.1096.0 to 2.1101.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -26,7 +26,7 @@
         "@balena/jellyfish-worker": "^21.0.6",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^19.1.9",
-        "aws-sdk": "^2.1096.0",
+        "aws-sdk": "^2.1101.0",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.2",
@@ -2838,9 +2838,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1096.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1096.0.tgz",
-      "integrity": "sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==",
+      "version": "2.1101.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1101.0.tgz",
+      "integrity": "sha512-7lyVb7GXGl8yyu954Qxf6vU6MrcgFlmKyTLBVXJyo3Phn1OB+qOExA55WtSC6gQiQ7e5TeWOn1RUHLg30ywTBA==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -14346,9 +14346,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1096.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1096.0.tgz",
-      "integrity": "sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==",
+      "version": "2.1101.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1101.0.tgz",
+      "integrity": "sha512-7lyVb7GXGl8yyu954Qxf6vU6MrcgFlmKyTLBVXJyo3Phn1OB+qOExA55WtSC6gQiQ7e5TeWOn1RUHLg30ywTBA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -40,7 +40,7 @@
     "@balena/jellyfish-worker": "^21.0.6",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^19.1.9",
-    "aws-sdk": "^2.1096.0",
+    "aws-sdk": "^2.1101.0",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@playwright/test": "^1.20.0",
         "autumndb": "^19.1.9",
         "ava": "^4.1.0",
-        "aws-sdk": "^2.1096.0",
+        "aws-sdk": "^2.1101.0",
         "bluebird": "^3.7.2",
         "catch-uncommitted": "^2.0.0",
         "cli-spinner": "^0.2.10",
@@ -2838,9 +2838,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1096.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1096.0.tgz",
-      "integrity": "sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==",
+      "version": "2.1101.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1101.0.tgz",
+      "integrity": "sha512-7lyVb7GXGl8yyu954Qxf6vU6MrcgFlmKyTLBVXJyo3Phn1OB+qOExA55WtSC6gQiQ7e5TeWOn1RUHLg30ywTBA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -14398,9 +14398,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1096.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1096.0.tgz",
-      "integrity": "sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==",
+      "version": "2.1101.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1101.0.tgz",
+      "integrity": "sha512-7lyVb7GXGl8yyu954Qxf6vU6MrcgFlmKyTLBVXJyo3Phn1OB+qOExA55WtSC6gQiQ7e5TeWOn1RUHLg30ywTBA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@playwright/test": "^1.20.0",
     "autumndb": "^19.1.9",
     "ava": "^4.1.0",
-    "aws-sdk": "^2.1096.0",
+    "aws-sdk": "^2.1101.0",
     "bluebird": "^3.7.2",
     "catch-uncommitted": "^2.0.0",
     "cli-spinner": "^0.2.10",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
