### PR TITLE
Dev: Switch to official MinIO image for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true npm run install:all
 ## Start services
 You can then run these commands in different terminal emulators, which will run all services in non-daemon mode:
 
-Start Postgres, Redis, and S3 services:
+Start Postgres, Redis, and MinIO services:
 ```sh
 npm run compose:local
 ```
@@ -83,6 +83,10 @@ The API will listen on `8000` and the UI will listen on `9000`. Open http://loca
 
 > Note: The development user is not available in production
 > (`NODE_ENV=production`)
+
+You can also view uploaded files by opening http://localhost:43697 and logging in with:
+- Username: `AKIAIOSFODNN7EXAMPLE`
+- Password: `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`
 
 ## Work with Dependencies
 There are times in which you may want to make changes a dependency while working on a service component.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -28,29 +28,23 @@ services:
       test: echo INFO | redis-cli | grep redis_version
       timeout: 5s
     command: redis-server --appendonly yes
-  s3:
-    image: balena/open-balena-s3:v2.13.10
+  minio-server:
+    image: quay.io/minio/minio
+    restart: always
     environment:
-      BUCKETS: jellyfish
-      MINIO_DOMAIN: ly.fish.local
-      S3_MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
-      S3_MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-    healthcheck:
-      test: /usr/src/app/docker-hc
-      interval: 45s
-      timeout: 15s
-      retries: 3
-    cap_add:
-      - SYS_RESOURCE
-      - SYS_ADMIN
-    security_opt:
-      - apparmor=unconfined
-    tmpfs:
-      - /run
-      - /sys/fs/cgroup
-    restart: unless-stopped
-    networks:
-      - internal
+      MINIO_ROOT_USER: AKIAIOSFODNN7EXAMPLE
+      MINIO_ROOT_PASSWORD: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    command: server /data --console-address ":9001"
     ports:
-      - '43680:80'
-      - '43697:43697'
+      - '43680:9000'
+      - '43697:9001'
+  minio-client:
+    image: minio/mc
+    depends_on:
+      - minio-server
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add minio-server http://minio-server:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY;
+      /usr/bin/mc mb --ignore-existing minio-server/jellyfish;
+      exit 0;
+      "


### PR DESCRIPTION
The open-balena-s3 image uses systemd and causes issues with systems
running cgroups v2. The official MinIO images do not have this problem.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>
