### PR TITLE
Update react-virtuoso from 2.10.2 to 2.12.0

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -65,7 +65,7 @@
         "react-swipeable": "^6.2.2",
         "react-textarea-autosize": "^8.3.3",
         "react-trello": "^2.2.11",
-        "react-virtuoso": "^2.10.2",
+        "react-virtuoso": "^2.12.0",
         "react-visibility-sensor": "^5.1.1",
         "redux": "^4.2.0",
         "redux-persist": "^6.0.0",
@@ -19741,9 +19741,9 @@
       }
     },
     "node_modules/react-virtuoso": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-2.10.2.tgz",
-      "integrity": "sha512-nQ8Wt/q64q6walcXo4y9SXkvZqjwuLiNUv7aKW3poKoZno8agTgeqcX1GMq3GPlaJ8wR5XMGwBxX4HONBMAGfg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-2.12.0.tgz",
+      "integrity": "sha512-P30H7GMQfqJxaS5N4I+yfLqaUpy6w8YjZjvvYhI5m6Jw/12dj77SzcX7/Xzs14y/EFhGaI0kkh+yaU0MNjhENw==",
       "dependencies": {
         "@virtuoso.dev/react-urx": "^0.2.12",
         "@virtuoso.dev/urx": "^0.2.12"
@@ -40748,9 +40748,9 @@
       }
     },
     "react-virtuoso": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-2.10.2.tgz",
-      "integrity": "sha512-nQ8Wt/q64q6walcXo4y9SXkvZqjwuLiNUv7aKW3poKoZno8agTgeqcX1GMq3GPlaJ8wR5XMGwBxX4HONBMAGfg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-2.12.0.tgz",
+      "integrity": "sha512-P30H7GMQfqJxaS5N4I+yfLqaUpy6w8YjZjvvYhI5m6Jw/12dj77SzcX7/Xzs14y/EFhGaI0kkh+yaU0MNjhENw==",
       "requires": {
         "@virtuoso.dev/react-urx": "^0.2.12",
         "@virtuoso.dev/urx": "^0.2.12"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -78,7 +78,7 @@
     "react-swipeable": "^6.2.2",
     "react-textarea-autosize": "^8.3.3",
     "react-trello": "^2.2.11",
-    "react-virtuoso": "^2.10.2",
+    "react-virtuoso": "^2.12.0",
     "react-visibility-sensor": "^5.1.1",
     "redux": "^4.2.0",
     "redux-persist": "^6.0.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>
