### PR TITLE
Revert recent changes to paid support thread view

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -15,7 +15,7 @@
         "@balena/jellyfish-metrics": "^2.0.84",
         "@balena/jellyfish-plugin-balena-api": "^5.0.16",
         "@balena/jellyfish-plugin-channels": "^3.1.13",
-        "@balena/jellyfish-plugin-default": "^27.4.7",
+        "@balena/jellyfish-plugin-default": "^27.4.11",
         "@balena/jellyfish-plugin-discourse": "^5.0.16",
         "@balena/jellyfish-plugin-flowdock": "^5.0.16",
         "@balena/jellyfish-plugin-front": "^5.0.15",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-default": {
-      "version": "27.4.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.4.7.tgz",
-      "integrity": "sha512-cGZSYojxfEe/PCV94nUs+OvHcROPixyYm/ngdcZ25HI0HuGV9kDn+1qZJx5Jt6UCDao13JuF5sN/63s/B6FwdA==",
+      "version": "27.4.11",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.4.11.tgz",
+      "integrity": "sha512-ErskwoGbMfMrlrxTJaxjN3YS7eV78TX61sSufvNQ7ojzbJukQGollJC0FRcVz5zPe5YpnGiclikFwxR0Bnv9BQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-environment": "^12.0.3",
@@ -11757,9 +11757,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "27.4.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.4.7.tgz",
-      "integrity": "sha512-cGZSYojxfEe/PCV94nUs+OvHcROPixyYm/ngdcZ25HI0HuGV9kDn+1qZJx5Jt6UCDao13JuF5sN/63s/B6FwdA==",
+      "version": "27.4.11",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.4.11.tgz",
+      "integrity": "sha512-ErskwoGbMfMrlrxTJaxjN3YS7eV78TX61sSufvNQ7ojzbJukQGollJC0FRcVz5zPe5YpnGiclikFwxR0Bnv9BQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-environment": "^12.0.3",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-metrics": "^2.0.84",
     "@balena/jellyfish-plugin-balena-api": "^5.0.16",
     "@balena/jellyfish-plugin-channels": "^3.1.13",
-    "@balena/jellyfish-plugin-default": "^27.4.7",
+    "@balena/jellyfish-plugin-default": "^27.4.11",
     "@balena/jellyfish-plugin-discourse": "^5.0.16",
     "@balena/jellyfish-plugin-flowdock": "^5.0.16",
     "@balena/jellyfish-plugin-front": "^5.0.15",


### PR DESCRIPTION
The recent changes were more performant but surfaced up a lot of stale
zombie threads in production from 2018/2019. Closing these caused very
heavy load on the API servers, due to lots of sync activity.
This needs to be resolved separately, and then we can revisit query
optimisations for the view.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
