### PR TITLE
Renovate: Ignore redis updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,10 @@
   "extends": [
     "github>product-os/renovate-config"
   ],
+  "ignoreDeps": [
+    "node",
+    "redis"
+  ],
   "packageRules": [
     {
       "groupName": "non-major-frontend",


### PR DESCRIPTION
Manually update redis image to keep the same version as production.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
