### PR TITLE
UI: Tooltip for sidemenu items with long name

### DIFF
--- a/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
+++ b/apps/ui/lib/components/HomeChannel/HomeChannel.tsx
@@ -203,11 +203,6 @@ const groupViews = memoize<any>((tail, bookmarks, userId, orgs) => {
 	};
 
 	if (bookmarks && bookmarks.length) {
-		for (const bookmark of bookmarks) {
-			if (bookmark.name && bookmark.name.length > 30) {
-				bookmark.name = `${bookmark.name.substring(0, 29)}...`;
-			}
-		}
 		const bookmarksTree = viewsToTree(
 			bookmarks,
 			{

--- a/apps/ui/lib/components/ViewLink/ViewLink.tsx
+++ b/apps/ui/lib/components/ViewLink/ViewLink.tsx
@@ -12,6 +12,8 @@ import {
 	UserAvatarLive,
 } from '../';
 
+const NAME_MAX_LENGTH = 30;
+
 export default class ViewLink extends React.Component<any, any> {
 	constructor(props) {
 		super(props);
@@ -86,6 +88,13 @@ export default class ViewLink extends React.Component<any, any> {
 		);
 	}
 
+	truncateName(name: string) {
+		if (name.length > NAME_MAX_LENGTH) {
+			return `${name.substring(0, NAME_MAX_LENGTH - 1)}...`;
+		}
+		return name;
+	}
+
 	render() {
 		const { isHomeView, activeSlice, card, isActive, user } = this.props;
 		const bookmarked = this.isBookmarked();
@@ -102,8 +111,16 @@ export default class ViewLink extends React.Component<any, any> {
 				.join(', ');
 		}
 
+		// Truncate name and set tooltip if necessary
+		let name = label || card.name || card.slug;
+		let tooltip = '';
+		if (name.length > NAME_MAX_LENGTH) {
+			tooltip = name;
+			name = this.truncateName(name);
+		}
+
 		return (
-			<Box>
+			<Box tooltip={{ text: tooltip, placement: 'right' }}>
 				<Flex
 					justifyContent="space-between"
 					bg={isActive && !activeSlice ? '#eee' : 'none'}
@@ -129,7 +146,7 @@ export default class ViewLink extends React.Component<any, any> {
 											return <UserAvatarLive key={slug} mr={2} userId={slug} />;
 										})}
 
-									{label || card.name || card.slug}
+									{name}
 								</Flex>
 
 								{isHomeView && (


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Show tooltip when hovering over an item in the left menu that has a truncated name. This applies to all items, but mostly applicable to bookmarks. Items with short names that weren't truncated don't need a tooltip so one isn't displayed.

**Long name**
![bookmark-hover](https://user-images.githubusercontent.com/45343541/191227568-45e23100-cb8f-47a4-a302-a9bc042a20d2.png)

***

**Short name**
![bookmark-short](https://user-images.githubusercontent.com/45343541/191227635-2dee1474-e7cc-4eba-8c9e-734927bb86e1.png)
