### PR TITLE
Revert repo type back to generic

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,4 +1,4 @@
-type: 'docker'
+type: 'generic'
 upstream:
   - repo: 'open-balena-base'
     url: 'https://github.com/balena-io/open-balena-base'


### PR DESCRIPTION
Revert back to generic as docker
causes the ResinCI/build/Docker
check to be automatically enabled
and required.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
