### PR TITLE
Don't exit on unhandled errors and rejections

### DIFF
--- a/apps/server/lib/index.ts
+++ b/apps/server/lib/index.ts
@@ -41,31 +41,15 @@ const DEFAULT_CONTEXT = {
 
 const onError = (error, message = 'Server error', ctx = DEFAULT_CONTEXT) => {
 	logger.error(ctx, message, error);
-	console.error({
-		context: ctx,
-		message,
-		error,
-	});
-	console.error('Process exiting');
-	setTimeout(() => {
-		process.exit(1);
-	}, 1000);
 };
 
 /**
  * `unhandledRejection` event means that a promise rejection wasn't handled.
- * Log query read timeouts, exit the process on other cases
+ * Log but don't exit the process because that may cause an operation to be interrupted
+ * and leave the system inconsistent.
  */
-process.on('unhandledRejection', (reason: Error | unknown, promise) => {
-	if (_.isError(reason) && reason.message === 'Query read timeout') {
-		// Don't exit, just log
-		logger.error(DEFAULT_CONTEXT, 'Unhandled Rejection', {
-			reason: reason.stack || reason,
-			promise,
-		});
-	} else {
-		return onError(reason, 'Unhandled Rejection');
-	}
+process.on('unhandledRejection', (reason: Error | unknown, _promise) => {
+	return onError(reason, 'Unhandled Rejection');
 });
 
 const startDate = new Date();

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -22,7 +22,7 @@
         "@balena/jellyfish-plugin-typeform": "^10.0.70",
         "@balena/jellyfish-worker": "^33.4.0",
         "@balena/socket-prometheus-metrics": "^0.0.3",
-        "autumndb": "^22.2.38",
+        "autumndb": "^22.2.42",
         "aws-sdk": "^2.1184.0",
         "bcrypt": "^5.0.1",
         "body-parser": "^1.20.0",
@@ -553,14 +553,14 @@
       }
     },
     "node_modules/@balena/jellyfish-assert": {
-      "version": "1.2.63",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.63.tgz",
-      "integrity": "sha512-HbAAok23yc8WSooMT/ix9QTBpv2WUYolwKzzfPABIFGSbilMmwPZdn46LObCgc1aDMDLcycrw07hKzRJiOA5Cw==",
+      "version": "1.2.67",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.67.tgz",
+      "integrity": "sha512-cwSqVRZ51v5pMQcyLj0LaAKI4BODO6fP/p7rm7IQeOOMmFKv1GRhQSQc590evE67MygLcqMBdhfapmWEy0YCYQ==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=12.15.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/@balena/jellyfish-client-sdk": {
@@ -612,12 +612,12 @@
       }
     },
     "node_modules/@balena/jellyfish-logger": {
-      "version": "5.1.59",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-5.1.59.tgz",
-      "integrity": "sha512-TuI7QKJSC4HV9oSXetVMXXujmXJ67x5Ol09GR+Uo5F1sVjzgJ4WHTY1X5dLfew0iLPWUfnco9WAwMvZah+mf2w==",
+      "version": "5.1.63",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-5.1.63.tgz",
+      "integrity": "sha512-p4chfxoVUwcHdYPJ45WKLd9X8zpS0gOMjOxwf5TTkJ/mXal6ZpJJdNflElTx3nbUdPgxwdIvq17suJuV6zIVsA==",
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.63",
-        "@balena/jellyfish-environment": "^14.0.0",
+        "@balena/jellyfish-assert": "^1.2.67",
+        "@balena/jellyfish-environment": "^14.0.3",
         "@sentry/node": "^7.12.1",
         "errio": "^1.2.2",
         "lodash": "^4.17.21",
@@ -626,46 +626,46 @@
         "winston-transport": "^4.5.0"
       },
       "engines": {
-        "node": ">=12.15.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/@balena/jellyfish-logger/node_modules/@balena/jellyfish-environment": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.0.tgz",
-      "integrity": "sha512-5jygYk3Sxj0d0LLPQ9K2n3GbGbM5kIrSbvvAPXE/+Irx/PIoe5Y8YYY4k67b+lO2iNCRvHNyMP6XVutGztDMXA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.3.tgz",
+      "integrity": "sha512-HD/GraVCU111JDvRmUNgHQ8JQIDb3yfl2JuGXBdZwv2h5d0mDRKLYMmmtaDf8yvrwAAaCESjVBTb2ejH9Na56w==",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.2",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=12.15.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/@balena/jellyfish-metrics": {
-      "version": "2.0.159",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.159.tgz",
-      "integrity": "sha512-Qu7gEAQ7A2oOhSXHbPEvqpsm5pT+yrsh2RqvAwUpnX4tHNzhaJQDOClloUNQxq3MddRov9/9mX3AjUq3d7cEfQ==",
+      "version": "2.0.162",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.162.tgz",
+      "integrity": "sha512-Q9u4BziXLbPCF0Z3JgpeaqvL+EeytjV669qo5yZ6+9KL/meUZ0L7uZa9kRy+t4OefO1PTfDLK5elrcY4zX8lzw==",
       "dependencies": {
-        "@balena/jellyfish-environment": "^14.0.0",
-        "@balena/jellyfish-logger": "^5.1.59",
+        "@balena/jellyfish-environment": "^14.0.3",
+        "@balena/jellyfish-logger": "^5.1.61",
         "@balena/node-metrics-gatherer": "^6.0.3",
         "express": "^4.18.1",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=12.15.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/@balena/jellyfish-metrics/node_modules/@balena/jellyfish-environment": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.0.tgz",
-      "integrity": "sha512-5jygYk3Sxj0d0LLPQ9K2n3GbGbM5kIrSbvvAPXE/+Irx/PIoe5Y8YYY4k67b+lO2iNCRvHNyMP6XVutGztDMXA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.3.tgz",
+      "integrity": "sha512-HD/GraVCU111JDvRmUNgHQ8JQIDb3yfl2JuGXBdZwv2h5d0mDRKLYMmmtaDf8yvrwAAaCESjVBTb2ejH9Na56w==",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.2",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=12.15.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/@balena/jellyfish-plugin-balena-api": {
@@ -3216,14 +3216,14 @@
       "license": "MIT"
     },
     "node_modules/autumndb": {
-      "version": "22.2.38",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.38.tgz",
-      "integrity": "sha512-2G4TaRj0Sb+LwZ8KKRsAQtDBBJgry2I8MV3pmcKVFzyYJWbvNhZOjIl5WiWWhNRbcUDswBT98ZSlYyGN7XVrZQ==",
+      "version": "22.2.44",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.44.tgz",
+      "integrity": "sha512-YklpC14Zy5b/Klaj+tgXW4u4EQ8XmPGMTU6EH8ocy2CMbPi8TzpXNQNX96cz+lPBvyOtEUv9y2vieIW5lkjFXQ==",
       "dependencies": {
-        "@balena/jellyfish-assert": "^1.2.63",
-        "@balena/jellyfish-environment": "^14.0.0",
-        "@balena/jellyfish-logger": "^5.1.59",
-        "@balena/jellyfish-metrics": "^2.0.159",
+        "@balena/jellyfish-assert": "^1.2.67",
+        "@balena/jellyfish-environment": "^14.0.3",
+        "@balena/jellyfish-logger": "^5.1.63",
+        "@balena/jellyfish-metrics": "^2.0.162",
         "bluebird": "^3.7.2",
         "commander": "^9.4.0",
         "fast-equals": "^4.0.3",
@@ -3249,19 +3249,19 @@
         "autumndb": "build/cli/index.js"
       },
       "engines": {
-        "node": ">=14.2.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/autumndb/node_modules/@balena/jellyfish-environment": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.0.tgz",
-      "integrity": "sha512-5jygYk3Sxj0d0LLPQ9K2n3GbGbM5kIrSbvvAPXE/+Irx/PIoe5Y8YYY4k67b+lO2iNCRvHNyMP6XVutGztDMXA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.3.tgz",
+      "integrity": "sha512-HD/GraVCU111JDvRmUNgHQ8JQIDb3yfl2JuGXBdZwv2h5d0mDRKLYMmmtaDf8yvrwAAaCESjVBTb2ejH9Na56w==",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.2",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=12.15.0"
+        "node": "^16.0.0"
       }
     },
     "node_modules/autumndb/node_modules/commander": {
@@ -12744,9 +12744,9 @@
       }
     },
     "@balena/jellyfish-assert": {
-      "version": "1.2.63",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.63.tgz",
-      "integrity": "sha512-HbAAok23yc8WSooMT/ix9QTBpv2WUYolwKzzfPABIFGSbilMmwPZdn46LObCgc1aDMDLcycrw07hKzRJiOA5Cw==",
+      "version": "1.2.67",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-assert/-/jellyfish-assert-1.2.67.tgz",
+      "integrity": "sha512-cwSqVRZ51v5pMQcyLj0LaAKI4BODO6fP/p7rm7IQeOOMmFKv1GRhQSQc590evE67MygLcqMBdhfapmWEy0YCYQ==",
       "requires": {
         "lodash": "^4.17.21"
       }
@@ -12791,12 +12791,12 @@
       }
     },
     "@balena/jellyfish-logger": {
-      "version": "5.1.59",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-5.1.59.tgz",
-      "integrity": "sha512-TuI7QKJSC4HV9oSXetVMXXujmXJ67x5Ol09GR+Uo5F1sVjzgJ4WHTY1X5dLfew0iLPWUfnco9WAwMvZah+mf2w==",
+      "version": "5.1.63",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-5.1.63.tgz",
+      "integrity": "sha512-p4chfxoVUwcHdYPJ45WKLd9X8zpS0gOMjOxwf5TTkJ/mXal6ZpJJdNflElTx3nbUdPgxwdIvq17suJuV6zIVsA==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.2.63",
-        "@balena/jellyfish-environment": "^14.0.0",
+        "@balena/jellyfish-assert": "^1.2.67",
+        "@balena/jellyfish-environment": "^14.0.3",
         "@sentry/node": "^7.12.1",
         "errio": "^1.2.2",
         "lodash": "^4.17.21",
@@ -12806,9 +12806,9 @@
       },
       "dependencies": {
         "@balena/jellyfish-environment": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.0.tgz",
-          "integrity": "sha512-5jygYk3Sxj0d0LLPQ9K2n3GbGbM5kIrSbvvAPXE/+Irx/PIoe5Y8YYY4k67b+lO2iNCRvHNyMP6XVutGztDMXA==",
+          "version": "14.0.3",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.3.tgz",
+          "integrity": "sha512-HD/GraVCU111JDvRmUNgHQ8JQIDb3yfl2JuGXBdZwv2h5d0mDRKLYMmmtaDf8yvrwAAaCESjVBTb2ejH9Na56w==",
           "requires": {
             "@humanwhocodes/env": "^2.2.2",
             "lodash": "^4.17.21"
@@ -12817,21 +12817,21 @@
       }
     },
     "@balena/jellyfish-metrics": {
-      "version": "2.0.159",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.159.tgz",
-      "integrity": "sha512-Qu7gEAQ7A2oOhSXHbPEvqpsm5pT+yrsh2RqvAwUpnX4tHNzhaJQDOClloUNQxq3MddRov9/9mX3AjUq3d7cEfQ==",
+      "version": "2.0.162",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-2.0.162.tgz",
+      "integrity": "sha512-Q9u4BziXLbPCF0Z3JgpeaqvL+EeytjV669qo5yZ6+9KL/meUZ0L7uZa9kRy+t4OefO1PTfDLK5elrcY4zX8lzw==",
       "requires": {
-        "@balena/jellyfish-environment": "^14.0.0",
-        "@balena/jellyfish-logger": "^5.1.59",
+        "@balena/jellyfish-environment": "^14.0.3",
+        "@balena/jellyfish-logger": "^5.1.61",
         "@balena/node-metrics-gatherer": "^6.0.3",
         "express": "^4.18.1",
         "lodash": "^4.17.21"
       },
       "dependencies": {
         "@balena/jellyfish-environment": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.0.tgz",
-          "integrity": "sha512-5jygYk3Sxj0d0LLPQ9K2n3GbGbM5kIrSbvvAPXE/+Irx/PIoe5Y8YYY4k67b+lO2iNCRvHNyMP6XVutGztDMXA==",
+          "version": "14.0.3",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.3.tgz",
+          "integrity": "sha512-HD/GraVCU111JDvRmUNgHQ8JQIDb3yfl2JuGXBdZwv2h5d0mDRKLYMmmtaDf8yvrwAAaCESjVBTb2ejH9Na56w==",
           "requires": {
             "@humanwhocodes/env": "^2.2.2",
             "lodash": "^4.17.21"
@@ -14857,14 +14857,14 @@
       "version": "0.4.0"
     },
     "autumndb": {
-      "version": "22.2.38",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.38.tgz",
-      "integrity": "sha512-2G4TaRj0Sb+LwZ8KKRsAQtDBBJgry2I8MV3pmcKVFzyYJWbvNhZOjIl5WiWWhNRbcUDswBT98ZSlYyGN7XVrZQ==",
+      "version": "22.2.44",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.44.tgz",
+      "integrity": "sha512-YklpC14Zy5b/Klaj+tgXW4u4EQ8XmPGMTU6EH8ocy2CMbPi8TzpXNQNX96cz+lPBvyOtEUv9y2vieIW5lkjFXQ==",
       "requires": {
-        "@balena/jellyfish-assert": "^1.2.63",
-        "@balena/jellyfish-environment": "^14.0.0",
-        "@balena/jellyfish-logger": "^5.1.59",
-        "@balena/jellyfish-metrics": "^2.0.159",
+        "@balena/jellyfish-assert": "^1.2.67",
+        "@balena/jellyfish-environment": "^14.0.3",
+        "@balena/jellyfish-logger": "^5.1.63",
+        "@balena/jellyfish-metrics": "^2.0.162",
         "bluebird": "^3.7.2",
         "commander": "^9.4.0",
         "fast-equals": "^4.0.3",
@@ -14888,9 +14888,9 @@
       },
       "dependencies": {
         "@balena/jellyfish-environment": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.0.tgz",
-          "integrity": "sha512-5jygYk3Sxj0d0LLPQ9K2n3GbGbM5kIrSbvvAPXE/+Irx/PIoe5Y8YYY4k67b+lO2iNCRvHNyMP6XVutGztDMXA==",
+          "version": "14.0.3",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-14.0.3.tgz",
+          "integrity": "sha512-HD/GraVCU111JDvRmUNgHQ8JQIDb3yfl2JuGXBdZwv2h5d0mDRKLYMmmtaDf8yvrwAAaCESjVBTb2ejH9Na56w==",
           "requires": {
             "@humanwhocodes/env": "^2.2.2",
             "lodash": "^4.17.21"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,7 +35,7 @@
     "@balena/jellyfish-plugin-typeform": "^10.0.70",
     "@balena/jellyfish-worker": "^33.4.0",
     "@balena/socket-prometheus-metrics": "^0.0.3",
-    "autumndb": "^22.2.38",
+    "autumndb": "^22.2.42",
     "aws-sdk": "^2.1184.0",
     "bcrypt": "^5.0.1",
     "body-parser": "^1.20.0",


### PR DESCRIPTION
Currently, JF exits on unhandled exceptions in an attempt to highlight the error. But what actually happens is that a worker exits, and it's then restarted, with the unwanted effect the worker exiting means a non-clean shutdown that may interrupt some operations, which is not needed. This is affecting at least:

Bug on autumndb, fixed in 22.2.42: https://sentry.io/organizations/balena/issues/3568604519/?environment=server&environment=prod&project=1366139&query=is%3Aunresolved

Query timeouts: 
* https://sentry.io/organizations/balena/issues/3337230685/?environment=server&environment=prod&project=1366139&query=is%3Aunresolved
* https://sentry.io/organizations/balena/issues/3475517541/?environment=server&environment=prod&project=1366139&query=is%3Aunresolved
* https://sentry.io/organizations/balena/issues/3164921816/?environment=server&environment=prod&project=1366139&query=is%3Aunresolved
* https://sentry.io/organizations/balena/issues/3354918880/?environment=server&environment=prod&project=1366139&query=is%3Aunresolved
* https://sentry.io/organizations/balena/issues/3475748626/?environment=server&environment=prod&project=1366139&query=is%3Aunresolved

This improvement logs the error so that it can be clearly seen in Sentry, but doesn't abort the process. These errors will appear as `mechanism: generic, handled: true` instead as `mechanism: onunhandledrejection, handled: false`

Change-type: minor
Signed-off-by: Ramiro Gonzalez <ramiro.gonzalez@balena.io>
