### PR TITLE
Server: Improve performance of discourse plugin

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -16,7 +16,7 @@
         "@balena/jellyfish-plugin-balena-api": "^5.0.19",
         "@balena/jellyfish-plugin-channels": "^3.2.1",
         "@balena/jellyfish-plugin-default": "^27.8.2",
-        "@balena/jellyfish-plugin-discourse": "^5.0.19",
+        "@balena/jellyfish-plugin-discourse": "^5.0.24",
         "@balena/jellyfish-plugin-flowdock": "^5.0.19",
         "@balena/jellyfish-plugin-front": "^5.0.18",
         "@balena/jellyfish-plugin-github": "^6.0.4",
@@ -824,54 +824,16 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-discourse": {
-      "version": "5.0.21",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-5.0.21.tgz",
-      "integrity": "sha512-a4hRTLOJpFl80783oljsmiCIpx/YgXp0n3xRIdl0ThLjAQCpHd9GUfRQtum+vsZ3bousXw58sddwu9FuSPUIjQ==",
+      "version": "5.0.24",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-5.0.24.tgz",
+      "integrity": "sha512-rUUK/qj7YlvbT6EIKe6biJPJIseip8VRXPual1T+ERfhA2dPVLr/QvS9BqLHpQJyIM9U8DENfbKfOGLiup4CPQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.34",
-        "@balena/jellyfish-worker": "^29.1.0",
-        "autumndb": "^20.1.7",
+        "@balena/jellyfish-worker": "^30.0.7",
+        "autumndb": "^20.1.10",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
         "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=14.2.0"
-      }
-    },
-    "node_modules/@balena/jellyfish-plugin-discourse/node_modules/@balena/jellyfish-worker": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-29.1.0.tgz",
-      "integrity": "sha512-Qc/2VjV1MSSlZ17cMGQW1kFtAmHRailRhC2qgAPpBHJafknngtQrRIB4zG3jVEp6dblBesPyr9bbzKiqtIm1kQ==",
-      "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.33",
-        "@balena/jellyfish-client-sdk": "^11.0.0",
-        "@balena/jellyfish-environment": "^12.0.7",
-        "@balena/jellyfish-jellyscript": "^7.0.14",
-        "@balena/jellyfish-logger": "^5.1.2",
-        "@balena/jellyfish-metrics": "^2.0.84",
-        "@graphile/logger": "^0.2.0",
-        "autumndb": "^20.1.2",
-        "axios": "^0.26.1",
-        "bcrypt": "^5.0.1",
-        "bluebird": "^3.7.2",
-        "countries-and-timezones": "^3.3.0",
-        "cron-parser": "^4.4.0",
-        "fast-equals": "^3.0.3",
-        "fast-json-patch": "^3.1.1",
-        "graphile-worker": "^0.13.0",
-        "is-uuid": "^1.0.2",
-        "iso8601-duration": "^2.1.1",
-        "json-e": "^4.4.3",
-        "just-permutations": "^2.0.1",
-        "lodash": "^4.17.21",
-        "nock": "^13.2.4",
-        "qs": "^6.10.3",
-        "semver": "^7.3.7",
-        "serialize-error": "8.1.0",
-        "skhema": "^6.0.6",
-        "typed-error": "^3.2.1",
-        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=14.2.0"
@@ -12219,53 +12181,16 @@
       }
     },
     "@balena/jellyfish-plugin-discourse": {
-      "version": "5.0.21",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-5.0.21.tgz",
-      "integrity": "sha512-a4hRTLOJpFl80783oljsmiCIpx/YgXp0n3xRIdl0ThLjAQCpHd9GUfRQtum+vsZ3bousXw58sddwu9FuSPUIjQ==",
+      "version": "5.0.24",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-discourse/-/jellyfish-plugin-discourse-5.0.24.tgz",
+      "integrity": "sha512-rUUK/qj7YlvbT6EIKe6biJPJIseip8VRXPual1T+ERfhA2dPVLr/QvS9BqLHpQJyIM9U8DENfbKfOGLiup4CPQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.34",
-        "@balena/jellyfish-worker": "^29.1.0",
-        "autumndb": "^20.1.7",
+        "@balena/jellyfish-worker": "^30.0.7",
+        "autumndb": "^20.1.10",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
         "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "@balena/jellyfish-worker": {
-          "version": "29.1.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-29.1.0.tgz",
-          "integrity": "sha512-Qc/2VjV1MSSlZ17cMGQW1kFtAmHRailRhC2qgAPpBHJafknngtQrRIB4zG3jVEp6dblBesPyr9bbzKiqtIm1kQ==",
-          "requires": {
-            "@balena/jellyfish-assert": "^1.2.33",
-            "@balena/jellyfish-client-sdk": "^11.0.0",
-            "@balena/jellyfish-environment": "^12.0.7",
-            "@balena/jellyfish-jellyscript": "^7.0.14",
-            "@balena/jellyfish-logger": "^5.1.2",
-            "@balena/jellyfish-metrics": "^2.0.84",
-            "@graphile/logger": "^0.2.0",
-            "autumndb": "^20.1.2",
-            "axios": "^0.26.1",
-            "bcrypt": "^5.0.1",
-            "bluebird": "^3.7.2",
-            "countries-and-timezones": "^3.3.0",
-            "cron-parser": "^4.4.0",
-            "fast-equals": "^3.0.3",
-            "fast-json-patch": "^3.1.1",
-            "graphile-worker": "^0.13.0",
-            "is-uuid": "^1.0.2",
-            "iso8601-duration": "^2.1.1",
-            "json-e": "^4.4.3",
-            "just-permutations": "^2.0.1",
-            "lodash": "^4.17.21",
-            "nock": "^13.2.4",
-            "qs": "^6.10.3",
-            "semver": "^7.3.7",
-            "serialize-error": "8.1.0",
-            "skhema": "^6.0.6",
-            "typed-error": "^3.2.1",
-            "uuid": "^8.3.2"
-          }
-        }
       }
     },
     "@balena/jellyfish-plugin-flowdock": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -29,7 +29,7 @@
     "@balena/jellyfish-plugin-balena-api": "^5.0.19",
     "@balena/jellyfish-plugin-channels": "^3.2.1",
     "@balena/jellyfish-plugin-default": "^27.8.2",
-    "@balena/jellyfish-plugin-discourse": "^5.0.19",
+    "@balena/jellyfish-plugin-discourse": "^5.0.24",
     "@balena/jellyfish-plugin-flowdock": "^5.0.19",
     "@balena/jellyfish-plugin-front": "^5.0.18",
     "@balena/jellyfish-plugin-github": "^6.0.4",


### PR DESCRIPTION
Update to include changes that reduce the number of actions enqueued
when mirror messages back to discourse.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
