### PR TITLE
Upgrade to @balena/jellyfish-plugin-default@27.8.2

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -15,7 +15,7 @@
         "@balena/jellyfish-metrics": "^2.0.85",
         "@balena/jellyfish-plugin-balena-api": "^5.0.19",
         "@balena/jellyfish-plugin-channels": "^3.2.1",
-        "@balena/jellyfish-plugin-default": "^27.7.1",
+        "@balena/jellyfish-plugin-default": "^27.8.2",
         "@balena/jellyfish-plugin-discourse": "^5.0.19",
         "@balena/jellyfish-plugin-flowdock": "^5.0.19",
         "@balena/jellyfish-plugin-front": "^5.0.18",
@@ -799,14 +799,14 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-default": {
-      "version": "27.8.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.8.0.tgz",
-      "integrity": "sha512-Elj6ecPmk/K3yErQNR5/6aocLTwzlhIOHSLsgP9BeepSFasRKs1Ad08JPECKyEPFF1jNhckBUDqn+gLVhiU5FA==",
+      "version": "27.8.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.8.2.tgz",
+      "integrity": "sha512-crmymypxuBR4d7+0f7bu+xju3SCKgruiixiiEqmOq3keS3yC36NjLRpuYFt/0BiQ+qoOSqRab5e9CHyuRrvLdw==",
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.29",
-        "@balena/jellyfish-environment": "^12.0.3",
-        "@balena/jellyfish-logger": "^5.1.0",
-        "@balena/jellyfish-worker": "^29.1.0",
+        "@balena/jellyfish-assert": "^1.2.34",
+        "@balena/jellyfish-environment": "^12.0.8",
+        "@balena/jellyfish-logger": "^5.1.3",
+        "@balena/jellyfish-worker": "^30.0.1",
         "autumndb": "^20.1.0",
         "axios": "^0.26.1",
         "bcrypt": "^5.0.1",
@@ -817,44 +817,6 @@
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21",
         "semver": "^7.3.7",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.2.0"
-      }
-    },
-    "node_modules/@balena/jellyfish-plugin-default/node_modules/@balena/jellyfish-worker": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-29.1.0.tgz",
-      "integrity": "sha512-Qc/2VjV1MSSlZ17cMGQW1kFtAmHRailRhC2qgAPpBHJafknngtQrRIB4zG3jVEp6dblBesPyr9bbzKiqtIm1kQ==",
-      "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.33",
-        "@balena/jellyfish-client-sdk": "^11.0.0",
-        "@balena/jellyfish-environment": "^12.0.7",
-        "@balena/jellyfish-jellyscript": "^7.0.14",
-        "@balena/jellyfish-logger": "^5.1.2",
-        "@balena/jellyfish-metrics": "^2.0.84",
-        "@graphile/logger": "^0.2.0",
-        "autumndb": "^20.1.2",
-        "axios": "^0.26.1",
-        "bcrypt": "^5.0.1",
-        "bluebird": "^3.7.2",
-        "countries-and-timezones": "^3.3.0",
-        "cron-parser": "^4.4.0",
-        "fast-equals": "^3.0.3",
-        "fast-json-patch": "^3.1.1",
-        "graphile-worker": "^0.13.0",
-        "is-uuid": "^1.0.2",
-        "iso8601-duration": "^2.1.1",
-        "json-e": "^4.4.3",
-        "just-permutations": "^2.0.1",
-        "lodash": "^4.17.21",
-        "nock": "^13.2.4",
-        "qs": "^6.10.3",
-        "semver": "^7.3.7",
-        "serialize-error": "8.1.0",
-        "skhema": "^6.0.6",
-        "typed-error": "^3.2.1",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -12235,14 +12197,14 @@
       }
     },
     "@balena/jellyfish-plugin-default": {
-      "version": "27.8.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.8.0.tgz",
-      "integrity": "sha512-Elj6ecPmk/K3yErQNR5/6aocLTwzlhIOHSLsgP9BeepSFasRKs1Ad08JPECKyEPFF1jNhckBUDqn+gLVhiU5FA==",
+      "version": "27.8.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-default/-/jellyfish-plugin-default-27.8.2.tgz",
+      "integrity": "sha512-crmymypxuBR4d7+0f7bu+xju3SCKgruiixiiEqmOq3keS3yC36NjLRpuYFt/0BiQ+qoOSqRab5e9CHyuRrvLdw==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.2.29",
-        "@balena/jellyfish-environment": "^12.0.3",
-        "@balena/jellyfish-logger": "^5.1.0",
-        "@balena/jellyfish-worker": "^29.1.0",
+        "@balena/jellyfish-assert": "^1.2.34",
+        "@balena/jellyfish-environment": "^12.0.8",
+        "@balena/jellyfish-logger": "^5.1.3",
+        "@balena/jellyfish-worker": "^30.0.1",
         "autumndb": "^20.1.0",
         "axios": "^0.26.1",
         "bcrypt": "^5.0.1",
@@ -12254,43 +12216,6 @@
         "lodash": "^4.17.21",
         "semver": "^7.3.7",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@balena/jellyfish-worker": {
-          "version": "29.1.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-29.1.0.tgz",
-          "integrity": "sha512-Qc/2VjV1MSSlZ17cMGQW1kFtAmHRailRhC2qgAPpBHJafknngtQrRIB4zG3jVEp6dblBesPyr9bbzKiqtIm1kQ==",
-          "requires": {
-            "@balena/jellyfish-assert": "^1.2.33",
-            "@balena/jellyfish-client-sdk": "^11.0.0",
-            "@balena/jellyfish-environment": "^12.0.7",
-            "@balena/jellyfish-jellyscript": "^7.0.14",
-            "@balena/jellyfish-logger": "^5.1.2",
-            "@balena/jellyfish-metrics": "^2.0.84",
-            "@graphile/logger": "^0.2.0",
-            "autumndb": "^20.1.2",
-            "axios": "^0.26.1",
-            "bcrypt": "^5.0.1",
-            "bluebird": "^3.7.2",
-            "countries-and-timezones": "^3.3.0",
-            "cron-parser": "^4.4.0",
-            "fast-equals": "^3.0.3",
-            "fast-json-patch": "^3.1.1",
-            "graphile-worker": "^0.13.0",
-            "is-uuid": "^1.0.2",
-            "iso8601-duration": "^2.1.1",
-            "json-e": "^4.4.3",
-            "just-permutations": "^2.0.1",
-            "lodash": "^4.17.21",
-            "nock": "^13.2.4",
-            "qs": "^6.10.3",
-            "semver": "^7.3.7",
-            "serialize-error": "8.1.0",
-            "skhema": "^6.0.6",
-            "typed-error": "^3.2.1",
-            "uuid": "^8.3.2"
-          }
-        }
       }
     },
     "@balena/jellyfish-plugin-discourse": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-metrics": "^2.0.85",
     "@balena/jellyfish-plugin-balena-api": "^5.0.19",
     "@balena/jellyfish-plugin-channels": "^3.2.1",
-    "@balena/jellyfish-plugin-default": "^27.7.1",
+    "@balena/jellyfish-plugin-default": "^27.8.2",
     "@balena/jellyfish-plugin-discourse": "^5.0.19",
     "@balena/jellyfish-plugin-flowdock": "^5.0.19",
     "@balena/jellyfish-plugin-front": "^5.0.18",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
