### PR TITLE
UI: Add ability to hide dates with uiSchema

### DIFF
--- a/apps/ui/lib/components/CardFields/index.tsx
+++ b/apps/ui/lib/components/CardFields/index.tsx
@@ -31,35 +31,44 @@ export default function CardFields({
 		typeSchema,
 	);
 
+	const uiSchema = getUiSchema(type, viewMode);
+	const showDates =
+		_.isNull(_.get(uiSchema, 'created_at')) &&
+		_.isNull(_.get(uiSchema, 'updated_at'))
+			? false
+			: true;
+
 	return (
 		<>
-			<Box py={2}>
-				{!!card.created_at && (
-					<Txt>
-						<em>Created {helpers.formatTimestamp(card.created_at)}</em>
-					</Txt>
-				)}
+			{showDates && (
+				<Box py={2}>
+					{!!card.created_at && (
+						<Txt>
+							<em>Created {helpers.formatTimestamp(card.created_at)}</em>
+						</Txt>
+					)}
 
-				{!!card.updated_at && (
-					<Txt>
-						<em>
-							Updated{' '}
-							{helpers.timeAgo(
-								_.get(
-									helpers.getLastUpdate(card),
-									['data', 'timestamp'],
-									card.updated_at,
-								) as any,
-							)}
-						</em>
-					</Txt>
-				)}
-			</Box>
+					{!!card.updated_at && (
+						<Txt>
+							<em>
+								Updated{' '}
+								{helpers.timeAgo(
+									_.get(
+										helpers.getLastUpdate(card),
+										['data', 'timestamp'],
+										card.updated_at,
+									) as any,
+								)}
+							</em>
+						</Txt>
+					)}
+				</Box>
+			)}
 
 			<Renderer
 				value={card}
 				schema={schema}
-				uiSchema={getUiSchema(type, viewMode)}
+				uiSchema={uiSchema}
 				extraContext={{
 					root: card,
 					fns: jsonSchemaFns,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

***

Add ability to hide `created_at` and `updated_at` fields for contract snippets when these two fields are set to `null` in a type contracts `uiSchema` configuration.