### PR TITLE
Allow livechat subdomains

### DIFF
--- a/apps/haproxy/haproxy.cfg
+++ b/apps/haproxy/haproxy.cfg
@@ -80,13 +80,15 @@ frontend http
 		# requests to wifi-connect (Host: 192.168.42.1)
 		default_backend wifi-connect-backend
 
-		acl host-ui-backend hdr_beg(host) -i "jel." "livechat."
+		acl host-ui-backend hdr_beg(host) -i "jel."
+		# Match any livechat subdomain
+		acl host-livechat-backend hdr_reg(host) -i "(^[^\.])?(livechat\.)"
 		# default public device URL(s) v1 always go to the Jellyfish UI
 		acl host-pdu-default hdr_beg(host) -i "${BALENA_DEVICE_UUID}"
 		# FIXME: balena-proxy should be adding X-Forwarded-For headers
-		http-request add-header X-Forwarded-Proto http if host-ui-backend
+		http-request add-header X-Forwarded-Proto http if host-ui-backend || host-livechat-backend
 		http-request add-header X-Forwarded-Proto https if host-pdu-default
-		use_backend ui-backend if host-ui-backend || host-pdu-default
+		use_backend ui-backend if host-ui-backend || host-pdu-default || host-livechat-backend
 
 		acl host-ca-backend hdr_beg(host) -i "ca."
 		# only allow CRL requests unauthenticated, protect everything else


### PR DESCRIPTION
Add wildcard subdomains to livechat. This will allow different users to have their own local storage instead of sharing.

Change-type: minor