### PR TITLE
Retry if a query times out to avoid inconsistencies between front and JF

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -15,7 +15,7 @@
         "@balena/jellyfish-metrics": "^2.0.140",
         "@balena/jellyfish-plugin-balena-api": "^6.0.91",
         "@balena/jellyfish-plugin-discourse": "^6.0.47",
-        "@balena/jellyfish-plugin-front": "^6.0.70",
+        "@balena/jellyfish-plugin-front": "^6.0.73",
         "@balena/jellyfish-plugin-github": "^8.0.50",
         "@balena/jellyfish-plugin-incidents": "^8.0.40",
         "@balena/jellyfish-plugin-outreach": "^5.0.76",
@@ -690,13 +690,13 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-front": {
-      "version": "6.0.70",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.70.tgz",
-      "integrity": "sha512-+Bmtx4ztrgvd9Nw4YPx+KF5Ey6P9VuV9KoWJyiqsPO4EqQ7kP33fnaumxxpnqUdSkAA3JL73XMf1b+IaSmgxRg==",
+      "version": "6.0.73",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.73.tgz",
+      "integrity": "sha512-MyhAWveuI2qtg/rDSpgUfQE5bc2Nq6/eHO5kFoJQpn0FqPlMi5sHzfTiS98hFIU8/NtUS/5Dl+KAYGnmhBsEyg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.57",
         "@balena/jellyfish-environment": "^13.0.7",
-        "@balena/jellyfish-worker": "^33.1.0",
+        "@balena/jellyfish-worker": "^33.2.0",
         "@types/sanitize-html": "^2.6.2",
         "axios": "^0.27.2",
         "bluebird": "^3.7.2",
@@ -12819,13 +12819,13 @@
       }
     },
     "@balena/jellyfish-plugin-front": {
-      "version": "6.0.70",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.70.tgz",
-      "integrity": "sha512-+Bmtx4ztrgvd9Nw4YPx+KF5Ey6P9VuV9KoWJyiqsPO4EqQ7kP33fnaumxxpnqUdSkAA3JL73XMf1b+IaSmgxRg==",
+      "version": "6.0.73",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-front/-/jellyfish-plugin-front-6.0.73.tgz",
+      "integrity": "sha512-MyhAWveuI2qtg/rDSpgUfQE5bc2Nq6/eHO5kFoJQpn0FqPlMi5sHzfTiS98hFIU8/NtUS/5Dl+KAYGnmhBsEyg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.57",
         "@balena/jellyfish-environment": "^13.0.7",
-        "@balena/jellyfish-worker": "^33.1.0",
+        "@balena/jellyfish-worker": "^33.2.0",
         "@types/sanitize-html": "^2.6.2",
         "axios": "^0.27.2",
         "bluebird": "^3.7.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@balena/jellyfish-metrics": "^2.0.140",
     "@balena/jellyfish-plugin-balena-api": "^6.0.91",
     "@balena/jellyfish-plugin-discourse": "^6.0.47",
-    "@balena/jellyfish-plugin-front": "^6.0.70",
+    "@balena/jellyfish-plugin-front": "^6.0.73",
     "@balena/jellyfish-plugin-github": "^8.0.50",
     "@balena/jellyfish-plugin-incidents": "^8.0.40",
     "@balena/jellyfish-plugin-outreach": "^5.0.76",


### PR DESCRIPTION
Bump jellyfish-plugin-front to v6.0.73

Change-type: patch
Signed-off-by: Ramiro Gonzalez <ramiro.gonzalez@balena.io>


