### PR TITLE
Upgrade logshipper to 1.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -378,7 +378,7 @@ services:
       io.balena.features.balena-socket: "1"
       io.balena.features.supervisor-api: "1"
   logshipper:
-    image: bh.cr/balenablocks/logshipper/1.0.0:rev12
+    image: bh.cr/balenablocks/logshipper/1.0.1:rev3
     environment:
       LOG: warn
     labels:


### PR DESCRIPTION
***

**Please remember to write tests for your changes**. We aim to automatically
deploy `master` to production, and we can't safely do this without a solid
test suite!
