### PR TITLE
UI: Improve performance of component unit testing

### DIFF
--- a/apps/ui/jest.config.js
+++ b/apps/ui/jest.config.js
@@ -2,19 +2,19 @@ module.exports = {
 	preset: 'ts-jest',
 	testEnvironment: 'jsdom',
 	testTimeout: 12000,
-	transformIgnorePatterns: [
-	],
+	transformIgnorePatterns: [],
 	globals: {
-		env: {}
+		env: {},
+		'ts-jest': {
+			isolatedModules: true,
+		},
 	},
 	transform: {
-		'node_modules/(entity-decode/(.*)|d3|internmap|delaunator|robust-predicates)': 'jest-esm-transformer',
+		'node_modules/(entity-decode/(.*)|d3|internmap|delaunator|robust-predicates)':
+			'jest-esm-transformer',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$':
-			'<rootDir>/file-transformer.js'
+			'<rootDir>/file-transformer.js',
 	},
-	setupFiles: [ '<rootDir>/test/setup.ts' ],
-	roots: [
-		'lib',
-		'test'
-	]
-}
+	setupFiles: ['<rootDir>/test/setup.ts'],
+	roots: ['lib', 'test'],
+};


### PR DESCRIPTION
This change turns off in-place typechecking when running unit test
files, dramatically improving test performance. Typechecking still
happens when the UI app is built, so we don't lose type security here,
and see a big improvement in performance.

See: https://github.com/kulshekhar/ts-jest/blob/main/website/docs/getting-started/options/isolatedModules.md

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
