### PR TITLE
Update unhandled server log call

### DIFF
--- a/apps/server/lib/index.ts
+++ b/apps/server/lib/index.ts
@@ -15,7 +15,7 @@ const DEFAULT_CONTEXT = {
 };
 
 const onError = (error, message = 'Server error', ctx = DEFAULT_CONTEXT) => {
-	logger.exception(ctx, message, error);
+	logger.error(ctx, message, error);
 	console.error({
 		context: ctx,
 		message,
@@ -64,7 +64,7 @@ try {
 			}
 		})
 		.catch((error) => {
-			logger.exception(context, 'Server error', error);
+			logger.error(context, 'Server error', error);
 			process.exit(1);
 		});
 } catch (error) {


### PR DESCRIPTION
logger.exception() requires the third argument
to be an Error object, but sometimes that is
not the case. A separate error about this is
then output, causing confusing logs.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
