### PR TITLE
Fix switching between lenses

### DIFF
--- a/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
@@ -79,7 +79,7 @@ const getTypesFromSchema = (schema) => {
 
 const setSliceFilter = (filters, lens, slice) => {
 	// We only want to filter by slice if the lens does not supports slices itself!
-	if (!_.get(lens, ['data', 'supportsSlices'])) {
+	if (!_.get(lens, ['data', 'supportsSlices']) && slice) {
 		filters.push({
 			$id: slice.$id,
 			anyOf: [slice],


### PR DESCRIPTION
`/all` view does not have `data.slices` field, causing `slice` being null.
Does kanban lens make sense if there is no slice? This is a quick fix, need to discuss this further.

Change-type: patch