### PR TITLE
UI: Default to providing the notification itself as the message context.

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
@@ -111,7 +111,9 @@ const Inbox = ({ channel }) => {
 		const read = (contract as any).data?.readBy?.includes(user.slug);
 
 		const source = contract.links?.['is attached to']?.[0];
-		const context = source?.links?.['is of']?.[0];
+		// The context is either the source of the message or the notification itself
+		const context =
+			source?.links?.['is of']?.[0] ?? contract?.links?.['has attached']?.[0];
 
 		const is121 = source?.data.dms ?? false;
 


### PR DESCRIPTION
If a message thread is not attached to anything, use the notification
itself as  context, which allows the notification archive functionality
to work as expected.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
