### PR TITLE
Go back to balena db image

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,11 +3,8 @@ networks:
   internal: {}
 services:
   postgres:
-    image: postgres:14
+    image: balena/open-balena-db:v5.1.0
     restart: unless-stopped
-    environment:
-      POSTGRES_PASSWORD: docker
-      POSTGRES_USER: docker
     networks:
       - internal
     ports:
@@ -15,7 +12,7 @@ services:
     healthcheck:
       interval: 15s
       retries: 3
-      test: ['CMD-SHELL', 'pg_isready -U docker']
+      test: pg_isready -U "${POSTGRES_USER}" -d postgres
       timeout: 5s
     command: ['postgres', '-c', 'fsync=off', '-c', 'synchronous_commit=off', '-c', 'full_page_writes=off']
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
 
   # https://github.com/balena-io/open-balena-db
   postgres:
-    image: postgres:14
+    image: balena/open-balena-db:v5.1.0
     restart: unless-stopped
     healthcheck:
       interval: 15s


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Saw the postgres service in production devices restarting with this output:
```
 postgres  The files belonging to this database system will be owned by user "postgres".
 postgres  This user must also own the server process.
 postgres  
 postgres  The database cluster will be initialized with locale "en_US.utf8".
 postgres  The default database encoding has accordingly been set to "UTF8".
 postgres  The default text search configuration will be set to "english".
 postgres  
 postgres  Data page checksums are disabled.
 postgres  
 postgres  initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
 postgres  If you want to create a new database system, either remove or empty
 postgres  the directory "/var/lib/postgresql/data" or run initdb
 postgres  with an argument other than "/var/lib/postgresql/data".
```