### PR TITLE
UI: Makes 'Add [Support|Chat] Thread' floating to save screen real est...

### DIFF
--- a/apps/ui/lib/components/InfiniteList.tsx
+++ b/apps/ui/lib/components/InfiniteList.tsx
@@ -15,7 +15,9 @@ const ScrollArea = styled<any>(Box)`
 	overflow-y: auto;
 	display: flex;
 	flex-direction: column;
+	padding-bottom: 100px;
 `;
+// unsure about the padding-bottom (it might not be at the right level, it should add 100px of white space a the end of the scroll list (so you can scroll the content 100px up when at the end))
 
 const TRIGGEROFFSET = 200;
 

--- a/apps/ui/lib/lens/common/ViewFooter/ViewFooter.tsx
+++ b/apps/ui/lib/lens/common/ViewFooter/ViewFooter.tsx
@@ -14,7 +14,10 @@ import * as notifications from '../../../services/notifications';
 import { RelationshipContract } from 'autumndb';
 
 const Footer = styled(Flex)`
-	border-top: 1px solid #eee;
+	// border-top: 1px solid #eee;
+	position: absolute;
+	bottom: 16px;
+	right: 16px;
 `;
 
 const DropUpButton = styled(DropDownButton).attrs({

--- a/apps/ui/lib/lens/list/Interleaved/component.tsx
+++ b/apps/ui/lib/lens/list/Interleaved/component.tsx
@@ -139,6 +139,20 @@ export const InterleavedList = (props: Props) => {
 			startReached={loadMoreContracts}
 			itemContent={itemContent}
 			overscan={10}
+			components={{
+				Footer: () => {
+					return (
+						<div
+							style={{
+								padding: '2rem',
+								textAlign: 'center',
+							}}
+						>
+							&nbsp;
+						</div>
+					);
+				},
+			}}
 		/>
 	);
 };

--- a/apps/ui/lib/lens/list/Simple/component.tsx
+++ b/apps/ui/lib/lens/list/Simple/component.tsx
@@ -77,6 +77,20 @@ export default function SimpleList(props: Props) {
 			endReached={loadMoreContracts}
 			itemContent={itemContent}
 			overscan={5}
+			components={{
+				Footer: () => {
+					return (
+						<div
+							style={{
+								padding: '2rem',
+								textAlign: 'center',
+							}}
+						>
+							&nbsp;
+						</div>
+					);
+				},
+			}}
 		/>
 	);
 }


### PR DESCRIPTION
Turned the Green add Thread button to floating and added some padding to the underlying scroll section to save some screen real estate and give an impression of space.