### PR TITLE
Dev: Remove old compose commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "docs:summary": "./scripts/architecture-summary.sh > ARCHITECTURE.md",
     "clean": "rimraf apps/*/packages/*",
     "postinstall": "(cd apps/server && npm i); (cd apps/ui && npm i)",
-    "compose:build": "docker-compose build",
-    "compose:up": "docker-compose up",
     "compose:local": "docker-compose -f docker-compose.local.yml up",
     "push": "./scripts/push.sh",
     "push:lib": "./scripts/push-lib.js",


### PR DESCRIPTION
Drop a couple npm run compose commands as they are no longer
usable after the move to balena

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>