### PR TITLE
Server: Drop Bluebird package

### DIFF
--- a/apps/server/lib/http/facades/auth.ts
+++ b/apps/server/lib/http/facades/auth.ts
@@ -1,4 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
+import { JsonSchema } from '@balena/jellyfish-types';
 import type {
 	Contract,
 	SessionContract,
@@ -22,7 +23,7 @@ export class AuthFacade extends QueryFacade {
 			'Session does not exist',
 		);
 
-		const schema = {
+		const schema: JsonSchema = {
 			type: 'object',
 			$$links: {
 				'is member of': {

--- a/apps/server/lib/http/facades/query.ts
+++ b/apps/server/lib/http/facades/query.ts
@@ -1,6 +1,7 @@
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
+import { JsonSchema } from '@balena/jellyfish-types';
+import { ViewContract } from '@balena/jellyfish-types/build/core';
 import { Kernel, errors as coreErrors } from 'autumndb';
-import Bluebird from 'bluebird';
 import _ from 'lodash';
 
 const logger = getLogger(__filename);
@@ -12,67 +13,73 @@ export class QueryFacade {
 		this.kernel = kernel;
 	}
 
-	async queryAPI(logContext: LogContext, session, query, options, ipAddress) {
-		return Bluebird.try(async () => {
-			if (!_.isString(query)) {
-				return query;
-			}
+	private async getQuerySchema(
+		logContext: LogContext,
+		session: string,
+		query: JsonSchema | string,
+	): Promise<JsonSchema | ViewContract> {
+		if (!_.isString(query)) {
+			return query;
+		}
 
-			// Now try and load the view by slug
-			const viewContractFromSlug = await this.kernel.getContractBySlug(
+		// Now try and load the view by slug
+		const viewContractFromSlug = await this.kernel.getContractBySlug(
+			logContext,
+			session,
+			`${query}@latest`,
+		);
+
+		if (
+			viewContractFromSlug &&
+			viewContractFromSlug.type.split('@')[0] === 'view'
+		) {
+			return viewContractFromSlug;
+		}
+
+		try {
+			// Try and load the view by id first
+			const viewContractFromId = await this.kernel.getContractById(
 				logContext,
 				session,
-				`${query}@latest`,
+				query,
 			);
 
 			if (
-				viewContractFromSlug &&
-				viewContractFromSlug.type.split('@')[0] === 'view'
+				!viewContractFromId ||
+				viewContractFromId.type.split('@')[0] !== 'view'
 			) {
-				return viewContractFromSlug;
-			}
-
-			try {
-				// Try and load the view by id first
-				const viewContractFromId = await this.kernel.getContractById(
-					logContext,
-					session,
-					query,
-				);
-
-				if (
-					!viewContractFromId ||
-					viewContractFromId.type.split('@')[0] !== 'view'
-				) {
-					throw new coreErrors.JellyfishNoView(`Unknown view: ${query}`);
-				}
-
-				return viewContractFromId;
-			} catch (error) {
 				throw new coreErrors.JellyfishNoView(`Unknown view: ${query}`);
 			}
-		}).then(async (schema) => {
-			const startDate = new Date();
 
-			logger.info(logContext, 'JSON Schema query start', {
-				date: startDate,
-				ip: ipAddress,
-				schema,
-			});
+			return viewContractFromId;
+		} catch (error) {
+			throw new coreErrors.JellyfishNoView(`Unknown view: ${query}`);
+		}
+	}
 
-			const data = await this.kernel.query(
-				logContext,
-				session,
-				schema,
-				options,
-			);
-			const endDate = new Date();
-			const queryTime = endDate.getTime() - startDate.getTime();
-			logger.info(logContext, 'JSON Schema query end', {
-				time: queryTime,
-			});
+	async queryAPI(
+		logContext: LogContext,
+		session: string,
+		queryIsh: JsonSchema | string,
+		options,
+		ipAddress,
+	) {
+		const schema = await this.getQuerySchema(logContext, session, queryIsh);
+		const startDate = new Date();
 
-			return data;
+		logger.info(logContext, 'JSON Schema query start', {
+			date: startDate,
+			ip: ipAddress,
+			schema,
 		});
+
+		const data = await this.kernel.query(logContext, session, schema, options);
+		const endDate = new Date();
+		const queryTime = endDate.getTime() - startDate.getTime();
+		logger.info(logContext, 'JSON Schema query end', {
+			time: queryTime,
+		});
+
+		return data;
 	}
 }

--- a/apps/server/lib/http/index.ts
+++ b/apps/server/lib/http/index.ts
@@ -2,7 +2,6 @@ import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import * as metrics from '@balena/jellyfish-metrics';
 import type { Sync, Worker } from '@balena/jellyfish-worker';
 import type { Kernel } from 'autumndb';
-import Bluebird from 'bluebird';
 import errio from 'errio';
 import http from 'http';
 import { attachMiddlewares } from './middlewares';
@@ -103,7 +102,7 @@ export const createServer = (logContext: LogContext, configuration: any) => {
 			ready = true;
 		},
 		stop: async () => {
-			await new Bluebird((resolve) => {
+			await new Promise((resolve) => {
 				server.close();
 				server.once('close', resolve);
 			});

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -28,7 +28,6 @@
         "autumndb": "^20.1.12",
         "aws-sdk": "^2.1148.0",
         "bcrypt": "^5.0.1",
-        "bluebird": "^3.7.2",
         "body-parser": "^1.20.0",
         "compression": "^1.7.4",
         "errio": "^1.2.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,7 +41,6 @@
     "autumndb": "^20.1.12",
     "aws-sdk": "^2.1148.0",
     "bcrypt": "^5.0.1",
-    "bluebird": "^3.7.2",
     "body-parser": "^1.20.0",
     "compression": "^1.7.4",
     "errio": "^1.2.2",

--- a/apps/server/test/integration/metrics.spec.ts
+++ b/apps/server/test/integration/metrics.spec.ts
@@ -1,5 +1,4 @@
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
-import Bluebird from 'bluebird';
 import request from 'request';
 import { v4 as uuidv4 } from 'uuid';
 import { bootstrap } from '../../lib/bootstrap';
@@ -24,7 +23,7 @@ afterAll(async () => {
 });
 
 const getMetrics = async () => {
-	return new Bluebird<any>((resolve, reject) => {
+	return new Promise<any>((resolve, reject) => {
 		const requestOptions = {
 			method: 'GET',
 			baseUrl: `http://localhost:${environment.metrics.ports.socket}`,

--- a/apps/server/test/integration/outreach-mirror.spec.ts
+++ b/apps/server/test/integration/outreach-mirror.spec.ts
@@ -1,6 +1,5 @@
 import { defaultEnvironment as environment } from '@balena/jellyfish-environment';
 import { strict as assert } from 'assert';
-import Bluebird from 'bluebird';
 import _ from 'lodash';
 import nock from 'nock';
 import querystring from 'querystring';
@@ -38,7 +37,7 @@ beforeEach(async () => {
 	helpers.beforeEach(test);
 
 	context.getProspect = async (id: string) => {
-		return new Bluebird((resolve, reject) => {
+		return new Promise((resolve, reject) => {
 			request(
 				{
 					method: 'GET',


### PR DESCRIPTION
In all cases we've been able to simplify code by either using native
promises or switching to async/await, removing the need for the Bluebird
package.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
