### PR TITLE
Bump logshipper to v1.0.0+rev12.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -378,7 +378,7 @@ services:
       io.balena.features.balena-socket: "1"
       io.balena.features.supervisor-api: "1"
   logshipper:
-    image: bh.cr/balenablocks/logshipper/0.2.1
+    image: bh.cr/balenablocks/logshipper/1.0.0:rev12
     environment:
       LOG: warn
     labels:


### PR DESCRIPTION
This logshipper version uses Vector API v2 which also enables compression.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>

***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
