### PR TITLE
UI: Remove compacting of notifications in inbox

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/EventBox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/EventBox.tsx
@@ -4,7 +4,6 @@ import path from 'path';
 import { Box, Button, Flex, Txt } from 'rendition';
 import styled from 'styled-components';
 import { Event, Icon, useSetup } from '../../../components';
-import { MESSAGE, WHISPER } from '../../../components/constants';
 import { ChannelContract, UIActor } from '../../../types';
 import { useSelector } from 'react-redux';
 import { selectors } from '../../../store';
@@ -41,15 +40,9 @@ export const EventBox = React.memo(
 		const user = useSelector(selectors.getCurrentUser());
 		const [isArchiving, setIsArchiving] = React.useState(false);
 
-		// Depending on the executed query, the matching contract could be a
-		// message/whisper or a thread. We need to account for both cases.
-		const typeBase = contract.type.split('@')[0];
-		let message = contract.links?.['has attached element']?.[0];
-		let source = contract;
-		if (typeBase === MESSAGE || typeBase === WHISPER) {
-			message = contract;
-			source = contract.links!['is attached to']?.[0];
-		}
+		const message = contract;
+		const source = contract.links!['is attached to']?.[0];
+
 		const hasNotification = !!message?.links?.['has attached']?.[0];
 
 		const read =
@@ -59,13 +52,7 @@ export const EventBox = React.memo(
 		const archiveNotification = React.useCallback(async () => {
 			setIsArchiving(true);
 
-			// There may be multiple notifications to clear, since we
-			// compact messages and their notifications from the same thread together
-			const notifications: Contract[] = [];
-
-			for (const event of source.links?.['has attached element'] ?? []) {
-				notifications.push(...(event?.links?.['has attached'] || []));
-			}
+			const notifications = message.links?.['has attached'] ?? [];
 
 			await Promise.all(
 				notifications.map(async (notification) => {

--- a/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
@@ -12,42 +12,40 @@ import { ChannelContract } from '../../../types';
 const getOpenQuery = (): JsonSchema => {
 	return {
 		type: 'object',
-		anyOf: [
-			{
-				$$links: {
-					'is of': {
-						type: 'object',
-					},
-				},
+		properties: {
+			type: {
+				enum: ['message@1.0.0', 'whisper@1.0.0'],
 			},
-			true,
-		],
+		},
 		$$links: {
-			'has attached element': {
+			'has attached': {
 				type: 'object',
 				properties: {
 					type: {
-						enum: ['message@1.0.0', 'whisper@1.0.0'],
+						const: 'notification@1.0.0',
 					},
-				},
-				$$links: {
-					'has attached': {
+					data: {
 						type: 'object',
 						properties: {
-							type: {
-								const: 'notification@1.0.0',
-							},
-							data: {
-								type: 'object',
-								properties: {
-									status: {
-										const: 'open',
-									},
-								},
+							status: {
+								const: 'open',
 							},
 						},
 					},
 				},
+			},
+			'is attached to': {
+				type: 'object',
+				anyOf: [
+					{
+						$$links: {
+							'is of': {
+								type: 'object',
+							},
+						},
+					},
+					true,
+				],
 			},
 		},
 	};
@@ -55,12 +53,9 @@ const getOpenQuery = (): JsonSchema => {
 
 const getArchivedQuery = (): JsonSchema => {
 	const query: any = getOpenQuery();
-	query.$$links['has attached element'].$$links[
-		'has attached'
-	].properties.data.properties.status.const = 'archived';
-	query.$$links['has attached element'].$$links[
-		'has attached'
-	].properties.data.required = ['status'];
+	query.$$links['has attached'].properties.data.properties.status.const =
+		'archived';
+	query.$$links['has attached'].properties.data.required = ['status'];
 
 	return query;
 };

--- a/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/InboxTab.tsx
@@ -3,41 +3,17 @@ import _ from 'lodash';
 import { SdkQueryOptions } from '@balena/jellyfish-client-sdk/build/types';
 import React, { useState } from 'react';
 import { Flex, Box } from 'rendition';
-import { Icon, useSetup } from '../../../components';
+import { Icon } from '../../../components';
 import { JsonSchema } from 'autumndb';
 import { useCursorEffect } from '../../../hooks';
 import { GroupedVirtuoso } from 'react-virtuoso';
 import { ChannelContract } from '../../../types';
 import { EventBox } from './EventBox';
 
-const getArchivedNotificationQuery = (): JsonSchema => ({
-	type: 'object',
-	properties: {
-		type: {
-			const: 'notification@1.0.0',
-		},
-		data: {
-			type: 'object',
-			required: ['status'],
-			properties: {
-				status: {
-					const: 'archived',
-				},
-			},
-		},
-	},
-});
-
 const DEFAULT_OPTIONS: SdkQueryOptions = {
 	limit: 25,
 	sortBy: 'created_at',
 	sortDir: 'desc',
-	links: {
-		'has attached element': {
-			sortBy: 'created_at',
-			sortDir: 'desc',
-		},
-	},
 };
 
 interface Props {
@@ -47,32 +23,10 @@ interface Props {
 }
 
 const Inbox = ({ channel, query, canArchive }: Props) => {
-	const { sdk } = useSetup()!;
-	const [threads, nextPage, hasNextPage, loading] = useCursorEffect(
+	const [inboxItems, nextPage, hasNextPage, loading] = useCursorEffect(
 		query,
 		DEFAULT_OPTIONS,
 	);
-
-	// This is a hack that will store a list of notification ids that have been archived
-	// whilst this component is alive. This is to prevent the notification from being shown
-	// even though it has been archived.
-	// We have to do this because the current streaming logic will not unmatch the messages
-	// if the notification contract changes.
-	// TODO: Fix this at the autumndb level and remove this code.
-	const [archivedNotifications, setArchivedNotifications] = useState<string[]>(
-		[],
-	);
-	React.useEffect(() => {
-		const stream = sdk.stream(getArchivedNotificationQuery());
-		stream.on('update', ({ data }) => {
-			if (data.after) {
-				setArchivedNotifications(archivedNotifications.concat(data.id));
-			}
-		});
-		return () => {
-			stream.close();
-		};
-	}, [archivedNotifications]);
 
 	const [isLoadingPage, setIsLoadingPage] = useState(false);
 
@@ -88,27 +42,14 @@ const Inbox = ({ channel, query, canArchive }: Props) => {
 	// See https://virtuoso.dev/#performance
 	const itemContent = (_index, contract) => {
 		return (
-			<EventBox contract={contract} channel={channel} canArchive={canArchive} />
+			<EventBox
+				key={contract.id}
+				contract={contract}
+				channel={channel}
+				canArchive={canArchive}
+			/>
 		);
 	};
-
-	const inboxItems = _.sortBy(
-		threads.filter((thread) => {
-			const nIds = _.map(
-				thread?.links?.['has attached element']?.[0]?.links?.['has attached'] ??
-					[],
-				'id',
-			);
-			return (
-				!nIds.length || !_.intersection(archivedNotifications, nIds).length
-			);
-		}),
-		// This is a hacky way to sort the threads by their most recent message.
-		// TODO: This should be done at the query level
-		(thread) => {
-			return thread?.links?.['has attached element']?.[0]?.created_at;
-		},
-	).reverse();
 
 	return (
 		<Flex


### PR DESCRIPTION
Each message you are notified of will now be a seperate item in the inbox. This change has been made to avoid the situation where notifications are missed, because they are obscured by a subsequent notification on the same context.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
