### PR TITLE
Server: Improve performance of front mirror triggers

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -18,8 +18,8 @@
         "@balena/jellyfish-plugin-default": "^27.7.1",
         "@balena/jellyfish-plugin-discourse": "^5.0.19",
         "@balena/jellyfish-plugin-flowdock": "^5.0.19",
-        "@balena/jellyfish-plugin-front": "^5.0.17",
-        "@balena/jellyfish-plugin-github": "^6.0.2",
+        "@balena/jellyfish-plugin-front": "^5.0.18",
+        "@balena/jellyfish-plugin-github": "^6.0.4",
         "@balena/jellyfish-plugin-outreach": "^4.1.19",
         "@balena/jellyfish-plugin-product-os": "^7.0.19",
         "@balena/jellyfish-plugin-typeform": "^8.0.18",
@@ -777,14 +777,14 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-front": {
-      "version": "5.0.17",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-5.0.17.tgz",
-      "integrity": "sha512-lNYVuNY/F32qc/at2ry2kl9Z/AJ3HPJdTf0DSx8tYjDE3XA/8SV7V+iwyI0mqg0IinQC96IIysrY1BCLpD4bmA==",
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-5.0.18.tgz",
+      "integrity": "sha512-XNilpI0g2GNZxvw6md2u6WYlKPRUIf5Z4lyAOiWN+rLjPqpruWldbX6FCUvQjWFoRQ1bX8K2+dekTJPXGdzklA==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.34",
         "@balena/jellyfish-environment": "^12.0.8",
         "@balena/jellyfish-plugin-default": "^27.7.1",
-        "@balena/jellyfish-worker": "^29.0.0",
+        "@balena/jellyfish-worker": "^29.1.0",
         "axios": "^0.26.1",
         "bluebird": "^3.7.2",
         "fast-json-patch": "^3.1.1",
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-github": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-6.0.3.tgz",
-      "integrity": "sha512-M+vPhcBZctW9cEnCVDzFi4W8r6nehrdNYZ0v8RtBaPLGHCl7tD0f15N2m3Fi4Tgb8vLeCM5lAb3cSAjG/P4glg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-6.0.4.tgz",
+      "integrity": "sha512-XFC2GoKiQS4Ox8f/lXIjOT5MXTZV6y4hz2P3d1JaLBiYyFXuYBW/6+auyAnKiRyQ3+M7B3hDM+erIlUphSDJOw==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.34",
         "@balena/jellyfish-worker": "^29.0.0",
@@ -11824,14 +11824,14 @@
       }
     },
     "@balena/jellyfish-plugin-front": {
-      "version": "5.0.17",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-5.0.17.tgz",
-      "integrity": "sha512-lNYVuNY/F32qc/at2ry2kl9Z/AJ3HPJdTf0DSx8tYjDE3XA/8SV7V+iwyI0mqg0IinQC96IIysrY1BCLpD4bmA==",
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-5.0.18.tgz",
+      "integrity": "sha512-XNilpI0g2GNZxvw6md2u6WYlKPRUIf5Z4lyAOiWN+rLjPqpruWldbX6FCUvQjWFoRQ1bX8K2+dekTJPXGdzklA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.34",
         "@balena/jellyfish-environment": "^12.0.8",
         "@balena/jellyfish-plugin-default": "^27.7.1",
-        "@balena/jellyfish-worker": "^29.0.0",
+        "@balena/jellyfish-worker": "^29.1.0",
         "axios": "^0.26.1",
         "bluebird": "^3.7.2",
         "fast-json-patch": "^3.1.1",
@@ -11844,9 +11844,9 @@
       }
     },
     "@balena/jellyfish-plugin-github": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-6.0.3.tgz",
-      "integrity": "sha512-M+vPhcBZctW9cEnCVDzFi4W8r6nehrdNYZ0v8RtBaPLGHCl7tD0f15N2m3Fi4Tgb8vLeCM5lAb3cSAjG/P4glg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-github/-/jellyfish-plugin-github-6.0.4.tgz",
+      "integrity": "sha512-XFC2GoKiQS4Ox8f/lXIjOT5MXTZV6y4hz2P3d1JaLBiYyFXuYBW/6+auyAnKiRyQ3+M7B3hDM+erIlUphSDJOw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.34",
         "@balena/jellyfish-worker": "^29.0.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@balena/jellyfish-plugin-default": "^27.7.1",
     "@balena/jellyfish-plugin-discourse": "^5.0.19",
     "@balena/jellyfish-plugin-flowdock": "^5.0.19",
-    "@balena/jellyfish-plugin-front": "^5.0.17",
+    "@balena/jellyfish-plugin-front": "^5.0.18",
     "@balena/jellyfish-plugin-github": "^6.0.2",
     "@balena/jellyfish-plugin-outreach": "^4.1.19",
     "@balena/jellyfish-plugin-product-os": "^7.0.19",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -32,7 +32,7 @@
     "@balena/jellyfish-plugin-discourse": "^5.0.19",
     "@balena/jellyfish-plugin-flowdock": "^5.0.19",
     "@balena/jellyfish-plugin-front": "^5.0.18",
-    "@balena/jellyfish-plugin-github": "^6.0.2",
+    "@balena/jellyfish-plugin-github": "^6.0.4",
     "@balena/jellyfish-plugin-outreach": "^4.1.19",
     "@balena/jellyfish-plugin-product-os": "^7.0.19",
     "@balena/jellyfish-plugin-typeform": "^8.0.18",


### PR DESCRIPTION
This change brings in a revised set of triggers for front that are much
less broad in what they match, resulting in less action requests being
generated.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
