### PR TITLE
Update plugin-outreach to 5.2.5

### DIFF
--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -20,7 +20,7 @@
         "@balena/jellyfish-plugin-github": "^9.0.0",
         "@balena/jellyfish-plugin-hubot": "^0.14.1",
         "@balena/jellyfish-plugin-incidents": "^8.0.252",
-        "@balena/jellyfish-plugin-outreach": "^5.2.1",
+        "@balena/jellyfish-plugin-outreach": "^5.2.5",
         "@balena/jellyfish-plugin-typeform": "^10.0.273",
         "@balena/jellyfish-worker": "^37.1.12",
         "@balena/socket-prometheus-metrics": "^0.0.3",
@@ -1087,13 +1087,13 @@
       }
     },
     "node_modules/@balena/jellyfish-plugin-outreach": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-5.2.1.tgz",
-      "integrity": "sha512-jJ4ylGS+XHu9KRwN/jJQNgG8kOktNMory4Ph4voknvgRqJ9qcttaARMTfKGbZk23m1sRipIkhOAV5By1wdrwAQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-5.2.5.tgz",
+      "integrity": "sha512-hjJ/66RAdoa6Tcu3zuk3t6JKUW7k1Ap0SqnTi83KmkyKNb4jKeS3Z5MyoaveAR48E2AXx8NO/3bLPRP8ZL0QuA==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.103",
         "@balena/jellyfish-environment": "^14.6.11",
-        "@balena/jellyfish-worker": "^37.1.15",
+        "@balena/jellyfish-worker": "^37.1.17",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       },
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@balena/jellyfish-worker": {
-      "version": "37.1.15",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-37.1.15.tgz",
-      "integrity": "sha512-2cUEb/KQ+EbV97yWfL74pQiKgTfItnNfdPSzSm41jkrdRTNjRID2VnO2ksrwJC6T47NdVsCbcZDwUaHY0g3vvw==",
+      "version": "37.1.17",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-37.1.17.tgz",
+      "integrity": "sha512-6ddYqJvJghUbelwfXFeVbzgWBnxiWyYjIxWZ8aesaeNiKzjKAFMj/bU55+VQSpE2OeX6uyPyxNNjLa6FfOBfcg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.103",
         "@balena/jellyfish-environment": "^14.6.11",
@@ -1184,7 +1184,7 @@
         "@balena/jellyfish-metrics": "^2.0.292",
         "@graphile/logger": "^0.2.0",
         "@types/node": "^17.0.41",
-        "autumndb": "^22.2.172",
+        "autumndb": "^22.2.173",
         "axios": "^0.27.2",
         "bcrypt": "^5.1.0",
         "blueimp-md5": "^2.19.0",
@@ -3295,9 +3295,9 @@
       "license": "MIT"
     },
     "node_modules/autumndb": {
-      "version": "22.2.172",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.172.tgz",
-      "integrity": "sha512-Kes2w6efKtHZvXVUq9dm5jUrtT001AYmSFqmDPekr8uw1LuZDCis0BaBtsyA8q/K0ZoH8nn/D0dcqBjVg6Ulog==",
+      "version": "22.2.173",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.173.tgz",
+      "integrity": "sha512-m8sCzfvJXK1knIuVc0wEphz3xxXnVHuJodycTx76kT8GB/TcAFAkqdH5CY6ZNuPY6RLitQ+edg56nnrX1/6FKg==",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.2.103",
         "@balena/jellyfish-environment": "^14.6.11",
@@ -12778,13 +12778,13 @@
       }
     },
     "@balena/jellyfish-plugin-outreach": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-5.2.1.tgz",
-      "integrity": "sha512-jJ4ylGS+XHu9KRwN/jJQNgG8kOktNMory4Ph4voknvgRqJ9qcttaARMTfKGbZk23m1sRipIkhOAV5By1wdrwAQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-plugin-outreach/-/jellyfish-plugin-outreach-5.2.5.tgz",
+      "integrity": "sha512-hjJ/66RAdoa6Tcu3zuk3t6JKUW7k1Ap0SqnTi83KmkyKNb4jKeS3Z5MyoaveAR48E2AXx8NO/3bLPRP8ZL0QuA==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.103",
         "@balena/jellyfish-environment": "^14.6.11",
-        "@balena/jellyfish-worker": "^37.1.15",
+        "@balena/jellyfish-worker": "^37.1.17",
         "is-uuid": "^1.0.2",
         "lodash": "^4.17.21"
       }
@@ -12853,9 +12853,9 @@
       }
     },
     "@balena/jellyfish-worker": {
-      "version": "37.1.15",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-37.1.15.tgz",
-      "integrity": "sha512-2cUEb/KQ+EbV97yWfL74pQiKgTfItnNfdPSzSm41jkrdRTNjRID2VnO2ksrwJC6T47NdVsCbcZDwUaHY0g3vvw==",
+      "version": "37.1.17",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-worker/-/jellyfish-worker-37.1.17.tgz",
+      "integrity": "sha512-6ddYqJvJghUbelwfXFeVbzgWBnxiWyYjIxWZ8aesaeNiKzjKAFMj/bU55+VQSpE2OeX6uyPyxNNjLa6FfOBfcg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.103",
         "@balena/jellyfish-environment": "^14.6.11",
@@ -12864,7 +12864,7 @@
         "@balena/jellyfish-metrics": "^2.0.292",
         "@graphile/logger": "^0.2.0",
         "@types/node": "^17.0.41",
-        "autumndb": "^22.2.172",
+        "autumndb": "^22.2.173",
         "axios": "^0.27.2",
         "bcrypt": "^5.1.0",
         "blueimp-md5": "^2.19.0",
@@ -14542,9 +14542,9 @@
       "version": "0.4.0"
     },
     "autumndb": {
-      "version": "22.2.172",
-      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.172.tgz",
-      "integrity": "sha512-Kes2w6efKtHZvXVUq9dm5jUrtT001AYmSFqmDPekr8uw1LuZDCis0BaBtsyA8q/K0ZoH8nn/D0dcqBjVg6Ulog==",
+      "version": "22.2.173",
+      "resolved": "https://registry.npmjs.org/autumndb/-/autumndb-22.2.173.tgz",
+      "integrity": "sha512-m8sCzfvJXK1knIuVc0wEphz3xxXnVHuJodycTx76kT8GB/TcAFAkqdH5CY6ZNuPY6RLitQ+edg56nnrX1/6FKg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.2.103",
         "@balena/jellyfish-environment": "^14.6.11",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -33,7 +33,7 @@
     "@balena/jellyfish-plugin-github": "^9.0.0",
     "@balena/jellyfish-plugin-hubot": "^0.14.1",
     "@balena/jellyfish-plugin-incidents": "^8.0.252",
-    "@balena/jellyfish-plugin-outreach": "^5.2.1",
+    "@balena/jellyfish-plugin-outreach": "^5.2.5",
     "@balena/jellyfish-plugin-typeform": "^10.0.273",
     "@balena/jellyfish-worker": "^37.1.12",
     "@balena/socket-prometheus-metrics": "^0.0.3",


### PR DESCRIPTION
Search for Outreach accounts before creating one

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>
