### PR TITLE
UI: Improve performance of chat group query

### DIFF
--- a/apps/ui/lib/components/ChatWidget/store/action-creators.ts
+++ b/apps/ui/lib/components/ChatWidget/store/action-creators.ts
@@ -37,24 +37,33 @@ const getLoop = (product: string): string => {
 const allGroupsWithUsersQuery: JsonSchema = {
 	type: 'object',
 	description: 'Get all groups with member user slugs',
-	required: ['type', 'name'],
 	$$links: {
 		'has group member': {
 			type: 'object',
-			required: ['slug'],
+			additionalProperties: false,
 			properties: {
+				active: {
+					type: 'boolean',
+					const: true,
+				},
 				slug: {
 					type: 'string',
 				},
 			},
-			additionalProperties: false,
 		},
 	},
 	properties: {
 		type: {
 			const: 'group@1.0.0',
 		},
+		name: {
+			type: 'string',
+		},
+		links: {
+			type: 'object',
+		},
 	},
+	additionalProperties: false,
 };
 
 // Card exists here until it's loaded

--- a/apps/ui/lib/store/actioncreators/index.ts
+++ b/apps/ui/lib/store/actioncreators/index.ts
@@ -57,11 +57,10 @@ const TOKEN_REFRESH_INTERVAL = 3 * 60 * 60 * 1000;
 const allGroupsWithUsersQuery: JsonSchema = {
 	type: 'object',
 	description: 'Get all groups with member user slugs',
-	required: ['type', 'name'],
 	$$links: {
 		'has group member': {
 			type: 'object',
-			required: ['slug', 'active'],
+			additionalProperties: false,
 			properties: {
 				active: {
 					type: 'boolean',
@@ -71,14 +70,20 @@ const allGroupsWithUsersQuery: JsonSchema = {
 					type: 'string',
 				},
 			},
-			additionalProperties: false,
 		},
 	},
 	properties: {
 		type: {
 			const: 'group@1.0.0',
 		},
+		name: {
+			type: 'string',
+		},
+		links: {
+			type: 'object',
+		},
 	},
+	additionalProperties: false,
 };
 
 const buildGlobalQueryMask = (loop: string | null): JsonSchema | null => {
@@ -542,6 +547,9 @@ export const actionCreators = {
 					sdk.getConfig(),
 				]).then(async ([loops, orgs, types, relationships, groups, config]) => {
 					const state = getState();
+
+					console.log({ allGroupsWithUsersQuery });
+					console.log({ groups });
 
 					// Check to see if we're still logged in
 					if (selectors.getSessionToken()(state)) {


### PR DESCRIPTION
Only return the fields required in the chat group query

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
