### PR TITLE
UI: Use HTTP API for initial contract data load

### DIFF
--- a/apps/ui/lib/core/store/actioncreators/index.ts
+++ b/apps/ui/lib/core/store/actioncreators/index.ts
@@ -641,7 +641,18 @@ export const actionCreators = {
 				query,
 			);
 
-			stream.on('dataset', ({ data: { cards: channels } }) => {
+			const queryOptions = {
+				limit: 1,
+				links: {
+					'has attached element': {
+						limit: 20,
+						sortBy: 'created_at',
+						sortDir: 'desc',
+					},
+				},
+			};
+
+			const handleResult = (result: Contract | undefined) => {
 				const currentChannel = _.find(selectors.getChannels(getState()), {
 					id: channel.id,
 				});
@@ -652,11 +663,11 @@ export const actionCreators = {
 
 				const clonedChannel = clone(currentChannel);
 
-				if (channels.length > 0) {
+				if (result) {
 					// Merge required in the event that this is a pagination query
 					clonedChannel.data.head = merge(
 						_.get(clonedChannel, ['data', 'head'], {}),
-						channels[0],
+						result,
 						{
 							arrayMerge: (destinationArray, sourceArray) => {
 								return _.union(destinationArray, sourceArray);
@@ -669,7 +680,22 @@ export const actionCreators = {
 					type: actions.UPDATE_CHANNEL,
 					value: clonedChannel,
 				});
+			};
+
+			sdk.query(query, queryOptions).then(([result]) => {
+				handleResult(result);
 			});
+
+			stream.on(
+				'dataset',
+				({
+					data: {
+						cards: [result],
+					},
+				}) => {
+					handleResult(result);
+				},
+			);
 
 			stream.on('update', ({ data: { after: newHead } }) => {
 				const currentChannel = _.find(selectors.getChannels(getState()), {
@@ -691,21 +717,6 @@ export const actionCreators = {
 					type: actions.UPDATE_CHANNEL,
 					value: clonedChannel,
 				});
-			});
-
-			stream.emit('queryDataset', {
-				data: {
-					schema: query,
-					options: {
-						links: {
-							'has attached element': {
-								limit: 20,
-								sortBy: 'created_at',
-								sortDir: 'desc',
-							},
-						},
-					},
-				},
 			});
 		};
 	},
@@ -824,7 +835,6 @@ export const actionCreators = {
 				type: actions.ADD_CHANNEL,
 				value: channel,
 			});
-			console.log({ channel });
 			return dispatch(actionCreators.loadChannelData(channel));
 		};
 	},


### PR DESCRIPTION
Using the HTTP API for the initial data load is notably faster than
waiting for a websocket connection and querying the payload over WSS,
resulting in a snappier UX.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
