### PR TITLE
Update @balena/jellyfish-worker from 23.0.4 to 23.0.5

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-outreach": "^2.0.136",
         "@balena/jellyfish-plugin-product-os": "^5.0.12",
         "@balena/jellyfish-plugin-typeform": "^5.2.6",
-        "@balena/jellyfish-worker": "^23.0.4",
+        "@balena/jellyfish-worker": "^23.0.5",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^19.1.33",
         "aws-sdk": "^2.1125.0",
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "23.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.4.tgz",
-      "integrity": "sha512-iD6Kq/8Ho60aGgW1xaeDHZIsfZiTp7CyOIOEJj5gDtHKVvPZDzt/cOVBht48980vLHN9MkWV/+nagMOQX/WnPQ==",
+      "version": "23.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.5.tgz",
+      "integrity": "sha512-bh6p78nIRvbhHka8dgr/1zfYGG9X2wXdKzOWBSdfeVMJhdoPuNDneUcFF8tgMz/nxZxnOFnXFYXduSwMFFQDLA==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.26",
         "@balena/jellyfish-client-sdk": "^10.3.8",
@@ -12890,9 +12890,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "23.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.4.tgz",
-      "integrity": "sha512-iD6Kq/8Ho60aGgW1xaeDHZIsfZiTp7CyOIOEJj5gDtHKVvPZDzt/cOVBht48980vLHN9MkWV/+nagMOQX/WnPQ==",
+      "version": "23.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.5.tgz",
+      "integrity": "sha512-bh6p78nIRvbhHka8dgr/1zfYGG9X2wXdKzOWBSdfeVMJhdoPuNDneUcFF8tgMz/nxZxnOFnXFYXduSwMFFQDLA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.26",
         "@balena/jellyfish-client-sdk": "^10.3.8",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,7 +36,7 @@
     "@balena/jellyfish-plugin-outreach": "^2.0.136",
     "@balena/jellyfish-plugin-product-os": "^5.0.12",
     "@balena/jellyfish-plugin-typeform": "^5.2.6",
-    "@balena/jellyfish-worker": "^23.0.4",
+    "@balena/jellyfish-worker": "^23.0.5",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^19.1.33",
     "aws-sdk": "^2.1125.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-outreach": "^2.0.136",
         "@balena/jellyfish-plugin-product-os": "^5.0.12",
         "@balena/jellyfish-plugin-typeform": "^5.2.6",
-        "@balena/jellyfish-worker": "^23.0.4",
+        "@balena/jellyfish-worker": "^23.0.5",
         "@balena/lint": "^6.2.0",
         "@playwright/test": "^1.21.1",
         "autumndb": "^19.1.33",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "23.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.4.tgz",
-      "integrity": "sha512-iD6Kq/8Ho60aGgW1xaeDHZIsfZiTp7CyOIOEJj5gDtHKVvPZDzt/cOVBht48980vLHN9MkWV/+nagMOQX/WnPQ==",
+      "version": "23.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.5.tgz",
+      "integrity": "sha512-bh6p78nIRvbhHka8dgr/1zfYGG9X2wXdKzOWBSdfeVMJhdoPuNDneUcFF8tgMz/nxZxnOFnXFYXduSwMFFQDLA==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.26",
@@ -12951,9 +12951,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "23.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.4.tgz",
-      "integrity": "sha512-iD6Kq/8Ho60aGgW1xaeDHZIsfZiTp7CyOIOEJj5gDtHKVvPZDzt/cOVBht48980vLHN9MkWV/+nagMOQX/WnPQ==",
+      "version": "23.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-23.0.5.tgz",
+      "integrity": "sha512-bh6p78nIRvbhHka8dgr/1zfYGG9X2wXdKzOWBSdfeVMJhdoPuNDneUcFF8tgMz/nxZxnOFnXFYXduSwMFFQDLA==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.26",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@balena/jellyfish-plugin-outreach": "^2.0.136",
     "@balena/jellyfish-plugin-product-os": "^5.0.12",
     "@balena/jellyfish-plugin-typeform": "^5.2.6",
-    "@balena/jellyfish-worker": "^23.0.4",
+    "@balena/jellyfish-worker": "^23.0.5",
     "@balena/lint": "^6.2.0",
     "@playwright/test": "^1.21.1",
     "autumndb": "^19.1.33",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
