### PR TITLE
Set grafana log level to error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,8 @@ services:
       interval: 15s
       retries: 3
       test: pgrep grafana-server
+    environment:
+      - GF_LOG_LEVEL=error
     restart: unless-stopped
     networks:
       - internal


### PR DESCRIPTION
Grafana logs were a bit too noisy

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
