### PR TITLE
Fix inbox to handle sent tab query results

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/EventBox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/EventBox.tsx
@@ -4,6 +4,7 @@ import path from 'path';
 import { Box, Button, Flex, Txt } from 'rendition';
 import styled from 'styled-components';
 import { Event, Icon, useSetup } from '../../../components';
+import { MESSAGE, WHISPER } from '../../../components/constants';
 import { ChannelContract, UIActor } from '../../../types';
 import { useSelector } from 'react-redux';
 import { selectors } from '../../../store';
@@ -29,115 +30,129 @@ const getActorHref = (actor: UIActor) => {
 interface Props {
 	contract: Contract;
 	channel: ChannelContract;
+	canArchive?: boolean;
 }
 
-export const EventBox = React.memo(({ channel, contract }: Props) => {
-	const { sdk } = useSetup()!;
-	const history = useHistory();
-	const groups = useSelector(selectors.getGroups());
-	const user = useSelector(selectors.getCurrentUser());
-	const [isArchiving, setIsArchiving] = React.useState(false);
+export const EventBox = React.memo(
+	({ channel, contract, canArchive }: Props) => {
+		const { sdk } = useSetup()!;
+		const history = useHistory();
+		const groups = useSelector(selectors.getGroups());
+		const user = useSelector(selectors.getCurrentUser());
+		const [isArchiving, setIsArchiving] = React.useState(false);
 
-	const message = contract.links?.['has attached element']?.[0];
-	const source = contract;
-	const hasNotification = !!message?.links?.['has attached']?.[0];
+		// Depending on the executed query, the matching contract could be a
+		// message/whisper or a thread. We need to account for both cases.
+		const typeBase = contract.type.split('@')[0];
+		let message = contract.links?.['has attached element']?.[0];
+		let source = contract;
+		if (typeBase === MESSAGE || typeBase === WHISPER) {
+			message = contract;
+			source = contract.links!['is attached to']?.[0];
+		}
+		const hasNotification = !!message?.links?.['has attached']?.[0];
 
-	const read =
-		!hasNotification ||
-		(!!user && (message as any).data?.readBy?.includes(user.slug));
+		const read =
+			!hasNotification ||
+			(!!user && (message as any).data?.readBy?.includes(user.slug));
 
-	const archiveNotification = React.useCallback(async () => {
-		setIsArchiving(true);
+		const archiveNotification = React.useCallback(async () => {
+			setIsArchiving(true);
 
-		// There may be multiple notifications to clear, since we
-		// compact messages and their notifications from the same thread together
-		const notifications: Contract[] = [];
+			// There may be multiple notifications to clear, since we
+			// compact messages and their notifications from the same thread together
+			const notifications: Contract[] = [];
 
-		for (const event of source.links?.['has attached element'] ?? []) {
-			notifications.push(...(event?.links?.['has attached'] || []));
+			for (const event of source.links?.['has attached element'] ?? []) {
+				notifications.push(...(event?.links?.['has attached'] || []));
+			}
+
+			await Promise.all(
+				notifications.map(async (notification) => {
+					try {
+						await sdk.card.update(notification.id, notification.type, [
+							{
+								op: notification.data.status ? 'replace' : 'add',
+								path: '/data/status',
+								value: 'archived',
+							},
+						]);
+					} catch (err) {
+						console.error(err);
+					}
+				}),
+			);
+			setIsArchiving(false);
+		}, [contract]);
+
+		const openChannel = React.useCallback(
+			(target: string) => {
+				const current = channel.data.target;
+
+				if (current) {
+					history.push(
+						path.join(
+							window.location.pathname.split(current)[0],
+							current,
+							target,
+						),
+					);
+				}
+			},
+			[channel],
+		);
+
+		if (!contract) {
+			return <Box p={3}>Loading...</Box>;
 		}
 
-		await Promise.all(
-			notifications.map(async (notification) => {
-				try {
-					await sdk.card.update(notification.id, notification.type, [
-						{
-							op: notification.data.status ? 'replace' : 'add',
-							path: '/data/status',
-							value: 'archived',
-						},
-					]);
-				} catch (err) {
-					console.error(err);
-				}
-			}),
-		);
-		setIsArchiving(false);
-	}, [contract]);
+		// The context is either the source of the message or the notification itself
+		const context =
+			source?.links?.['is of']?.[0] ?? message?.links?.['has attached']?.[0];
 
-	const openChannel = React.useCallback(
-		(target: string) => {
-			const current = channel.data.target;
+		const messageCount = source?.links?.['has attached element']?.length ?? 0;
 
-			if (current) {
-				history.push(
-					path.join(
-						window.location.pathname.split(current)[0],
-						current,
-						target,
-					),
-				);
-			}
-		},
-		[channel],
-	);
+		const is121 = source?.data.dms ?? false;
 
-	if (!contract) {
-		return <Box p={3}>Loading...</Box>;
-	}
-
-	// The context is either the source of the message or the notification itself
-	const context =
-		source?.links?.['is of']?.[0] ?? message?.links?.['has attached']?.[0];
-
-	const messageCount = source?.links?.['has attached element']?.length ?? 0;
-
-	const is121 = source?.data.dms ?? false;
-
-	return (
-		<InboxMessageWrapper className={read ? 'event-read' : 'event-unread'}>
-			<Flex
-				flexDirection="column"
-				alignItems="flex-end"
-				pt={2}
-				pr={2}
-				className="notifications-meta-container"
-			>
-				{messageCount > 1 && (
-					<Txt className="notifications-count" bold>
-						+ {messageCount} more
-					</Txt>
-				)}
-				<Button
-					className="notifications-archive-button"
-					tooltip={{
-						text: 'Archive this notification',
-						placement: 'left',
-					}}
-					plain
-					icon={<Icon name={isArchiving ? 'cog' : 'box'} spin={isArchiving} />}
-					onClick={archiveNotification}
+		return (
+			<InboxMessageWrapper className={read ? 'event-read' : 'event-unread'}>
+				<Flex
+					flexDirection="column"
+					alignItems="flex-end"
+					pt={2}
+					pr={2}
+					className="notifications-meta-container"
+				>
+					{messageCount > 1 && (
+						<Txt className="notifications-count" bold>
+							+ {messageCount} more
+						</Txt>
+					)}
+					{canArchive && (
+						<Button
+							className="notifications-archive-button"
+							tooltip={{
+								text: 'Archive this notification',
+								placement: 'left',
+							}}
+							plain
+							icon={
+								<Icon name={isArchiving ? 'cog' : 'box'} spin={isArchiving} />
+							}
+							onClick={archiveNotification}
+						/>
+					)}
+				</Flex>
+				<Event
+					openChannel={openChannel}
+					user={user}
+					groups={groups}
+					getActorHref={getActorHref}
+					card={message}
+					is121={is121}
+					context={context}
 				/>
-			</Flex>
-			<Event
-				openChannel={openChannel}
-				user={user}
-				groups={groups}
-				getActorHref={getActorHref}
-				card={message}
-				is121={is121}
-				context={context}
-			/>
-		</InboxMessageWrapper>
-	);
-});
+			</InboxMessageWrapper>
+		);
+	},
+);

--- a/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
@@ -127,7 +127,7 @@ const Inbox = ({ channel }: Props) => {
 		<Column pt={2}>
 			<Tabs>
 				<Tab title="Open">
-					<InboxTab query={openQuery} channel={channel} />
+					<InboxTab query={openQuery} channel={channel} canArchive={true} />
 				</Tab>
 				<Tab title="Archived">
 					<InboxTab query={archivedQuery} channel={channel} />

--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
@@ -37,9 +37,10 @@ const DEFAULT_OPTIONS: SdkQueryOptions = {
 interface Props {
 	channel: ChannelContract;
 	query: JsonSchema;
+	canArchive?: boolean;
 }
 
-const Inbox = ({ channel, query }: Props) => {
+const Inbox = ({ channel, query, canArchive }: Props) => {
 	const { sdk } = useSetup()!;
 	const [threads, nextPage, hasNextPage, loading] = useCursorEffect(
 		query,
@@ -80,7 +81,9 @@ const Inbox = ({ channel, query }: Props) => {
 	// An oddity of react-virtuoso is that the `itemContent` cannot be a memoized component, but it can call out to a memoized component.
 	// See https://virtuoso.dev/#performance
 	const itemContent = (_index, contract) => {
-		return <EventBox contract={contract} channel={channel} />;
+		return (
+			<EventBox contract={contract} channel={channel} canArchive={canArchive} />
+		);
 	};
 
 	const inboxItems = threads.filter((thread) => {


### PR DESCRIPTION
Update the EventBox component used in the new Inbox to properly
handle cases in which the query results in a message/whisper contract
and stop assuming result is always a thread. Also add prop to toggle
archive button - should only be able to archive things from the open
tab.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>