### PR TITLE
Ignore registry token-auth env vars in the fleet when running e2e.

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -344,10 +344,6 @@ jobs:
             --service registry \
             --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
 
-          balena env add REGISTRY_TOKEN_AUTH_CERT_ISSUER '' \
-            --service registry \
-            --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
-
           balena env add REGISTRY2_S3_CLOUDFRONT_ENDPOINT '' \
             --service registry \
             --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
@@ -372,6 +368,9 @@ jobs:
             --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
 
           balena env add INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION '' \
+            --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
+
+          balena env add REGISTRY_TOKEN_AUTH_CERT_ISSUER '' \
             --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
 
           balena env add REGISTRY_TOKEN_AUTH_CERT_PUB '' \


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
