### PR TITLE
Lucianbuzzo/tab selection persist

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -23,6 +23,7 @@ import type { JsonSchema } from '@balena/jellyfish-types';
 import type {
 	Contract,
 	LoopContract,
+	TypeContract,
 	UserContract,
 	ViewContract,
 } from '@balena/jellyfish-types/build/core';
@@ -198,7 +199,7 @@ export const selectors = {
 	getChatWidgetOpen: (state) => {
 		return _.get(state.ui, ['chatWidget', 'open']);
 	},
-	getTypes: (state) => {
+	getTypes: (state): TypeContract[] => {
 		return state.core.types;
 	},
 	getLoops: (state): LoopContract[] => {

--- a/apps/ui/lib/hocs/with-default-get-actor-href.ts
+++ b/apps/ui/lib/hocs/with-default-get-actor-href.ts
@@ -1,7 +1,8 @@
 import path from 'path';
+import { UIActor } from '../types';
 import { withDefaultProps } from './with-default-props';
 
-const getActorHref = (actor: any) => {
+const getActorHref = (actor: UIActor) => {
 	return path.join(location.pathname, actor.card.slug);
 };
 

--- a/apps/ui/lib/layouts/TabbedContractLayout/index.tsx
+++ b/apps/ui/lib/layouts/TabbedContractLayout/index.tsx
@@ -30,6 +30,7 @@ export type OwnProps = Pick<LensRendererProps, 'card' | 'channel'> & {
 	tabs?: React.ReactNode[];
 	actionItems?: React.ReactNode;
 	primaryTabTitle?: string;
+	title?: JSX.Element;
 };
 
 export interface StateProps {
@@ -81,6 +82,7 @@ class TabbedContractLayout extends React.Component<Props, State> {
 			actionItems,
 			children,
 			tabs,
+			title,
 			primaryTabTitle,
 		} = this.props;
 
@@ -98,6 +100,7 @@ class TabbedContractLayout extends React.Component<Props, State> {
 			<CardLayout
 				data-test={this.props['data-test']}
 				overflowY
+				title={title}
 				card={card}
 				channel={channel}
 				actionItems={actionItems}

--- a/apps/ui/lib/layouts/TabbedContractLayout/index.tsx
+++ b/apps/ui/lib/layouts/TabbedContractLayout/index.tsx
@@ -29,6 +29,7 @@ export type OwnProps = Pick<LensRendererProps, 'card' | 'channel'> & {
 	children?: React.ReactNode;
 	tabs?: React.ReactNode[];
 	actionItems?: React.ReactNode;
+	primaryTabTitle?: string;
 };
 
 export interface StateProps {
@@ -73,7 +74,15 @@ class TabbedContractLayout extends React.Component<Props, State> {
 	}
 
 	render() {
-		const { card, channel, types, actionItems, children, tabs } = this.props;
+		const {
+			card,
+			channel,
+			types,
+			actionItems,
+			children,
+			tabs,
+			primaryTabTitle,
+		} = this.props;
 
 		const type = helpers.getType(card.type, types);
 
@@ -99,7 +108,7 @@ class TabbedContractLayout extends React.Component<Props, State> {
 					activeIndex={this.state.activeIndex}
 					onActive={this.setActiveIndex}
 				>
-					<Tab title="Info">
+					<Tab title={primaryTabTitle || 'Info'}>
 						<Box
 							p={3}
 							flex={1}

--- a/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/RelationshipsTab.tsx
@@ -173,39 +173,6 @@ export const RelationshipsTab: React.FunctionComponent<Props> = ({
 
 	// Fetch relationships as view data when the component loads
 	React.useEffect(() => {
-		const query: JSONSchema = {
-			description: `Fetch all contracts linked to ${card.slug}`,
-			type: 'object',
-			// HACK: Include type here to force linked contracts to return type (see issue #6602)
-			required: ['id', 'type'],
-			properties: {
-				id: {
-					const: card.id,
-				},
-			},
-			anyOf: relationships
-				.map((relationship) => {
-					return {
-						$$links: {
-							[relationship.link]: {
-								type: 'object',
-								required: ['type'],
-								additionalProperties: false,
-								properties:
-									relationship.type === '*'
-										? {}
-										: {
-												type: {
-													const: `${relationship.type}@1.0.0`,
-												},
-										  },
-							},
-						},
-					} as JSONSchema;
-				})
-				.concat(true as JSONSchema),
-		};
-
 		Promise.all(
 			relationships.map(async (relationship) => {
 				const schema = {

--- a/apps/ui/lib/lens/common/RelationshipsTab/index.tsx
+++ b/apps/ui/lib/lens/common/RelationshipsTab/index.tsx
@@ -1,23 +1,35 @@
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { selectors } from '../../../core';
+import { bindActionCreators } from '../../../bindactioncreators';
+import { actionCreators, selectors } from '../../../core';
 import {
 	getViewId,
 	RelationshipsTab as InnerRelationshipsTab,
 	StateProps,
+	DispatchProps,
 	OwnProps,
+	SLUG,
 } from './RelationshipsTab';
 
 export { getRelationships } from './RelationshipsTab';
 
 const mapStateToProps = (state, props): StateProps => {
 	const viewData = selectors.getViewData(state, getViewId(props.card.id));
+	const target = props.card.type;
 	return {
 		viewData,
 		types: selectors.getTypes(state),
+		lensState: selectors.getLensState(state, SLUG, target),
 	};
 };
 
-export const RelationshipsTab = connect<StateProps, {}, OwnProps>(
+const mapDispatchToProps = (dispatch): DispatchProps => {
+	return {
+		actions: bindActionCreators(actionCreators, dispatch),
+	};
+};
+
+export const RelationshipsTab = connect<StateProps, DispatchProps, OwnProps>(
 	mapStateToProps,
+	mapDispatchToProps,
 )(InnerRelationshipsTab);

--- a/apps/ui/lib/lens/full/Channel/index.tsx
+++ b/apps/ui/lib/lens/full/Channel/index.tsx
@@ -1,26 +1,10 @@
 import * as _ from 'lodash';
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { Flex, Divider, Tab, Tabs, Theme } from 'rendition';
-import * as helpers from '../../../services/helpers';
-import { actionCreators, selectors } from '../../../core';
+import { Flex, Tab } from 'rendition';
 import { LensContract, LensRendererProps } from '../../../types';
-import CardLayout from '../../../layouts/CardLayout';
-import styled from 'styled-components';
 import Dashboard from './Dashboard';
 import LiveCollection from '../../common/LiveCollection';
-
-export const SingleCardTabs = styled(Tabs)`
-	flex: 1;
-	> [role='tablist'] {
-		height: 100%;
-	}
-	> [role='tabpanel'] {
-		flex: 1;
-		overflow-y: auto;
-	}
-`;
+import TabbedContractLayout from '../../../layouts/TabbedContractLayout';
 
 interface State {
 	mineQuery: any;
@@ -88,16 +72,14 @@ class ChannelRenderer extends React.Component<LensRendererProps, State> {
 	}
 
 	render() {
-		const { card } = this.props;
+		const { card, channel } = this.props;
 
 		return (
-			<CardLayout {...this.props}>
-				<Divider width="100%" color={helpers.colorHash(card.type)} />
-
-				<SingleCardTabs>
-					<Tab title="Dashboard">
-						<Dashboard filter={(card.data.filter as any).schema} />
-					</Tab>
+			<TabbedContractLayout
+				card={card}
+				channel={channel}
+				primaryTabTitle="Dashboard"
+				tabs={[
 					<Tab title="Owned by me">
 						<Flex
 							flexDirection="column"
@@ -114,7 +96,7 @@ class ChannelRenderer extends React.Component<LensRendererProps, State> {
 								card={this.props.card}
 							/>
 						</Flex>
-					</Tab>
+					</Tab>,
 
 					<Tab title="All">
 						<Flex
@@ -132,7 +114,7 @@ class ChannelRenderer extends React.Component<LensRendererProps, State> {
 								card={this.props.card}
 							/>
 						</Flex>
-					</Tab>
+					</Tab>,
 
 					<Tab title="Unowned">
 						<Flex
@@ -150,9 +132,11 @@ class ChannelRenderer extends React.Component<LensRendererProps, State> {
 								card={this.props.card}
 							/>
 						</Flex>
-					</Tab>
-				</SingleCardTabs>
-			</CardLayout>
+					</Tab>,
+				]}
+			>
+				<Dashboard filter={(card.data.filter as any).schema} />
+			</TabbedContractLayout>
 		);
 	}
 }

--- a/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
+++ b/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
@@ -40,25 +40,12 @@ const makeLogLink = (commit?: Contract) => {
 
 export default class CheckRun extends React.Component<
 	{ card: Contract; channel: any; types: any; actionItems: any },
-	{ tree?: Contract; commit?: Contract; activeIndex: number }
+	{ tree?: Contract; commit?: Contract }
 > {
 	interval: NodeJS.Timeout | null = null;
 
 	constructor(props) {
 		super(props);
-
-		const tail = _.get(this.props.card.links, ['has attached element'], []);
-
-		const comms = _.filter(tail, (item) => {
-			const typeBase = item.type.split('@')[0];
-			return typeBase === 'message' || typeBase === 'whisper';
-		});
-
-		this.state = {
-			activeIndex: comms.length ? 1 : 0,
-		};
-
-		this.setActiveIndex = this.setActiveIndex.bind(this);
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {
@@ -66,12 +53,6 @@ export default class CheckRun extends React.Component<
 			!circularDeepEqual(nextState, this.state) ||
 			!circularDeepEqual(nextProps, this.props)
 		);
-	}
-
-	setActiveIndex(activeIndex) {
-		this.setState({
-			activeIndex,
-		});
 	}
 
 	componentDidMount() {

--- a/apps/ui/lib/lens/full/Loop/Loop.tsx
+++ b/apps/ui/lib/lens/full/Loop/Loop.tsx
@@ -1,14 +1,11 @@
 import { circularDeepEqual } from 'fast-equals';
 import _ from 'lodash';
 import React from 'react';
-import { Box, Card, Divider, Flex, Tab, Tabs, Theme } from 'rendition';
+import { Box, Card, Flex, Tabs } from 'rendition';
 import styled from 'styled-components';
 import { Icon, Link } from '../../../components';
-import * as helpers from '../../../services/helpers';
-import CardLayout from '../../../layouts/CardLayout';
-import Timeline from '../../list/Timeline';
-import { RelationshipsTab, customQueryTabs } from '../../common';
 import { sdk } from '../../../core';
+import TabbedContractLayout from '../../../layouts/TabbedContractLayout';
 
 const WIDTH = 160;
 
@@ -36,16 +33,6 @@ const LOOP_CONTRACTS = {
 		status: 'open',
 	},
 };
-
-export const SingleCardTabs = styled(Tabs)`
-	flex: 1;
-	> [role='tablist'] {
-		height: 100%;
-	}
-	> [role='tabpanel'] {
-		flex: 1;
-	}
-`;
 
 const Corner = (props: { rotate: number } = { rotate: 0 }) => {
 	return (
@@ -199,108 +186,75 @@ export default class LoopFull extends React.Component<any, any> {
 	render() {
 		const { card, channel, types } = this.props;
 
-		const type = helpers.getType(card.type, types);
-
-		const tail = _.get(card.links, ['has attached element'], []);
-
 		const { support, patterns, improvements, projects, pulls, topics } =
 			this.state;
 
 		return (
-			<CardLayout overflowY card={card} channel={channel}>
-				<Divider width="100%" color={helpers.colorHash(card.type)} />
+			<TabbedContractLayout card={card} channel={channel}>
+				<Box width={420} mx="auto">
+					<Flex alignItems="center">
+						<Corner rotate={90} />
 
-				<SingleCardTabs
-					activeIndex={this.state.activeIndex}
-					onActive={this.setActiveIndex}
-				>
-					<Tab title="Info">
-						<Box
-							p={3}
-							flex={1}
-							style={{
-								maxWidth: Theme.breakpoints[2],
-							}}
-						>
-							<Box width={420} mx="auto">
-								<Flex alignItems="center">
-									<Corner rotate={90} />
+						<Card p={2} small width={WIDTH} style={{ textAlign: 'center' }}>
+							Environment
+						</Card>
 
-									<Card
-										p={2}
-										small
-										width={WIDTH}
-										style={{ textAlign: 'center' }}
-									>
-										Environment
-									</Card>
+						<Corner rotate={180} />
+					</Flex>
 
-									<Corner rotate={180} />
-								</Flex>
+					<Flex justifyContent="space-between" alignItems="center">
+						<LinkBox
+							label="Pull Requests"
+							path="/view-all-pull-requests"
+							total={pulls}
+						/>
 
-								<Flex justifyContent="space-between" alignItems="center">
-									<LinkBox
-										label="Pull Requests"
-										path="/view-all-pull-requests"
-										total={pulls}
-									/>
+						<LinkBox
+							label="Support"
+							path={'/view-all-support-threads'}
+							total={support}
+						/>
+					</Flex>
 
-									<LinkBox
-										label="Support"
-										path={'/view-all-support-threads'}
-										total={support}
-									/>
-								</Flex>
+					<Flex justifyContent="space-between" alignItems="center">
+						<Arrow rotate={0} />
 
-								<Flex justifyContent="space-between" alignItems="center">
-									<Arrow rotate={0} />
+						<LinkBox
+							label="Brainstorm Topics"
+							path="/view-all-brainstorm-topics"
+							total={topics}
+						/>
 
-									<LinkBox
-										label="Brainstorm Topics"
-										path="/view-all-brainstorm-topics"
-										total={topics}
-									/>
+						<Arrow rotate={180} />
+					</Flex>
 
-									<Arrow rotate={180} />
-								</Flex>
+					<Flex justifyContent="space-between" alignItems="center">
+						<LinkBox
+							label="Projects"
+							path="/view-all-projects"
+							total={projects}
+						/>
 
-								<Flex justifyContent="space-between" alignItems="center">
-									<LinkBox
-										label="Projects"
-										path="/view-all-projects"
-										total={projects}
-									/>
+						<LinkBox
+							label="Patterns"
+							path="/view-all-patterns"
+							total={patterns}
+						/>
+					</Flex>
 
-									<LinkBox
-										label="Patterns"
-										path="/view-all-patterns"
-										total={patterns}
-									/>
-								</Flex>
+					<Flex alignItems="center">
+						<Corner rotate={0} />
 
-								<Flex alignItems="center">
-									<Corner rotate={0} />
+						<LinkBox
+							label="Improvements"
+							path="/view-all-improvements"
+							total={improvements}
+						/>
 
-									<LinkBox
-										label="Improvements"
-										path="/view-all-improvements"
-										total={improvements}
-									/>
-
-									<Corner rotate={270} />
-								</Flex>
-							</Box>
-						</Box>
-					</Tab>
-
-					<Tab title="Timeline">
-						<Timeline.data.renderer card={card} allowWhispers tail={tail} />
-					</Tab>
-
-					{customQueryTabs(card, type, channel)}
-					<RelationshipsTab card={card} channel={channel} />
-				</SingleCardTabs>
-			</CardLayout>
+						<Corner rotate={270} />
+					</Flex>
+				</Box>
+			</TabbedContractLayout>
 		);
 	}
 }

--- a/apps/ui/lib/lens/full/Loop/Loop.tsx
+++ b/apps/ui/lib/lens/full/Loop/Loop.tsx
@@ -120,15 +120,7 @@ export default class LoopFull extends React.Component<any, any> {
 	constructor(props) {
 		super(props);
 
-		const tail = _.get(this.props.card.links, ['has attached element'], []);
-
-		const comms = _.filter(tail, (item) => {
-			const typeBase = item.type.split('@')[0];
-			return typeBase === 'message' || typeBase === 'whisper';
-		});
-
 		this.state = {
-			activeIndex: comms.length ? 1 : 0,
 			tree: null,
 			support: null,
 			patterns: null,
@@ -137,8 +129,6 @@ export default class LoopFull extends React.Component<any, any> {
 			pulls: null,
 			topics: null,
 		};
-
-		this.setActiveIndex = this.setActiveIndex.bind(this);
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {
@@ -146,12 +136,6 @@ export default class LoopFull extends React.Component<any, any> {
 			!circularDeepEqual(nextState, this.state) ||
 			!circularDeepEqual(nextProps, this.props)
 		);
-	}
-
-	setActiveIndex(activeIndex) {
-		this.setState({
-			activeIndex,
-		});
 	}
 
 	componentDidMount() {
@@ -184,7 +168,7 @@ export default class LoopFull extends React.Component<any, any> {
 	}
 
 	render() {
-		const { card, channel, types } = this.props;
+		const { card, channel } = this.props;
 
 		const { support, patterns, improvements, projects, pulls, topics } =
 			this.state;

--- a/apps/ui/lib/lens/full/Loop/index.tsx
+++ b/apps/ui/lib/lens/full/Loop/index.tsx
@@ -1,32 +1,9 @@
 import _ from 'lodash';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { createLazyComponent } from '../../../components/SafeLazy';
-import { actionCreators, selectors } from '../../../core';
 
 export const Loop = createLazyComponent(
 	() => import(/* webpackChunkName: "lens-check-run" */ './Loop'),
 );
-
-const mapStateToProps = (state) => {
-	return {
-		types: selectors.getTypes(state),
-	};
-};
-
-const mapDispatchToProps = (dispatch) => {
-	return {
-		actions: bindActionCreators(
-			_.pick(actionCreators, [
-				'createLink',
-				'addChannel',
-				'getLinks',
-				'queryAPI',
-			]),
-			dispatch,
-		),
-	};
-};
 
 const lens = {
 	slug: 'lens-full-default',
@@ -36,7 +13,7 @@ const lens = {
 	data: {
 		format: 'full',
 		icon: 'address-card',
-		renderer: connect(mapStateToProps, mapDispatchToProps)(Loop),
+		renderer: Loop,
 		filter: {
 			type: 'object',
 			properties: {

--- a/apps/ui/lib/lens/full/SingleCard/SingleCard.tsx
+++ b/apps/ui/lib/lens/full/SingleCard/SingleCard.tsx
@@ -1,9 +1,8 @@
 import { circularDeepEqual } from 'fast-equals';
 import _ from 'lodash';
 import React from 'react';
-import { BoundActionCreators, LensRendererProps } from '../../../types';
+import { LensRendererProps } from '../../../types';
 import { TypeContract } from '@balena/jellyfish-types/build/core';
-import { actionCreators } from '../../../core';
 import TabbedContractLayout from '../../../layouts/TabbedContractLayout';
 
 export type OwnProps = LensRendererProps;
@@ -14,39 +13,12 @@ export interface StateProps {
 
 type Props = StateProps & OwnProps;
 
-interface State {
-	activeIndex: number;
-}
-
-export default class SingleCardFull extends React.Component<Props, State> {
-	constructor(props: Props) {
-		super(props);
-
-		const tail = _.get(this.props.card.links, ['has attached element'], []);
-
-		const comms = _.filter(tail, (item) => {
-			const typeBase = item.type.split('@')[0];
-			return typeBase === 'message' || typeBase === 'whisper';
-		});
-
-		this.state = {
-			activeIndex: comms.length ? 1 : 0,
-		};
-
-		this.setActiveIndex = this.setActiveIndex.bind(this);
-	}
-
+export default class SingleCardFull extends React.Component<Props> {
 	shouldComponentUpdate(nextProps, nextState) {
 		return (
 			!circularDeepEqual(nextState, this.state) ||
 			!circularDeepEqual(nextProps, this.props)
 		);
-	}
-
-	setActiveIndex(activeIndex) {
-		this.setState({
-			activeIndex,
-		});
 	}
 
 	render() {

--- a/apps/ui/lib/lens/full/SupportThread/SupportThreadBase.tsx
+++ b/apps/ui/lib/lens/full/SupportThread/SupportThreadBase.tsx
@@ -1,7 +1,7 @@
 import { circularDeepEqual } from 'fast-equals';
 import _ from 'lodash';
 import React from 'react';
-import { Box, Divider, Flex, Tab, Txt } from 'rendition';
+import { Box, Divider, Flex, Txt } from 'rendition';
 import styled from 'styled-components';
 import {
 	ColorHashPill,
@@ -15,11 +15,8 @@ import {
 import * as notifications from '../../../services/notifications';
 import * as helpers from '../../../services/helpers';
 import { sdk, actionCreators } from '../../../core';
-import { RelationshipsTab, customQueryTabs } from '../../common';
-import Timeline from '../../list/Timeline';
-import CardLayout from '../../../layouts/CardLayout';
 import CardFields from '../../../components/CardFields';
-import { SingleCardTabs } from '../../../layouts/TabbedContractLayout';
+import TabbedContractLayout from '../../../layouts/TabbedContractLayout';
 import { SubscribeButton } from './SubscribeButton';
 import {
 	Contract,
@@ -257,7 +254,7 @@ export default class SupportThreadBase extends React.Component<Props, State> {
 			| null;
 
 		return (
-			<CardLayout
+			<TabbedContractLayout
 				card={card}
 				channel={channel}
 				title={
@@ -378,61 +375,41 @@ export default class SupportThreadBase extends React.Component<Props, State> {
 					</React.Fragment>
 				}
 			>
-				<Divider width="100%" color={helpers.colorHash(card.type)} />
+				<>
+					{statusDescription && (
+						<Txt
+							color="text.light"
+							data-test="support-thread__status-description"
+						>
+							{statusDescription}
+						</Txt>
+					)}
 
-				<SingleCardTabs
-					activeIndex={this.state.activeIndex}
-					onActive={this.setActiveIndex}
-				>
-					<Tab title="Info">
-						<Box px={3}>
-							{statusDescription && (
-								<Txt
-									color="text.light"
-									data-test="support-thread__status-description"
-								>
-									{statusDescription}
-								</Txt>
-							)}
-
-							{highlights.length > 0 && (
-								<Box pt={2}>
-									<Txt bold>Highlights</Txt>
-									<Extract py={2}>
-										{_.map(highlights, (statusEvent) => {
-											return (
-												<Event
-													key={statusEvent.id}
-													card={statusEvent}
-													user={this.props.user}
-													groups={this.props.groups}
-													mb={1}
-													threadIsMirrored={isMirrored}
-													getActorHref={getActorHref}
-												/>
-											);
-										})}
-									</Extract>
-									<Divider width="100%" />
-								</Box>
-							)}
-
-							<CardFields card={card} type={typeContract} />
+					{highlights.length > 0 && (
+						<Box pt={2}>
+							<Txt bold>Highlights</Txt>
+							<Extract py={2}>
+								{_.map(highlights, (statusEvent) => {
+									return (
+										<Event
+											key={statusEvent.id}
+											card={statusEvent}
+											user={this.props.user}
+											groups={this.props.groups}
+											mb={1}
+											threadIsMirrored={isMirrored}
+											getActorHref={getActorHref}
+										/>
+									);
+								})}
+							</Extract>
+							<Divider width="100%" />
 						</Box>
-					</Tab>
+					)}
 
-					<Tab data-test="timeline-tab" title="Timeline">
-						<Timeline.data.renderer
-							card={card}
-							allowWhispers
-							tail={_.get(this.props.card.links, ['has attached element'], [])}
-						/>
-					</Tab>
-
-					{customQueryTabs(card, typeContract, channel)}
-					<RelationshipsTab card={card} channel={channel} />
-				</SingleCardTabs>
-			</CardLayout>
+					<CardFields card={card} type={typeContract} />
+				</>
+			</TabbedContractLayout>
 		);
 	}
 }

--- a/apps/ui/lib/lens/full/SupportThread/SupportThreadBase.tsx
+++ b/apps/ui/lib/lens/full/SupportThread/SupportThreadBase.tsx
@@ -56,7 +56,6 @@ interface State {
 	actor: UIActor | null;
 	isClosing: boolean;
 	highlights: Contract[];
-	activeIndex: number;
 }
 
 export default class SupportThreadBase extends React.Component<Props, State> {
@@ -66,13 +65,11 @@ export default class SupportThreadBase extends React.Component<Props, State> {
 		this.reopen = this.reopen.bind(this);
 		this.close = this.close.bind(this);
 		this.archive = this.archive.bind(this);
-		this.setActiveIndex = this.setActiveIndex.bind(this);
 
 		this.state = {
 			actor: null,
 			isClosing: false,
 			highlights: [],
-			activeIndex: 0,
 		};
 	}
 
@@ -87,12 +84,6 @@ export default class SupportThreadBase extends React.Component<Props, State> {
 		});
 
 		this.loadHighlights(this.props.card.id);
-	}
-
-	setActiveIndex(activeIndex) {
-		this.setState({
-			activeIndex,
-		});
 	}
 
 	reopen() {

--- a/apps/ui/lib/lens/full/SupportThread/index.tsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.tsx
@@ -12,7 +12,6 @@ export const SupportThreadBase = createLazyComponent(
 
 const mapStateToProps = (state) => {
 	return {
-		accounts: selectors.getAccounts(state),
 		types: selectors.getTypes(state),
 		groups: selectors.getGroups(state),
 		user: selectors.getCurrentUser(state),

--- a/apps/ui/lib/lens/full/SupportThread/index.tsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.tsx
@@ -1,16 +1,18 @@
 import { connect } from 'react-redux';
-import { bindActionCreators, compose } from 'redux';
+import { compose } from 'redux';
+import { bindActionCreators } from '../../../bindactioncreators';
 import { withDefaultGetActorHref } from '../../../components';
-import { actionCreators, selectors, sdk } from '../../../core';
+import { actionCreators, selectors } from '../../../core';
 import { createLazyComponent } from '../../../components/SafeLazy';
 import * as _ from 'lodash';
+import type { StateProps, DispatchProps, OwnProps } from './SupportThreadBase';
 
 export const SupportThreadBase = createLazyComponent(
 	() =>
 		import(/* webpackChunkName: "lens-support-thread" */ './SupportThreadBase'),
 );
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state): StateProps => {
 	return {
 		types: selectors.getTypes(state),
 		groups: selectors.getGroups(state),
@@ -18,12 +20,9 @@ const mapStateToProps = (state) => {
 	};
 };
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch): DispatchProps => {
 	return {
-		actions: bindActionCreators(
-			_.pick(actionCreators, ['addChannel', 'getActor', 'removeChannel']),
-			dispatch,
-		),
+		actions: bindActionCreators(actionCreators, dispatch),
 	};
 };
 
@@ -36,7 +35,10 @@ export default {
 		format: 'full',
 		icon: 'address-card',
 		renderer: compose(
-			connect(mapStateToProps, mapDispatchToProps),
+			connect<StateProps, DispatchProps, OwnProps>(
+				mapStateToProps,
+				mapDispatchToProps,
+			),
 			withDefaultGetActorHref(),
 		)(SupportThreadBase),
 		filter: {

--- a/apps/ui/lib/services/helpers.ts
+++ b/apps/ui/lib/services/helpers.ts
@@ -15,7 +15,7 @@ import { SchemaSieve } from 'rendition';
 import skhema from 'skhema';
 import { DetectUA } from 'detect-ua';
 import { MESSAGE, WHISPER, SUMMARY, RATING } from '../components/constants';
-import { Channel, JSONPatch } from '../types';
+import { Channel, JSONPatch, UIActor } from '../types';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type {
 	Contract,
@@ -739,13 +739,8 @@ export const stringToNumber = function (input: string, max: number) {
 // Get the actor from the create event if it is available, otherwise use the
 // first message creator
 export const getCreator = async (
-	getActorFn: (actor: string) => UserContract,
-	card: Contract<
-		ContractData,
-		{
-			[key: string]: Contract<{ actor: string }>;
-		}
-	>,
+	getActorFn: (actor: string) => Promise<UIActor | null>,
+	card: Contract,
 ) => {
 	const timeline = _.sortBy(
 		_.get(card.links, ['has attached element'], []),
@@ -770,7 +765,7 @@ export const getCreator = async (
 	if (!createCard) {
 		return null;
 	}
-	return getActorFn(_.get(createCard, ['data', 'actor']));
+	return getActorFn(_.get(createCard, ['data', 'actor']) as string);
 };
 
 export const getCreateCard = (card: Contract): Contract | undefined => {
@@ -855,7 +850,9 @@ export const getActorIdFromCard = _.memoize(
 	},
 );
 
-export const generateActorFromUserCard = (card: UserContract) => {
+export const generateActorFromUserCard = (
+	card: UserContract,
+): UIActor | null => {
 	if (!card) {
 		return null;
 	}

--- a/apps/ui/lib/types.ts
+++ b/apps/ui/lib/types.ts
@@ -84,3 +84,17 @@ export interface LensRendererProps {
 	totalPages: number;
 	tailTypes: TypeContract[];
 }
+
+export interface ChatGroup {
+	isMine: boolean;
+	name: string;
+	users: string[];
+}
+
+export interface UIActor {
+	name: string;
+	email: string | string[];
+	avatarUrl?: string | null;
+	proxy: boolean;
+	card: UserContract;
+}


### PR DESCRIPTION
This PR converts many Lenses to use the new `TabbedContractLayout` component, and also adds preservation of tab selection and relationship selection to the UI. The selection is per type, so navigating to a different contract of the same type will keep the same tabs active.