### PR TITLE
Update @balena/jellyfish-plugin-front from 6.0.62 to 6.0.63

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -15,7 +15,7 @@
         "@balena/jellyfish-metrics": "^2.0.131",
         "@balena/jellyfish-plugin-balena-api": "^6.0.91",
         "@balena/jellyfish-plugin-discourse": "^6.0.47",
-        "@balena/jellyfish-plugin-front": "^6.0.62",
+        "@balena/jellyfish-plugin-front": "^6.0.63",
         "@balena/jellyfish-plugin-github": "^8.0.50",
         "@balena/jellyfish-plugin-incidents": "^8.0.37",
         "@balena/jellyfish-plugin-outreach": "^5.0.34",
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-front": {
-      "version": "6.0.62",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.62.tgz",
-      "integrity": "sha512-j+N8lOiqAdanHZTxfxpNu6Ip/yeiKs7HGYrMnJHIa6t7GXC36s5jWvNzIxodO3SEcWF6VelDXU1LqV+mGItbrQ==",
+      "version": "6.0.63",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.63.tgz",
+      "integrity": "sha512-1wnbn7iCnGXiCJZ26tTUU2EeZDqV6cEfDhBExq+MDw2uymdf3aNRVPjHeT5DfikxWL3zvd3okhPSwPXafXZWig==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.54",
         "@balena/jellyfish-environment": "^13.0.4",
@@ -13324,9 +13324,9 @@
       }
     },
     "@balena/jellyfish-plugin-front": {
-      "version": "6.0.62",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.62.tgz",
-      "integrity": "sha512-j+N8lOiqAdanHZTxfxpNu6Ip/yeiKs7HGYrMnJHIa6t7GXC36s5jWvNzIxodO3SEcWF6VelDXU1LqV+mGItbrQ==",
+      "version": "6.0.63",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.63.tgz",
+      "integrity": "sha512-1wnbn7iCnGXiCJZ26tTUU2EeZDqV6cEfDhBExq+MDw2uymdf3aNRVPjHeT5DfikxWL3zvd3okhPSwPXafXZWig==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.54",
         "@balena/jellyfish-environment": "^13.0.4",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-metrics": "^2.0.131",
     "@balena/jellyfish-plugin-balena-api": "^6.0.91",
     "@balena/jellyfish-plugin-discourse": "^6.0.47",
-    "@balena/jellyfish-plugin-front": "^6.0.62",
+    "@balena/jellyfish-plugin-front": "^6.0.63",
     "@balena/jellyfish-plugin-github": "^8.0.50",
     "@balena/jellyfish-plugin-incidents": "^8.0.37",
     "@balena/jellyfish-plugin-outreach": "^5.0.34",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
