### PR TITLE
UI: If inbox notifications have the same source group them together

### DIFF
--- a/apps/ui/lib/components/Event/Message/Header.tsx
+++ b/apps/ui/lib/components/Event/Message/Header.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import _ from 'lodash';
 import styled from 'styled-components';
-import { Theme, Flex, Txt, Button } from 'rendition';
+import { Theme, Flex, Txt } from 'rendition';
 import type { Contract, UserContract } from 'autumndb';
 import { Link } from '../../Link';
 import HoverMenu, { EventContextProps } from './Context';
 import { username, getUserTooltipText } from '../../../services/helpers';
-import Icon from '../../Icon';
-import { useSetup } from '../../SetupProvider';
 
 const HeaderWrapper = styled(Flex)`
 	position: relative;
@@ -34,7 +32,6 @@ interface EventHeaderProps extends Omit<EventContextProps, 'isOwnMessage'> {
 }
 
 const EventHeader = (props: EventHeaderProps) => {
-	const { sdk } = useSetup()!;
 	const {
 		isMessage,
 		user,
@@ -46,8 +43,6 @@ const EventHeader = (props: EventHeaderProps) => {
 		context,
 		...contextProps
 	} = props;
-
-	const [isArchiving, setIsArchiving] = React.useState(false);
 
 	const getTimelineElement = React.useCallback(() => {
 		const targetCard = _.get(card, ['links', 'is attached to', '0'], card);
@@ -75,27 +70,8 @@ const EventHeader = (props: EventHeaderProps) => {
 		);
 	}, [actor, card]);
 
-	const archiveNotification = React.useCallback(async () => {
-		const notification = card?.links?.['has attached'][0];
-
-		setIsArchiving(true);
-		if (notification) {
-			try {
-				await sdk.card.update(notification.id, notification.type, [
-					{
-						op: notification.data.status ? 'replace' : 'add',
-						path: '/data/status',
-						value: 'archived',
-					},
-				]);
-			} catch (err) {
-				console.error(err);
-			}
-		}
-		setIsArchiving(false);
-	}, ['card']);
-
-	const contextName = context?.name;
+	const contextName =
+		context?.type === 'notification@1.0.0' ? 'Notification' : context?.name;
 
 	const isOwnMessage = user.id === _.get(card, ['data', 'actor']);
 
@@ -148,7 +124,7 @@ const EventHeader = (props: EventHeaderProps) => {
 								1 to 1
 							</Txt>
 						)}
-						{contextName && (
+						{context && contextName && (
 							<Link color={'#B8B8B8'} mr={1} append={context.slug}>
 								{contextName}
 							</Link>
@@ -157,21 +133,6 @@ const EventHeader = (props: EventHeaderProps) => {
 				)}
 
 				{!squashTop && !isMessage && getTimelineElement()}
-
-				{(context || is121) && (
-					<Button
-						tooltip={{
-							text: 'Archive this notification',
-							placement: 'left',
-						}}
-						plain
-						icon={
-							<Icon name={isArchiving ? 'cog' : 'box'} spin={isArchiving} />
-						}
-						onClick={archiveNotification}
-						mr={1}
-					/>
-				)}
 			</Flex>
 
 			{!(context || is121) && (

--- a/apps/ui/lib/lens/misc/Inbox/EventBox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/EventBox.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Contract } from 'autumndb';
+import path from 'path';
+import { Box, Button, Flex, Txt } from 'rendition';
+import styled from 'styled-components';
+import { Event, Icon, useSetup } from '../../../components';
+import { ChannelContract, UIActor } from '../../../types';
+import { useSelector } from 'react-redux';
+import { selectors } from '../../../store';
+import { useHistory } from 'react-router-dom';
+
+const InboxMessageWrapper = styled(Box)`
+	position: relative;
+	&.event-unread {
+		background: #ffeb838a;
+	}
+
+	.notifications-meta-container {
+		position: absolute;
+		right: 0;
+		z-index: 9;
+	}
+`;
+
+const getActorHref = (actor: UIActor) => {
+	return path.join(location.pathname, actor.card.slug);
+};
+
+interface Props {
+	contract: Contract;
+	channel: ChannelContract;
+}
+
+export const EventBox = React.memo(({ channel, contract }: Props) => {
+	const { sdk } = useSetup()!;
+	const history = useHistory();
+	const groups = useSelector(selectors.getGroups());
+	const user = useSelector(selectors.getCurrentUser());
+	const [isArchiving, setIsArchiving] = React.useState(false);
+
+	const message = contract.links?.['has attached element']?.[0];
+	const source = contract;
+	const hasNotification = !!message?.links?.['has attached']?.[0];
+
+	const read =
+		!hasNotification ||
+		(!!user && (message as any).data?.readBy?.includes(user.slug));
+
+	const archiveNotification = React.useCallback(async () => {
+		setIsArchiving(true);
+
+		// There may be multiple notifications to clear, since we
+		// compact messages and their notifications from the same thread together
+		const notifications: Contract[] = [];
+
+		for (const event of source.links?.['has attached element'] ?? []) {
+			notifications.push(...(event?.links?.['has attached'] || []));
+		}
+
+		await Promise.all(
+			notifications.map(async (notification) => {
+				try {
+					await sdk.card.update(notification.id, notification.type, [
+						{
+							op: notification.data.status ? 'replace' : 'add',
+							path: '/data/status',
+							value: 'archived',
+						},
+					]);
+				} catch (err) {
+					console.error(err);
+				}
+			}),
+		);
+		setIsArchiving(false);
+	}, [contract]);
+
+	const openChannel = React.useCallback(
+		(target: string) => {
+			const current = channel.data.target;
+
+			if (current) {
+				history.push(
+					path.join(
+						window.location.pathname.split(current)[0],
+						current,
+						target,
+					),
+				);
+			}
+		},
+		[channel],
+	);
+
+	if (!contract) {
+		return <Box p={3}>Loading...</Box>;
+	}
+
+	// The context is either the source of the message or the notification itself
+	const context =
+		source?.links?.['is of']?.[0] ?? message?.links?.['has attached']?.[0];
+
+	const messageCount = source?.links?.['has attached element']?.length ?? 0;
+
+	const is121 = source?.data.dms ?? false;
+
+	return (
+		<InboxMessageWrapper className={read ? 'event-read' : 'event-unread'}>
+			<Flex
+				flexDirection="column"
+				alignItems="flex-end"
+				pt={2}
+				pr={2}
+				className="notifications-meta-container"
+			>
+				{messageCount > 1 && (
+					<Txt className="notifications-count" bold>
+						+ {messageCount} more
+					</Txt>
+				)}
+				<Button
+					className="notifications-archive-button"
+					tooltip={{
+						text: 'Archive this notification',
+						placement: 'left',
+					}}
+					plain
+					icon={<Icon name={isArchiving ? 'cog' : 'box'} spin={isArchiving} />}
+					onClick={archiveNotification}
+				/>
+			</Flex>
+			<Event
+				openChannel={openChannel}
+				user={user}
+				groups={groups}
+				getActorHref={getActorHref}
+				card={message}
+				is121={is121}
+				context={context}
+			/>
+		</InboxMessageWrapper>
+	);
+});

--- a/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
@@ -12,40 +12,42 @@ import { ChannelContract } from '../../../types';
 const getOpenQuery = (): JsonSchema => {
 	return {
 		type: 'object',
-		properties: {
-			type: {
-				enum: ['message@1.0.0', 'whisper@1.0.0'],
+		anyOf: [
+			{
+				$$links: {
+					'is of': {
+						type: 'object',
+					},
+				},
 			},
-		},
+			true,
+		],
 		$$links: {
-			'has attached': {
+			'has attached element': {
 				type: 'object',
 				properties: {
 					type: {
-						const: 'notification@1.0.0',
+						enum: ['message@1.0.0', 'whisper@1.0.0'],
 					},
-					data: {
+				},
+				$$links: {
+					'has attached': {
 						type: 'object',
 						properties: {
-							status: {
-								const: 'open',
+							type: {
+								const: 'notification@1.0.0',
+							},
+							data: {
+								type: 'object',
+								properties: {
+									status: {
+										const: 'open',
+									},
+								},
 							},
 						},
 					},
 				},
-			},
-			'is attached to': {
-				type: 'object',
-				anyOf: [
-					{
-						$$links: {
-							'is of': {
-								type: 'object',
-							},
-						},
-					},
-					true,
-				],
 			},
 		},
 	};
@@ -53,9 +55,12 @@ const getOpenQuery = (): JsonSchema => {
 
 const getArchivedQuery = (): JsonSchema => {
 	const query: any = getOpenQuery();
-	query.$$links['has attached'].properties.data.properties.status.const =
-		'archived';
-	query.$$links['has attached'].properties.data.required = ['status'];
+	query.$$links['has attached element'].$$links[
+		'has attached'
+	].properties.data.properties.status.const = 'archived';
+	query.$$links['has attached element'].$$links[
+		'has attached'
+	].properties.data.required = ['status'];
 
 	return query;
 };


### PR DESCRIPTION
Inbox notifications for messages and whispers that come from the same
source are now grouped together. Archiving the notification will also
archive all of the grouped notifications.

![image](https://user-images.githubusercontent.com/15064535/186437663-1bf36b0b-c96a-4c30-a0f8-38691cec9178.png)


Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
