### PR TITLE
Add Flowdock archive

### DIFF
--- a/apps/server/lib/plugins.ts
+++ b/apps/server/lib/plugins.ts
@@ -1,5 +1,6 @@
 import { balenaApiPlugin } from '@balena/jellyfish-plugin-balena-api';
 import { discoursePlugin } from '@balena/jellyfish-plugin-discourse';
+import { flowdockPlugin } from '@balena/jellyfish-plugin-flowdock';
 import { frontPlugin } from '@balena/jellyfish-plugin-front';
 import { githubPlugin } from '@balena/jellyfish-plugin-github';
 import { incidentsPlugin } from '@balena/jellyfish-plugin-incidents';
@@ -16,5 +17,6 @@ export function getPlugins(): PluginDefinition[] {
 		frontPlugin(),
 		balenaApiPlugin(),
 		incidentsPlugin(),
+		flowdockPlugin(),
 	] as any;
 }

--- a/apps/server/nodemon.json
+++ b/apps/server/nodemon.json
@@ -14,6 +14,7 @@
     "node_modules/@balena/jellyfish-plugin-github/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-typeform/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-incidents/build/**/*.js",
+    "node_modules/@balena/jellyfish-plugin-flowdock/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-front/build/**/*.js",
     "node_modules/@balena/jellyfish-plugin-outreach/build/**/*.js",
     "node_modules/@balena/jellyfish-worker/build/**/*.js",

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -15,6 +15,7 @@
         "@balena/jellyfish-metrics": "^2.0.201",
         "@balena/jellyfish-plugin-balena-api": "^6.0.196",
         "@balena/jellyfish-plugin-discourse": "^6.0.119",
+        "@balena/jellyfish-plugin-flowdock": "^7.0.0",
         "@balena/jellyfish-plugin-front": "^6.0.220",
         "@balena/jellyfish-plugin-github": "^8.0.167",
         "@balena/jellyfish-plugin-incidents": "^8.0.148",
@@ -707,6 +708,17 @@
       "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@balena/jellyfish-plugin-flowdock": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-flowdock/-/jellyfish-plugin-flowdock-7.0.0.tgz",
+      "integrity": "sha512-Ch4XOVFHY5bGrD2XYQSxrtR+A+MsLWfnHBt3V4pw1fwS+qLCMwGRLZOhTa+dOO98jfeuf0nGNGA7n4v5q3fVMg==",
+      "dependencies": {
+        "@balena/jellyfish-worker": "^34.1.36"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@balena/jellyfish-plugin-front": {
@@ -12175,6 +12187,14 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
           "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ=="
         }
+      }
+    },
+    "@balena/jellyfish-plugin-flowdock": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-flowdock/-/jellyfish-plugin-flowdock-7.0.0.tgz",
+      "integrity": "sha512-Ch4XOVFHY5bGrD2XYQSxrtR+A+MsLWfnHBt3V4pw1fwS+qLCMwGRLZOhTa+dOO98jfeuf0nGNGA7n4v5q3fVMg==",
+      "requires": {
+        "@balena/jellyfish-worker": "^34.1.36"
       }
     },
     "@balena/jellyfish-plugin-front": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "@balena/jellyfish-metrics": "^2.0.201",
     "@balena/jellyfish-plugin-balena-api": "^6.0.196",
     "@balena/jellyfish-plugin-discourse": "^6.0.119",
+    "@balena/jellyfish-plugin-flowdock": "^7.0.0",
     "@balena/jellyfish-plugin-front": "^6.0.220",
     "@balena/jellyfish-plugin-github": "^8.0.167",
     "@balena/jellyfish-plugin-incidents": "^8.0.148",


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Bring back `jellyfish-plugin-flowdock`, this time though for archive data only.
