### PR TITLE
Improve notification sorting in inbox

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
@@ -29,7 +29,7 @@ const getArchivedNotificationQuery = (): JsonSchema => ({
 });
 
 const DEFAULT_OPTIONS: SdkQueryOptions = {
-	limit: 15,
+	limit: 25,
 	sortBy: 'created_at',
 	sortDir: 'desc',
 	links: {
@@ -92,14 +92,23 @@ const Inbox = ({ channel, query, canArchive }: Props) => {
 		);
 	};
 
-	const inboxItems = threads.filter((thread) => {
-		const nIds = _.map(
-			thread?.links?.['has attached element']?.[0]?.links?.['has attached'] ??
-				[],
-			'id',
-		);
-		return !nIds.length || !_.intersection(archivedNotifications, nIds).length;
-	});
+	const inboxItems = _.sortBy(
+		threads.filter((thread) => {
+			const nIds = _.map(
+				thread?.links?.['has attached element']?.[0]?.links?.['has attached'] ??
+					[],
+				'id',
+			);
+			return (
+				!nIds.length || !_.intersection(archivedNotifications, nIds).length
+			);
+		}),
+		// This is a hacky way to sort the threads by their most recent message.
+		// TODO: This should be done at the query level
+		(thread) => {
+			return thread?.links?.['has attached element']?.[0]?.created_at;
+		},
+	).reverse();
 
 	return (
 		<Flex

--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
@@ -32,6 +32,12 @@ const DEFAULT_OPTIONS: SdkQueryOptions = {
 	limit: 15,
 	sortBy: 'created_at',
 	sortDir: 'desc',
+	links: {
+		'has attached element': {
+			sortBy: 'created_at',
+			sortDir: 'desc',
+		},
+	},
 };
 
 interface Props {


### PR DESCRIPTION
This change ensures that the most recent message in a thread is shown and that the threads are sorted by order of most recent message.
Practically this means that you should see the most recent messages first, and at the top of the inbox.