### PR TITLE
Improve timeline pagination logic

### DIFF
--- a/apps/ui/lib/components/InfiniteList.tsx
+++ b/apps/ui/lib/components/InfiniteList.tsx
@@ -72,6 +72,19 @@ export const InfiniteList = React.forwardRef<any, InfiniteListProps>(
 						scrollAreaRef.current && isScrolledToTop(scrollAreaRef.current)
 					);
 				},
+				getScrollBottom() {
+					const containerHeight = scrollAreaRef.current?.clientHeight || 0;
+					const scrollHeight = scrollAreaRef.current?.scrollHeight || 0;
+					const scrollTop = scrollAreaRef.current?.scrollTop || 0;
+					return scrollHeight - (scrollTop + containerHeight);
+				},
+				setScrollBottom(bottom: number) {
+					const containerHeight = scrollAreaRef.current?.clientHeight || 0;
+					const scrollHeight = scrollAreaRef.current?.scrollHeight || 0;
+					scrollAreaRef.current?.scrollTo({
+						top: scrollHeight - (containerHeight + bottom),
+					});
+				},
 			};
 
 			if (typeof ref === 'function') {


### PR DESCRIPTION
This change fixes a number of issues with timeline pagination.
1) It fixes an issue where the timeline would always paginate multiple times on
	 initial load.
2) It fixes an issue where the timeline would "stick" at the top and
	 continue to load every page.
3) It fixes an issue where, upon paginating, the timeline would jump,
	 not retaining its position.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
