### PR TITLE
UI: Prefer linked target to hardcoded target when clicking a message

### DIFF
--- a/apps/ui/lib/components/Event/Message/index.tsx
+++ b/apps/ui/lib/components/Event/Message/index.tsx
@@ -53,8 +53,10 @@ const MessageIconWrapper = styled(Box)`
 	}
 `;
 
-const getTargetId = (card: Contract<{ target: string }>) => {
-	return _.get(card, ['data', 'target']) || card.id;
+const getTargetId = (card: Contract<{ target: string }>): string => {
+	const linkedTarget = card?.links?.['is attached to']?.[0].id ?? null;
+	const ownTarget = card.data?.target ?? null;
+	return linkedTarget || ownTarget || card.id;
 };
 
 interface MessageIconProps {


### PR DESCRIPTION
This makes the on-click behaviour much more responsive to context than
it used to be, by relying on the linked data if it's available.
For example, the message may have initially targeted and entity that no
longer exists, but is being queried through a more recent link. By using
the link data, it is much more likely that clicking the message will
result in the correct behaviour.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
