### PR TITLE
Update autumndb from 19.1.41 to 19.3.1

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -25,7 +25,7 @@
         "@balena/jellyfish-plugin-typeform": "^5.2.13",
         "@balena/jellyfish-worker": "^23.0.17",
         "@balena/socket-prometheus-metrics": "^0.0.3",
-        "autumndb": "^19.1.41",
+        "autumndb": "^19.3.1",
         "aws-sdk": "^2.1130.0",
         "bcrypt": "^5.0.1",
         "bluebird": "^3.7.2",
@@ -2979,9 +2979,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/autumndb": {
-      "version": "19.1.41",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.1.41.tgz",
-      "integrity": "sha512-0nkcZo/I4kk/vx1glO+VoQ6yert2yH+9uEVCrlH5WkiFtIH4w6D0YlMmXs/qqrdm/QpyNXAcHJFKZMUBiP2IfA==",
+      "version": "19.3.1",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.3.1.tgz",
+      "integrity": "sha512-nP0Dmig0W/aGqHSNYb00hWtxZoOXC8LlxfZtzC2EdROCyIT7OcjvDM9/ZMM+W/RZWGsRNp39Ga/uKT/LYfyogg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-environment": "^11.0.3",
@@ -14645,9 +14645,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "autumndb": {
-      "version": "19.1.41",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.1.41.tgz",
-      "integrity": "sha512-0nkcZo/I4kk/vx1glO+VoQ6yert2yH+9uEVCrlH5WkiFtIH4w6D0YlMmXs/qqrdm/QpyNXAcHJFKZMUBiP2IfA==",
+      "version": "19.3.1",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.3.1.tgz",
+      "integrity": "sha512-nP0Dmig0W/aGqHSNYb00hWtxZoOXC8LlxfZtzC2EdROCyIT7OcjvDM9/ZMM+W/RZWGsRNp39Ga/uKT/LYfyogg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-environment": "^11.0.3",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -38,7 +38,7 @@
     "@balena/jellyfish-plugin-typeform": "^5.2.13",
     "@balena/jellyfish-worker": "^23.0.17",
     "@balena/socket-prometheus-metrics": "^0.0.3",
-    "autumndb": "^19.1.41",
+    "autumndb": "^19.3.1",
     "aws-sdk": "^2.1130.0",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@balena/jellyfish-worker": "^23.0.17",
         "@balena/lint": "^6.2.0",
         "@playwright/test": "^1.21.1",
-        "autumndb": "^19.1.41",
+        "autumndb": "^19.3.1",
         "ava": "^4.2.0",
         "aws-sdk": "^2.1130.0",
         "bluebird": "^3.7.2",
@@ -2736,9 +2736,9 @@
       "dev": true
     },
     "node_modules/autumndb": {
-      "version": "19.1.41",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.1.41.tgz",
-      "integrity": "sha512-0nkcZo/I4kk/vx1glO+VoQ6yert2yH+9uEVCrlH5WkiFtIH4w6D0YlMmXs/qqrdm/QpyNXAcHJFKZMUBiP2IfA==",
+      "version": "19.3.1",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.3.1.tgz",
+      "integrity": "sha512-nP0Dmig0W/aGqHSNYb00hWtxZoOXC8LlxfZtzC2EdROCyIT7OcjvDM9/ZMM+W/RZWGsRNp39Ga/uKT/LYfyogg==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.29",
@@ -14192,9 +14192,9 @@
       "dev": true
     },
     "autumndb": {
-      "version": "19.1.41",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.1.41.tgz",
-      "integrity": "sha512-0nkcZo/I4kk/vx1glO+VoQ6yert2yH+9uEVCrlH5WkiFtIH4w6D0YlMmXs/qqrdm/QpyNXAcHJFKZMUBiP2IfA==",
+      "version": "19.3.1",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-19.3.1.tgz",
+      "integrity": "sha512-nP0Dmig0W/aGqHSNYb00hWtxZoOXC8LlxfZtzC2EdROCyIT7OcjvDM9/ZMM+W/RZWGsRNp39Ga/uKT/LYfyogg==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.29",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@balena/jellyfish-worker": "^23.0.17",
     "@balena/lint": "^6.2.0",
     "@playwright/test": "^1.21.1",
-    "autumndb": "^19.1.41",
+    "autumndb": "^19.3.1",
     "ava": "^4.2.0",
     "aws-sdk": "^2.1130.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
