### PR TITLE
Update haproxy config

### DIFF
--- a/apps/haproxy/haproxy.cfg
+++ b/apps/haproxy/haproxy.cfg
@@ -1,10 +1,10 @@
 global
-tune.ssl.default-dh-param 1024
+  tune.ssl.default-dh-param 1024
 
 defaults
-  timeout connect 5000
-  timeout client 60000
-  timeout server 60000
+  timeout connect 5s
+  timeout client 180s
+  timeout server 180s
   default-server init-addr last,libc,none
 
 resolvers docker-bridge-resolver
@@ -12,10 +12,10 @@ resolvers docker-bridge-resolver
   hold valid 0ms
 
 frontend http_80_in
-mode http
-option forwardfor
-bind *:80
-http-request add-header X-Forwarded-Proto http
+  mode http
+  option forwardfor
+  bind *:80
+  http-request add-header X-Forwarded-Proto http
 
 acl host_ui_backend hdr_dom(host) -i jel.ly.fish.local livechat.ly.fish.local
 use_backend ui_backend if host_ui_backend
@@ -33,59 +33,63 @@ acl host_prometheus_backend hdr_dom(host) -i prometheus.ly.fish.local
 use_backend prometheus_backend if host_prometheus_backend
 
 frontend tcp_5432_in
-mode tcp
-bind *:5432
-default_backend postgres_backend
+    mode tcp
+    bind *:5432
+    timeout client 0
+    default_backend postgres_backend
 
 frontend tcp_6379_in
-mode tcp
-bind *:6379
-default_backend redis_backend
+    mode tcp
+    bind *:6379
+    timeout client 0
+    default_backend redis_backend
 
 frontend tcp_3000_in
-mode tcp
-bind *:3000
-default_backend grafana_backend
+    mode tcp
+    bind *:3000
+    default_backend grafana_backend
 
 frontend tcp_9090_in
-mode tcp
-bind *:9090
-default_backend prometheus_backend
+    mode tcp
+    bind *:9090
+    default_backend prometheus_backend
 
 backend ui_backend
-mode http
-option forwardfor
-balance roundrobin
-server ui ui:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
+    mode http
+    option forwardfor
+    balance roundrobin
+    server ui ui:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
 
 backend redis_backend
-mode tcp
-server redis redis:6379 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 6379
+    mode tcp
+    timeout server 0
+    server redis redis:6379 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 6379
 
 backend postgres_backend
-mode tcp
-server postgres postgres:5432 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 5432
+    mode tcp
+    timeout server 0
+    server postgres postgres:5432 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 5432
 
 backend api_backend
-mode http
-option forwardfor
-balance roundrobin
-server api api:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
+    mode http
+    option forwardfor
+    balance roundrobin
+    server api api:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
 
 backend registry_backend
-mode http
-option forwardfor
-balance roundrobin
-server registry registry:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
+    mode http
+    option forwardfor
+    balance roundrobin
+    server registry registry:80 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 80
 
 backend grafana_backend
-mode http
-option forwardfor
-balance roundrobin
-server grafana grafana:3000 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 3000
+    mode http
+    option forwardfor
+    balance roundrobin
+    server grafana grafana:3000 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 3000
 
 backend prometheus_backend
-mode http
-option forwardfor
-balance roundrobin
-server prometheus prometheus:9090 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 9090
+    mode http
+    option forwardfor
+    balance roundrobin
+    server prometheus prometheus:9090 resolvers docker-bridge-resolver resolve-prefer ipv4 check port 9090


### PR DESCRIPTION
Update whitespace to match official examples.
Update timeouts to help avoid unnecessary disconnects.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Main change here is in the haproxy timeout settings. When using `npm run compose:database` to run Postgres and Redis through haproxy in local compose to work with a local instance of the Jellyfish server not in compose, the connection would timeout and cause the server to crash. This crash is something that should be dealt with in AutumnDB (more intelligent reconnect attempts when necessary), but we also don't need to be strict at all with Postgres and Redis connection timeouts as this is only used during local development. This will change though when we move to run production Jellyfish on balena and therefore use haproxy in production, in which case we should probably drop Postgres and Redis haproxy entries entirely.

Original PR: https://github.com/product-os/jellyfish/pull/8364