### PR TITLE
Rename 'was built into' relationships to 'was transformed to'.

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -22,7 +22,7 @@
         "@balena/jellyfish-plugin-outreach": "^4.2.1",
         "@balena/jellyfish-plugin-product-os": "^7.1.3",
         "@balena/jellyfish-plugin-typeform": "^9.0.0",
-        "@balena/jellyfish-worker": "^31.1.0",
+        "@balena/jellyfish-worker": "^31.1.1",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^20.3.3",
         "aws-sdk": "^2.1157.0",
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-31.1.0.tgz",
-      "integrity": "sha512-sf2rfeEC9CA9Lr+iIzSzE4PCNZTnJXT8VBudjXCr1nhoXWcLc+3PTLGZO4wyRY9KWk2TwCtsHBHEBt8YNPE+YQ==",
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-31.1.1.tgz",
+      "integrity": "sha512-w1khzxp1vNwDetA73n1x384r4+gefCUjCZ0jMqywz9vpiz78lGdcIjTW1KHlrWod2r0WmzYP9ov/NIzoYfl2Jw==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.39",
         "@balena/jellyfish-environment": "^12.2.0",
@@ -11875,9 +11875,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-31.1.0.tgz",
-      "integrity": "sha512-sf2rfeEC9CA9Lr+iIzSzE4PCNZTnJXT8VBudjXCr1nhoXWcLc+3PTLGZO4wyRY9KWk2TwCtsHBHEBt8YNPE+YQ==",
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-31.1.1.tgz",
+      "integrity": "sha512-w1khzxp1vNwDetA73n1x384r4+gefCUjCZ0jMqywz9vpiz78lGdcIjTW1KHlrWod2r0WmzYP9ov/NIzoYfl2Jw==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.39",
         "@balena/jellyfish-environment": "^12.2.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,7 +35,7 @@
     "@balena/jellyfish-plugin-outreach": "^4.2.1",
     "@balena/jellyfish-plugin-product-os": "^7.1.3",
     "@balena/jellyfish-plugin-typeform": "^9.0.0",
-    "@balena/jellyfish-worker": "^31.1.0",
+    "@balena/jellyfish-worker": "^31.1.1",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^20.3.3",
     "aws-sdk": "^2.1157.0",

--- a/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
+++ b/apps/ui/lib/lens/full/CheckRun/CheckRun.tsx
@@ -23,7 +23,7 @@ export const SingleCardTabs = styled(Tabs)`
 
 // The maximum depth to explore the graph
 const GRAPH_DEPTH = 3;
-const BUILT_VERB = 'was built into';
+const TRANSFORMED_VERB = 'was transformed to';
 const MERGE_VERB = 'was merged as';
 
 const hourInMs = 60 * 60 * 1000;
@@ -73,7 +73,7 @@ export default withSetup(
 		}
 
 		// Loads the commit contract attached to this check run and then recursively loads all
-		// contracts that it was built into, creating a tree of contracts that can be used to
+		// contracts that it was transformed to, creating a tree of contracts that can be used to
 		// represent a chain of transformers
 		async loadTransformerData() {
 			const { card } = this.props;
@@ -85,7 +85,7 @@ export default withSetup(
 			}
 			const commit = withCommit.links['is attached to commit'][0];
 
-			const getWasBuiltInto = async (contract: Contract) => {
+			const getWasTransformedTo = async (contract: Contract) => {
 				// Build a recursive links query to a maximum depth
 				let fragment = {};
 				_.times(GRAPH_DEPTH, () => {
@@ -93,7 +93,7 @@ export default withSetup(
 						anyOf: [
 							{
 								$$links: {
-									[BUILT_VERB]: {
+									[TRANSFORMED_VERB]: {
 										type: 'object',
 										...fragment,
 									},
@@ -124,7 +124,7 @@ export default withSetup(
 				return contractWithLinks;
 			};
 
-			const result = await getWasBuiltInto(commit);
+			const result = await getWasTransformedTo(commit);
 
 			this.setState({
 				tree: result,


### PR DESCRIPTION
Also bumps jellyfish-worker to v31.1.1.

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
