### PR TITLE
Revert "Include private messages in direct mentions tab"

### DIFF
--- a/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
+++ b/apps/ui/lib/lens/misc/Inbox/Inbox.tsx
@@ -52,29 +52,8 @@ const getOpenQuery = (): JsonSchema => {
 };
 
 const getDirectQuery = (user: UserContract): JsonSchema => {
-	// Get any messages from 1 to 1 conversations
-	const dmsQuery: any = getOpenQuery();
-	dmsQuery.$$links['is attached to'] = {
-		type: 'object',
-		properties: {
-			type: {
-				const: 'thread@1.0.0',
-			},
-			data: {
-				type: 'object',
-				required: ['dms'],
-				properties: {
-					dms: {
-						const: true,
-					},
-				},
-			},
-		},
-	};
-
-	// Get any messages that directly mention/alert the user
-	const directQuery: any = getOpenQuery();
-	directQuery.properties.data = {
+	const query: any = getOpenQuery();
+	query.properties.data = {
 		type: 'object',
 		properties: {
 			payload: {
@@ -112,9 +91,7 @@ const getDirectQuery = (user: UserContract): JsonSchema => {
 		},
 	};
 
-	return {
-		anyOf: [dmsQuery, directQuery],
-	};
+	return query;
 };
 
 const getArchivedQuery = (): JsonSchema => {

--- a/test/e2e/ui/index.spec.js
+++ b/test/e2e/ui/index.spec.js
@@ -865,58 +865,6 @@ test.describe('Chat', () => {
 		await page2.close()
 	})
 
-	test('1 to 1 messages should appear in the inbox direct mentions tab', async ({
-		page,
-		browser
-	}) => {
-		const newContext = await browser.newContext()
-		const page2 = await newContext.newPage()
-		await Promise.all([
-			login(page, users.community),
-			login(page2, users.community2)
-		])
-
-		// Create thread for messages
-		const threadDetails = {
-			type: 'thread@1.0.0',
-			markers: [ `${user.slug}+${user2.slug}` ],
-			data: {
-				dms: true,
-				actors: [
-					user.slug,
-					user2.slug
-				]
-			}
-		}
-		const thread = await page.evaluate((options) => {
-			return window.sdk.card.create(options)
-		}, threadDetails)
-
-		// Create message on thread
-		const messageEvent = {
-			target: thread,
-			slug: `message-${uuid()}`,
-			tags: [],
-			type: 'message',
-			payload: {
-				message: `${uuid()}`
-			}
-		}
-		await page.evaluate((event) => {
-			return window.sdk.event.create(event)
-		}, messageEvent)
-
-		// Navigate to the inbox page
-		await page2.goto('/inbox')
-		await page2.locator('[data-test="inbox-direct-mentions-tab"]').click()
-		const messageText = await macros.getElementText(
-			page2,
-			'[data-test="event-card__message"]'
-		)
-		expect(messageText.trim()).toEqual(messageEvent.payload.message)
-		await page2.close()
-	})
-
 	test('Direct mentions should appear in the inbox direct mentions tab', async ({
 		page,
 		browser


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Reverts product-os/jellyfish#9359

Query causes timeouts right now because the database is too large (works fine in development/CI). Going with different strategy for the time being.