### PR TITLE
UI: Use full fieldname for column headers in CSV download

### DIFF
--- a/apps/ui/lib/lens/full/View/Header/index.tsx
+++ b/apps/ui/lib/lens/full/View/Header/index.tsx
@@ -75,7 +75,7 @@ export default React.memo<HeaderProps>((props) => {
 		? Object.keys(csvData[0]).map((key) => {
 				return {
 					key,
-					label: key.split('.').pop(),
+					label: key,
 				};
 		  })
 		: [];


### PR DESCRIPTION
This change fixes an issue where multiple fields in a data set can have the same name, making the CSV column ambiguous.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
