### PR TITLE
UI: Fix link verbs in link modal

### DIFF
--- a/apps/ui/lib/components/LinkModal/LinkModal.tsx
+++ b/apps/ui/lib/components/LinkModal/LinkModal.tsx
@@ -2,20 +2,17 @@ import React from 'react';
 import _ from 'lodash';
 import { strict as assert } from 'assert';
 import pluralize from 'pluralize';
-import { Badge, Modal, Select, Txt, Box } from 'rendition';
+import { Badge, Modal, Select, Txt } from 'rendition';
 import * as notifications from '../../services/notifications';
 import { Icon } from '../';
 import type { Contract, ContractSummary, TypeContract } from 'autumndb';
 import { AutoCompleteCardSelect } from '../AutoCompleteCardSelect';
-import { Hideable } from '../Hideable';
 import * as linkUtils from './util';
 import { TypeFilter } from './TypeFilter';
 import * as helpers from '../../services/helpers';
 import type { RelationshipContract } from 'autumndb';
 import { BoundActionCreators } from '../../types';
 import { actionCreators } from '../../store';
-
-const HideableBox = Hideable(Box);
 
 export interface StateProps {
 	allTypes: TypeContract[];
@@ -95,14 +92,12 @@ export const LinkModal: React.FunctionComponent<Props> = ({
 		for (const r of filteredRelationships) {
 			if (r.data.from.type === fromType) {
 				targets.push({ name: r.name as string });
-				targets.push({ name: r.data.inverseName as string });
 			} else {
 				targets.push({ name: r.data.inverseName as string });
-				targets.push({ name: r.name as string });
 			}
 		}
 		setLinkType(targets[0]);
-		return targets;
+		return _.uniqWith(targets, _.isEqual);
 	}, [fromType, linkVerb, selectedTarget]);
 
 	const onDone = async () => {
@@ -190,20 +185,18 @@ export const LinkModal: React.FunctionComponent<Props> = ({
 				{cards[0].name || cards[0].slug}
 			</Txt>
 			{!linkVerb && (
-				<HideableBox isHidden={!selectedTarget || linkTypeTargets.length === 1}>
-					<Select
-						mb={3}
-						id="card-linker--type-select"
-						value={linkType || _.first(linkTypeTargets)}
-						onChange={({ option }: { option: { name: string } }) => {
-							setLinkType(option);
-						}}
-						labelKey="name"
-						valueKey="name"
-						options={linkTypeTargets}
-						data-test="card-linker--type__input"
-					/>
-				</HideableBox>
+				<Select
+					mb={3}
+					id="card-linker--type-select"
+					value={linkType || _.first(linkTypeTargets)}
+					onChange={({ option }: { option: { name: string } }) => {
+						setLinkType(option);
+					}}
+					labelKey="name"
+					valueKey="name"
+					options={linkTypeTargets}
+					data-test="card-linker--type__input"
+				/>
 			)}
 			{!target && validTypes.length > 1 && (
 				<TypeFilter


### PR DESCRIPTION
Remove odd hidden box wrapping link verb select component.
Remove possibility of duplicate link verbs from list.
Only add link verbs to the select list that are valid for the
selected target contract type.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

**Before**
![before-1](https://user-images.githubusercontent.com/45343541/179342910-9e6407b5-19d0-4383-8991-0275fe32b8d3.png)
![before-2](https://user-images.githubusercontent.com/45343541/179342913-f113ca62-a0f2-4647-affe-882a25524b5e.png)

**After**
![after-1](https://user-images.githubusercontent.com/45343541/179342918-6a78fc91-138d-43dc-ac1d-e92ce6775bb0.png)
![after-2](https://user-images.githubusercontent.com/45343541/179342924-7602e304-c78e-4ace-acd2-9994b8462bb6.png)