### PR TITLE
Add agents/channels tabs

### DIFF
--- a/apps/ui/lib/lens/full/Channel/index.tsx
+++ b/apps/ui/lib/lens/full/Channel/index.tsx
@@ -9,6 +9,7 @@ import TabbedContractLayout from '../../../layouts/TabbedContractLayout';
 interface State {
 	mineQuery: any;
 	unownedQuery: any;
+	agentsQuery: any;
 }
 
 class ChannelRenderer extends React.Component<LensRendererProps, State> {
@@ -65,9 +66,30 @@ class ChannelRenderer extends React.Component<LensRendererProps, State> {
 			],
 		};
 
+		const agentsQuery = {
+			title: 'Users marked as agents for this channel',
+			type: 'object',
+			properties: {
+				type: {
+					const: 'user@1.0.0',
+				},
+			},
+			$$links: {
+				'is agent for': {
+					type: 'object',
+					properties: {
+						id: {
+							const: card.id,
+						},
+					},
+				},
+			},
+		};
+
 		this.state = {
 			mineQuery,
 			unownedQuery,
+			agentsQuery,
 		};
 	}
 
@@ -125,10 +147,28 @@ class ChannelRenderer extends React.Component<LensRendererProps, State> {
 							}}
 						>
 							<LiveCollection
-								key={2}
+								key={3}
 								hideFooter
 								channel={this.props.channel}
 								query={this.state.unownedQuery}
+								card={this.props.card}
+							/>
+						</Flex>
+					</Tab>,
+
+					<Tab title="Agents">
+						<Flex
+							flexDirection="column"
+							flex="1"
+							style={{
+								maxWidth: '100%',
+							}}
+						>
+							<LiveCollection
+								key={4}
+								hideFooter
+								channel={this.props.channel}
+								query={this.state.agentsQuery}
 								card={this.props.card}
 							/>
 						</Flex>

--- a/apps/ui/lib/lens/full/MyUser/MyUser.tsx
+++ b/apps/ui/lib/lens/full/MyUser/MyUser.tsx
@@ -39,6 +39,7 @@ interface State {
 	improvements: Contract[];
 	milestones: Contract[];
 	issues: Contract[];
+	channelsQuery: JsonSchema;
 }
 
 export default class MyUser extends React.Component<Props, State> {
@@ -158,6 +159,25 @@ export default class MyUser extends React.Component<Props, State> {
 			},
 		};
 
+		const channelsQuery: JsonSchema = {
+			type: 'object',
+			$$links: {
+				'has agent': {
+					type: 'object',
+					properties: {
+						id: {
+							const: props.card.id,
+						},
+					},
+				},
+			},
+			properties: {
+				type: {
+					const: 'channel@1.0.0',
+				},
+			},
+		};
+
 		this.state = {
 			submitting: false,
 			changePassword: {},
@@ -171,6 +191,7 @@ export default class MyUser extends React.Component<Props, State> {
 			improvements: [],
 			milestones: [],
 			issues: [],
+			channelsQuery,
 		};
 	}
 
@@ -351,6 +372,23 @@ export default class MyUser extends React.Component<Props, State> {
 								hideFooter
 								channel={this.props.channel}
 								query={this.state.orgsQuery}
+								card={this.props.card}
+							/>
+						</Flex>
+					</Tab>,
+					<Tab title="Assigned Channels" key="channels">
+						<Flex
+							flexDirection="column"
+							flex="1"
+							style={{
+								maxWidth: '100%',
+							}}
+						>
+							<LiveCollection
+								key="channels"
+								hideFooter
+								channel={this.props.channel}
+								query={this.state.channelsQuery}
 								card={this.props.card}
 							/>
 						</Flex>


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

***

Closes https://github.com/product-os/jellyfish/issues/8597

- Add a new "Agents" tab to the `Channel` lens that displays all users linked to the channel as an agent.
- Add a new "Assigned Channels" tab to the `MyUser` lens that display all channels the user is an agent of.

Depends on:
- https://github.com/product-os/jellyfish-client-sdk/pull/578