### PR TITLE
UI: Fix layout issues for linkable contracts when creating a new contract

### DIFF
--- a/apps/ui/lib/lens/actions/CreateLens/CreateLens.tsx
+++ b/apps/ui/lib/lens/actions/CreateLens/CreateLens.tsx
@@ -578,7 +578,6 @@ export default withSetup(
 								const targets = _.map(links[key], 'target');
 								return (
 									<Box
-										px={3}
 										mt={3}
 										key={key}
 										data-test={`segment-card--${_.get(segment, ['type'])}`}
@@ -598,6 +597,7 @@ export default withSetup(
 										</Box>
 
 										<LinkOrCreate
+											fixed
 											card={selectedTypeTarget}
 											segment={segment}
 											onSave={this.saveLink}
@@ -606,7 +606,7 @@ export default withSetup(
 								);
 							})}
 						</FormBox>
-						<Flex justifyContent="flex-end" my={3} flex={0}>
+						<Flex justifyContent="flex-end" m={3} flex={0}>
 							<Button onClick={this.close} mr={2}>
 								Cancel
 							</Button>

--- a/apps/ui/lib/lens/common/LinkOrCreate/index.tsx
+++ b/apps/ui/lib/lens/common/LinkOrCreate/index.tsx
@@ -28,6 +28,7 @@ export interface DispatchProps {
 }
 
 interface OwnProps {
+	fixed?: boolean;
 	card: Contract;
 	segment: {
 		link: string;
@@ -99,17 +100,26 @@ class LinkOrCreate extends React.Component<Props, State> {
 	};
 
 	render() {
-		const { card, segment, types, onSave } = this.props;
+		const { card, segment, types, onSave, fixed } = this.props;
 		const { showLinkModal } = this.state;
 
 		const type = _.find(types, {
 			slug: helpers.getRelationshipTargetType(segment),
 		});
 
+		const style: any = fixed
+			? { position: 'relative', right: 0, marginRight: 0 }
+			: {};
+
 		return (
 			<>
 				{segment.link && type && (
-					<Footer mr={1} flexWrap="wrap" justifyContent="flex-end">
+					<Footer
+						style={style}
+						mr={1}
+						flexWrap="wrap"
+						justifyContent="flex-end"
+					>
 						<Button
 							mr={2}
 							mt={2}


### PR DESCRIPTION
This fixes a bug where the buttons to add or link a new contract on creation would obscure the submit button at the bottom of the screen.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
