### PR TITLE
Limit concurrent Renovate PRs to 1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "github>product-os/renovate-config"
   ],
+  "prConcurrentLimit": 1,
   "packageRules": [
     {
       "matchPackagePatterns": ["puppeteer"],


### PR DESCRIPTION
Limit concurrent Renovate PRs to reduce unnecessary
load on balena builders and reduce CI flakiness

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>