### PR TITLE
UI: Truncate bookmark names

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -203,6 +203,11 @@ const groupViews = memoize<any>((tail, bookmarks, userId, orgs) => {
 	};
 
 	if (bookmarks && bookmarks.length) {
+		for (const bookmark of bookmarks) {
+			if (bookmark.name.length > 30) {
+				bookmark.name = `${bookmark.name.substring(0, 29)}...`;
+			}
+		}
 		const bookmarksTree = viewsToTree(
 			bookmarks,
 			{


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Ideally we should have a more elegant solution, but this is better than what we have now and allows users to bookmark contracts that have very long names without breaking their sidebars.
