### PR TITLE
Update @balena/jellyfish-plugin-default from 27.4.11 to 27.5.0

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -15,7 +15,7 @@
         "@balena/jellyfish-metrics": "^2.0.84",
         "@balena/jellyfish-plugin-balena-api": "^5.0.16",
         "@balena/jellyfish-plugin-channels": "^3.1.13",
-        "@balena/jellyfish-plugin-default": "^27.4.11",
+        "@balena/jellyfish-plugin-default": "^27.5.0",
         "@balena/jellyfish-plugin-discourse": "^5.0.16",
         "@balena/jellyfish-plugin-flowdock": "^5.0.16",
         "@balena/jellyfish-plugin-front": "^5.0.15",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-default": {
-      "version": "27.4.11",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.4.11.tgz",
-      "integrity": "sha512-ErskwoGbMfMrlrxTJaxjN3YS7eV78TX61sSufvNQ7ojzbJukQGollJC0FRcVz5zPe5YpnGiclikFwxR0Bnv9BQ==",
+      "version": "27.5.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.5.0.tgz",
+      "integrity": "sha512-A83h7LP2ywNrGAOe8Olw2yNJi13dTQs98zaClhihi28BXItLQSluIkARrEpzlhiBg7+e3pccbMLZnmUDIaHeJA==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-environment": "^12.0.3",
@@ -11778,9 +11778,9 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "27.4.11",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.4.11.tgz",
-      "integrity": "sha512-ErskwoGbMfMrlrxTJaxjN3YS7eV78TX61sSufvNQ7ojzbJukQGollJC0FRcVz5zPe5YpnGiclikFwxR0Bnv9BQ==",
+      "version": "27.5.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.5.0.tgz",
+      "integrity": "sha512-A83h7LP2ywNrGAOe8Olw2yNJi13dTQs98zaClhihi28BXItLQSluIkARrEpzlhiBg7+e3pccbMLZnmUDIaHeJA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.29",
         "@balena/jellyfish-environment": "^12.0.3",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-metrics": "^2.0.84",
     "@balena/jellyfish-plugin-balena-api": "^5.0.16",
     "@balena/jellyfish-plugin-channels": "^3.1.13",
-    "@balena/jellyfish-plugin-default": "^27.4.11",
+    "@balena/jellyfish-plugin-default": "^27.5.0",
     "@balena/jellyfish-plugin-discourse": "^5.0.16",
     "@balena/jellyfish-plugin-flowdock": "^5.0.16",
     "@balena/jellyfish-plugin-front": "^5.0.15",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
