### PR TITLE
Remove Livepush library scope assumption

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,6 @@ Dockerfile
 postgres_data
 **/node_modules
 **/package*.json.*
-.libs/*/package*.json
-.libs/*/*.tgz*
-.libs/*/lib
+.libs/**/package*.json
+.libs/**/*.tgz*
+.libs/**/lib

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Add endpoints to local hosts file:
 ```
 
 If you are going to be working with any libraries, clone them under `.libs` and checkout your branches.
+Be sure to clone them with the right scope if necessary, for example:
+```
+cd .libs
+mkdir -p @balena
+cd @balena
+git clone git@github.com:product-os/jellyfish-worker.git
+```
 
 Finally, deploy everything to the device by executing `npm run push` from the repository root.
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -16,7 +16,7 @@ COPY ./apps/server/tsconfig.build.json /usr/src/jellyfish/apps/server/tsconfig.b
 #dev-run=/usr/src/jellyfish/scripts/install-packages.js
 
 #dev-cmd-live=cd /usr/src/jellyfish/apps/server && npm run dev
-#dev-copy=./.libs/ /usr/src/jellyfish/apps/server/node_modules/@balena/
+#dev-copy=./.libs/ /usr/src/jellyfish/apps/server/node_modules/
 COPY ./apps/server/lib/ /usr/src/jellyfish/apps/server/lib/
 RUN npm run build
 


### PR DESCRIPTION
Until now our Livepush library setup has
assumed that all library package names
would be scoped under balena. This is
no longer the case for autumndb, so
removing this assumption.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>