### PR TITLE
Fix getting types from view schema

### DIFF
--- a/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
@@ -314,20 +314,16 @@ export default withSetup(
 
 			const viewTailTypes = helpers.getTypesFromSchema(query);
 
-			// If the schema doesn't hint at a type, use the pseudo-master type "card"
 			const tailTypes = _.compact(
-				_.map(viewTailTypes || ['card'], (tailType) => {
-					const typeContract = helpers.getType(tailType, types);
-					if (!typeContract) {
-						console.warn(
-							`Type "${tailType}" was not found in types array (${JSON.stringify(
-								types.map((type) => type.slug),
-							)})`,
-						);
-					}
-					return typeContract;
+				_.map(viewTailTypes, (tailType) => {
+					return helpers.getType(tailType, types);
 				}),
 			);
+
+			// If the schema doesn't hint at a type, use the pseudo-master type "card"
+			if (!tailTypes.length) {
+				tailTypes.push(helpers.getType('card', types));
+			}
 
 			const initialSearchTerm = _.get(seed, ['searchTerm']);
 

--- a/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
+++ b/apps/ui/lib/lens/common/LiveCollection/Renderer.tsx
@@ -34,50 +34,6 @@ import {
 import { unpackLinksSchema } from './Header/Filters/filter-utils';
 import { Setup, withSetup } from '../../../components/SetupProvider';
 
-/**
- * Extracts an array of types that are defined in a schema
- *
- * @param {Object} schema
- *
- * @returns {String[]} - an array of types that are defined in the view card's filter
- */
-const getTypesFromSchema = (schema) => {
-	let value: string[] = [];
-	const types =
-		_.get(schema, ['properties', 'type', 'const']) ||
-		_.get(schema, ['properties', 'type', 'enum']);
-	if (types) {
-		value = _.castArray(types);
-	}
-	if (schema.allOf) {
-		for (const item of schema.allOf) {
-			let found = getTypesFromSchema(item);
-			if (found) {
-				value = value.concat(found);
-				break;
-			}
-			if (item.anyOf) {
-				for (const subschema of item.anyOf) {
-					found = getTypesFromSchema(subschema);
-					if (found) {
-						value = value.concat(found);
-					}
-				}
-			}
-		}
-	}
-	if (!value.length && schema.oneOf) {
-		for (const item of schema.oneOf) {
-			const found = getTypesFromSchema(item.schema);
-			if (found) {
-				value = value.concat(found);
-			}
-		}
-	}
-	// Default to the `card` type, which will give a sensible schema
-	return value.length > 0 ? _.uniq(value) : null;
-};
-
 const setSliceFilter = (filters, lens, slice) => {
 	// We only want to filter by slice if the lens does not supports slices itself!
 	if (!_.get(lens, ['data', 'supportsSlices']) && slice) {
@@ -356,12 +312,22 @@ export default withSetup(
 				this.props.userActiveLens &&
 				this.getLensBySlug(this.props.userActiveLens);
 
-			const viewTailTypes = getTypesFromSchema(query);
+			const viewTailTypes = helpers.getTypesFromSchema(query);
 
 			// If the schema doesn't hint at a type, use the pseudo-master type "card"
-			const tailTypes = _.map(viewTailTypes || ['card'], (tailType) => {
-				return helpers.getType(tailType, types);
-			});
+			const tailTypes = _.compact(
+				_.map(viewTailTypes || ['card'], (tailType) => {
+					const typeContract = helpers.getType(tailType, types);
+					if (!typeContract) {
+						console.warn(
+							`Type "${tailType}" was not found in types array (${JSON.stringify(
+								types.map((type) => type.slug),
+							)})`,
+						);
+					}
+					return typeContract;
+				}),
+			);
 
 			const initialSearchTerm = _.get(seed, ['searchTerm']);
 

--- a/apps/ui/lib/services/helpers.ts
+++ b/apps/ui/lib/services/helpers.ts
@@ -159,11 +159,16 @@ export const getTypesFromViewCard = (card: ViewContract) => {
 		return _.castArray(card.data.types);
 	}
 
+	// Normalize { allOf: [{ schema: <schema> }] } weirdness into `{ allOf: [<schema>] }`
+	const normalize = (item: { schema: any }) => {
+		return item.schema;
+	};
+
 	return getTypesFromSchema({
 		...(typeof card.data.schema === 'object' ? card.data.schema : {}),
-		oneOf: card.data.oneOf,
-		allOf: card.data.allOf,
-		anyOf: card.data.anyOf,
+		oneOf: card.data.oneOf?.map(normalize),
+		allOf: card.data.allOf?.map(normalize),
+		anyOf: card.data.anyOf?.map(normalize),
 	});
 };
 

--- a/apps/ui/lib/services/helpers.ts
+++ b/apps/ui/lib/services/helpers.ts
@@ -102,11 +102,48 @@ export const appendToChannelPath = (
 	return `/${route}`;
 };
 
-const getTypesFromSchema = (schema: JsonSchema): string[] => {
+/**
+ * Extracts an array of types that are defined in a schema
+ *
+ * @param {Object} schema
+ *
+ * @returns {String[]} - an array of types that are defined in the view card's filter
+ */
+export const getTypesFromSchema = (schema) => {
+	let value: string[] = [];
 	const types =
 		_.get(schema, ['properties', 'type', 'const']) ||
 		_.get(schema, ['properties', 'type', 'enum']);
-	return types && _.castArray(types);
+	if (types) {
+		value = _.castArray(types);
+	}
+	if (schema.allOf) {
+		for (const item of schema.allOf) {
+			let found = getTypesFromSchema(item);
+			if (found) {
+				value = value.concat(found);
+				break;
+			}
+			if (item.anyOf) {
+				for (const subschema of item.anyOf) {
+					found = getTypesFromSchema(subschema);
+					if (found) {
+						value = value.concat(found);
+					}
+				}
+			}
+		}
+	}
+	if (!value.length && schema.oneOf) {
+		for (const item of schema.oneOf) {
+			const found = getTypesFromSchema(item.schema);
+			if (found) {
+				value = value.concat(found);
+			}
+		}
+	}
+	// Default to the `card` type, which will give a sensible schema
+	return value.length > 0 ? _.uniq(value) : null;
 };
 
 /**
@@ -117,46 +154,17 @@ const getTypesFromSchema = (schema: JsonSchema): string[] => {
  * @returns {String[]} - an array of types that are defined in the view card's filter
  */
 export const getTypesFromViewCard = (card: ViewContract) => {
-	let value: string[] = [];
-
 	// First check if the view has explicitly declared types
 	if (!_.isEmpty(card.data.types)) {
 		return _.castArray(card.data.types);
 	}
 
-	if (card.data.allOf) {
-		for (const item of card.data.allOf) {
-			let found = getTypesFromSchema(item.schema);
-			if (found) {
-				value = found;
-				break;
-			}
-			if (typeof item.schema === 'object' && item.schema.anyOf) {
-				for (const subschema of item.schema.anyOf) {
-					found = getTypesFromSchema(subschema);
-					if (found) {
-						break;
-					}
-				}
-			}
-			if (found) {
-				value = found;
-				break;
-			}
-		}
-	}
-	if (!value.length && card.data.oneOf) {
-		for (const item of card.data.oneOf) {
-			const found = getTypesFromSchema(item.schema);
-			if (found) {
-				value = found;
-				break;
-			}
-		}
-	}
-
-	// Default to the `card` type, which will give a sensible schema
-	return value.length > 0 ? _.uniq(value) : ['card'];
+	return getTypesFromSchema({
+		...(typeof card.data.schema === 'object' ? card.data.schema : {}),
+		oneOf: card.data.oneOf,
+		allOf: card.data.allOf,
+		anyOf: card.data.anyOf,
+	});
 };
 
 export const formatTimestamp = (stamp: number | string, prefix = false) => {

--- a/apps/ui/lib/services/helpers.ts
+++ b/apps/ui/lib/services/helpers.ts
@@ -136,7 +136,7 @@ export const getTypesFromSchema = (schema) => {
 	}
 	if (!value.length && schema.oneOf) {
 		for (const item of schema.oneOf) {
-			const found = getTypesFromSchema(item.schema);
+			const found = getTypesFromSchema(item);
 			if (found) {
 				value = value.concat(found);
 			}


### PR DESCRIPTION
User can't fetch `ui-theme` type, so he gets `[ undefined ]` in `tailTypes` array that causes ui to crash.
This pr also removes duplicate code for getting types from schema.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/p-cyclops/threads/hIbAiZLV-aTP9pXiKY9Uq3416pD