### PR TITLE
UI: Don't include messages attached to deleted threads in notification count

### DIFF
--- a/apps/ui/lib/components/MentionsCount.tsx
+++ b/apps/ui/lib/components/MentionsCount.tsx
@@ -61,6 +61,9 @@ const getQuery = (user: UserContract): JsonSchema => {
 					},
 				},
 			},
+			// By requiring the "is attached to" link to be present, we ensure that we don't show
+			// notifications for messages that are attached to deleted threads.
+			'is attached to': true,
 		},
 	};
 };


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
