### PR TITLE
UI: Allow click event propagation for left menu items

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -590,7 +590,6 @@ export default withSetup(
 						flex={1}
 						data-test="home-channel__drawer"
 						ref={this.wrapper}
-						// onClick={helpers.swallowEvent as any}
 						isMobile={isMobile}
 					>
 						{collapsed && (

--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -590,7 +590,7 @@ export default withSetup(
 						flex={1}
 						data-test="home-channel__drawer"
 						ref={this.wrapper}
-						onClick={helpers.swallowEvent as any}
+						// onClick={helpers.swallowEvent as any}
 						isMobile={isMobile}
 					>
 						{collapsed && (


### PR DESCRIPTION
[CTRL/CMD] + Click on an element of the left menu *doesn't* open the link in a new tab.

While : 
- Click on an element of the left menu trigger the internal routing in the same window
- [CTRL/CMD] + Click on an element of the top menu (i.e. inbox) open the link in a new tab
- Right click on the element -> open in a new tab, opens a new tab from the link (expected behavior with [CTRL/CMD] + click)

The culprit is the commented line. The whole left side menu is wrapped into a slider/drawer component which catch the click event and stop its propagation.

I'm not sure why this `SwallowEvent` has been set on that element. 
Either it's not required or it should be more selective on the context (i.e. only applies on the handle when the drawer is hidden or something like that).

@karaxuna you're the last one who touched this part, but it looks like it was to add TS types, so you may or may not have more context (But i don't know who else to ping about it).

My rather shallow manual testing didn't show any problem removing the line but it might have some hidden implication.