### PR TITLE
Show timestamp for more events

### DIFF
--- a/apps/ui/lib/components/Event/Message/Header.tsx
+++ b/apps/ui/lib/components/Event/Message/Header.tsx
@@ -135,7 +135,15 @@ const EventHeader = (props: EventHeaderProps) => {
 				{!squashTop && !isMessage && getTimelineElement()}
 			</Flex>
 
-			{!(context || is121) && (
+			{context || is121 ? (
+				<HoverMenu
+					card={card}
+					{...contextProps}
+					isOwnMessage={isOwnMessage}
+					isMessage={isMessage}
+					menuOptions={false}
+				/>
+			) : (
 				<HoverMenu
 					card={card}
 					{...contextProps}


### PR DESCRIPTION
Show the timestamp portion of the event hover element for events that
have a context contract or are a part of 121 conversations.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>