### PR TITLE
Update worker to 32.1.2

### DIFF
--- a/apps/server/lib/bootstrap.ts
+++ b/apps/server/lib/bootstrap.ts
@@ -87,42 +87,42 @@ export const bootstrap = async (logContext: LogContext, options: any) => {
 		}
 	};
 
-	logger.info(logContext, 'Inserting test user', {
-		username: environment.test.user.username,
-		role: environment.test.user.role,
-	});
-
-	assert.INTERNAL(
-		logContext,
-		environment.test.user.username,
-		autumndbErrors.JellyfishInvalidEnvironmentVariable as any,
-		`No test username: ${environment.test.user.username}`,
-	);
-
-	assert.INTERNAL(
-		logContext,
-		environment.test.user.role,
-		autumndbErrors.JellyfishInvalidEnvironmentVariable as any,
-		`No test role: ${environment.test.user.role}`,
-	);
-
-	const userContract = await kernel.replaceContract(
-		logContext,
-		kernel.adminSession()!,
-		{
-			slug: `user-${environment.test.user.username}`,
-			type: 'user@1.0.0',
-			name: 'Test User',
-			data: {
-				email: 'test@jel.ly.fish',
-				hash: 'PASSWORDLESS',
-				roles: [environment.test.user.role],
-			},
-		},
-	);
-
 	// Need test user during development and CI.
 	if (!environment.isProduction() || environment.isCI()) {
+		logger.info(logContext, 'Inserting test user', {
+			username: environment.test.user.username,
+			role: environment.test.user.role,
+		});
+
+		assert.INTERNAL(
+			logContext,
+			environment.test.user.username,
+			autumndbErrors.JellyfishInvalidEnvironmentVariable as any,
+			`No test username: ${environment.test.user.username}`,
+		);
+
+		assert.INTERNAL(
+			logContext,
+			environment.test.user.role,
+			autumndbErrors.JellyfishInvalidEnvironmentVariable as any,
+			`No test role: ${environment.test.user.role}`,
+		);
+
+		const userContract = await kernel.replaceContract(
+			logContext,
+			kernel.adminSession()!,
+			{
+				slug: `user-${environment.test.user.username}`,
+				type: 'user@1.0.0',
+				name: 'Test User',
+				data: {
+					email: 'test@jel.ly.fish',
+					hash: 'PASSWORDLESS',
+					roles: [environment.test.user.role, 'user-operator'],
+				},
+			},
+		);
+
 		logger.info(logContext, 'Setting test user password', {
 			username: environment.test.user.username,
 			role: environment.test.user.role,

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -21,7 +21,7 @@
         "@balena/jellyfish-plugin-incidents": "^7.1.0",
         "@balena/jellyfish-plugin-outreach": "^5.0.1",
         "@balena/jellyfish-plugin-typeform": "^10.0.0",
-        "@balena/jellyfish-worker": "^32.1.0",
+        "@balena/jellyfish-worker": "^32.1.2",
         "@balena/socket-prometheus-metrics": "^0.0.3",
         "autumndb": "^21.2.0",
         "aws-sdk": "^2.1157.0",
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.1.0.tgz",
-      "integrity": "sha512-hmItDK7y0PLRCP8OZm2byNvmnS+r/zX8iws3QPo/Wd7KfWz8K/uAjvOERR0GcMI+i2wH7C9uOWpaop2lBOdoTw==",
+      "version": "32.1.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.1.2.tgz",
+      "integrity": "sha512-n/jj2ylzOaCe5iobqXpevOtEo/9TXlL6JMkfAEN+A1GT10EMs62Sa5VCYFBtCpVO7/dBeBNKwRDc9yMNNjK/sg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.39",
         "@balena/jellyfish-environment": "^12.3.0",
@@ -933,7 +933,7 @@
         "@balena/jellyfish-metrics": "^2.0.91",
         "@graphile/logger": "^0.2.0",
         "@types/node": "^17.0.41",
-        "autumndb": "^21.1.4",
+        "autumndb": "^21.2.0",
         "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
         "blueimp-md5": "^2.19.0",
@@ -12072,9 +12072,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.1.0.tgz",
-      "integrity": "sha512-hmItDK7y0PLRCP8OZm2byNvmnS+r/zX8iws3QPo/Wd7KfWz8K/uAjvOERR0GcMI+i2wH7C9uOWpaop2lBOdoTw==",
+      "version": "32.1.2",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-32.1.2.tgz",
+      "integrity": "sha512-n/jj2ylzOaCe5iobqXpevOtEo/9TXlL6JMkfAEN+A1GT10EMs62Sa5VCYFBtCpVO7/dBeBNKwRDc9yMNNjK/sg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.39",
         "@balena/jellyfish-environment": "^12.3.0",
@@ -12083,7 +12083,7 @@
         "@balena/jellyfish-metrics": "^2.0.91",
         "@graphile/logger": "^0.2.0",
         "@types/node": "^17.0.41",
-        "autumndb": "^21.1.4",
+        "autumndb": "^21.2.0",
         "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
         "blueimp-md5": "^2.19.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -34,7 +34,7 @@
     "@balena/jellyfish-plugin-incidents": "^7.1.0",
     "@balena/jellyfish-plugin-outreach": "^5.0.1",
     "@balena/jellyfish-plugin-typeform": "^10.0.0",
-    "@balena/jellyfish-worker": "^32.1.0",
+    "@balena/jellyfish-worker": "^32.1.2",
     "@balena/socket-prometheus-metrics": "^0.0.3",
     "autumndb": "^21.2.0",
     "aws-sdk": "^2.1157.0",


### PR DESCRIPTION
Don't allow normal users to update other user contracts. user-admin
and users with operator role are allowed to edit other user contracts.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Testing https://github.com/product-os/jellyfish-worker/pull/1645
