### PR TITLE
Server: Lint code as part of docker build

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -19,6 +19,9 @@ COPY ./apps/server/run.sh /usr/src/jellyfish/apps/server/run.sh
 #dev-cmd-live=cd /usr/src/jellyfish/apps/server && npm run dev
 #dev-copy=./.libs/ /usr/src/jellyfish/apps/server/node_modules/
 COPY ./apps/server/lib/ /usr/src/jellyfish/apps/server/lib/
+COPY ./apps/server/test/ /usr/src/jellyfish/apps/server/test/
+COPY ./apps/server/tslint.json /usr/src/jellyfish/apps/server/tslint.json
+RUN npm run lint
 RUN npm run build
 
 # Production debugging scripts

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=16.0.0"
   },
   "scripts": {
-    "lint": "eslint --ext .js,.jsx scripts test && npm run lint:check && npm run lint:deps &&  npm run lint:server",
+    "lint": "eslint --ext .js,.jsx scripts test && npm run lint:check && npm run lint:deps",
     "lint:check": "shellcheck scripts/*.sh scripts/*/*.sh",
     "lint:deps": "deplint && depcheck --ignore-bin-package --ignores=@balena/jellyfish-*,shellcheck",
     "lint:catch": "catch-uncommitted --skip-node-versionbot-changes --exclude=VERSION,.versionbot/",


### PR DESCRIPTION
This change is part of continuing work to have the SUT container only
deal with e2e testing of the application instead of loading the source
code for the entire application so it can run lint and unit tests.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
