### PR TITLE
Increase server stack trace limit

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,7 +18,7 @@
     "test": "catch-uncommitted --skip-node-versionbot-changes && npm run lint && npm run test:integration",
     "doc": "typedoc lib/",
     "prepack": "npm run build",
-    "start": "node --abort-on-uncaught-exception --stack-trace-limit=100 build/index.js",
+    "start": "node --abort-on-uncaught-exception --stack-trace-limit=1000 build/index.js",
     "dev": "NODE_ENV=development nodemon --inspect=0.0.0.0 ./lib/index.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Need more stack trace information on server crashes

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
