### PR TITLE
UI: Include dedicated improvements in count on user table

### DIFF
--- a/apps/ui/lib/lens/misc/UserTable/UserTable.tsx
+++ b/apps/ui/lib/lens/misc/UserTable/UserTable.tsx
@@ -103,17 +103,6 @@ export default class CardTable extends ContractTable {
 					? format(parseISO(timestamp), 'MM/dd/yyyy hh:mm:ss')
 					: null;
 			},
-			/*
-			['links.owns']: (_field, item) => {
-				const temp: any = {};
-				for (const key in item) {
-					if (key.startsWith('links.owns')) {
-						_.set(temp, key, item[key]);
-					}
-				}
-				return temp?.links?.owns?.length;
-			},
-			*/
 		};
 
 		return _.map(paths, ({ title, path }) => {
@@ -141,7 +130,9 @@ export default class CardTable extends ContractTable {
 				...contract,
 				links: {
 					...contract.links,
-					owns: contract.links.owns?.length || 0,
+					owns:
+						(contract.links.owns?.length || 0) +
+						(contract.links['is dedicated to']?.length || 0),
 				},
 			});
 		});

--- a/apps/ui/lib/lens/misc/UserTable/index.ts
+++ b/apps/ui/lib/lens/misc/UserTable/index.ts
@@ -69,30 +69,37 @@ const lens = {
 		queryOptions: {
 			limit: 300,
 			mask: (query: any) => {
+				// Include improvements the user owns or is dedicated to
+				const improvementQuery = {
+					type: 'object',
+					properties: {
+						type: {
+							const: 'improvement@1.0.0',
+						},
+						data: {
+							type: 'object',
+							properties: {
+								// Don't include finished improvements
+								status: {
+									not: {
+										enum: ['denied-or-failed', 'completed'],
+									},
+								},
+							},
+						},
+					},
+				};
 				if (query.anyOf) {
 					query.anyOf.push({
 						anyOf: [
 							{
 								$$links: {
-									owns: {
-										type: 'object',
-										properties: {
-											type: {
-												const: 'improvement@1.0.0',
-											},
-											data: {
-												type: 'object',
-												properties: {
-													// Don't include finished improvements
-													status: {
-														not: {
-															enum: ['denied-or-failed', 'completed'],
-														},
-													},
-												},
-											},
-										},
-									},
+									'is dedicated to': improvementQuery,
+								},
+							},
+							{
+								$$links: {
+									owns: improvementQuery,
 								},
 							},
 							true,


### PR DESCRIPTION
Previously the user table would only show the number of owned
improvements, but wouldn't include "dedicated" users, which indicates
they are working on an improvement but not the owner.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
