### PR TITLE
Server: Cluster process for better resource utilisation

### DIFF
--- a/apps/server/lib/index.ts
+++ b/apps/server/lib/index.ts
@@ -3,12 +3,22 @@ import { getLogger } from '@balena/jellyfish-logger';
 import { v4 as uuidv4 } from 'uuid';
 import { bootstrap } from './bootstrap';
 import { getPlugins } from './plugins';
+import cluster from 'node:cluster';
+import { cpus } from 'node:os';
+import process from 'node:process';
 
 // Avoid including package.json in the build output!
 // tslint:disable-next-line: no-var-requires
 const packageJSON = require('../../../package.json');
 
 const logger = getLogger(__filename);
+
+let numCPUs = cpus().length;
+
+const MAX_WORKERS = process.env.MAX_WORKERS;
+if (MAX_WORKERS) {
+	numCPUs = Math.min(numCPUs, parseInt(MAX_WORKERS, 10));
+}
 
 const DEFAULT_CONTEXT = {
 	id: `SERVER-ERROR-${environment.pod.name}-${packageJSON.version}`,
@@ -31,42 +41,71 @@ process.on('unhandledRejection', (error) => {
 	return onError(error, 'Unhandled Server Error');
 });
 
-const id = uuidv4();
-const context = {
-	id: `SERVER-${packageJSON.version}-${environment.pod.name}-${id}`,
+const startDate = new Date();
+
+const run = async () => {
+	if (cluster.isPrimary) {
+		logger.info(
+			DEFAULT_CONTEXT,
+			`Primary worker started, spawning ${numCPUs} workers`,
+			{
+				time: startDate.getTime(),
+			},
+		);
+
+		// Fork workers.
+		for (let i = 0; i < numCPUs; i++) {
+			cluster.fork();
+		}
+
+		cluster.on('exit', (worker, code, signal) => {
+			logger.info(DEFAULT_CONTEXT, `worker ${worker.process.pid} died`, {
+				code,
+				signal,
+			});
+		});
+	} else {
+		const id = uuidv4();
+		const context = {
+			id: `SERVER-${packageJSON.version}-${environment.pod.name}-worker#${cluster.worker?.id}-${id}`,
+		};
+
+		logger.info(context, `Starting server with worker ${cluster.worker?.id}`, {
+			time: startDate.getTime(),
+		});
+
+		try {
+			const options = {
+				plugins: getPlugins(),
+				onError,
+			};
+
+			bootstrap(context, options)
+				.then((server) => {
+					const endDate = new Date();
+					const timeToStart = endDate.getTime() - startDate.getTime();
+
+					logger.info(context, 'Server started', {
+						time: timeToStart,
+						port: server.port,
+					});
+
+					process.send!({ msg: 'worker-started' });
+
+					if (timeToStart > 10000) {
+						logger.warn(context, 'Slow server startup time', {
+							time: timeToStart,
+						});
+					}
+				})
+				.catch((error) => {
+					logger.error(context, 'Server error', error);
+					process.exit(1);
+				});
+		} catch (error) {
+			onError(error);
+		}
+	}
 };
 
-const startDate = new Date();
-logger.info(context, 'Starting server', {
-	time: startDate.getTime(),
-});
-
-try {
-	const options = {
-		plugins: getPlugins(),
-		onError,
-	};
-
-	bootstrap(context, options)
-		.then((server) => {
-			const endDate = new Date();
-			const timeToStart = endDate.getTime() - startDate.getTime();
-
-			logger.info(context, 'Server started', {
-				time: timeToStart,
-				port: server.port,
-			});
-
-			if (timeToStart > 10000) {
-				logger.warn(context, 'Slow server startup time', {
-					time: timeToStart,
-				});
-			}
-		})
-		.catch((error) => {
-			logger.error(context, 'Server error', error);
-			process.exit(1);
-		});
-} catch (error) {
-	onError(error);
-}
+run();

--- a/apps/server/lib/index.ts
+++ b/apps/server/lib/index.ts
@@ -55,11 +55,14 @@ const run = async () => {
 
 		// Fork workers.
 		for (let i = 0; i < numCPUs; i++) {
-			cluster.fork();
+			const startWorker = () => {
+				cluster.fork().on('exit', startWorker);
+			};
+			startWorker();
 		}
 
 		cluster.on('exit', (worker, code, signal) => {
-			logger.info(DEFAULT_CONTEXT, `worker ${worker.process.pid} died`, {
+			logger.warn(DEFAULT_CONTEXT, `worker ${worker.process.pid} died`, {
 				code,
 				signal,
 			});


### PR DESCRIPTION
This change will fork the server process using the cluster module. It
will create as many worker processes as there are CPUs available. The
number of process can be overriden with the `MAX_WORKERS` env var.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
