### PR TITLE
UI: Automatically mark message as read if it has an attached notification

### DIFF
--- a/apps/ui/lib/components/Event/Message/index.tsx
+++ b/apps/ui/lib/components/Event/Message/index.tsx
@@ -169,7 +169,7 @@ export default class Event extends React.Component<Props, State> {
 	};
 
 	saveEditedMessage = () => {
-		const { sdk, user, card, onUpdateCard } = this.props;
+		const { card, onUpdateCard } = this.props;
 		if (this.state.editedMessage === parseMessage(helpers.getMessage(card))) {
 			// No change or empty message - just finish editing now
 			this.onStopEditing();
@@ -202,13 +202,6 @@ export default class Event extends React.Component<Props, State> {
 					onUpdateCard(this.props.card, patch)
 						.then(async () => {
 							this.onStopEditing();
-
-							// If the edit happens to add a mention of the current user,
-							// we need to mark this message as read!
-							const updatedCard = await sdk.card.get(card.id);
-							if (updatedCard) {
-								sdk.card.markAsRead(user.slug, updatedCard as any);
-							}
 						})
 						.catch(() => {
 							this.setState({


### PR DESCRIPTION


Previously we would check the mentions* and alerts* fields, and only
mark a message as read if these fields contain the user slug. With the
switch to notifications we can simply check to see if the message has
attached notification for the current user.
This also means that marking a message as read when it is visible will
work for threads where the user is subscribed.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
