### PR TITLE
CI: Drop shellcheck install from test base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # https://github.com/product-os/jellyfish-base-images
 # https://registry.hub.docker.com/r/resinci/jellyfish-test
-FROM resinci/jellyfish-test:v3.1.0 AS base
+FROM resinci/jellyfish-test:v4.0.0 AS base
 
 # --- run unit tests
 FROM base AS test


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

We are installing shellcheck through npm and therefore
do not need to have it installed in the test base image
as well.