### PR TITLE
Bump worker, simplify contract stream

### DIFF
--- a/[
+++ b/[
@@ -165,18 +165,20 @@ export const bootstrap = async (logContext: LogContext, options: any) => {
 
 	// For better performance, commonly accessed contracts are stored in cache in the worker.
 	// These contracts are streamed from the DB, so the worker always has the most up to date version of them.
-	const transformerContractsStream = await kernel.stream(
+	const workerContractsStream = await kernel.stream(
 		logContext,
 		kernel.adminSession()!,
-		SCHEMA_ACTIVE_TRANSFORMERS,
+		{
+			anyOf: [
+				SCHEMA_ACTIVE_TRANSFORMERS,
+			],
+		},
 	);
 
 	const closeWorker = async () => {
 		await worker.consumer.cancel();
-		transformerContractsStream.removeAllListeners();
-		transformerContractsStream.close();
-		worker.contractsStream.removeAllListeners();
-		worker.contractsStream.close();
+		workerContractsStream.removeAllListeners();
+		workerContractsStream.close();
 		await kernel.disconnect(logContext);
 		if (cache) {
 			await cache.disconnect();
@@ -194,10 +196,10 @@ export const bootstrap = async (logContext: LogContext, options: any) => {
 			.catch(errorFunction);
 	};
 
-	transformerContractsStream.once('error', errorHandler);
+	workerContractsStream.once('error', errorHandler);
 
 	// On a stream event, update the stored contracts in the worker
-	transformerContractsStream.on('data', (change: autumndb.StreamChange) => {
+	workerContractsStream.on('data', (change: autumndb.StreamChange) => {
 		const contract = change.after;
 		if (
 			change.type === 'update' ||
@@ -216,11 +218,8 @@ export const bootstrap = async (logContext: LogContext, options: any) => {
 		}
 	});
 
-	const transformers = await kernel.query(
-		logContext,
-		kernel.adminSession()!,
-		SCHEMA_ACTIVE_TRANSFORMERS,
-	);
+	const transformers = await kernel.query(logContext, kernel.adminSession()!, SCHEMA_ACTIVE_TRANSFORMERS);
+
 	logger.info(logContext, 'Loading transformers', {
 		transformers: transformers.length,
 	});

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-outreach": "^2.0.100",
         "@balena/jellyfish-plugin-product-os": "^4.0.57",
         "@balena/jellyfish-plugin-typeform": "^5.1.21",
-        "@balena/jellyfish-worker": "^21.1.13",
+        "@balena/jellyfish-worker": "^21.2.0",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^19.1.16",
         "aws-sdk": "^2.1111.0",
@@ -930,9 +930,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "21.1.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.1.13.tgz",
-      "integrity": "sha512-FKS7zoCXCIYWJteL+adSPTLVds+/wQeoyG/oDhv3CzI2/mcWA5dy5Vp4xErETEPNeewt7bhLKIfh95PhaFe81Q==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.2.0.tgz",
+      "integrity": "sha512-bcN7+R37FVkPdEHnQ/R+yUzdhGn+Q58OZKhsFk2glWCZrXWFoh+GJS7aRXN1rwDWj18xVcqGpsFpOyN0dNtcNg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.23",
         "@balena/jellyfish-client-sdk": "^10.3.1",
@@ -13069,9 +13069,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "21.1.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.1.13.tgz",
-      "integrity": "sha512-FKS7zoCXCIYWJteL+adSPTLVds+/wQeoyG/oDhv3CzI2/mcWA5dy5Vp4xErETEPNeewt7bhLKIfh95PhaFe81Q==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.2.0.tgz",
+      "integrity": "sha512-bcN7+R37FVkPdEHnQ/R+yUzdhGn+Q58OZKhsFk2glWCZrXWFoh+GJS7aRXN1rwDWj18xVcqGpsFpOyN0dNtcNg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.23",
         "@balena/jellyfish-client-sdk": "^10.3.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,7 +37,7 @@
     "@balena/jellyfish-plugin-outreach": "^2.0.100",
     "@balena/jellyfish-plugin-product-os": "^4.0.57",
     "@balena/jellyfish-plugin-typeform": "^5.1.21",
-    "@balena/jellyfish-worker": "^21.1.13",
+    "@balena/jellyfish-worker": "^21.2.0",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^19.1.16",
     "aws-sdk": "^2.1111.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-outreach": "^2.0.100",
         "@balena/jellyfish-plugin-product-os": "^4.0.57",
         "@balena/jellyfish-plugin-typeform": "^5.1.21",
-        "@balena/jellyfish-worker": "^21.1.13",
+        "@balena/jellyfish-worker": "^21.2.0",
         "@balena/lint": "^6.2.0",
         "@playwright/test": "^1.20.2",
         "autumndb": "^19.1.16",
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "21.1.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.1.13.tgz",
-      "integrity": "sha512-FKS7zoCXCIYWJteL+adSPTLVds+/wQeoyG/oDhv3CzI2/mcWA5dy5Vp4xErETEPNeewt7bhLKIfh95PhaFe81Q==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.2.0.tgz",
+      "integrity": "sha512-bcN7+R37FVkPdEHnQ/R+yUzdhGn+Q58OZKhsFk2glWCZrXWFoh+GJS7aRXN1rwDWj18xVcqGpsFpOyN0dNtcNg==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.23",
@@ -13076,9 +13076,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "21.1.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.1.13.tgz",
-      "integrity": "sha512-FKS7zoCXCIYWJteL+adSPTLVds+/wQeoyG/oDhv3CzI2/mcWA5dy5Vp4xErETEPNeewt7bhLKIfh95PhaFe81Q==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-21.2.0.tgz",
+      "integrity": "sha512-bcN7+R37FVkPdEHnQ/R+yUzdhGn+Q58OZKhsFk2glWCZrXWFoh+GJS7aRXN1rwDWj18xVcqGpsFpOyN0dNtcNg==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.23",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@balena/jellyfish-plugin-outreach": "^2.0.100",
     "@balena/jellyfish-plugin-product-os": "^4.0.57",
     "@balena/jellyfish-plugin-typeform": "^5.1.21",
-    "@balena/jellyfish-worker": "^21.1.13",
+    "@balena/jellyfish-worker": "^21.2.0",
     "@balena/lint": "^6.2.0",
     "@playwright/test": "^1.20.2",
     "autumndb": "^19.1.16",


### PR DESCRIPTION
The worker now updates itself using its own
stream when new type or triggered action
contracts are added to the system.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
