### PR TITLE
Update @balena/jellyfish-metrics from 2.0.85 to 2.0.87

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -12,7 +12,7 @@
         "@balena/jellyfish-assert": "^1.2.34",
         "@balena/jellyfish-environment": "^12.0.8",
         "@balena/jellyfish-logger": "^5.1.3",
-        "@balena/jellyfish-metrics": "^2.0.85",
+        "@balena/jellyfish-metrics": "^2.0.87",
         "@balena/jellyfish-plugin-balena-api": "^5.0.19",
         "@balena/jellyfish-plugin-channels": "^3.2.1",
         "@balena/jellyfish-plugin-default": "^27.8.2",
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@balena/jellyfish-metrics": {
-      "version": "2.0.86",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.86.tgz",
-      "integrity": "sha512-d7HYrOrk3zfBTyriPqHMsXYXq//f/UBG6ybc4DtBH/f2OVM3lVucx6FKgYXhU+GR4gnznqFdsdH/sS409bEVvw==",
+      "version": "2.0.87",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.87.tgz",
+      "integrity": "sha512-Ymyvn2CLzw8W2ftyTebr0xVEIVTtX9l7I731sWVDHgPRunWKBNrcUh2z9h1LkczN95EhKou7poz0xkbuDVaTDw==",
       "dependencies": {
         "@balena/jellyfish-environment": "^12.0.4",
         "@balena/jellyfish-logger": "^5.1.0",
@@ -12082,9 +12082,9 @@
       }
     },
     "@balena/jellyfish-metrics": {
-      "version": "2.0.86",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.86.tgz",
-      "integrity": "sha512-d7HYrOrk3zfBTyriPqHMsXYXq//f/UBG6ybc4DtBH/f2OVM3lVucx6FKgYXhU+GR4gnznqFdsdH/sS409bEVvw==",
+      "version": "2.0.87",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.87.tgz",
+      "integrity": "sha512-Ymyvn2CLzw8W2ftyTebr0xVEIVTtX9l7I731sWVDHgPRunWKBNrcUh2z9h1LkczN95EhKou7poz0xkbuDVaTDw==",
       "requires": {
         "@balena/jellyfish-environment": "^12.0.4",
         "@balena/jellyfish-logger": "^5.1.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,7 +25,7 @@
     "@balena/jellyfish-assert": "^1.2.34",
     "@balena/jellyfish-environment": "^12.0.8",
     "@balena/jellyfish-logger": "^5.1.3",
-    "@balena/jellyfish-metrics": "^2.0.85",
+    "@balena/jellyfish-metrics": "^2.0.87",
     "@balena/jellyfish-plugin-balena-api": "^5.0.19",
     "@balena/jellyfish-plugin-channels": "^3.2.1",
     "@balena/jellyfish-plugin-default": "^27.8.2",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
