### PR TITLE
Add SQL to archive old contracts

### DIFF
--- a/sql/archive-tables.sql
+++ b/sql/archive-tables.sql
@@ -1,0 +1,7 @@
+SET statement_timeout=0;
+
+-- Create archive_cards table
+CREATE TABLE IF NOT EXISTS public.archive_cards (LIKE cards INCLUDING ALL);
+
+-- Create archive_links2 table
+CREATE TABLE IF NOT EXISTS public.archive_links2 (LIKE links2 INCLUDING ALL);

--- a/sql/archive.sql
+++ b/sql/archive.sql
@@ -1,0 +1,48 @@
+SET statement_timeout=0;
+
+-- Move old contracts to archive tables
+DO $$
+DECLARE
+    contract_ids UUID[];
+    link_ids UUID[];
+    primary_link_ids: UUID[];
+    secondary_link_ids: UUID[];
+BEGIN
+    LOOP
+        -- Select contracts we no longer need in the main table
+        SELECT array_agg(id) INTO contract_ids FROM (
+            SELECT id FROM cards WHERE (type='execute@1.0.0' OR (type='session@1.0.0' AND slug!='session-admin-kernel') OR type='external-event@1.0.0' OR active=false)
+                AND created_at < to_char(CURRENT_DATE - INTERVAL '3 months', 'YYYY-MM-DD')::date LIMIT 1000
+        ) as subset;
+        IF (contract_ids IS NULL) THEN
+            RAISE INFO 'No more matching contracts found, quitting...';
+            EXIT;
+        END IF;
+        RAISE INFO 'Archiving % contracts...', array_length(contract_ids, 1);
+
+        -- Select links for matching contracts
+        SELECT array_agg(id) INTO primary_link_ids FROM links2 WHERE fromid = ANY(contract_ids) OR toid = ANY(contract_ids);
+        SELECT array_agg(id) INTO secondary_link_ids FROM links2 WHERE fromid = ANY(primary_link_ids) OR toid = ANY(primary_link_ids);
+        link_ids = array_cat(primary_link_ids, secondary_link_ids);
+        RAISE INFO 'Archiving % links...', array_length(link_ids, 1);
+
+        -- Archive link records from links2 table
+        WITH moved_rows AS (
+            DELETE FROM links2 WHERE id = ANY(link_ids) OR fromid = ANY(link_ids) OR toid = ANY(link_ids) RETURNING *
+        ) INSERT INTO archive_links2 SELECT * FROM moved_rows;
+
+        -- Archive link records from cards table
+        WITH moved_rows AS (
+            DELETE FROM cards WHERE type='link@1.0.0' AND id = ANY(link_ids) RETURNING *
+        ) INSERT INTO archive_cards SELECT * FROM moved_rows;
+
+        -- Archive contract records from cards table
+        WITH moved_rows AS (
+            DELETE FROM cards WHERE id = ANY(contract_ids) RETURNING *
+        ) INSERT INTO archive_cards SELECT * FROM moved_rows;
+
+        -- Sleep for 1 second so as to not overload the database
+        PERFORM pg_sleep(1);
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/sql/generate.sql
+++ b/sql/generate.sql
@@ -1,0 +1,301 @@
+CREATE EXTENSION IF NOT EXISTS hstore;
+DO $$
+DECLARE
+    link_map HSTORE;
+    link_names TEXT[];
+BEGIN
+    link_map = hstore(
+        ARRAY['has attached element','is attached to','is creator of','was created by','executes','is executed by'],
+        ARRAY['is attached to','has attached element','was created by','is creator of','is executed by','executes']
+    );
+
+    -- Clear important bits
+    TRUNCATE links2, cards RESTART IDENTITY;
+
+    -- Disable triggers or this will go on for ages
+    SET session_replication_role = replica;
+
+    -- Seed 250k user contracts
+    RAISE INFO 'Creating user contracts...';
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'user-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'user@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{"hash": "' || md5(random()::text || clock_timestamp()::text) || '", "email": "' || md5(random()::text || clock_timestamp()::text) || '@' || md5(random()::text || clock_timestamp()::text) || '.' || md5(random()::text || clock_timestamp()::text) || '"}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM generate_series(1, 250000);
+
+    -- Create 1.5 session cards for each user
+    RAISE INFO 'Creating session contracts...';
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'session-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'session@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM generate_series(1, (
+        SELECT floor(1.5 * count(*))::int
+        FROM cards
+        WHERE cards.type = 'user@1.0.0'
+    ));
+
+    -- Randomly link sessions to users
+    RAISE INFO 'Linking session contracts to user contracts...';
+    WITH users AS MATERIALIZED (
+        SELECT array_agg(cards.id) AS ids
+        FROM cards
+        WHERE cards.type = 'user@1.0.0'
+        ORDER BY random()
+    )
+    INSERT INTO links2 (id, forward, fromid, name, toid)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        true,
+        users.ids[(random() * (array_length(users.ids, 1) - 1) + 1)::int],
+        (SELECT id FROM strings WHERE string='is creator of'),
+        cards.id
+    FROM cards, users
+    WHERE cards.type = 'session@1.0.0';
+
+    WITH users AS MATERIALIZED (
+        SELECT array_agg(cards.id) AS ids
+        FROM cards
+        WHERE cards.type = 'user@1.0.0'
+        ORDER BY random()
+    )
+    INSERT INTO links2 (id, forward, fromid, name, toid)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        false,
+        cards.id,
+        (SELECT id FROM strings WHERE string='was created by'),
+        users.ids[(random() * (array_length(users.ids, 1) - 1) + 1)::int]
+    FROM cards, users
+    WHERE cards.type = 'session@1.0.0';
+
+    -- Seed 500k thread contracts
+    RAISE INFO 'Creating thread contracts...';
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'thread-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'thread@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM generate_series(1, 500000);
+
+    -- Create 5 message cards for each thread
+    RAISE INFO 'Creating messages on threads...';
+    WITH users AS MATERIALIZED (
+        SELECT array_agg(cards.id) AS ids
+        FROM cards
+        WHERE cards.type = 'user@1.0.0'
+        ORDER BY random()
+    )
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'message-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'message@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{"actor": "' || (SELECT users.ids[(random() * (array_length(users.ids, 1) - 1) + 1)::int]) || '", "target": "' || (SELECT users.ids[(random() * (array_length(users.ids, 1) - 1) + 1)::int]) || '", "payload": {"message": "' || md5(random()::text || clock_timestamp()::text) || '"}, "timestamp": "' || (NOW() + (random() * (interval '90 days')) + '30 days')::text || '"}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM
+        generate_series(1, (
+            SELECT 5 * count(*)
+            FROM cards
+            WHERE cards.type = 'thread@1.0.0'
+        )),
+        users;
+
+    -- Randomly link messages to threads
+    RAISE INFO 'Linking messages to threads...';
+    WITH threads AS MATERIALIZED (
+        SELECT array_agg(threads.id) AS ids
+        FROM cards AS threads
+        WHERE threads.type = 'thread@1.0.0'
+        ORDER BY random()
+    )
+    INSERT INTO links2 (id, forward, fromid, name, toid)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        true,
+        threads.ids[(random() * (array_length(threads.ids, 1) - 1) + 1)::int],
+        (SELECT id FROM strings WHERE string='has attached element'),
+        cards.id
+    FROM cards, threads
+    WHERE cards.type = 'message@1.0.0';
+
+    WITH threads AS MATERIALIZED (
+        SELECT array_agg(threads.id) AS ids
+        FROM cards AS threads
+        WHERE threads.type = 'thread@1.0.0'
+        ORDER BY random()
+    )
+    INSERT INTO links2 (id, forward, fromid, name, toid)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        false,
+        cards.id,
+        (SELECT id FROM strings WHERE string='is attached to'),
+        threads.ids[(random() * (array_length(threads.ids, 1) - 1) + 1)::int]
+    FROM cards, threads
+    WHERE cards.type = 'message@1.0.0';
+
+    -- Seed 1m action-request cards
+    RAISE INFO 'Creating action-request contracts...';
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'action-request-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'action-request@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{"actor": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "epoch": ' || extract(EPOCH FROM (NOW() + (random() * (interval '90 days')) + '30 days'))::integer || ', "input": {"id": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '"}, "action": "action-create-card@1.0.0", "context": {"id": "REQUEST-28.0.3-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "api": "SERVER-28.0.3-localhost-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '"}, "arguments": {"reason": null, "properties": {"data": {"actor": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "expiration": "' || (NOW() + (random() * (interval '90 days')) + '30 days')::text || '"}, "slug": "session-ui-user-johndoe-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "linked_at": {}}}, "timestamp": "' || (NOW() + (random() * (interval '90 days')) + '30 days')::text || '"}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM generate_series(1, 1000000);
+
+    -- Create exactly one execute card for each action-request
+    RAISE INFO 'Creating execute contracts...';
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'execute-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'execute@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{"actor": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "target": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "payload": {"card": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "data": {"id": "' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "slug": "session-ui-user-johndoe-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) || '", "type": "session@1.0.0", "version": "1.0.0"}, "error": false, "action": "action-create-card@1.0.0", "timestamp": "' || (NOW() + (random() * (interval '90 days')) + '30 days')::text || '"}, "timestamp": "' || (NOW() + (random() * (interval '90 days')) + '30 days')::text || '"}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM generate_series(1, (
+        SELECT count(*)
+        FROM cards
+        WHERE cards.type = 'action-request@1.0.0'
+    ));
+
+    -- Link execute and action request cards 1-1
+    RAISE INFO 'Linking execute contracts to action-request contracts...';
+    INSERT INTO links2 (id, forward, fromid, name, toid)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        true,
+        pairs.fromid,
+        (SELECT id FROM strings WHERE string='executes'),
+        pairs.toId
+    FROM unnest(
+        (
+            SELECT array_agg(cards.id)
+            FROM cards
+            WHERE cards.type = 'execute@1.0.0'
+        ),
+        (
+            SELECT array_agg(cards.id)
+            FROM cards
+            WHERE cards.type = 'action-request@1.0.0'
+        )
+    ) AS pairs(fromId, toId);
+    INSERT INTO links2 (id, forward, fromid, name, toid)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        false,
+        pairs.fromid,
+        (SELECT id FROM strings WHERE string='is executed by'),
+        pairs.toId
+    FROM unnest(
+        (
+            SELECT array_agg(cards.id)
+            FROM cards
+            WHERE cards.type = 'action-request@1.0.0'
+        ),
+        (
+            SELECT array_agg(cards.id)
+            FROM cards
+            WHERE cards.type = 'execute@1.0.0'
+        )
+    ) AS pairs(fromId, toId);
+
+    -- Create links cards from the links2 table
+    RAISE INFO 'Creating link contracts from links2 table...';
+    INSERT INTO cards (id, slug, type, active, version_major, version_minor, version_patch, name, tags, markers, links, requires, capabilities, data, linked_at, created_at)
+    SELECT
+        uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'link-' || uuid_in(md5(random()::text || clock_timestamp()::text)::cstring),
+        'link@1.0.0',
+        random() > .01,
+        1,
+        0,
+        0,
+        (SELECT string FROM strings WHERE id=links2.name),
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        '{}',
+        ('{"inverseName": "' || (link_map->(SELECT string FROM strings WHERE id=links2.name)) || '", "from": {"id": "' || links2.fromId || '"}, "to": {"id": "' || links2.toId || '"}}')::json,
+        '{}',
+        (NOW() + (random() * (interval '90 days')) + '30 days')
+    FROM links2;
+
+    -- Reenable triggers
+    SET session_replication_role = DEFAULT;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Optimize for benchmark
+VACUUM FULL ANALYZE;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Add SQL to create archive tables and then move old contracts to these archive tables. Should run this regularly with [pg_cron](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL_pg_cron.html#PostgreSQL_pg_cron.enable), once a month?