### PR TITLE
Stream thread highlights

### DIFF
--- a/apps/ui/lib/lens/full/SupportThread/index.tsx
+++ b/apps/ui/lib/lens/full/SupportThread/index.tsx
@@ -1,7 +1,5 @@
 import { connect } from 'react-redux';
-import { compose } from 'redux';
 import { bindActionCreators } from '../../../bindactioncreators';
-import { withDefaultGetActorHref } from '../../../components';
 import { actionCreators, selectors } from '../../../store';
 import { createLazyComponent } from '../../../components/SafeLazy';
 import * as _ from 'lodash';
@@ -34,12 +32,9 @@ export default {
 	data: {
 		format: 'full',
 		icon: 'address-card',
-		renderer: compose(
-			connect<StateProps, DispatchProps, OwnProps>(
-				mapStateToProps,
-				mapDispatchToProps,
-			),
-			withDefaultGetActorHref(),
+		renderer: connect<StateProps, DispatchProps, OwnProps>(
+			mapStateToProps,
+			mapDispatchToProps,
 		)(SupportThreadBase),
 		filter: {
 			type: 'object',


### PR DESCRIPTION
We previously used thread's  `linked_at` property to detect updates and fetch highlights. Now we stream highlights directly.

Change-type: patch
