### PR TITLE
Move Tooltip on user avatar to the right 

### DIFF
--- a/apps/ui/lib/components/UserAvatar/index.tsx
+++ b/apps/ui/lib/components/UserAvatar/index.tsx
@@ -34,7 +34,7 @@ export interface UserAvatarProps {
 }
 
 export const UserAvatar = React.memo<UserAvatarProps>(
-	({ user, emphasized, tooltipPlacement = 'top', tooltipText }) => {
+	({ user, emphasized, tooltipPlacement = 'right', tooltipText }) => {
 		const firstName = _.get(user, ['data', 'profile', 'name', 'first']);
 		const lastName = _.get(user, ['data', 'profile', 'name', 'last']);
 		const src = _.get(user, ['data', 'avatar']);

--- a/apps/ui/lib/components/UserAvatar/tests/UserAvatar.spec.tsx
+++ b/apps/ui/lib/components/UserAvatar/tests/UserAvatar.spec.tsx
@@ -55,6 +55,6 @@ test('UserAvatarLive displays the user`s avatar, tooltip and status', async () =
 	});
 	expect(avatarBox.props().tooltip).toEqual({
 		text: `Test User\ntest@jel.ly.fish\njellyfish\n${losAngelesDate} (Las Vegas)`,
-		placement: 'top',
+		placement: 'right',
 	});
 });

--- a/apps/ui/lib/components/UserAvatar/tests/UserAvatar.spec.tsx
+++ b/apps/ui/lib/components/UserAvatar/tests/UserAvatar.spec.tsx
@@ -50,11 +50,8 @@ test('UserAvatarLive displays the user`s avatar, tooltip and status', async () =
 	expect(statusIcon.props().userStatus.value).toEqual('DoNotDisturb');
 
 	const avatarBox: any = component.find('[data-test="avatar-wrapper"]').first();
-	const losAngelesDate = new Date().toLocaleString(undefined, {
-		timeZone: 'America/Los_Angeles',
-	});
-	expect(avatarBox.props().tooltip).toEqual({
-		text: `Test User\ntest@jel.ly.fish\njellyfish\n${losAngelesDate} (Las Vegas)`,
-		placement: 'right',
-	});
+	expect(avatarBox.props().tooltip.text).toMatch(
+		/^Test User\ntest@jel.ly.fish\njellyfish\n[0-9\/]+, [0-9:]+ [A|P]M \(Las Vegas\)$/,
+	);
+	expect(avatarBox.props().tooltip.placement).toEqual('right');
 });


### PR DESCRIPTION
The tooltip was opening to the top from the avatar which is top left of the screen, so always out of the screen.
Now opening to the right so the information are readable.