### PR TITLE
Server: Allow external support users to read relationships

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -20,7 +20,7 @@
         "@balena/jellyfish-plugin-github": "^8.0.0",
         "@balena/jellyfish-plugin-outreach": "^5.0.1",
         "@balena/jellyfish-plugin-typeform": "^10.0.0",
-        "@balena/jellyfish-worker": "^32.0.0",
+        "@balena/jellyfish-worker": "^32.0.4",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^21.0.0",
         "aws-sdk": "^2.1157.0",
@@ -664,9 +664,9 @@
       "dev": true
     },
     "node_modules/@balena/jellyfish-environment": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.2.2.tgz",
-      "integrity": "sha512-1mGUnqg3uvGou/kCfQ+IDaTRNgku7OYgOuKtul7ZQqE3V9jW9Ewl5N60tRIaaClb6M3mXpGgAysQIQ0JUsrJIg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.3.0.tgz",
+      "integrity": "sha512-/d/a0j4FfDtK5RM8h+ypO+8nyg1Cbp25VVHaN6rcxikefuXHFHEV6pYN3aPZdmBEipgNM52zX50p2K7LIfZJzw==",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.0",
         "lodash": "^4.17.21"
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.0.0.tgz",
-      "integrity": "sha512-rM5pMdtt0Vuz8T6j+kQUYuOJ5Xq+twgdc5FfA/vISg4U0JTh6jw/8kmao3rHzUtzM3unkqxKM9J7s3skXRmI6w==",
+      "version": "32.0.4",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.0.4.tgz",
+      "integrity": "sha512-HcUFVHK+YJtldceowZI9WaSP99KmDGQlzEaf5Xd2D4GrdEEFIH65A2cq8yFMLCPAcnnUG3sr3HhBGohHrH0iCg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.39",
         "@balena/jellyfish-environment": "^12.2.0",
@@ -972,7 +972,7 @@
         "@balena/jellyfish-metrics": "^2.0.91",
         "@graphile/logger": "^0.2.0",
         "@types/node": "^17.0.41",
-        "autumndb": "^21.0.0",
+        "autumndb": "^21.1.1",
         "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
         "blueimp-md5": "^2.19.0",
@@ -2886,12 +2886,12 @@
       "license": "MIT"
     },
     "node_modules/autumndb": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-21.0.0.tgz",
-      "integrity": "sha512-P9wYKJgkaOCkp4Y1eoENnUxmKQpLGQkYjVDhi8mGBy3aMBw8bBghSruvgBfr8Fb5/uvTEQdJTVTea2wI2/4Aug==",
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-21.1.2.tgz",
+      "integrity": "sha512-f0dbus0vQ83PJZiBd+h6Lcd+TfPFuTvPjWEyFyZHUCbzChW0WPBsGvCeOvUm8e35Z5TnkmgR8eCuoA0eSIx/jQ==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.40",
-        "@balena/jellyfish-environment": "^12.2.0",
+        "@balena/jellyfish-environment": "^12.3.0",
         "@balena/jellyfish-logger": "^5.1.7",
         "@balena/jellyfish-metrics": "^2.0.92",
         "bluebird": "^3.7.2",
@@ -2905,7 +2905,7 @@
         "lodash": "^4.17.21",
         "pg": "^8.7.3",
         "pg-format": "^1.0.4",
-        "redis": "4.1.0",
+        "redis": "4.2.0",
         "redis-mock": "^0.56.3",
         "semver": "^7.3.7",
         "skhema": "^6.0.6",
@@ -2922,6 +2922,19 @@
         "node": ">=14.2.0"
       }
     },
+    "node_modules/autumndb/node_modules/@redis/client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.2.0.tgz",
+      "integrity": "sha512-a8Nlw5fv2EIAFJxTDSSDVUT7yfBGpZO96ybZXzQpgkyLg/dxtQ1uiwTc0EGfzg1mrPjZokeBSEGTbGXekqTNOg==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/autumndb/node_modules/commander": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
@@ -2934,6 +2947,19 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.1.tgz",
       "integrity": "sha512-OXqyj3MD0p8Kee16Jz7CbCnXo+5CHKKu4xBh5UhC1NbmMkHn8WScLRy/B2q5UOlWMlNSQJc4mwXW30Lz+JUZJw=="
+    },
+    "node_modules/autumndb/node_modules/redis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.2.0.tgz",
+      "integrity": "sha512-bCR0gKVhIXFg8zCQjXEANzgI01DDixtPZgIUZHBCmwqixnu+MK3Tb2yqGjh+HCLASQVVgApiwhNkv+FoedZOGQ==",
+      "dependencies": {
+        "@redis/bloom": "1.0.2",
+        "@redis/client": "1.2.0",
+        "@redis/graph": "1.0.1",
+        "@redis/json": "1.0.3",
+        "@redis/search": "1.0.6",
+        "@redis/time-series": "1.0.3"
+      }
     },
     "node_modules/aws-sdk": {
       "version": "2.1157.0",
@@ -11872,9 +11898,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.2.2.tgz",
-      "integrity": "sha512-1mGUnqg3uvGou/kCfQ+IDaTRNgku7OYgOuKtul7ZQqE3V9jW9Ewl5N60tRIaaClb6M3mXpGgAysQIQ0JUsrJIg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-12.3.0.tgz",
+      "integrity": "sha512-/d/a0j4FfDtK5RM8h+ypO+8nyg1Cbp25VVHaN6rcxikefuXHFHEV6pYN3aPZdmBEipgNM52zX50p2K7LIfZJzw==",
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "lodash": "^4.17.21"
@@ -12121,9 +12147,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.0.0.tgz",
-      "integrity": "sha512-rM5pMdtt0Vuz8T6j+kQUYuOJ5Xq+twgdc5FfA/vISg4U0JTh6jw/8kmao3rHzUtzM3unkqxKM9J7s3skXRmI6w==",
+      "version": "32.0.4",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.0.4.tgz",
+      "integrity": "sha512-HcUFVHK+YJtldceowZI9WaSP99KmDGQlzEaf5Xd2D4GrdEEFIH65A2cq8yFMLCPAcnnUG3sr3HhBGohHrH0iCg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.39",
         "@balena/jellyfish-environment": "^12.2.0",
@@ -12132,7 +12158,7 @@
         "@balena/jellyfish-metrics": "^2.0.91",
         "@graphile/logger": "^0.2.0",
         "@types/node": "^17.0.41",
-        "autumndb": "^21.0.0",
+        "autumndb": "^21.1.1",
         "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
         "blueimp-md5": "^2.19.0",
@@ -13600,12 +13626,12 @@
       "version": "0.4.0"
     },
     "autumndb": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-21.0.0.tgz",
-      "integrity": "sha512-P9wYKJgkaOCkp4Y1eoENnUxmKQpLGQkYjVDhi8mGBy3aMBw8bBghSruvgBfr8Fb5/uvTEQdJTVTea2wI2/4Aug==",
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-21.1.2.tgz",
+      "integrity": "sha512-f0dbus0vQ83PJZiBd+h6Lcd+TfPFuTvPjWEyFyZHUCbzChW0WPBsGvCeOvUm8e35Z5TnkmgR8eCuoA0eSIx/jQ==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.40",
-        "@balena/jellyfish-environment": "^12.2.0",
+        "@balena/jellyfish-environment": "^12.3.0",
         "@balena/jellyfish-logger": "^5.1.7",
         "@balena/jellyfish-metrics": "^2.0.92",
         "bluebird": "^3.7.2",
@@ -13619,7 +13645,7 @@
         "lodash": "^4.17.21",
         "pg": "^8.7.3",
         "pg-format": "^1.0.4",
-        "redis": "4.1.0",
+        "redis": "4.2.0",
         "redis-mock": "^0.56.3",
         "semver": "^7.3.7",
         "skhema": "^6.0.6",
@@ -13630,6 +13656,16 @@
         "uuid-v4-regex": "^1.0.2"
       },
       "dependencies": {
+        "@redis/client": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.2.0.tgz",
+          "integrity": "sha512-a8Nlw5fv2EIAFJxTDSSDVUT7yfBGpZO96ybZXzQpgkyLg/dxtQ1uiwTc0EGfzg1mrPjZokeBSEGTbGXekqTNOg==",
+          "requires": {
+            "cluster-key-slot": "1.1.0",
+            "generic-pool": "3.8.2",
+            "yallist": "4.0.0"
+          }
+        },
         "commander": {
           "version": "9.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
@@ -13639,6 +13675,19 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.1.tgz",
           "integrity": "sha512-OXqyj3MD0p8Kee16Jz7CbCnXo+5CHKKu4xBh5UhC1NbmMkHn8WScLRy/B2q5UOlWMlNSQJc4mwXW30Lz+JUZJw=="
+        },
+        "redis": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-4.2.0.tgz",
+          "integrity": "sha512-bCR0gKVhIXFg8zCQjXEANzgI01DDixtPZgIUZHBCmwqixnu+MK3Tb2yqGjh+HCLASQVVgApiwhNkv+FoedZOGQ==",
+          "requires": {
+            "@redis/bloom": "1.0.2",
+            "@redis/client": "1.2.0",
+            "@redis/graph": "1.0.1",
+            "@redis/json": "1.0.3",
+            "@redis/search": "1.0.6",
+            "@redis/time-series": "1.0.3"
+          }
         }
       }
     },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -33,7 +33,7 @@
     "@balena/jellyfish-plugin-github": "^8.0.0",
     "@balena/jellyfish-plugin-outreach": "^5.0.1",
     "@balena/jellyfish-plugin-typeform": "^10.0.0",
-    "@balena/jellyfish-worker": "^32.0.0",
+    "@balena/jellyfish-worker": "^32.0.4",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^21.0.0",
     "aws-sdk": "^2.1157.0",


### PR DESCRIPTION
This fixes a bug where external support users are unable to directly
create links between contracts because the SDK needs to read
relationships to create the correct link.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
