### PR TITLE
Set NODE_ENV=development for server dev

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,7 +20,7 @@
     "doc": "typedoc lib/",
     "prepack": "npm run build",
     "start": "node --abort-on-uncaught-exception --stack-trace-limit=100 build/index.js",
-    "dev": "nodemon --inspect=0.0.0.0 ./lib/index.ts"
+    "dev": "NODE_ENV=development nodemon --inspect=0.0.0.0 ./lib/index.ts"
   },
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.23",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Ensure that `NODE_ENV` is set to `development` when running the server during development.
