### PR TITLE
Backend: Handle preflight requests for /hooks

### DIFF
--- a/apps/server/lib/http/routes.ts
+++ b/apps/server/lib/http/routes.ts
@@ -543,6 +543,11 @@ export const attachRoutes = (
 				return response.status(200).end();
 			}
 
+			// Handle CORS pre-flight OPTIONS requests
+			if (request.method.match(/^options$/i)) {
+				return response.status(204).end();
+			}
+
 			const integrationToken = environment.integration[request.params.provider];
 
 			try {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

---

Need to return a `204` response for `OPTIONS` requests before the request body is validated through `isEventValid` methods. These checks throw a 500 because there is no payload to `JSON.parse()` for `OPTIONS` requests. The subsequent request after `OPTIONS` is then processed normally.