### PR TITLE
Update @balena/jellyfish-plugin-github from 3.0.3 to 3.0.5

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -19,7 +19,7 @@
         "@balena/jellyfish-plugin-discourse": "^3.0.0",
         "@balena/jellyfish-plugin-flowdock": "^3.0.0",
         "@balena/jellyfish-plugin-front": "^3.0.0",
-        "@balena/jellyfish-plugin-github": "^3.0.3",
+        "@balena/jellyfish-plugin-github": "^3.0.5",
         "@balena/jellyfish-plugin-outreach": "^3.0.0",
         "@balena/jellyfish-plugin-product-os": "^5.0.24",
         "@balena/jellyfish-plugin-typeform": "^6.1.0",
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-github": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.3.tgz",
-      "integrity": "sha512-Du+HKPSjVUO2BFyW6VQsHyJe4sfRcuvHamvscUr8eFN63vJgjMHyhIEbdvN45Xe4GEdVpc9ndUkjJlfHmnUbiA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.5.tgz",
+      "integrity": "sha512-hJSIs14QWztlvHaOxw8iWrmnGK3xb3orJOm6oqPyxjt1K0jrbaEFu2hvLG8m4Uq2No+2O4rcRzqlLJ8dulhfCQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-worker": "^24.2.0",
@@ -841,10 +841,54 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.6.2",
         "@octokit/rest": "^18.12.0",
-        "autumndb": "^19.3.1",
+        "autumndb": "^20.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">=14.2.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-plugin-github/node_modules/@balena/jellyfish-environment": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.0.0.tgz",
+      "integrity": "sha512-NjBUAyY/Q88G74mz9G53e8ben2K64AJyV0fT3R6Ae5jwxWP0A6iswB8kzQu63ZhhkKvIkkcUTmKsR7lov2OZaQ==",
+      "dependencies": {
+        "@humanwhocodes/env": "^2.2.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=12.15.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-plugin-github/node_modules/autumndb": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-20.0.1.tgz",
+      "integrity": "sha512-QQ51AcoY0WvBTupSxq4qvq4I6vJwk9I6fBAE4MnTuhK+TA9HxxJ+NPP3due7MnKj6j2MhJ2k0DHUo0z/3bcssw==",
+      "dependencies": {
+        "@balena/jellyfish-assert": "^1.2.29",
+        "@balena/jellyfish-environment": "^12.0.0",
+        "@balena/jellyfish-logger": "^5.0.31",
+        "@balena/jellyfish-metrics": "^2.0.76",
+        "bluebird": "^3.7.2",
+        "fast-equals": "^3.0.2",
+        "fast-json-patch": "^3.1.1",
+        "json-e": "^4.4.3",
+        "json-schema": "^0.4.0",
+        "json-schema-deref-sync": "^0.14.0",
+        "lodash": "^4.17.21",
+        "pg": "^8.7.3",
+        "pg-format": "^1.0.4",
+        "redis": "4.0.6",
+        "redis-mock": "^0.56.3",
+        "semver": "^7.3.7",
+        "skhema": "^6.0.6",
+        "stopword": "^2.0.2",
+        "traverse": "^0.6.6",
+        "typed-error": "^3.2.1",
+        "uuid": "^8.3.2",
+        "uuid-v4-regex": "^1.0.2"
       },
       "engines": {
         "node": ">=14.2.0"
@@ -12827,9 +12871,9 @@
       }
     },
     "@balena/jellyfish-plugin-github": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.3.tgz",
-      "integrity": "sha512-Du+HKPSjVUO2BFyW6VQsHyJe4sfRcuvHamvscUr8eFN63vJgjMHyhIEbdvN45Xe4GEdVpc9ndUkjJlfHmnUbiA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.5.tgz",
+      "integrity": "sha512-hJSIs14QWztlvHaOxw8iWrmnGK3xb3orJOm6oqPyxjt1K0jrbaEFu2hvLG8m4Uq2No+2O4rcRzqlLJ8dulhfCQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-worker": "^24.2.0",
@@ -12837,10 +12881,50 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.6.2",
         "@octokit/rest": "^18.12.0",
-        "autumndb": "^19.3.1",
+        "autumndb": "^20.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-environment": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.0.0.tgz",
+          "integrity": "sha512-NjBUAyY/Q88G74mz9G53e8ben2K64AJyV0fT3R6Ae5jwxWP0A6iswB8kzQu63ZhhkKvIkkcUTmKsR7lov2OZaQ==",
+          "requires": {
+            "@humanwhocodes/env": "^2.2.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "autumndb": {
+          "version": "20.0.1",
+          "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-20.0.1.tgz",
+          "integrity": "sha512-QQ51AcoY0WvBTupSxq4qvq4I6vJwk9I6fBAE4MnTuhK+TA9HxxJ+NPP3due7MnKj6j2MhJ2k0DHUo0z/3bcssw==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.2.29",
+            "@balena/jellyfish-environment": "^12.0.0",
+            "@balena/jellyfish-logger": "^5.0.31",
+            "@balena/jellyfish-metrics": "^2.0.76",
+            "bluebird": "^3.7.2",
+            "fast-equals": "^3.0.2",
+            "fast-json-patch": "^3.1.1",
+            "json-e": "^4.4.3",
+            "json-schema": "^0.4.0",
+            "json-schema-deref-sync": "^0.14.0",
+            "lodash": "^4.17.21",
+            "pg": "^8.7.3",
+            "pg-format": "^1.0.4",
+            "redis": "4.0.6",
+            "redis-mock": "^0.56.3",
+            "semver": "^7.3.7",
+            "skhema": "^6.0.6",
+            "stopword": "^2.0.2",
+            "traverse": "^0.6.6",
+            "typed-error": "^3.2.1",
+            "uuid": "^8.3.2",
+            "uuid-v4-regex": "^1.0.2"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-outreach": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -32,7 +32,7 @@
     "@balena/jellyfish-plugin-discourse": "^3.0.0",
     "@balena/jellyfish-plugin-flowdock": "^3.0.0",
     "@balena/jellyfish-plugin-front": "^3.0.0",
-    "@balena/jellyfish-plugin-github": "^3.0.3",
+    "@balena/jellyfish-plugin-github": "^3.0.5",
     "@balena/jellyfish-plugin-outreach": "^3.0.0",
     "@balena/jellyfish-plugin-product-os": "^5.0.24",
     "@balena/jellyfish-plugin-typeform": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@balena/jellyfish-plugin-discourse": "^3.0.0",
         "@balena/jellyfish-plugin-flowdock": "^3.0.0",
         "@balena/jellyfish-plugin-front": "^3.0.0",
-        "@balena/jellyfish-plugin-github": "^3.0.3",
+        "@balena/jellyfish-plugin-github": "^3.0.5",
         "@balena/jellyfish-plugin-outreach": "^3.0.0",
         "@balena/jellyfish-plugin-product-os": "^5.0.24",
         "@balena/jellyfish-plugin-typeform": "^6.1.0",
@@ -1040,9 +1040,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-github": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.3.tgz",
-      "integrity": "sha512-Du+HKPSjVUO2BFyW6VQsHyJe4sfRcuvHamvscUr8eFN63vJgjMHyhIEbdvN45Xe4GEdVpc9ndUkjJlfHmnUbiA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.5.tgz",
+      "integrity": "sha512-hJSIs14QWztlvHaOxw8iWrmnGK3xb3orJOm6oqPyxjt1K0jrbaEFu2hvLG8m4Uq2No+2O4rcRzqlLJ8dulhfCQ==",
       "dev": true,
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.29",
@@ -1051,10 +1051,56 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.6.2",
         "@octokit/rest": "^18.12.0",
-        "autumndb": "^19.3.1",
+        "autumndb": "^20.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">=14.2.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-plugin-github/node_modules/@balena/jellyfish-environment": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.0.0.tgz",
+      "integrity": "sha512-NjBUAyY/Q88G74mz9G53e8ben2K64AJyV0fT3R6Ae5jwxWP0A6iswB8kzQu63ZhhkKvIkkcUTmKsR7lov2OZaQ==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/env": "^2.2.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=12.15.0"
+      }
+    },
+    "node_modules/@balena/jellyfish-plugin-github/node_modules/autumndb": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-20.0.1.tgz",
+      "integrity": "sha512-QQ51AcoY0WvBTupSxq4qvq4I6vJwk9I6fBAE4MnTuhK+TA9HxxJ+NPP3due7MnKj6j2MhJ2k0DHUo0z/3bcssw==",
+      "dev": true,
+      "dependencies": {
+        "@balena/jellyfish-assert": "^1.2.29",
+        "@balena/jellyfish-environment": "^12.0.0",
+        "@balena/jellyfish-logger": "^5.0.31",
+        "@balena/jellyfish-metrics": "^2.0.76",
+        "bluebird": "^3.7.2",
+        "fast-equals": "^3.0.2",
+        "fast-json-patch": "^3.1.1",
+        "json-e": "^4.4.3",
+        "json-schema": "^0.4.0",
+        "json-schema-deref-sync": "^0.14.0",
+        "lodash": "^4.17.21",
+        "pg": "^8.7.3",
+        "pg-format": "^1.0.4",
+        "redis": "4.0.6",
+        "redis-mock": "^0.56.3",
+        "semver": "^7.3.7",
+        "skhema": "^6.0.6",
+        "stopword": "^2.0.2",
+        "traverse": "^0.6.6",
+        "typed-error": "^3.2.1",
+        "uuid": "^8.3.2",
+        "uuid-v4-regex": "^1.0.2"
       },
       "engines": {
         "node": ">=14.2.0"
@@ -12758,9 +12804,9 @@
       }
     },
     "@balena/jellyfish-plugin-github": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.3.tgz",
-      "integrity": "sha512-Du+HKPSjVUO2BFyW6VQsHyJe4sfRcuvHamvscUr8eFN63vJgjMHyhIEbdvN45Xe4GEdVpc9ndUkjJlfHmnUbiA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-3.0.5.tgz",
+      "integrity": "sha512-hJSIs14QWztlvHaOxw8iWrmnGK3xb3orJOm6oqPyxjt1K0jrbaEFu2hvLG8m4Uq2No+2O4rcRzqlLJ8dulhfCQ==",
       "dev": true,
       "requires": {
         "@balena/jellyfish-assert": "^1.2.29",
@@ -12769,10 +12815,52 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.6.2",
         "@octokit/rest": "^18.12.0",
-        "autumndb": "^19.3.1",
+        "autumndb": "^20.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "@balena/jellyfish-environment": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.0.0.tgz",
+          "integrity": "sha512-NjBUAyY/Q88G74mz9G53e8ben2K64AJyV0fT3R6Ae5jwxWP0A6iswB8kzQu63ZhhkKvIkkcUTmKsR7lov2OZaQ==",
+          "dev": true,
+          "requires": {
+            "@humanwhocodes/env": "^2.2.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "autumndb": {
+          "version": "20.0.1",
+          "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-20.0.1.tgz",
+          "integrity": "sha512-QQ51AcoY0WvBTupSxq4qvq4I6vJwk9I6fBAE4MnTuhK+TA9HxxJ+NPP3due7MnKj6j2MhJ2k0DHUo0z/3bcssw==",
+          "dev": true,
+          "requires": {
+            "@balena/jellyfish-assert": "^1.2.29",
+            "@balena/jellyfish-environment": "^12.0.0",
+            "@balena/jellyfish-logger": "^5.0.31",
+            "@balena/jellyfish-metrics": "^2.0.76",
+            "bluebird": "^3.7.2",
+            "fast-equals": "^3.0.2",
+            "fast-json-patch": "^3.1.1",
+            "json-e": "^4.4.3",
+            "json-schema": "^0.4.0",
+            "json-schema-deref-sync": "^0.14.0",
+            "lodash": "^4.17.21",
+            "pg": "^8.7.3",
+            "pg-format": "^1.0.4",
+            "redis": "4.0.6",
+            "redis-mock": "^0.56.3",
+            "semver": "^7.3.7",
+            "skhema": "^6.0.6",
+            "stopword": "^2.0.2",
+            "traverse": "^0.6.6",
+            "typed-error": "^3.2.1",
+            "uuid": "^8.3.2",
+            "uuid-v4-regex": "^1.0.2"
+          }
+        }
       }
     },
     "@balena/jellyfish-plugin-outreach": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@balena/jellyfish-plugin-discourse": "^3.0.0",
     "@balena/jellyfish-plugin-flowdock": "^3.0.0",
     "@balena/jellyfish-plugin-front": "^3.0.0",
-    "@balena/jellyfish-plugin-github": "^3.0.3",
+    "@balena/jellyfish-plugin-github": "^3.0.5",
     "@balena/jellyfish-plugin-outreach": "^3.0.0",
     "@balena/jellyfish-plugin-product-os": "^5.0.24",
     "@balena/jellyfish-plugin-typeform": "^6.1.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
