### PR TITLE
Temporarily remove plugin-incidents

### DIFF
--- a/apps/server/lib/plugins.ts
+++ b/apps/server/lib/plugins.ts
@@ -3,7 +3,6 @@ import { discoursePlugin } from '@balena/jellyfish-plugin-discourse';
 import { flowdockPlugin } from '@balena/jellyfish-plugin-flowdock';
 import { frontPlugin } from '@balena/jellyfish-plugin-front';
 import { githubPlugin } from '@balena/jellyfish-plugin-github';
-import { incidentsPlugin } from '@balena/jellyfish-plugin-incidents';
 import { outreachPlugin } from '@balena/jellyfish-plugin-outreach';
 import { typeformPlugin } from '@balena/jellyfish-plugin-typeform';
 import { PluginDefinition } from '@balena/jellyfish-worker';
@@ -17,6 +16,5 @@ export function getPlugins(): PluginDefinition[] {
 		outreachPlugin(),
 		frontPlugin(),
 		balenaApiPlugin(),
-		incidentsPlugin(),
 	] as any;
 }

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -18,7 +18,6 @@
         "@balena/jellyfish-plugin-flowdock": "^5.0.48",
         "@balena/jellyfish-plugin-front": "^6.0.3",
         "@balena/jellyfish-plugin-github": "^8.0.0",
-        "@balena/jellyfish-plugin-incidents": "^6.1.0",
         "@balena/jellyfish-plugin-outreach": "^5.0.1",
         "@balena/jellyfish-plugin-typeform": "^10.0.0",
         "@balena/jellyfish-worker": "^32.0.4",
@@ -930,19 +929,6 @@
       "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@balena/jellyfish-plugin-incidents": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-incidents/-/jellyfish-plugin-incidents-6.1.0.tgz",
-      "integrity": "sha512-YunRpYIsil+xhMDlRhuX0+K4p2V3ID+LfZW26IlXwlettbuR/q05Te4Z3Vv8qwY1I3sDcqP9EhFuqEZBllCMvA==",
-      "dependencies": {
-        "@balena/jellyfish-environment": "^12.3.0",
-        "axios": "^0.27.2",
-        "skhema": "^6.0.6"
-      },
-      "engines": {
-        "node": ">=14.2.0"
       }
     },
     "node_modules/@balena/jellyfish-plugin-outreach": {
@@ -12135,16 +12121,6 @@
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
           "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
         }
-      }
-    },
-    "@balena/jellyfish-plugin-incidents": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-incidents/-/jellyfish-plugin-incidents-6.1.0.tgz",
-      "integrity": "sha512-YunRpYIsil+xhMDlRhuX0+K4p2V3ID+LfZW26IlXwlettbuR/q05Te4Z3Vv8qwY1I3sDcqP9EhFuqEZBllCMvA==",
-      "requires": {
-        "@balena/jellyfish-environment": "^12.3.0",
-        "axios": "^0.27.2",
-        "skhema": "^6.0.6"
       }
     },
     "@balena/jellyfish-plugin-outreach": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,6 @@
     "@balena/jellyfish-plugin-flowdock": "^5.0.48",
     "@balena/jellyfish-plugin-front": "^6.0.3",
     "@balena/jellyfish-plugin-github": "^8.0.0",
-    "@balena/jellyfish-plugin-incidents": "^6.1.0",
     "@balena/jellyfish-plugin-outreach": "^5.0.1",
     "@balena/jellyfish-plugin-typeform": "^10.0.0",
     "@balena/jellyfish-worker": "^32.0.4",


### PR DESCRIPTION
Removing plugin-incidents as adding it in caused heavy locking
in the production database on deployment. Will be adding this
plugin back in once the underlying cause has been fixed.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
