### PR TITLE
UI: Use snippet lens for Kanban board cards

### DIFF
--- a/apps/ui/lib/lens/misc/Kanban/Card.tsx
+++ b/apps/ui/lib/lens/misc/Kanban/Card.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Card as RenditionCard } from 'rendition';
+
+export const Card = (props) => {
+	const contract = props.card;
+	const { getLenses } = require('../../');
+	const lenses = getLenses('snippet', contract);
+	const snippetLens = lenses[0];
+	return (
+		<RenditionCard p={0} style={{ maxWidth: 256 }}>
+			<snippetLens.data.renderer card={contract} />
+		</RenditionCard>
+	);
+};

--- a/apps/ui/lib/lens/misc/Kanban/Kanban.tsx
+++ b/apps/ui/lib/lens/misc/Kanban/Kanban.tsx
@@ -7,6 +7,7 @@ import skhema from 'skhema';
 import * as notifications from '../../../services/notifications';
 import * as helpers from '../../../services/helpers';
 import { analytics, sdk } from '../../../core';
+import { Card } from './Card';
 
 const TrelloWrapper = styled(Flex)`
 	height: 100%;
@@ -161,6 +162,7 @@ export default class Kanban extends React.Component<any, any> {
 				id: `${schema.description}`,
 				cards: [],
 				title: label,
+				label: '(0)',
 			};
 			if (!cards.length) {
 				lanes.push(lane);
@@ -171,6 +173,7 @@ export default class Kanban extends React.Component<any, any> {
 			});
 			lane.cards = _.map(slicedCards, cardMapper);
 			cards = remaining;
+			lane.label = `(${lane.cards.length})`;
 			lanes.push(lane);
 		});
 
@@ -190,7 +193,9 @@ export default class Kanban extends React.Component<any, any> {
 			lanes: this.getLanes(),
 		};
 
-		const components = {};
+		const components = {
+			Card,
+		};
 
 		return (
 			<TrelloWrapper data-test={`lens--${SLUG}`} flexDirection="column">


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
