### PR TITLE
UI: Load all results when generating a CSV download

### DIFF
--- a/apps/ui/lib/components/CSVDownloadModal.tsx
+++ b/apps/ui/lib/components/CSVDownloadModal.tsx
@@ -1,0 +1,122 @@
+import _ from 'lodash';
+import React from 'react';
+import { CSVLink } from 'react-csv';
+import { Box, Modal, Txt } from 'rendition';
+import styled from 'styled-components';
+import { Contract } from '@balena/jellyfish-types/build/core';
+import { flatten } from 'flat';
+import { JsonSchema } from '@balena/jellyfish-types';
+import { sdk } from '../core';
+import Icon from './Icon';
+
+// Style CSV link to match rendition theme
+const CSVLinkWrapper = styled(Box)`
+	a {
+		display: block;
+		font-size: 14px;
+		color: #00aeef;
+		text-decoration: none;
+		display: block !important;
+		cursor: pointer;
+	}
+`;
+
+interface HeaderProps {
+	query: JsonSchema;
+	onDone: () => void;
+}
+
+interface CSVData {
+	name: string;
+	rows: Array<{ [key: string]: any }>;
+	headers: Array<{ label: string; key: string }>;
+}
+
+export default React.memo<HeaderProps>((props) => {
+	const { query } = props;
+
+	const [csvData, setCSVData] = React.useState<CSVData | null>(null);
+
+	const load = async () => {
+		const limit = 500;
+		let data: Contract[] = [];
+		while (true) {
+			const results = await sdk.query(query, { limit, skip: data.length });
+			if (results.length) {
+				data = data.concat(results);
+			} else if (data.length < limit) {
+				break;
+			} else {
+				break;
+			}
+		}
+
+		const name = `contracts_${new Date().toISOString()}.csv`;
+		const rows = data.map((item) => {
+			// To keep the CSV functionality simple, don't include any link data in the output
+			const flattened: any = flatten(
+				{
+					...item,
+					links: {},
+					linked_at: item.linked_at || {},
+				},
+				{
+					// "safe" option preserves arrays, preventing a new header being created for each tag/marker
+					safe: true,
+				},
+			);
+			// react-csv does not correctly escape double quotes in fields, so it has to be done here.
+			// Once https://github.com/react-csv/react-csv/pull/287 is resolved, we need to remove this code
+			return _.mapValues(flattened, (field) => {
+				// escape all non-escaped double-quotes (double double-quotes escape them in CSV)
+				return _.isString(field)
+					? field.replace(/([^"]|^)"(?=[^"]|$)/g, '$1""')
+					: field;
+			});
+		});
+
+		const headers = rows.length
+			? Object.keys(rows[0]).map((key) => {
+					return {
+						key,
+						label: key,
+					};
+			  })
+			: [];
+
+		setCSVData({
+			name,
+			headers,
+			rows,
+		});
+	};
+	React.useEffect(() => {
+		load();
+	}, []);
+
+	return (
+		<Modal
+			title="Download data as CSV"
+			done={props.onDone}
+			cancel={props.onDone}
+			primaryButtonProps={{ style: { display: 'none' } }}
+		>
+			{!csvData && (
+				<Txt>
+					Generating CSV... <Icon name="cog" spin />
+				</Txt>
+			)}
+			{!!csvData && (
+				<CSVLinkWrapper>
+					<CSVLink
+						data={csvData.rows}
+						headers={csvData.headers as any}
+						filename={csvData.name}
+					>
+						{csvData.name}
+					</CSVLink>
+				</CSVLinkWrapper>
+			)}
+		</Modal>
+	);
+});

--- a/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
@@ -313,6 +313,7 @@ export interface OwnProps {
 	channel: ChannelContract;
 	card: Contract;
 	onResultsChange?: (collection: Contract[] | null) => any;
+	onQueryUpdate?: (query: JsonSchema) => any;
 	seed?: any;
 	hideFooter?: boolean;
 	useSlices?: boolean;
@@ -639,7 +640,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 	}
 
 	loadViewWithFilters(filters) {
-		const { actions, card, query } = this.props;
+		const { actions, card, query, onQueryUpdate } = this.props;
 		const { searchFilter } = this.state;
 
 		// Omnisearch runs a full text query over a large set of contracts, so we apply
@@ -670,6 +671,10 @@ export default class ViewRenderer extends React.Component<Props, State> {
 			isOmniSearch ? { allOf: [] } : clone(query),
 			targetFilters,
 		);
+
+		if (onQueryUpdate) {
+			onQueryUpdate(viewQuery);
+		}
 
 		this.setState({
 			query: viewQuery,

--- a/apps/ui/lib/lens/full/View/ViewRenderer.tsx
+++ b/apps/ui/lib/lens/full/View/ViewRenderer.tsx
@@ -50,6 +50,7 @@ interface State {
 	redirectTo: null | string;
 	query: JsonSchema | null;
 	results: Contract[] | null;
+	queryWithFilters: JsonSchema | null;
 }
 
 export default class ViewRenderer extends React.Component<Props, State> {
@@ -65,6 +66,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 		this.state = {
 			redirectTo: null,
 			query,
+			queryWithFilters: null,
 			results: null,
 		};
 	}
@@ -72,11 +74,14 @@ export default class ViewRenderer extends React.Component<Props, State> {
 	handleResultsChange = (results: Contract[] | null) => {
 		this.setState({ results });
 	};
+	handleQueryUpdate = (queryWithFilters: JsonSchema) => {
+		this.setState({ queryWithFilters });
+	};
 
 	render() {
 		const { channel, isMobile, card } = this.props;
 
-		const { redirectTo, results, query } = this.state;
+		const { redirectTo, results, query, queryWithFilters } = this.state;
 
 		if (redirectTo) {
 			return <Redirect push to={redirectTo} />;
@@ -99,6 +104,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 					contract={card}
 					channel={channel}
 					results={results}
+					query={queryWithFilters || query}
 				/>
 
 				<LiveCollection
@@ -107,6 +113,7 @@ export default class ViewRenderer extends React.Component<Props, State> {
 					query={query}
 					seed={channel.data.seed}
 					onResultsChange={this.handleResultsChange}
+					onQueryUpdate={this.handleQueryUpdate}
 					useSlices
 				/>
 			</Flex>


### PR DESCRIPTION
Previously, only the results loaded into the client would be downloaded.
Now all matching results are loaded, paginating data if necessary.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
