### PR TITLE
UI: Fix generation of kanban columns when viewing related contracts

### DIFF
--- a/apps/ui/lib/lens/misc/Kanban/Kanban.tsx
+++ b/apps/ui/lib/lens/misc/Kanban/Kanban.tsx
@@ -143,12 +143,12 @@ export default withSetup(
 				};
 				return helpers.getSchemaSlices(schema, this.props.types) || [];
 			}
-			// Otherwise spoof a view
+			// Otherwise spoof a schema
 			if (this.props.tail && this.props.tail.length > 0) {
 				const sample: any = _.first(this.props.tail);
 				const schema: any = _.set(
 					{},
-					['schema', 'properties', 'type', 'const'],
+					['properties', 'type', 'const'],
 					sample.type,
 				);
 				return helpers.getSchemaSlices(schema, this.props.types) || [];

--- a/apps/ui/lib/lens/misc/Kanban/Kanban.tsx
+++ b/apps/ui/lib/lens/misc/Kanban/Kanban.tsx
@@ -1,13 +1,20 @@
 import _ from 'lodash';
 import React from 'react';
-import styled from 'styled-components';
+import { RouteComponentProps } from 'react-router-dom';
 import ReactTrello from 'react-trello';
 import { Flex } from 'rendition';
 import skhema from 'skhema';
+import styled from 'styled-components';
 import * as notifications from '../../../services/notifications';
 import * as helpers from '../../../services/helpers';
 import { Card } from './Card';
-import { withSetup } from '../../../components';
+import { Setup, withSetup } from '../../../components/SetupProvider';
+import { actionCreators } from '../../../store';
+import type { BoundActionCreators, LensRendererProps } from '../../../types';
+import type {
+	Contract,
+	TypeContract,
+} from '@balena/jellyfish-types/build/core';
 
 const TrelloWrapper = styled(Flex)`
 	height: 100%;
@@ -27,7 +34,7 @@ const UNSORTED_GROUP_ID = 'JELLYFISH_UNSORTED_GROUP';
 
 export const SLUG = 'lens-kanban';
 
-const cardMapper = (card) => {
+const cardMapper = (card: Contract) => {
 	const message = _.find(
 		_.get(card, ['links', 'has attached element']),
 		(linkedCard) => {
@@ -44,32 +51,41 @@ const cardMapper = (card) => {
 	};
 };
 
+export type OwnProps = LensRendererProps;
+export interface StateProps {
+	types: TypeContract[];
+}
+
+export interface DispatchProps {
+	actions: BoundActionCreators<typeof actionCreators>;
+}
+
+type Props = StateProps &
+	DispatchProps &
+	OwnProps &
+	RouteComponentProps &
+	Setup;
+
 export default withSetup(
-	class Kanban extends React.Component<any, any> {
-		constructor(props) {
+	class Kanban extends React.Component<Props, {}> {
+		constructor(props: Props) {
 			super(props);
 
-			this.openCreateChannel = this.openCreateChannel.bind(this);
 			this.handleDragEnd = this.handleDragEnd.bind(this);
 			this.onCardClick = this.onCardClick.bind(this);
 		}
 
-		openCreateChannel() {
-			const { type, actions, card } = this.props;
-			actions.openCreateChannel(card, type);
-		}
-
-		onCardClick(cardId) {
-			const card = _.find(this.props.tail, {
+		onCardClick(cardId: string) {
+			const card: Contract = _.find(this.props.tail, {
 				id: cardId,
-			});
+			})!;
 
 			this.props.history.push(
 				helpers.appendToChannelPath(this.props.channel, card),
 			);
 		}
 
-		handleDragEnd(cardId, _sourceLaneId, targetLaneId) {
+		handleDragEnd(cardId: string, _sourceLaneId: string, targetLaneId: string) {
 			const card = _.find(this.props.tail, {
 				id: cardId,
 			});
@@ -123,7 +139,7 @@ export default withSetup(
 			// If the head contract is a view, use it to find the slices
 			if (head && head.type.split('@')[0] === 'view') {
 				const schema = {
-					allOf: head.data.allOf.map((block) => block.schema),
+					allOf: (head as any).data.allOf.map((block) => block.schema),
 				};
 				return helpers.getSchemaSlices(schema, this.props.types) || [];
 			}
@@ -144,11 +160,6 @@ export default withSetup(
 			if (!this.props.tail || !this.props.tail.length) {
 				return [];
 			}
-			const activeSlice = _.get(this.props, [
-				'subscription',
-				'data',
-				'activeSlice',
-			]);
 			let cards = this.props.tail.slice();
 			const lanes: any[] = [];
 			const slices = this.getSlices();

--- a/apps/ui/lib/lens/misc/Kanban/index.ts
+++ b/apps/ui/lib/lens/misc/Kanban/index.ts
@@ -1,32 +1,30 @@
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { bindActionCreators } from 'redux';
+import { bindActionCreators } from '../../../bindactioncreators';
 import { actionCreators, selectors } from '../../../store';
 import { createLazyComponent } from '../../../components/SafeLazy';
 import { SLUG } from './Kanban';
+import type { DispatchProps, StateProps, OwnProps } from './Kanban';
+import { LensContract } from '../../../types';
 
 export const Kanban = createLazyComponent(
 	() => import(/* webpackChunkName: "lens-kanban" */ './Kanban'),
 );
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state): StateProps => {
 	return {
 		types: selectors.getTypes()(state),
-		user: selectors.getCurrentUser()(state),
 	};
 };
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch): DispatchProps => {
 	return {
-		actions: bindActionCreators(
-			_.pick(actionCreators, ['addChannel', 'openCreateChannel']),
-			dispatch,
-		),
+		actions: bindActionCreators(actionCreators, dispatch),
 	};
 };
 
-const lens = {
+const lens: LensContract = {
 	slug: SLUG,
 	type: 'lens',
 	version: '1.0.0',
@@ -36,7 +34,12 @@ const lens = {
 		label: 'Kanban',
 		icon: 'columns',
 		format: 'list',
-		renderer: withRouter(connect(mapStateToProps, mapDispatchToProps)(Kanban)),
+		renderer: withRouter(
+			connect<StateProps, DispatchProps, OwnProps>(
+				mapStateToProps,
+				mapDispatchToProps,
+			)(Kanban),
+		),
 		filter: {
 			type: 'array',
 			items: {
@@ -50,7 +53,7 @@ const lens = {
 		},
 		queryOptions: {
 			limit: 500,
-			sortBy: ['created_at'],
+			sortBy: 'created_at',
 			sortDir: 'desc',
 		},
 	},

--- a/apps/ui/lib/services/helpers.ts
+++ b/apps/ui/lib/services/helpers.ts
@@ -15,7 +15,7 @@ import { SchemaSieve } from 'rendition';
 import skhema from 'skhema';
 import { DetectUA } from 'detect-ua';
 import { MESSAGE, WHISPER, SUMMARY, RATING } from '../components/constants';
-import { Channel, JSONPatch, UIActor } from '../types';
+import { ChannelContract, JSONPatch, UIActor } from '../types';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type {
 	Contract,
@@ -60,7 +60,7 @@ export const pathWithoutTarget = (target: string) => {
 	return `/${filtered}`;
 };
 
-export const pathWithoutChannel = (channel: Channel) => {
+export const pathWithoutChannel = (channel: ChannelContract) => {
 	return pathWithoutTarget(channel.data.target);
 };
 
@@ -80,7 +80,10 @@ export const cardReference = (card: any) => {
 	return card.slug || card.id;
 };
 
-export const appendToChannelPath = (channel: Channel, card: Contract) => {
+export const appendToChannelPath = (
+	channel: ChannelContract,
+	card: Contract,
+) => {
 	const parts: string[] = [];
 	const pieces = window.location.pathname.split('/');
 	const target = _.get(channel, ['data', 'target']);

--- a/apps/ui/lib/types.ts
+++ b/apps/ui/lib/types.ts
@@ -6,10 +6,6 @@ import type {
 } from '@balena/jellyfish-types/build/core';
 import React from 'react';
 
-export type Channel = Contract<{
-	target: string;
-}>;
-
 export interface JSONPatch {
 	op: 'add' | 'remove' | 'replace';
 	path: string[] | string;
@@ -53,7 +49,7 @@ export interface LensContract
 			limit?: number;
 			sortBy?: string;
 			sortDir?: 'asc' | 'desc';
-			mask: (query: JsonSchema) => JsonSchema;
+			mask?: (query: JsonSchema) => JsonSchema;
 		};
 	};
 }


### PR DESCRIPTION
Previously column generation would not work correctly when viewing
a collection of related contracts (as opposed to viewing a collection in
a view).

Notably, this fixes milestones and issues being displayed in kanban columns:

![image](https://user-images.githubusercontent.com/15064535/171147622-ec760e67-d874-491e-b953-45f90a77a202.png)
