### PR TITLE
Server: Update to latest jellyfish-worker@30.0.9

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -23,7 +23,7 @@
         "@balena/jellyfish-plugin-outreach": "^4.1.19",
         "@balena/jellyfish-plugin-product-os": "^7.0.19",
         "@balena/jellyfish-plugin-typeform": "^8.0.18",
-        "@balena/jellyfish-worker": "^30.0.7",
+        "@balena/jellyfish-worker": "^30.0.9",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^20.1.10",
         "aws-sdk": "^2.1148.0",
@@ -1217,9 +1217,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "30.0.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-30.0.7.tgz",
-      "integrity": "sha512-tdl6drAd/somTw7UPwunzYDXZhFzj4BGHR4sgIzC19WINBOGD+XM3fjpUsQUdlYJciDRkVUqdJAyo5jnMmCx+w==",
+      "version": "30.0.9",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-30.0.9.tgz",
+      "integrity": "sha512-+vjlhM06J64vU65Cf91MKRDwdo9cPv7U7Bkb0mRfBbXukyFAr8ItAdeF8xhT64afWMOJVRIUmdmJp5feGLFoWQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.33",
         "@balena/jellyfish-client-sdk": "^11.0.0",
@@ -12580,9 +12580,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "30.0.7",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-30.0.7.tgz",
-      "integrity": "sha512-tdl6drAd/somTw7UPwunzYDXZhFzj4BGHR4sgIzC19WINBOGD+XM3fjpUsQUdlYJciDRkVUqdJAyo5jnMmCx+w==",
+      "version": "30.0.9",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-30.0.9.tgz",
+      "integrity": "sha512-+vjlhM06J64vU65Cf91MKRDwdo9cPv7U7Bkb0mRfBbXukyFAr8ItAdeF8xhT64afWMOJVRIUmdmJp5feGLFoWQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.33",
         "@balena/jellyfish-client-sdk": "^11.0.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jellyfish-server",
   "version": "0.0.1",
-  "codename": "cephea",
+  "codename": "snappy",
   "private": true,
   "description": "The Jellyfish Server App",
   "engines": {
@@ -36,7 +36,7 @@
     "@balena/jellyfish-plugin-outreach": "^4.1.19",
     "@balena/jellyfish-plugin-product-os": "^7.0.19",
     "@balena/jellyfish-plugin-typeform": "^8.0.18",
-    "@balena/jellyfish-worker": "^30.0.7",
+    "@balena/jellyfish-worker": "^30.0.9",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^20.1.10",
     "aws-sdk": "^2.1148.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "52.0.35",
   "homepage": "https://github.com/product-os/jellyfish",
   "description": "The Jellyfish Project",
-  "codename": "proclaimer",
+  "codename": "snappy",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes an issue where some triggers would not run if they matched on
an inverse relationship name.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
